### PR TITLE
Use reduce() instead of filter().length

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -32,9 +32,10 @@ export function makeQueryCache() {
 
   const notifyGlobalListeners = () => {
     listeners.forEach(d => d(cache))
-    cache.isFetching = Object.values(queryCache.queries).filter(
-      query => query.state.isFetching
-    ).length
+    cache.isFetching = Object.values(queryCache.queries).reduce(
+      (acc, query) => query.state.isFetching ? acc + 1 : acc,
+      0,
+    )
   }
 
   cache.subscribe = cb => {


### PR DESCRIPTION
Running `filter()` to get the count of items that satisfy the predicate still produces intermediate array that allocates memory every time this function runs. It can be avoided by using `reduce()`.