### PR TITLE
fix(prefetchQuery): Throw error when throwOnError is set

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -413,7 +413,7 @@ export function makeQueryCache() {
                   instance.onSettled && instance.onSettled(undefined, error)
               )
 
-              // throw error
+              throw error
             }
           }
         })()

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -24,6 +24,20 @@ describe('queryCache', () => {
     expect(second).toBe(first)
   })
 
+  test('prefetchQuery should throw error when throwOnError is true', async () => {
+    const fetchFn = () =>
+      new Promise(() => {
+        throw new Error('error')
+      })
+
+    await expect(
+      queryCache.prefetchQuery('key', undefined, fetchFn, {
+        retry: false,
+        throwOnError: true,
+      })
+    ).rejects.toThrow(new Error('error'))
+  })
+
   test('should notify listeners when new query is added', () => {
     const callback = jest.fn()
 


### PR DESCRIPTION
Fixes #309 

The previous test added for #167 still passes, so I would assume this is safe.

## Changes

- prefetchQuery: Add test case for `throwOnError` set to `true`
- Uncomment `throw error` that was commented in #167 