### PR TITLE
add unminified esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "tannerlinsley/react-query",
   "main": "index.js",
-  "module": "dist/react-query.min.mjs",
+  "module": "dist/react-query.mjs",
   "sideEffects": false,
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,16 @@ export default [
   {
     input: 'src/index.js',
     output: {
+      file: 'dist/react-query.mjs',
+      format: 'es',
+      sourcemap: true,
+    },
+    external,
+    plugins: [babel()],
+  },
+  {
+    input: 'src/index.js',
+    output: {
       file: 'dist/react-query.min.mjs',
       format: 'es',
       sourcemap: true,


### PR DESCRIPTION
Otherwise, anyone using modern tooling will get the minified module which makes debugging really difficult.