### PR TITLE
feature: useMutation onSuccess, onError, onSettled now have access to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,11 @@ Mutations without variables are not that useful, so let's add some variables to 
 To pass `variables` to your `mutate` function, call `mutate` with an object.
 
 ```js
+
+// Notice how the fetcher function receives an object containing
+// all possible variables
+const createTodo = ({title}) => { /* trigger an http request */ }
+
 const CreateTodo = () => {
   const [title, setTitle] = useState('')
   const [mutate] = useMutation(createTodo)
@@ -1265,6 +1270,23 @@ mutate(
 // The query below will be updated with the response from the
 // successful mutation
 const { status, data, error } = useQuery(['todo', { id: 5 }], fetchTodoByID)
+```
+
+
+You might want to tight the `onSuccess` logic into a reusable mutation, for that you can
+create a custom hook like this:
+
+```js
+
+const useMutateTodo = () => {
+  return useMutate(editTodo, {
+    // Notice the second argument is the variables object that the `mutate` function receives
+    onSuccess: (data, variables) => {
+      queryCache.setQueryData(['todo', { id: variables.id }], data)
+    },
+  })
+}
+
 ```
 
 ## Resetting Mutation State
@@ -2041,15 +2063,16 @@ const promise = mutate(variables, {
 - `mutationFn: Function(variables) => Promise`
   - **Required**
   - A function that performs an asynchronous task and returns a promise.
-- `onSuccess: Function(data) => Promise | undefined`
+  - `variables` is an object that `mutate` will pass to your `mutationFn`
+- `onSuccess: Function(data, variables) => Promise | undefined`
   - Optional
   - This function will fire when the mutation is successful and will be passed the mutation's result.
   - If a promise is returned, it will be awaited and resolved before proceeding
-- `onError: Function(err) => Promise | undefined`
+- `onError: Function(err, variables) => Promise | undefined`
   - Optional
   - This function will fire if the mutation encounters an error and will be passed the error.
   - If a promise is returned, it will be awaited and resolved before proceeding
-- `onSettled: Function(data, error) => Promise | undefined`
+- `onSettled: Function(data, error, variables) => Promise | undefined`
   - Optional
   - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
   - If a promise is returned, it will be awaited and resolved before proceeding

--- a/src/useMutation.js
+++ b/src/useMutation.js
@@ -79,8 +79,8 @@ export function useMutation(mutationFn, config = {}) {
 
       try {
         const data = await getMutationFn()(variables)
-        await resolvedOptions.onSuccess(data)
-        await resolvedOptions.onSettled(data, null)
+        await resolvedOptions.onSuccess(data, variables)
+        await resolvedOptions.onSettled(data, null, variables)
 
         if (latestMutationRef.current === mutationId) {
           dispatch({ type: actionResolve, data })
@@ -89,8 +89,8 @@ export function useMutation(mutationFn, config = {}) {
         return data
       } catch (error) {
         Console.error(error)
-        await resolvedOptions.onError(error)
-        await resolvedOptions.onSettled(undefined, error)
+        await resolvedOptions.onError(error, variables)
+        await resolvedOptions.onSettled(undefined, error, variables)
 
         if (latestMutationRef.current === mutationId) {
           dispatch({ type: actionReject, error })


### PR DESCRIPTION
[Issue 268](https://github.com/tannerlinsley/react-query/issues/268#issuecomment-601942701)

- Now `useMutation` `onSuccess`, `onError` and `onSettled` receive as a new argument the mutation `variables`
- added documentation and examples to convey this fact
- added examples to be a bit more clear that the `mutationFn` needs to be a function that receives a single argument in the form of an object (instead of using multiple arguments, one for each argument the user needs to pass to the mutation function).


Let me know what you think @tannerlinsley 