### PR TITLE
fix(prefetchQuery): Support force option when calling query.fetch

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -160,7 +160,7 @@ export function makeQueryCache() {
     if (query.state.isStale || force) {
       // Trigger a fetch and return the promise
       try {
-        const res = await query.fetch()
+        const res = await query.fetch({ force })
         query.wasPrefetched = true
         return res
       } catch (err) {

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -24,6 +24,16 @@ describe('queryCache', () => {
     expect(second).toBe(first)
   })
 
+  test('prefetchQuery should force fetch', async () => {
+    const fetchFn = () => Promise.resolve('fresh')
+    const first = await queryCache.prefetchQuery('key', fetchFn, {
+      initialData: 'initial',
+      force: true,
+    })
+
+    expect(first).toBe('fresh')
+  })
+
   test('should notify listeners when new query is added', () => {
     const callback = jest.fn()
 


### PR DESCRIPTION
Fixes #311 

## Changes

- prefetchQuery: Passthru `force` option when calling `query.fetch`
- Add test coverage