### PR TITLE
fix: edge case when refetching infinite query

### DIFF
--- a/src/useInfiniteQuery.js
+++ b/src/useInfiniteQuery.js
@@ -28,11 +28,20 @@ export function useInfiniteQuery(...args) {
         data.push(await originalQueryFn(...args))
         rebuiltPageVariables.push(args)
       } else {
+        // get an up-to-date cursor based on the previous data set
+        const nextCursor = getGetFetchMore()(data[data.length - 1], data);
+
+        // break early if there's no next cursor
+        // otherwise we'll start from the beginning
+        // which will cause unwanted duplication
+        if (!nextCursor) {
+          break;
+        }
+
         const pageArgs = [
           // remove the last argument (the previously saved cursor)
           ...args.slice(0, -1),
-          // generate an up-to-date cursor based on the previous data set
-          getGetFetchMore()(data[data.length - 1], data),
+          nextCursor
         ]
 
         data.push(await originalQueryFn(...pageArgs))


### PR DESCRIPTION
@tannerlinsley 
An edge case wasn't handled in the previous PR that fixed the infinite query https://github.com/tannerlinsley/react-query/issues/407
This fixes the issue by breaking early if there is no next cursor.

