### PR TITLE
remove extraneous curly brace from default query keys

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.js": {
-    "bundled": 29752,
-    "minified": 14834,
-    "gzipped": 4211
+    "bundled": 29796,
+    "minified": 14847,
+    "gzipped": 4213
   },
   "dist/index.es.js": {
-    "bundled": 29232,
-    "minified": 14370,
-    "gzipped": 4110,
+    "bundled": 29276,
+    "minified": 14383,
+    "gzipped": 4111,
     "treeshaked": {
       "rollup": {
-        "code": 3476,
+        "code": 3472,
         "import_statements": 21
       },
       "webpack": {
-        "code": 4497
+        "code": 4493
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -769,7 +769,7 @@ function defaultQueryKeySerializerFn(queryKey) {
     const variablesHash = variablesIsObject ? stableStringify(variables) : ''
 
     return [
-      `${id}${variablesHash ? `_${variablesHash}}` : ''}`,
+      `${id}${variablesHash ? `_${variablesHash}` : ''}`,
       id,
       variablesHash,
       variables,


### PR DESCRIPTION
This was bugging me 😄 
Thanks for a great library!