### PR TITLE
Add test for useQuery in manual mode

### DIFF
--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -138,4 +138,23 @@ describe('useQuery', () => {
 
     expect(queryFn).toHaveBeenCalledWith('test', variables)
   })
+
+  // See https://github.com/tannerlinsley/react-query/issues/161
+  it('should not fetch query when `manual` is set to `true`', async () => {
+    const queryFn = jest.fn()
+
+    function Page() {
+      const { data = 'default' } = useQuery('test', queryFn, { manual: true })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+    await waitForElement(() => rendered.getByText('default'))
+    expect(queryFn).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Covers https://github.com/tannerlinsley/react-query/issues/161

I've double-checked that it fails without the fix