### PR TITLE
Output ES module from rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repository": "tannerlinsley/react-query",
   "main": "index.js",
+  "module": "dist/react-query.min.mjs",
   "sideEffects": false,
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,13 +23,20 @@ export default [
   },
   {
     input: 'src/index.js',
-    output: {
-      name: 'ReactQuery',
-      file: 'dist/react-query.production.min.js',
-      format: 'umd',
-      sourcemap: true,
-      globals,
-    },
+    output: [
+      {
+        name: 'ReactQuery',
+        file: 'dist/react-query.production.min.js',
+        format: 'umd',
+        sourcemap: true,
+        globals,
+      },
+      {
+        file: 'dist/react-query.min.mjs',
+        format: 'es',
+        sourcemap: true,
+      },
+    ],
     external,
     plugins: [babel(), terser(), size()],
   },


### PR DESCRIPTION
After v1.0.12 our rollup build broke due to namedExports no longer being available to rollup due to the `NODE_ENV` + `require()` dev/prod logic. That forces us to explicitly alias all react-query exports in our rollup-config, however building an es module makes rollup happy.

I guess the dev / prod build is not that required for es modules, and libraries like redux only provides a single minified es build.