### PR TITLE
fix: getQueryArgs object syntax queryKey bug

### DIFF
--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -585,4 +585,35 @@ describe('useQuery', () => {
     await act(() => sleep(200))
     expect(callback.mock.calls.length).toBeLessThan(5)
   })
+  it('it should support falsy queryKey in query object syntax', async () => {
+    const queryFn = jest.fn()
+    queryFn.mockImplementation(() => 'data')
+
+    function Page() {
+      useQuery({
+        queryKey: false && 'key',
+        queryFn,
+      })
+      return null
+    }
+    render(<Page />)
+
+    const cachedQueries = Object.keys(queryCache.queries).length
+    expect(queryFn).not.toHaveBeenCalled()
+    expect(cachedQueries).toEqual(0)
+  })
+  it('it should throw when using query syntax and missing required keys', async () => {
+    // mock console.error to avoid the wall of red text,
+    // you could also do this on beforeEach/afterEach
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => {})
+
+    function Page() {
+      const query = useQuery({})
+      return null
+    }
+    expect(() => render(<Page />)).toThrowError(/queryKey|queryFn/)
+
+    console.error.mockRestore()
+  })
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,9 +88,16 @@ export function isOnline() {
 }
 
 export function getQueryArgs(args) {
-  if (isObject(args[0]) && args[0].queryKey) {
-    const { queryKey, variables = [], queryFn, config = {} } = args[0]
-    return [queryKey, variables, queryFn, config]
+  if (isObject(args[0])) {
+    if (
+      args[0].hasOwnProperty('queryKey') &&
+      args[0].hasOwnProperty('queryFn')
+    ) {
+      const { queryKey, variables = [], queryFn, config = {} } = args[0]
+      return [queryKey, variables, queryFn, config]
+    } else {
+      throw new Error('queryKey and queryFn keys are required.')
+    }
   }
   if (typeof args[2] === 'function') {
     const [queryKey, variables = [], queryFn, config = {}] = args


### PR DESCRIPTION
fixes bug where passing queryKey falsy values would use whole object as the queryKey

it also adds a check for required `queryKey`, `queryFn` keys as only `config` and `variables` keys get a default value.

--

https://github.com/tannerlinsley/react-query/blob/5663e67b8d452a0e4a883ce42f382c8936115857/src/utils.js#L91

```js
useQuery({queryKey: false && ['user', {data}], queryFn: fetcher, ...)
```
queryCache queryHash: `'{"queryKey":false}'`
