### PR TITLE
Do not refetch manual queries on window focus

### DIFF
--- a/src/setFocusHandler.js
+++ b/src/setFocusHandler.js
@@ -15,6 +15,10 @@ const onWindowFocus = () => {
           return false
         }
 
+        if (query.config.manual === true) {
+          return false
+        }
+
         if (query.shouldContinueRetryOnFocus) {
           // delete promise, so `fetch` will create new one
           delete query.promise

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -196,6 +196,29 @@ describe('useQuery', () => {
     expect(queryFn).not.toHaveBeenCalled()
   })
 
+  it('should not refetch query on focus when `manual` is set to `true`', async () => {
+    const queryFn = jest.fn()
+
+    function Page() {
+      const { data = 'default' } = useQuery('test', queryFn, { manual: true })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+    await waitForElement(() => rendered.getByText('default'))
+
+    act(() => {
+      window.dispatchEvent(new FocusEvent('focus'))
+    })
+
+    expect(queryFn).not.toHaveBeenCalled()
+  })
+
   it('should set status to error if queryFn throws', async () => {
     function Page() {
       const { status, error } = useQuery(


### PR DESCRIPTION
I'm not sure whether it was intended or not, but I believe manual query shouldn't be refetched on window focus.
Or at least manual query which was not fetched yet shouldn't be refetched on window focus.
What do you think?