### PR TITLE
fix(typescript): changed root location of `types` relative to `main` index.js to fix import autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "tannerlinsley/react-query",
   "homepage": "https://github.com/tannerlinsley/react-query#readme",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "module": "dist/react-query.mjs",
-  "types": "types",
   "sideEffects": false,
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",


### PR DESCRIPTION
Fixes #427 