### PR TITLE
Add throw error for useMutation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -583,6 +583,7 @@ export function useMutation(
         }
 
         setIsLoading(false)
+        throw error
       }
     },
     [refetchQueriesOnFailure, refetchQueries]


### PR DESCRIPTION
When using `useMutation` Hook in an event handler like when you submit a form sometimes you want to be able to access errors response from the server inside the event like

```
<Form onSubmit={(values) => {
  try {
      await mutate({ title })
      // Todo was successfully created
    } catch (error) {
      // Uh oh, something went wrong
    }
}}>
...
</Form>
```

Because the error is not return like the response, was not able to access error message in a try/catch