### PR TITLE
fix setQueryData not creating a new query

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -176,7 +176,7 @@ export function makeQueryCache() {
   cache.setQueryData = (queryKey, updater, { exact } = {}) => {
     let queries = findQueries(queryKey, { exact })
 
-    if (!queries) {
+    if (!queries || queries.length === 0) {
       queries = [
         cache._buildQuery(
           queryKey,

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -2,7 +2,7 @@ import { queryCache } from '../index'
 
 describe('queryCache', () => {
   afterEach(() => {
-    queryCache.clear();
+    queryCache.clear()
   })
 
   test('setQueryData does not crash if query could not be found', () => {
@@ -40,5 +40,17 @@ describe('queryCache', () => {
     queryCache.prefetchQuery('test', () => {}, { initialData: 'initial' })
 
     expect(callback).toHaveBeenCalled()
+  })
+
+  test('setQueryData creates a new query if query was not found, using exact', () => {
+    queryCache.setQueryData('foo', 'bar', { exact: true })
+
+    expect(queryCache.getQueryData('foo')).toBe('bar')
+  })
+
+  test('setQueryData creates a new query if query was not found', () => {
+    queryCache.setQueryData('baz', 'qux')
+
+    expect(queryCache.getQueryData('baz')).toBe('qux')
   })
 })


### PR DESCRIPTION
When not using `{ exact: true }`, `findQueries` would return an empty array, which would skip the check at https://github.com/tannerlinsley/react-query/blob/master/src/queryCache.js#L179, thus never actually creating a query