### PR TITLE
fix: call updater function for setQueryData

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -464,7 +464,7 @@ export function defaultQueryReducer(state, action) {
       return {
         ...state,
         status: statusSuccess,
-        data: functionalUpdate(action.updater, action.updater),
+        data: functionalUpdate(action.updater, state.data),
         error: null,
         isStale: false,
         isFetching: false,

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -84,4 +84,16 @@ describe('queryCache', () => {
 
     expect(queryCache.getQuery('key').state.isStale).toEqual(true)
   })
+
+  test('setQueryData updater function works as expected', () => {
+    const updater = jest.fn(oldData => `new data + ${oldData}`);
+
+    queryCache.setQueryData('updater', 'test data')
+    queryCache.setQueryData('updater', updater)
+
+    expect(updater).toHaveBeenCalled()
+    expect(queryCache.getQuery('updater').state.data).toEqual(
+      'new data + test data'
+    )
+  })
 })


### PR DESCRIPTION
Last update changed something and now using the updater function on `setQueryData` sends a function instead of the old data to the updater function, making impossible to update query data this way.

Added a small test to cover this use case.