### PR TITLE
fix(utils): compare equals first to prevent error on null variables

### DIFF
--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -16,6 +16,14 @@ describe('queryCache', () => {
     ).not.toThrow()
   })
 
+  test('setQueryData does not crash when variable is null', () => {
+    queryCache.setQueryData(['USER', { userId: null }], 'Old Data')
+
+    expect(() =>
+      queryCache.setQueryData(['USER', { userId: null }], 'New Data')
+    ).not.toThrow()
+  })
+
   test('prefetchQuery returns the cached data on cache hits', async () => {
     const fetchFn = () => Promise.resolve('data')
     const first = await queryCache.prefetchQuery('key', fetchFn)

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,6 +63,10 @@ export function isObject(a) {
 }
 
 export function deepIncludes(a, b) {
+  if (a === b) {
+    return true
+  }
+
   if (typeof a !== typeof b) {
     return false
   }
@@ -71,7 +75,7 @@ export function deepIncludes(a, b) {
     return !Object.keys(b).some(key => !deepIncludes(a[key], b[key]))
   }
 
-  return a === b
+  return false
 }
 
 export function isDocumentVisible() {


### PR DESCRIPTION
Today, when updating a query with `setQueryData` and this query is null, throw an error: `Cannot convert undefined or null to object`.

This PR is to prevent this case.

Sandbox demonstrating the error: https://codesandbox.io/s/white-snow-fdec7