### PR TITLE
Add Scarf dependency for installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ $ npm i --save react-query
 $ yarn add react-query
 ```
 
-React Query uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect anonymized installation analytics. These anlytics help support the maintainers of this library. However, if you'd like to opt out, you can do so by setting `scarfSettings.enabled = false` in your project's `package.json`. Alternatively, you can set the environment variable `SCARF_ANALYTICS=false` before you install.
+React Query uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect anonymized installation analytics. These analytics help support the maintainers of this library. However, if you'd like to opt out, you can do so by setting `scarfSettings.enabled = false` in your project's `package.json`. Alternatively, you can set the environment variable `SCARF_ANALYTICS=false` before you install.
 
 # Queries
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ $ npm i --save react-query
 $ yarn add react-query
 ```
 
+React Query uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect
+anonymized installation analytics. These anlytics help support the maintainers
+of this library. However, if you'd like to opt out, you can do so by setting the
+environment variable `SCARF_ANALYTICS=false` before you install, or by setting
+`scarfSettings.enabled = false` in your project's `package.json`.
+
 # Queries
 
 To make a new query, call the `useQuery` hook with at least:

--- a/README.md
+++ b/README.md
@@ -302,11 +302,7 @@ $ npm i --save react-query
 $ yarn add react-query
 ```
 
-React Query uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect
-anonymized installation analytics. These anlytics help support the maintainers
-of this library. However, if you'd like to opt out, you can do so by setting
-`scarfSettings.enabled = false` in your project's `package.json`. Alternatively,
-you can set the environment variable `SCARF_ANALYTICS=false` before you install.
+React Query uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect anonymized installation analytics. These anlytics help support the maintainers of this library. However, if you'd like to opt out, you can do so by setting `scarfSettings.enabled = false` in your project's `package.json`. Alternatively, you can set the environment variable `SCARF_ANALYTICS=false` before you install.
 
 # Queries
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ React Query uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect
 anonymized installation analytics. These anlytics help support the maintainers
 of this library. However, if you'd like to opt out, you can do so by setting
 `scarfSettings.enabled = false` in your project's `package.json`. Alternatively,
-you can the environment variable `SCARF_ANALYTICS=false` before you install.
+you can set the environment variable `SCARF_ANALYTICS=false` before you install.
 
 # Queries
 

--- a/README.md
+++ b/README.md
@@ -304,9 +304,9 @@ $ yarn add react-query
 
 React Query uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect
 anonymized installation analytics. These anlytics help support the maintainers
-of this library. However, if you'd like to opt out, you can do so by setting the
-environment variable `SCARF_ANALYTICS=false` before you install, or by setting
-`scarfSettings.enabled = false` in your project's `package.json`.
+of this library. However, if you'd like to opt out, you can do so by setting
+`scarfSettings.enabled = false` in your project's `package.json`. Alternatively,
+you can the environment variable `SCARF_ANALYTICS=false` before you install.
 
 # Queries
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "@scarf/scarf": "^0.1.3"
+  },
   "peerDependencies": {
     "react": "^16.6.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,6 +1827,11 @@
   dependencies:
     estree-walker "^1.0.1"
 
+"@scarf/scarf@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-0.1.3.tgz#536f4fe54c613fca20f84dc7700ed3b8f1fb73cf"
+  integrity sha512-ftMyZO7Mi8JQh8XLBcuH3erPGmT4CU4s131nsZIDC7/PYXxaDCJtOzbz3okH0YiTAif+DSIlFhX6d7FXLOtnvA==
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"


### PR DESCRIPTION
This change adds a dependency on Scarf for installation analytics to support the maintainers of React Query.

Discussion from everyone is welcome! Some background on the library and the problem it's solving can be found in this post here: https://github.com/scarf-sh/scarf-js/blob/master/WHY.org. The package README (https://github.com/scarf-sh/scarf-js) has more info on exactly what data is sent on each install.

The data Scarf collects will help maintainers by keeping them informed about how the package is being used and will help drive sponsorship to support all the work that goes into React Query.