### PR TITLE
Fix cancelQueries is not a function error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,9 @@ function makeQuery(options) {
         // Cancel any side-effects
         query.cancelled = cancelledError
 
-        query.cancelQueries()
+        if (query.cancelQueries) {
+          query.cancelQueries()
+        }
 
         // Mark as inactive
         query.setState(old => {


### PR DESCRIPTION
This closes issue https://github.com/tannerlinsley/react-query/issues/103, and maintains the ability to cancel queries.