### PR TITLE
enhanced setQueryData to update multiple queries

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 31777,
-    "minified": 16088,
-    "gzipped": 4619
+    "bundled": 32204,
+    "minified": 16235,
+    "gzipped": 4653
   },
   "dist/index.es.js": {
-    "bundled": 31236,
-    "minified": 15605,
-    "gzipped": 4517,
+    "bundled": 31663,
+    "minified": 15752,
+    "gzipped": 4552,
     "treeshaked": {
       "rollup": {
         "code": 3329,


### PR DESCRIPTION
This is a little example implementation of the requested feature of Issue https://github.com/tannerlinsley/react-query/issues/135.

_I basically just copied the logic from `refetchQuery`. Haven't tested it fully yet, will add some tests and an example usage later._