### PR TITLE
Fix automatic call of onIntersect function in infinite-scroll example

### DIFF
--- a/examples/load-more-infinite-scroll/hooks/useIntersectionObserver.js
+++ b/examples/load-more-infinite-scroll/hooks/useIntersectionObserver.js
@@ -8,11 +8,15 @@ export default function useIntersectionObserver({
   rootMargin = '0px',
 }) {
   React.useEffect(() => {
-    const observer = new IntersectionObserver(onIntersect, {
-      root: root && root.current,
-      rootMargin,
-      threshold,
-    })
+    const observer = new IntersectionObserver(
+      entries =>
+        entries.forEach(entry => entry.isIntersecting && onIntersect()),
+      {
+        root: root && root.current,
+        rootMargin,
+        threshold,
+      }
+    )
 
     const el = target && target.current
 

--- a/examples/load-more-infinite-scroll/pages/index.js
+++ b/examples/load-more-infinite-scroll/pages/index.js
@@ -32,7 +32,7 @@ export default () => {
 
   useIntersectionObserver({
     target: loadMoreButtonRef,
-    onIntersect: () => fetchMore(),
+    onIntersect: fetchMore,
   })
 
   return (


### PR DESCRIPTION
Hi there? There is a weird issue i'm facing whenever i run infinite scroll example. I don't know whether it is intentional but it has to do with how the **useIntersectionObserver** hook is implemented.

**THE PROBLEM**
Additional API calls are called on page mount when the intended behavior was to make API calls depending on whether an intersection occurred. For example, three API calls are made when the infinite-scroll example page mounts or window refocus, disregarding the fact that these API calls should only be triggered sequentially when the target element intersects. It should be noted that this has nothing to do with **refetchOnMount** or **refetchOnWindowFocus** implementation.

**SOLUTION**
Mozilla's [MDN docs on using IntersectionObserver API](https://developer.mozilla.org/enUS/docs/Web/API/Intersection_Observer_API) makes it clear that the callback passed to the intersectionObserver function is passed **entries** parameter which is an array of IntersectionObserverEntry objects each containing updated intersection data for one of your observed elements. Solution is to make api calls based on the entries parameter. Also, instead of immediately invoking the **fetchMore** function, we simply pass it to **useIntersectionObserver** and be invoked inside it depending on whether the target element intersects.