### PR TITLE
Change 'todos' ID to 'projects' in pagination example

### DIFF
--- a/examples/pagination/pages/index.js
+++ b/examples/pagination/pages/index.js
@@ -7,7 +7,7 @@ export default () => {
   const [page, setPage] = React.useState(0)
 
   const { status, resolvedData, data, error, isFetching } = usePaginatedQuery(
-    ['todos', page],
+    ['projects', page],
     (key, page = 0) => fetch('/api/projects?page=' + page)
   )
 


### PR DESCRIPTION
We are fetching projects in this example, so calling it 'todos' didn't make sense to me.