### PR TITLE
fix: comment typo 'upsubscribe' to 'unsubscribe'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -548,7 +548,7 @@ export async function prefetchQuery(queryKey, queryFn, config = {}) {
   try {
     return await query.fetch({ force: config.force })
   } finally {
-    // Since this is not a hook, upsubscribe after we're done
+    // Since this is not a hook, unsubscribe after we're done
     unsubscribeFromQuery()
   }
 }


### PR DESCRIPTION
When reviewing the source, I noticed a small typo in a comment. Sorry to be annoying. I see it as testing the waters of contributing to the package. 😄 