### PR TITLE
Add per-query refetchOnWindowFocus option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ const {
   refetchInterval,
   retry,
   retryDelay,
+  refetchOnWindowFocus,
   onSuccess,
   onError,
   suspense,
@@ -1241,6 +1242,10 @@ const {
 - `refetchInterval: false | Integer`
   - Optional
   - If set to a number, all queries will continuously refetch at this frequency in milliseconds.
+- `refetchOnWindowFocus: Boolean`
+  - Optional
+  - Set this to `false` to disable automatic refetching on window focus (useful, when `refetchAllOnWindowFocus` is set to `true`).
+  - Set this to `true` to enable automatic refetching on window focus (useful, when `refetchAllOnWindowFocus` is set to `false`).
 - `onError: Function(err) => void`
   - Optional
   - This function will fire if the query encounters an error (after all retries have happened) and will be passed the error.

--- a/src/index.js
+++ b/src/index.js
@@ -11,13 +11,16 @@ let eventsBinded = false
 if (typeof window !== 'undefined' && window.addEventListener && !eventsBinded) {
   const revalidate = () => {
     const { refetchAllOnWindowFocus } = defaultConfig
-    if (refetchAllOnWindowFocus && isDocumentVisible() && isOnline())
-      refetchAllQueries({ shouldRefetchQuery: (query) => {
-        if (query.config.refetchOnWindowFocus === false) {
-          return false
-        }
-        return true
-      }}).catch(error => {
+    if (isDocumentVisible() && isOnline())
+      refetchAllQueries({
+        shouldRefetchQuery: (query) => {
+          if (typeof query.config.refetchOnWindowFocus === 'undefined') {
+            return refetchAllOnWindowFocus;
+          } else {
+            return query.config.refetchOnWindowFocus;
+          }
+        },
+      }).catch(error => {
         console.error(error.message)
       })
   }


### PR DESCRIPTION
Currently there's `refetchAllOnWindowFocus` provider option, which allows to control refetching on window focus for all queries.

This PR adds `refetchOnWindowFocus` option to `useQuery`, which allows to control refetching on window focus on per-query basis.