### PR TITLE
do not call dispatch on removed query

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -231,7 +231,9 @@ export function makeQueryCache() {
         return
       }
       query.staleTimeout = setTimeout(() => {
-        dispatch({ type: actionMarkStale })
+        if (queryCache.getQuery(query.queryKey)) {
+          dispatch({ type: actionMarkStale })
+        }
       }, query.config.staleTime)
     }
 


### PR DESCRIPTION
I'm not sure why, but it looks like this is necessary afterall. I promise I tested this exact change in my app. You can watch the livestream if you don't believe me 😅