### PR TITLE
Remove fast async nodent runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,5 +9,11 @@
     ],
     "@babel/react"
   ],
-  "plugins": ["module:fast-async"]
+  "plugins": [
+    ["module:fast-async", {
+      "compiler": {
+        "noRuntime": true
+      }
+    }]
+  ]
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.js": {
-    "bundled": 35248,
-    "minified": 17174,
-    "gzipped": 4955
+    "bundled": 28066,
+    "minified": 14050,
+    "gzipped": 4017
   },
   "dist/index.es.js": {
-    "bundled": 34754,
-    "minified": 16734,
-    "gzipped": 4858,
+    "bundled": 27572,
+    "minified": 13610,
+    "gzipped": 3920,
     "treeshaked": {
       "rollup": {
-        "code": 6280,
+        "code": 3168,
         "import_statements": 21
       },
       "webpack": {
-        "code": 7302
+        "code": 4190
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-react": "7.x",
     "eslint-plugin-react-hooks": "1.5.0",
     "eslint-plugin-standard": "^4.0.0",
+    "fast-async": "^6.3.8",
     "prettier": "^1.18.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,11 +1701,6 @@ core-js-compat@^3.1.1:
     browserslist "^4.7.2"
     semver "^6.3.0"
 
-core-js@3:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.3.6.tgz#6ad1650323c441f45379e176ed175c0d021eac92"
-  integrity sha512-u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA==
-
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
`fast-async` injects the nodent runtime, which adds `Function.prototype.$asyncbind` to the output.

This runtime method is not used in the output, so we can remove it.

Resolves #46 