### PR TITLE
Fix typo it's -> its

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ React Query exports a set of hooks that attempt to address these issues. Out of 
 <details>
 <summary>Inspiration & Hat-Tipping</summary>
 <br />
-A big thanks to both [Draqula](https://github.com/vadimdemedes/draqula) for inspiring a lot of React Query's original API and documentation and also [Zeit's SWR](https://github.com/zeit/swr) and it's creators for inspiring even further customizations and examples. You all rock!
+A big thanks to both [Draqula](https://github.com/vadimdemedes/draqula) for inspiring a lot of React Query's original API and documentation and also [Zeit's SWR](https://github.com/zeit/swr) and its creators for inspiring even further customizations and examples. You all rock!
 
 </details>
 


### PR DESCRIPTION
Does what it says on the tin 🙂 