### PR TITLE
Make sure query is refetched specified number of times

### DIFF
--- a/examples/sandbox/src/index.app.js
+++ b/examples/sandbox/src/index.app.js
@@ -62,7 +62,7 @@ let queryTimeMin = 1000;
 let queryTimeMax = 2000;
 
 const fetchTodos = (key, { filter } = {}) => {
-  console.log("fetchTodos", { filter });
+  console.info("fetchTodos", { filter });
   const promise = new Promise((resolve, reject) => {
     setTimeout(() => {
       if (Math.random() < errorRate) {
@@ -74,13 +74,13 @@ const fetchTodos = (key, { filter } = {}) => {
     }, queryTimeMin + Math.random() * (queryTimeMax - queryTimeMin));
   });
 
-  promise.cancel = () => console.log("cancelled", filter);
+  promise.cancel = () => console.info("cancelled", filter);
 
   return promise;
 };
 
 const fetchTodoById = (key, { id }) => {
-  console.log("fetchTodoById", { id });
+  console.info("fetchTodoById", { id });
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       if (Math.random() < errorRate) {
@@ -94,7 +94,7 @@ const fetchTodoById = (key, { id }) => {
 };
 
 const postTodo = ({ name, notes }) => {
-  console.log("postTodo", { name, notes });
+  console.info("postTodo", { name, notes });
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       if (Math.random() < errorRate) {
@@ -110,7 +110,7 @@ const postTodo = ({ name, notes }) => {
 };
 
 const patchTodo = todo => {
-  console.log("patchTodo", todo);
+  console.info("patchTodo", todo);
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       if (Math.random() < errorRate) {

--- a/examples/suspense/src/queries.js
+++ b/examples/suspense/src/queries.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export async function fetchProjects(key) {
-  console.log("fetch projects");
+  console.info("fetch projects");
   let { data } = await axios.get(
     `https://api.github.com/users/tannerlinsley/repos?sort=updated`
   );
@@ -10,7 +10,7 @@ export async function fetchProjects(key) {
 }
 
 export async function fetchProject(key, { id }) {
-  console.log("fetch project id", id);
+  console.info("fetch project id", id);
   let { data } = await axios.get(
     `https://api.github.com/repos/tannerlinsley/${id}`
   );

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",
     "test:dev": "jest --watch",
-    "test:ci": "yarn test:jest --runInBand",
+    "test:ci": "yarn test:jest",
     "test:jest": "jest --coverage",
     "test:coverage": "yarn test:jest; open coverage/lcov-report/index.html",
     "build": "NODE_ENV=production rollup -c",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",
     "test:dev": "jest --watch",
-    "test:ci": "yarn test:jest --maxWorkers=2 --testTimeout=50000",
+    "test:ci": "yarn test:jest --runInBand",
     "test:jest": "jest --coverage",
     "test:coverage": "yarn test:jest; open coverage/lcov-report/index.html",
     "build": "NODE_ENV=production rollup -c",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",
     "test:dev": "jest --watch",
-    "test:ci": "yarn test:jest --maxWorkers=2",
+    "test:ci": "yarn test:jest --maxWorkers=2 --testTimeout=50000",
     "test:jest": "jest --coverage",
     "test:coverage": "yarn test:jest; open coverage/lcov-report/index.html",
     "build": "NODE_ENV=production rollup -c",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",
     "test:dev": "jest --watch",
-    "test:ci": "yarn test:jest",
+    "test:ci": "yarn test:jest --runInBand",
     "test:jest": "jest --coverage",
     "test:coverage": "yarn test:jest; open coverage/lcov-report/index.html",
     "build": "NODE_ENV=production rollup -c",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",
     "test:dev": "jest --watch",
-    "test:ci": "yarn test:jest --runInBand",
+    "test:ci": "yarn test:jest --maxWorkers=2",
     "test:jest": "jest --coverage",
     "test:coverage": "yarn test:jest; open coverage/lcov-report/index.html",
     "build": "NODE_ENV=production rollup -c",

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -306,7 +306,7 @@ export function makeQueryCache() {
           })
         }
 
-        // throw error
+        throw error
       }
     }
 
@@ -381,7 +381,7 @@ export function makeQueryCache() {
                   instance.onSettled && instance.onSettled(undefined, error)
               )
 
-              throw error
+              // throw error
             }
           }
         })()

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -206,7 +206,7 @@ export function makeQueryCache() {
         () => {
           cache.removeQueries(d => d.queryHash === query.queryHash)
         },
-        typeof query.state.data === 'undefined' ? 0 : query.config.cacheTime
+        (typeof query.state.data === 'undefined' && query.state.status === 'success') ? 0 : query.config.cacheTime
       )
     }
 

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -253,6 +253,7 @@ export function makeQueryCache() {
 
     // Set up the fetch function
     const tryFetchData = async (queryFn, ...args) => {
+      console.log('tryFetchData', new Date());
       try {
         // Perform the query
         const promise = queryFn(...query.config.queryFnParamsFilter(args))

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -206,7 +206,7 @@ export function makeQueryCache() {
         () => {
           cache.removeQueries(d => d.queryHash === query.queryHash)
         },
-        (typeof query.state.data === 'undefined' && query.state.status === 'success') ? 0 : query.config.cacheTime
+        (typeof query.state.data === 'undefined' && query.state.status !== 'error') ? 0 : query.config.cacheTime
       )
     }
 

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -253,7 +253,6 @@ export function makeQueryCache() {
 
     // Set up the fetch function
     const tryFetchData = async (queryFn, ...args) => {
-      console.log('tryFetchData', query.queryHash, new Date());
       try {
         // Perform the query
         const promise = queryFn(...query.config.queryFnParamsFilter(args))

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -276,7 +276,7 @@ export function makeQueryCache() {
         if (
           // Only retry if the document is visible
           query.config.retry === true ||
-          query.state.failureCount < query.config.retry
+          query.state.failureCount <= query.config.retry
         ) {
           if (!isDocumentVisible()) {
             return new Promise(noop)

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -253,7 +253,7 @@ export function makeQueryCache() {
 
     // Set up the fetch function
     const tryFetchData = async (queryFn, ...args) => {
-      console.log('tryFetchData', new Date());
+      console.log('tryFetchData', query.queryHash, new Date());
       try {
         // Perform the query
         const promise = queryFn(...query.config.queryFnParamsFilter(args))

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -157,4 +157,26 @@ describe('useQuery', () => {
     await waitForElement(() => rendered.getByText('default'))
     expect(queryFn).not.toHaveBeenCalled()
   })
+
+  it('should set status to error if queryFn throws', async () => {
+    function Page() {
+      const { status } = useQuery(
+        'test',
+        () => {
+          return Promise.reject('Error test')
+        },
+        { retry: false },
+      )
+
+      return (
+        <div>
+          <h1>{status}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    await waitForElement(() => rendered.getByText('error'))
+  })
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -159,6 +159,7 @@ describe('useQuery', () => {
   })
 
   it('should set status to error if queryFn throws', async () => {
+    console.log('should set status to error if queryFn throws')
     function Page() {
       const { status } = useQuery(
         'test',
@@ -181,6 +182,7 @@ describe('useQuery', () => {
   })
 
   it('should retry specified number of times', async () => {
+    console.log('should retry specified number of times')
     const queryFn = jest.fn()
     queryFn.mockImplementation(() => {
       return Promise.reject('Error test')

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -202,11 +202,11 @@ describe('useQuery', () => {
 
     const rendered = render(<Page />)
 
-    await waitForElement(() => rendered.getByText('loading'), { timeout: 20000 })
-    await waitForElement(() => rendered.getByText('error'), { timeout: 20000 })
+    await waitForElement(() => rendered.getByText('loading'), { timeout: 50000 })
+    await waitForElement(() => rendered.getByText('error'), { timeout: 50000 })
 
     // query should fail `retry + 1` times, since first time isn't a "retry"
-    await waitForElement(() => rendered.getByText('Failed 2 times'), { timeout: 20000 })
+    await waitForElement(() => rendered.getByText('Failed 2 times'), { timeout: 50000 })
 
     expect(queryFn).toHaveBeenCalledTimes(2)
   })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -209,5 +209,5 @@ describe('useQuery', () => {
     await waitForElement(() => rendered.getByText('Failed 2 times'), { timeout: 20000 })
 
     expect(queryFn).toHaveBeenCalledTimes(2)
-  }, 20000)
+  })
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -179,4 +179,33 @@ describe('useQuery', () => {
 
     await waitForElement(() => rendered.getByText('error'))
   })
+
+  it('should retry specified number of times', async () => {
+    const queryFn = jest.fn();
+    queryFn.mockImplementation(() => {
+      return Promise.reject('Error test')
+    })
+
+    function Page() {
+      const { status, failureCount } = useQuery(
+        'test',
+        queryFn,
+        { retry: 1, retryDelay: 1 },
+      )
+
+      return (
+        <div>
+          <h1>{status}</h1>
+          <h2>Failed {failureCount} times</h2>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    await waitForElement(() => rendered.getByText('error'))
+    // query should fail `retry + 1` times, since first time isn't a "retry"
+    await waitForElement(() => rendered.getByText('Failed 2 times'))
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -202,11 +202,11 @@ describe('useQuery', () => {
 
     const rendered = render(<Page />)
 
-    rendered.getByText('loading')
+    await waitForElement(() => rendered.getByText('loading'), { timeout: 20000 })
 
     // query should fail `retry + 1` times, since first time isn't a "retry"
-    await waitForElement(() => rendered.getByText('Failed 2 times'))
+    await waitForElement(() => rendered.getByText('Failed 2 times'), { timeout: 20000 })
 
     expect(queryFn).toHaveBeenCalledTimes(2)
-  })
+  }, 20000)
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -165,7 +165,7 @@ describe('useQuery', () => {
         () => {
           return Promise.reject('Error test')
         },
-        { retry: false },
+        { retry: false }
       )
 
       return (
@@ -181,17 +181,16 @@ describe('useQuery', () => {
   })
 
   it('should retry specified number of times', async () => {
-    const queryFn = jest.fn();
+    const queryFn = jest.fn()
     queryFn.mockImplementation(() => {
       return Promise.reject('Error test')
     })
 
     function Page() {
-      const { status, failureCount } = useQuery(
-        'test',
-        queryFn,
-        { retry: 1, retryDelay: 1 },
-      )
+      const { status, failureCount } = useQuery('test', queryFn, {
+        retry: 1,
+        retryDelay: 1,
+      })
 
       return (
         <div>
@@ -203,9 +202,11 @@ describe('useQuery', () => {
 
     const rendered = render(<Page />)
 
-    await waitForElement(() => rendered.getByText('error'), { timeout: 10000 })
+    rendered.getByText('loading')
+
     // query should fail `retry + 1` times, since first time isn't a "retry"
     await waitForElement(() => rendered.getByText('Failed 2 times'))
+
     expect(queryFn).toHaveBeenCalledTimes(2)
-  }, 10000)
+  })
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -203,6 +203,7 @@ describe('useQuery', () => {
     const rendered = render(<Page />)
 
     await waitForElement(() => rendered.getByText('loading'), { timeout: 20000 })
+    await waitForElement(() => rendered.getByText('error'), { timeout: 20000 })
 
     // query should fail `retry + 1` times, since first time isn't a "retry"
     await waitForElement(() => rendered.getByText('Failed 2 times'), { timeout: 20000 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -202,11 +202,11 @@ describe('useQuery', () => {
 
     const rendered = render(<Page />)
 
-    await waitForElement(() => rendered.getByText('loading'), { timeout: 50000 })
-    await waitForElement(() => rendered.getByText('error'), { timeout: 50000 })
+    await waitForElement(() => rendered.getByText('loading'))
+    await waitForElement(() => rendered.getByText('error'))
 
     // query should fail `retry + 1` times, since first time isn't a "retry"
-    await waitForElement(() => rendered.getByText('Failed 2 times'), { timeout: 50000 })
+    await waitForElement(() => rendered.getByText('Failed 2 times'))
 
     expect(queryFn).toHaveBeenCalledTimes(2)
   })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -159,7 +159,6 @@ describe('useQuery', () => {
   })
 
   it('should set status to error if queryFn throws', async () => {
-    console.log('should set status to error if queryFn throws')
     function Page() {
       const { status } = useQuery(
         'test',
@@ -182,7 +181,6 @@ describe('useQuery', () => {
   })
 
   it('should retry specified number of times', async () => {
-    console.log('should retry specified number of times')
     const queryFn = jest.fn()
     queryFn.mockImplementation(() => {
       return Promise.reject('Error test')

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -203,9 +203,9 @@ describe('useQuery', () => {
 
     const rendered = render(<Page />)
 
-    await waitForElement(() => rendered.getByText('error'))
+    await waitForElement(() => rendered.getByText('error'), { timeout: 10000 })
     // query should fail `retry + 1` times, since first time isn't a "retry"
     await waitForElement(() => rendered.getByText('Failed 2 times'))
     expect(queryFn).toHaveBeenCalledTimes(2)
-  }, 6000)
+  }, 10000)
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -207,5 +207,5 @@ describe('useQuery', () => {
     // query should fail `retry + 1` times, since first time isn't a "retry"
     await waitForElement(() => rendered.getByText('Failed 2 times'))
     expect(queryFn).toHaveBeenCalledTimes(2)
-  })
+  }, 6000)
 })


### PR DESCRIPTION
If `retry` is set to 1, I would expect `useQuery` to try once again after fail