### PR TITLE
#124 Refetched query fetch should catch the promise call directly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -447,15 +447,8 @@ export function useQuery(queryKey, queryFn, config = {}) {
     if (config.refetchInterval && !query.refetchInterval) {
       query.refetchInterval = setInterval(() => {
         if (isDocumentVisible() || config.refetchIntervalInBackground) {
-          try {
-            query.fetch().catch(err => {
-              Console.error(err)
-              // Swallow this error, since it is handled elsewhere
-            })
-          } catch (err) {
-            Console.error(err)
-            // Swallow this error, since it is handled elsewhere
-          }
+          // Swallow this error, since it is handled elsewhere
+          query.fetch().catch(Console.error)
         }
       }, config.refetchInterval)
 

--- a/src/index.js
+++ b/src/index.js
@@ -448,7 +448,10 @@ export function useQuery(queryKey, queryFn, config = {}) {
       query.refetchInterval = setInterval(() => {
         if (isDocumentVisible() || config.refetchIntervalInBackground) {
           try {
-            query.fetch()
+            query.fetch().catch(err => {
+              Console.error(err)
+              // Swallow this error, since it is handled elsewhere
+            })
           } catch (err) {
             Console.error(err)
             // Swallow this error, since it is handled elsewhere


### PR DESCRIPTION
@tannerlinsley The change you made for #124 doesn't seem correct (and doesn't work in my own testing of the sandbox mentioned).  

The try catch wouldn't catch the throw in the promise, whereas this would.

(you might want to just take out the try/catch entirely and catch the promise this way, up to you)

Great job btw, it's a fantastic library!