### PR TITLE
update guard against missing `document`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ function makeQuery(options) {
         query.config.retry === true ||
         query.state.failureCount < query.config.retry
       ) {
-        if (typeof document !== 'undefined' && !isDocumentVisible()) {
+        if (!isDocumentVisible()) {
           return new Promise(r => {})
         }
 
@@ -781,6 +781,7 @@ function isObject(a) {
 
 function isDocumentVisible() {
   return (
+    typeof document === 'undefined' ||
     document.visibilityState === undefined ||
     document.visibilityState === 'visible' ||
     document.visibilityState === 'prerender'


### PR DESCRIPTION
Pull request https://github.com/tannerlinsley/react-query/pull/38 added the guard for missing document on react native, this PR adds the check to the isDocumentVisible function so that the missing document error does not appear for things like intervals and other checks for visible document etc.