### PR TITLE
Fix query state being set to "success" when query function throw

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -306,7 +306,7 @@ export function makeQueryCache() {
           })
         }
 
-        // throw error
+        throw error
       }
     }
 
@@ -381,7 +381,7 @@ export function makeQueryCache() {
                   instance.onSettled && instance.onSettled(undefined, error)
               )
 
-              throw error
+              // throw error
             }
           }
         })()

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -157,4 +157,26 @@ describe('useQuery', () => {
     await waitForElement(() => rendered.getByText('default'))
     expect(queryFn).not.toHaveBeenCalled()
   })
+
+  it('should set status to error if queryFn throws', async () => {
+    function Page() {
+      const { status } = useQuery(
+        'test',
+        () => {
+          return Promise.reject('Error test')
+        },
+        { retry: false },
+      )
+
+      return (
+        <div>
+          <h1>{status}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    await waitForElement(() => rendered.getByText('error'))
+  })
 })


### PR DESCRIPTION
Bug reproduction: https://codesandbox.io/s/musing-framework-jvo0s