### PR TITLE
Add `queryFnParamsFilter` to `useQuery` API section in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1792,7 +1792,8 @@ const {
   onSettled,
   suspense,
   initialData,
-  refetchOnMount
+  refetchOnMount,
+  queryFnParamsFilter
 })
 
 // or using the object syntax
@@ -1875,6 +1876,10 @@ const queryInfo = useQuery({
   - Optional
   - Defaults to `true`
   - If set to `false`, will disable additional instances of a query to trigger background refetches
+- `queryFnParamsFilter: Function(args) => filteredArgs`
+  - Optional
+  - This function will filter the params that get passed to `queryFn`.
+  - For example, you can filter out the first query key from the params by using `queryFnParamsFilter: args => args.slice(1)`.
 
 ### Returns
 


### PR DESCRIPTION
`queryFnParamsFilter` was mentioned in [`ReactQueryConfigProvider` section in the readme](https://github.com/lukyth/react-query#reactqueryconfigprovider), but not in the `useQuery` API section itself, so I added it there.

The code example was from [this issue](https://github.com/tannerlinsley/react-query/issues/145#issuecomment-590377800), since it's probably something many people are looking for (myself included).