### PR TITLE
Fix `quiries` typo in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2496,7 +2496,7 @@ queryCache.clear()
 
 ## `useIsFetching`
 
-`useIsFetching` is an optional hook that returns the `number` of the quiries that your application is loading or fetching in the background (useful for app-wide loading indicators).
+`useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or fetching in the background (useful for app-wide loading indicators).
 
 ```js
 import { useIsFetching } from 'react-query'
@@ -2507,7 +2507,7 @@ const isFetching = useIsFetching()
 ### Returns
 
 - `isFetching: Int`
-  - Will be the `number` of the quiries that your application is currently loading or fetching in the background.
+  - Will be the `number` of the queries that your application is currently loading or fetching in the background.
 
 ## `ReactQueryConfigProvider`
 


### PR DESCRIPTION
Noticed when reading through the documentation two instances of `queries` spelled incorrectly :+1: 