### PR TITLE
feat: query cache provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2598,7 +2598,7 @@ function App() {
 
 ## `ReactQueryCacheProvider`
 
-`ReactQueryCacheProvider` is an optional provider component for explicitly setting the query cache used by `useQuery`. This is useful for creating component-level caches that are not completely global, as well as making truly isolated unit tests.
+`ReactQueryCacheProvider` is an optional provider component for explicitly setting the query cache used by React Query. This is useful for creating component-level caches that are not completely global, as well as making truly isolated unit tests.
 
 ```js
 import { ReactQueryCacheProvider, makeQueryCache } from 'react-query';

--- a/README.md
+++ b/README.md
@@ -256,8 +256,10 @@ This library is being built and maintained by me, @tannerlinsley and I am always
   - [`queryCache.isFetching`](#querycacheisfetching)
   - [`queryCache.subscribe`](#querycachesubscribe)
   - [`queryCache.clear`](#querycacheclear)
+  - [`useQueryCache`](#usequerycache)
   - [`useIsFetching`](#useisfetching)
   - [`ReactQueryConfigProvider`](#reactqueryconfigprovider)
+  - [`ReactQueryCacheProvider`](#reactquerycacheprovider)
   - [`setConsole`](#setconsole)
 - [Contributors ✨](#contributors-)
 
@@ -2522,6 +2524,18 @@ queryCache.clear()
 - `queries: Array<Query>`
   - This will be an array containing the queries that were found.
 
+## `useQueryCache`
+
+The `useQueryCache` hook returns the current queryCache instance.
+
+```js
+import { useQueryCache } from 'react-query';
+
+const queryCache = useQueryCache()
+```
+
+If you are using the `ReactQueryCacheProvider` to set a custom cache, you cannot simply import `{ queryCache }` any more. This hook will ensure you're getting the correct instance.
+
 ## `useIsFetching`
 
 `useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or fetching in the background (useful for app-wide loading indicators).
@@ -2581,6 +2595,29 @@ function App() {
 - `config: Object`
   - Must be **stable** or **memoized**. Do not create an inline object!
   - For non-global properties please see their usage in both the [`useQuery` hook](#usequery) and the [`useMutation` hook](#usemutation).
+
+## `ReactQueryCacheProvider`
+
+`ReactQueryCacheProvider` is an optional provider component for explicitly setting the query cache used by `useQuery`. This is useful for creating component-level caches that are not completely global, as well as making truly isolated unit tests.
+
+```js
+import { ReactQueryCacheProvider, makeQueryCache } from 'react-query';
+
+const queryCache = makeQueryCache()
+
+function App() {
+  return (
+    <ReactQueryCacheProvider queryCache={queryCache}>
+      ...
+    </ReactQueryCacheProvider>
+  )
+}
+```
+
+### Options
+- `queryCache: Object`
+  - In instance of queryCache, you can use the `makeQueryCache` factory to create this.
+  - If not provided, a new cache will be generated.
 
 ## `setConsole`
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,9 @@
-export { queryCache } from './queryCache'
+export {
+  queryCache,
+  makeQueryCache,
+  ReactQueryCacheProvider,
+  useQueryCache,
+} from './queryCache'
 export { ReactQueryConfigProvider } from './config'
 export { setFocusHandler } from './setFocusHandler'
 export { useIsFetching } from './useIsFetching'

--- a/src/index.production.js
+++ b/src/index.production.js
@@ -1,4 +1,9 @@
-export { queryCache } from './queryCache'
+export {
+  queryCache,
+  makeQueryCache,
+  ReactQueryCacheProvider,
+  useQueryCache,
+} from './queryCache'
 export { ReactQueryConfigProvider } from './config'
 export { setFocusHandler } from './setFocusHandler'
 export { useIsFetching } from './useIsFetching'

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import {
   isServer,
   functionalUpdate,
@@ -13,6 +14,25 @@ import {
 import { defaultConfigRef } from './config'
 
 export const queryCache = makeQueryCache()
+
+export const defaultQueryCacheRef = {
+  current: queryCache
+}
+
+export const queryCacheContext = React.createContext(queryCache)
+
+export function useQueryCache() {
+  return React.useContext(queryCacheContext)
+}
+
+export function ReactQueryCacheProvider({ queryCache, children }) {
+  defaultQueryCacheRef.current = queryCache || makeQueryCache()
+  return (
+    <queryCacheContext.Provider value={defaultQueryCacheRef.current}>
+      {children}
+    </queryCacheContext.Provider>
+  )
+}
 
 const actionInit = {}
 const actionFailed = {}
@@ -32,7 +52,7 @@ export function makeQueryCache() {
   }
 
   const notifyGlobalListeners = () => {
-    cache.isFetching = Object.values(queryCache.queries).reduce(
+    cache.isFetching = Object.values(cache.queries).reduce(
       (acc, query) => (query.state.isFetching ? acc + 1 : acc),
       0
     )
@@ -129,6 +149,7 @@ export function makeQueryCache() {
       query.config = { ...query.config, ...config }
     } else {
       query = makeQuery({
+        cache,
         queryKey,
         queryHash,
         queryVariables,
@@ -212,6 +233,7 @@ export function makeQueryCache() {
   }
 
   function makeQuery(options) {
+    const queryCache = options.cache
     const reducer = options.config.queryReducer || defaultQueryReducer
 
     const noQueryHash = typeof options.queryHash === 'undefined'

--- a/src/setFocusHandler.js
+++ b/src/setFocusHandler.js
@@ -1,6 +1,6 @@
 import { isOnline, isDocumentVisible, Console, isServer } from './utils'
 import { defaultConfigRef } from './config'
-import { queryCache } from './queryCache'
+import { defaultQueryCacheRef } from './queryCache'
 
 const visibilityChangeEvent = 'visibilitychange'
 const focusEvent = 'focus'
@@ -9,7 +9,7 @@ const onWindowFocus = () => {
   const { refetchAllOnWindowFocus } = defaultConfigRef.current
 
   if (isDocumentVisible() && isOnline()) {
-    queryCache
+    defaultQueryCacheRef.current
       .refetchQueries(query => {
         if (!query.instances.length) {
           return false

--- a/src/setFocusHandler.js
+++ b/src/setFocusHandler.js
@@ -1,6 +1,6 @@
 import { isOnline, isDocumentVisible, Console, isServer } from './utils'
 import { defaultConfigRef } from './config'
-import { defaultQueryCacheRef } from './queryCache'
+import { queryCaches } from './queryCache'
 
 const visibilityChangeEvent = 'visibilitychange'
 const focusEvent = 'focus'
@@ -9,29 +9,31 @@ const onWindowFocus = () => {
   const { refetchAllOnWindowFocus } = defaultConfigRef.current
 
   if (isDocumentVisible() && isOnline()) {
-    defaultQueryCacheRef.current
-      .refetchQueries(query => {
-        if (!query.instances.length) {
-          return false
-        }
+    queryCaches.forEach(queryCache =>
+      queryCache
+        .refetchQueries(query => {
+          if (!query.instances.length) {
+            return false
+          }
 
-        if (query.config.manual === true) {
-          return false
-        }
+          if (query.config.manual === true) {
+            return false
+          }
 
-        if (query.shouldContinueRetryOnFocus) {
-          // delete promise, so `fetch` will create new one
-          delete query.promise
-          return true
-        }
+          if (query.shouldContinueRetryOnFocus) {
+            // delete promise, so `fetch` will create new one
+            delete query.promise
+            return true
+          }
 
-        if (typeof query.config.refetchOnWindowFocus === 'undefined') {
-          return refetchAllOnWindowFocus
-        } else {
-          return query.config.refetchOnWindowFocus
-        }
-      })
-      .catch(Console.error)
+          if (typeof query.config.refetchOnWindowFocus === 'undefined') {
+            return refetchAllOnWindowFocus
+          } else {
+            return query.config.refetchOnWindowFocus
+          }
+        })
+        .catch(Console.error)
+    )
   }
 }
 

--- a/src/tests/ReactQueryCacheProvider.test.js
+++ b/src/tests/ReactQueryCacheProvider.test.js
@@ -134,7 +134,7 @@ describe('ReactQueryCacheProvider', () => {
     expect(cache2.getQuery('test1')).not.toBeDefined()
     expect(cache2.getQuery('test2')).toBeDefined()
   })
-  test.only('when cache changes, previous cache is cleaned', () => {
+  test('when cache changes, previous cache is cleaned', () => {
     let caches = []
     const customCache = makeQueryCache()
 

--- a/src/tests/ReactQueryCacheProvider.test.js
+++ b/src/tests/ReactQueryCacheProvider.test.js
@@ -1,0 +1,177 @@
+import React, { useEffect } from 'react'
+import { render, cleanup, waitForElement } from '@testing-library/react'
+import {
+  ReactQueryCacheProvider,
+  makeQueryCache,
+  queryCache,
+  useQuery,
+  useQueryCache,
+} from '../index'
+import { sleep } from './utils'
+
+describe('ReactQueryCacheProvider', () => {
+  afterEach(() => {
+    cleanup()
+    queryCache.clear()
+  })
+
+  test('when not used, falls back to global cache', async () => {
+    function Page() {
+      const { data } = useQuery('test', async () => {
+        await sleep(10)
+        return 'test'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    await waitForElement(() => rendered.getByText('test'))
+
+    expect(queryCache.getQuery('test')).toBeDefined()
+  })
+  test('sets a specific cache for all queries to use', async () => {
+    const cache = makeQueryCache()
+
+    function Page() {
+      const { data } = useQuery('test', async () => {
+        await sleep(10)
+        return 'test'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(
+      <ReactQueryCacheProvider queryCache={cache}>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
+
+    await waitForElement(() => rendered.getByText('test'))
+
+    expect(queryCache.getQuery('test')).not.toBeDefined()
+    expect(cache.getQuery('test')).toBeDefined()
+  })
+  test('implicitly creates a new cache for all queries to use', async () => {
+    function Page() {
+      const { data } = useQuery('test', async () => {
+        await sleep(10)
+        return 'test'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
+
+    await waitForElement(() => rendered.getByText('test'))
+
+    expect(queryCache.getQuery('test')).not.toBeDefined()
+  })
+  test('allows multiple caches to be partitioned', async () => {
+    const cache1 = makeQueryCache()
+    const cache2 = makeQueryCache()
+
+    function Page1() {
+      const { data } = useQuery('test1', async () => {
+        await sleep(10)
+        return 'test1'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+    function Page2() {
+      const { data } = useQuery('test2', async () => {
+        await sleep(10)
+        return 'test2'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(
+      <>
+        <ReactQueryCacheProvider queryCache={cache1}>
+          <Page1 />
+        </ReactQueryCacheProvider>
+        <ReactQueryCacheProvider queryCache={cache2}>
+          <Page2 />
+        </ReactQueryCacheProvider>
+      </>
+    )
+
+    await waitForElement(() => rendered.getByText('test1'))
+    await waitForElement(() => rendered.getByText('test2'))
+
+    expect(cache1.getQuery('test1')).toBeDefined()
+    expect(cache1.getQuery('test2')).not.toBeDefined()
+    expect(cache2.getQuery('test1')).not.toBeDefined()
+    expect(cache2.getQuery('test2')).toBeDefined()
+  })
+  test.only('when cache changes, previous cache is cleaned', () => {
+    let caches = []
+    const customCache = makeQueryCache()
+
+    function Page() {
+      const queryCache = useQueryCache()
+      useEffect(() => {
+        caches.push(queryCache)
+      }, [queryCache])
+
+      const { data } = useQuery('test', async () => {
+        await sleep(10)
+        return 'test'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    function App({ cache }) {
+      return (
+        <ReactQueryCacheProvider queryCache={cache}>
+          <Page />
+        </ReactQueryCacheProvider>
+      )
+    }
+
+    const rendered = render(<App />)
+
+    expect(caches).toHaveLength(1)
+    jest.spyOn(caches[0], 'clear')
+
+    rendered.rerender(<App cache={customCache} />)
+
+    expect(caches).toHaveLength(2)
+    expect(caches[0].clear).toHaveBeenCalled()
+  })
+})

--- a/src/tests/config.test.js
+++ b/src/tests/config.test.js
@@ -1,6 +1,10 @@
 import React from 'react'
 import { render, waitForElement, cleanup } from '@testing-library/react'
-import { ReactQueryConfigProvider, useQuery, ReactQueryCacheProvider } from '../index'
+import {
+  ReactQueryConfigProvider,
+  useQuery,
+  ReactQueryCacheProvider,
+} from '../index'
 
 import { sleep } from './utils'
 

--- a/src/tests/config.test.js
+++ b/src/tests/config.test.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import { render, waitForElement, cleanup } from '@testing-library/react'
-import { ReactQueryConfigProvider, useQuery, queryCache } from '../index'
+import { ReactQueryConfigProvider, useQuery, ReactQueryCacheProvider } from '../index'
 
 import { sleep } from './utils'
 
 describe('config', () => {
   afterEach(() => {
-    queryCache.clear()
     cleanup()
   })
 
@@ -33,7 +32,9 @@ describe('config', () => {
 
     const rendered = render(
       <ReactQueryConfigProvider config={config}>
-        <Page />
+        <ReactQueryCacheProvider>
+          <Page />
+        </ReactQueryCacheProvider>
       </ReactQueryConfigProvider>
     )
 

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -1,13 +1,10 @@
-import { queryCache } from '../index'
-import { act } from '@testing-library/react'
+import { makeQueryCache } from '../index'
 import { sleep } from './utils'
 
 describe('queryCache', () => {
-  afterEach(() => {
-    queryCache.clear()
-  })
 
   test('setQueryData does not crash if query could not be found', () => {
+    const queryCache = makeQueryCache();
     expect(() =>
       queryCache.setQueryData(['USER', { userId: 1 }], prevUser => ({
         ...prevUser,
@@ -17,6 +14,7 @@ describe('queryCache', () => {
   })
 
   test('setQueryData does not crash when variable is null', () => {
+    const queryCache = makeQueryCache();
     queryCache.setQueryData(['USER', { userId: null }], 'Old Data')
 
     expect(() =>
@@ -25,6 +23,7 @@ describe('queryCache', () => {
   })
 
   test('prefetchQuery returns the cached data on cache hits', async () => {
+    const queryCache = makeQueryCache();
     const fetchFn = () => Promise.resolve('data')
     const first = await queryCache.prefetchQuery('key', fetchFn)
     const second = await queryCache.prefetchQuery('key', fetchFn)
@@ -33,6 +32,7 @@ describe('queryCache', () => {
   })
 
   test('prefetchQuery should force fetch', async () => {
+    const queryCache = makeQueryCache();
     const fetchFn = () => Promise.resolve('fresh')
     const first = await queryCache.prefetchQuery('key', fetchFn, {
       initialData: 'initial',
@@ -43,6 +43,7 @@ describe('queryCache', () => {
   })
 
   test('prefetchQuery should throw error when throwOnError is true', async () => {
+    const queryCache = makeQueryCache();
     const fetchFn = () =>
       new Promise(() => {
         throw new Error('error')
@@ -57,6 +58,7 @@ describe('queryCache', () => {
   })
 
   test('should notify listeners when new query is added', () => {
+    const queryCache = makeQueryCache();
     const callback = jest.fn()
 
     queryCache.subscribe(callback)
@@ -67,6 +69,7 @@ describe('queryCache', () => {
   })
 
   test('should notify subsribers when new query with initialData is added', () => {
+    const queryCache = makeQueryCache();
     const callback = jest.fn()
 
     queryCache.subscribe(callback)
@@ -77,18 +80,21 @@ describe('queryCache', () => {
   })
 
   test('setQueryData creates a new query if query was not found, using exact', () => {
+    const queryCache = makeQueryCache();
     queryCache.setQueryData('foo', 'bar', { exact: true })
 
     expect(queryCache.getQueryData('foo')).toBe('bar')
   })
 
   test('setQueryData creates a new query if query was not found', () => {
+    const queryCache = makeQueryCache();
     queryCache.setQueryData('baz', 'qux')
 
     expect(queryCache.getQueryData('baz')).toBe('qux')
   })
 
   test('removeQueries does not crash when exact is provided', async () => {
+    const queryCache = makeQueryCache();
     const fetchFn = () => Promise.resolve('data')
 
     // check the query was added to the cache
@@ -103,6 +109,7 @@ describe('queryCache', () => {
   })
 
   test('setQueryData schedules stale timeouts appropriately', async () => {
+    const queryCache = makeQueryCache();
     queryCache.setQueryData('key', 'test data', { staleTime: 100 })
 
     expect(queryCache.getQuery('key').state.data).toEqual('test data')
@@ -118,6 +125,7 @@ describe('queryCache', () => {
   })
 
   test('setQueryData updater function works as expected', () => {
+    const queryCache = makeQueryCache();
     const updater = jest.fn(oldData => `new data + ${oldData}`)
 
     queryCache.setQueryData('updater', 'test data')
@@ -130,6 +138,7 @@ describe('queryCache', () => {
   })
 
   test('getQueries should return queries that partially match queryKey', async () => {
+    const queryCache = makeQueryCache();
     const fetchData1 = () => Promise.resolve('data1')
     const fetchData2 = () => Promise.resolve('data2')
     const fetchDifferentData = () => Promise.resolve('data3')
@@ -142,6 +151,7 @@ describe('queryCache', () => {
   })
 
   test('stale timeout dispatch is not called if query is no longer in the query cache', async () => {
+    const queryCache = makeQueryCache();
     const queryKey = 'key'
     const fetchData = () => Promise.resolve('data')
     await queryCache.prefetchQuery(queryKey, fetchData)
@@ -153,6 +163,7 @@ describe('queryCache', () => {
   })
 
   test('query is garbage collected when unsubscribed to', async () => {
+    const queryCache = makeQueryCache();
     const queryKey = 'key'
     const fetchData = () => Promise.resolve('data')
     await queryCache.prefetchQuery(queryKey, fetchData, { cacheTime: 0 })
@@ -166,6 +177,7 @@ describe('queryCache', () => {
   })
 
   test('query is not garbage collected unless markedForGarbageCollection is true', async () => {
+    const queryCache = makeQueryCache();
     const queryKey = 'key'
     const fetchData = () => Promise.resolve(undefined)
     await queryCache.prefetchQuery(queryKey, fetchData, { cacheTime: 0 })

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -2,9 +2,8 @@ import { makeQueryCache } from '../index'
 import { sleep } from './utils'
 
 describe('queryCache', () => {
-
   test('setQueryData does not crash if query could not be found', () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     expect(() =>
       queryCache.setQueryData(['USER', { userId: 1 }], prevUser => ({
         ...prevUser,
@@ -14,7 +13,7 @@ describe('queryCache', () => {
   })
 
   test('setQueryData does not crash when variable is null', () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     queryCache.setQueryData(['USER', { userId: null }], 'Old Data')
 
     expect(() =>
@@ -23,7 +22,7 @@ describe('queryCache', () => {
   })
 
   test('prefetchQuery returns the cached data on cache hits', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const fetchFn = () => Promise.resolve('data')
     const first = await queryCache.prefetchQuery('key', fetchFn)
     const second = await queryCache.prefetchQuery('key', fetchFn)
@@ -32,7 +31,7 @@ describe('queryCache', () => {
   })
 
   test('prefetchQuery should force fetch', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const fetchFn = () => Promise.resolve('fresh')
     const first = await queryCache.prefetchQuery('key', fetchFn, {
       initialData: 'initial',
@@ -43,7 +42,7 @@ describe('queryCache', () => {
   })
 
   test('prefetchQuery should throw error when throwOnError is true', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const fetchFn = () =>
       new Promise(() => {
         throw new Error('error')
@@ -58,7 +57,7 @@ describe('queryCache', () => {
   })
 
   test('should notify listeners when new query is added', () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const callback = jest.fn()
 
     queryCache.subscribe(callback)
@@ -69,7 +68,7 @@ describe('queryCache', () => {
   })
 
   test('should notify subsribers when new query with initialData is added', () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const callback = jest.fn()
 
     queryCache.subscribe(callback)
@@ -80,21 +79,21 @@ describe('queryCache', () => {
   })
 
   test('setQueryData creates a new query if query was not found, using exact', () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     queryCache.setQueryData('foo', 'bar', { exact: true })
 
     expect(queryCache.getQueryData('foo')).toBe('bar')
   })
 
   test('setQueryData creates a new query if query was not found', () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     queryCache.setQueryData('baz', 'qux')
 
     expect(queryCache.getQueryData('baz')).toBe('qux')
   })
 
   test('removeQueries does not crash when exact is provided', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const fetchFn = () => Promise.resolve('data')
 
     // check the query was added to the cache
@@ -109,7 +108,7 @@ describe('queryCache', () => {
   })
 
   test('setQueryData schedules stale timeouts appropriately', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     queryCache.setQueryData('key', 'test data', { staleTime: 100 })
 
     expect(queryCache.getQuery('key').state.data).toEqual('test data')
@@ -125,7 +124,7 @@ describe('queryCache', () => {
   })
 
   test('setQueryData updater function works as expected', () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const updater = jest.fn(oldData => `new data + ${oldData}`)
 
     queryCache.setQueryData('updater', 'test data')
@@ -138,7 +137,7 @@ describe('queryCache', () => {
   })
 
   test('getQueries should return queries that partially match queryKey', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const fetchData1 = () => Promise.resolve('data1')
     const fetchData2 = () => Promise.resolve('data2')
     const fetchDifferentData = () => Promise.resolve('data3')
@@ -151,7 +150,7 @@ describe('queryCache', () => {
   })
 
   test('stale timeout dispatch is not called if query is no longer in the query cache', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const queryKey = 'key'
     const fetchData = () => Promise.resolve('data')
     await queryCache.prefetchQuery(queryKey, fetchData)
@@ -163,7 +162,7 @@ describe('queryCache', () => {
   })
 
   test('query is garbage collected when unsubscribed to', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const queryKey = 'key'
     const fetchData = () => Promise.resolve('data')
     await queryCache.prefetchQuery(queryKey, fetchData, { cacheTime: 0 })
@@ -177,7 +176,7 @@ describe('queryCache', () => {
   })
 
   test('query is not garbage collected unless markedForGarbageCollection is true', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     const queryKey = 'key'
     const fetchData = () => Promise.resolve(undefined)
     await queryCache.prefetchQuery(queryKey, fetchData, { cacheTime: 0 })

--- a/src/tests/suspense.test.js
+++ b/src/tests/suspense.test.js
@@ -1,12 +1,11 @@
 import { render, waitForElement, fireEvent, cleanup } from '@testing-library/react'
 import * as React from 'react'
 
-import { useQuery, queryCache } from '../index'
+import { useQuery, ReactQueryCacheProvider } from '../index'
 import { sleep } from './utils'
 
 describe("useQuery's in Suspense mode", () => {
   afterEach(() => {
-    queryCache.clear()
     cleanup()
   })
 
@@ -21,9 +20,11 @@ describe("useQuery's in Suspense mode", () => {
     }
 
     const rendered = render(
-      <React.Suspense fallback="loading">
-        <Page />
-      </React.Suspense>
+      <ReactQueryCacheProvider>
+        <React.Suspense fallback="loading">
+          <Page />
+        </React.Suspense>
+      </ReactQueryCacheProvider>
     )
 
     await waitForElement(() => rendered.getByText('rendered'))
@@ -80,9 +81,11 @@ describe("useQuery's in Suspense mode", () => {
     }
 
     const rendered = render(
-      <React.Suspense fallback="loading">
-        <Page />
-      </React.Suspense>
+      <ReactQueryCacheProvider>
+        <React.Suspense fallback="loading">
+          <Page />
+        </React.Suspense>
+      </ReactQueryCacheProvider>
     )
 
     await waitForElement(() => rendered.getByText('rendered'))

--- a/src/tests/suspense.test.js
+++ b/src/tests/suspense.test.js
@@ -1,7 +1,7 @@
 import { render, waitForElement, fireEvent, cleanup } from '@testing-library/react'
 import * as React from 'react'
 
-import { useQuery, ReactQueryCacheProvider } from '../index'
+import { useQuery, ReactQueryCacheProvider, queryCache } from '../index'
 import { sleep } from './utils'
 
 describe("useQuery's in Suspense mode", () => {

--- a/src/tests/useInfiniteQuery.test.js
+++ b/src/tests/useInfiniteQuery.test.js
@@ -6,7 +6,11 @@ import {
 } from '@testing-library/react'
 import * as React from 'react'
 
-import { useInfiniteQuery, ReactQueryCacheProvider, useQueryCache } from '../index'
+import {
+  useInfiniteQuery,
+  ReactQueryCacheProvider,
+  useQueryCache,
+} from '../index'
 import { sleep } from './utils'
 
 const pageSize = 10
@@ -242,7 +246,7 @@ describe('useInfiniteQuery', () => {
     }
 
     function Page() {
-      const queryCache = useQueryCache();
+      const queryCache = useQueryCache()
       const fetchCountRef = React.useRef(0)
       const {
         status,

--- a/src/tests/useInfiniteQuery.test.js
+++ b/src/tests/useInfiniteQuery.test.js
@@ -6,7 +6,7 @@ import {
 } from '@testing-library/react'
 import * as React from 'react'
 
-import { useInfiniteQuery, queryCache } from '../index'
+import { useInfiniteQuery, ReactQueryCacheProvider, useQueryCache } from '../index'
 import { sleep } from './utils'
 
 const pageSize = 10
@@ -30,7 +30,6 @@ const fetchItems = async (page, ts) => {
 
 describe('useInfiniteQuery', () => {
   afterEach(() => {
-    queryCache.clear()
     cleanup()
   })
 
@@ -100,7 +99,11 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Loading...')
 
@@ -196,7 +199,11 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Item: 9')
     rendered.getByText('Page 0: 0')
@@ -235,6 +242,7 @@ describe('useInfiniteQuery', () => {
     }
 
     function Page() {
+      const queryCache = useQueryCache();
       const fetchCountRef = React.useRef(0)
       const {
         status,
@@ -305,7 +313,11 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Loading...')
 

--- a/src/tests/useIsFetching.test.js
+++ b/src/tests/useIsFetching.test.js
@@ -6,13 +6,12 @@ import {
 } from '@testing-library/react'
 import * as React from 'react'
 
-import { useQuery, queryCache, useIsFetching } from '../index'
+import { useQuery, ReactQueryCacheProvider, useIsFetching } from '../index'
 import { sleep } from './utils'
 
 describe('useIsFetching', () => {
   afterEach(() => {
     cleanup()
-    queryCache.clear()
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/105
@@ -35,7 +34,11 @@ describe('useIsFetching', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('isFetching: 0')
     fireEvent.click(rendered.getByText('setReady'))

--- a/src/tests/usePaginatedQuery.test.js
+++ b/src/tests/usePaginatedQuery.test.js
@@ -7,12 +7,11 @@ import {
 import * as React from 'react'
 import { sleep } from './utils'
 
-import { usePaginatedQuery, queryCache } from '../index'
+import { usePaginatedQuery, ReactQueryCacheProvider } from '../index'
 
 describe('usePaginatedQuery', () => {
   afterEach(() => {
     cleanup()
-    queryCache.clear()
   })
 
   it('should use previous page data while fetching the next page', async () => {
@@ -34,7 +33,11 @@ describe('usePaginatedQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Data undefined')
     await waitForElement(() => rendered.getByText('Data 1'))
@@ -69,7 +72,11 @@ describe('usePaginatedQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Data 0')
 
@@ -109,7 +116,11 @@ describe('usePaginatedQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Data 0')
 

--- a/src/tests/useQuery-SSR.test.js
+++ b/src/tests/useQuery-SSR.test.js
@@ -4,15 +4,12 @@
 
 import React from 'react'
 import { renderToString } from 'react-dom/server'
-import { usePaginatedQuery, queryCache } from '../index'
+import { usePaginatedQuery, ReactQueryCacheProvider, makeQueryCache } from '../index'
 
 describe('useQuery SSR', () => {
-  afterEach(() => {
-    queryCache.clear()
-  })
-
   // See https://github.com/tannerlinsley/react-query/issues/70
   it('should not cache queries on server', async () => {
+    const queryCache = makeQueryCache();
     function Page() {
       const [page, setPage] = React.useState(1)
       const { resolvedData } = usePaginatedQuery(
@@ -31,7 +28,11 @@ describe('useQuery SSR', () => {
       )
     }
 
-    renderToString(<Page />)
+    renderToString(
+      <ReactQueryCacheProvider queryCache={queryCache}>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     expect(queryCache.queries).toEqual({})
   })

--- a/src/tests/useQuery-SSR.test.js
+++ b/src/tests/useQuery-SSR.test.js
@@ -4,12 +4,16 @@
 
 import React from 'react'
 import { renderToString } from 'react-dom/server'
-import { usePaginatedQuery, ReactQueryCacheProvider, makeQueryCache } from '../index'
+import {
+  usePaginatedQuery,
+  ReactQueryCacheProvider,
+  makeQueryCache,
+} from '../index'
 
 describe('useQuery SSR', () => {
   // See https://github.com/tannerlinsley/react-query/issues/70
   it('should not cache queries on server', async () => {
-    const queryCache = makeQueryCache();
+    const queryCache = makeQueryCache()
     function Page() {
       const [page, setPage] = React.useState(1)
       const { resolvedData } = usePaginatedQuery(

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -2,7 +2,12 @@ import { render, act, waitForElement, fireEvent, cleanup } from '@testing-librar
 import { ErrorBoundary } from 'react-error-boundary'
 import * as React from 'react'
 
-import { useQuery, useQueryCache, makeQueryCache, ReactQueryCacheProvider } from '../index'
+import {
+  useQuery,
+  useQueryCache,
+  makeQueryCache,
+  ReactQueryCacheProvider,
+} from '../index'
 import { sleep } from './utils'
 
 describe('useQuery', () => {
@@ -525,7 +530,7 @@ describe('useQuery', () => {
           setPrefetched(true)
         }
         prefetch()
-      }, [ queryCache ])
+      }, [queryCache])
 
       return (
         <div>
@@ -768,7 +773,13 @@ describe('useQuery', () => {
       useQuery({})
       return null
     }
-    expect(() => render(<ReactQueryCacheProvider><Page/></ReactQueryCacheProvider>)).toThrowError(/queryKey|queryFn/)
+    expect(() =>
+      render(
+        <ReactQueryCacheProvider>
+          <Page />
+        </ReactQueryCacheProvider>
+      )
+    ).toThrowError(/queryKey|queryFn/)
 
     console.error.mockRestore()
   })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -1,13 +1,13 @@
-import { render, act, waitForElement, fireEvent } from '@testing-library/react'
+import { render, act, waitForElement, fireEvent, cleanup } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary'
 import * as React from 'react'
 
-import { useQuery, queryCache } from '../index'
+import { useQuery, useQueryCache, makeQueryCache, ReactQueryCacheProvider } from '../index'
 import { sleep } from './utils'
 
 describe('useQuery', () => {
   afterEach(() => {
-    queryCache.clear()
+    cleanup()
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/105
@@ -25,7 +25,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('default')
     await waitForElement(() => rendered.getByText('test'))
@@ -52,7 +56,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('First Data: init')
     rendered.getByText('Second Data: init')
@@ -74,7 +82,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     // use "act" to wait for state update and prevent console warning
 
@@ -97,7 +109,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('First Status: success')
     await waitForElement(() => rendered.getByText('Second Status: loading'))
@@ -119,7 +135,11 @@ describe('useQuery', () => {
       )
     }
 
-    const { getByTestId } = render(<Page />)
+    const { getByTestId } = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => getByTestId('status'))
     act(() => {
@@ -148,7 +168,11 @@ describe('useQuery', () => {
       )
     }
 
-    const { findByText } = render(<Page />)
+    const { findByText } = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await findByText('success')
   })
@@ -166,7 +190,11 @@ describe('useQuery', () => {
       return null
     }
 
-    render(<Page />)
+    render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     expect(queryFn).toHaveBeenCalledWith('test', variables)
   })
@@ -185,7 +213,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
     await waitForElement(() => rendered.getByText('default'))
     expect(queryFn).not.toHaveBeenCalled()
   })
@@ -203,7 +235,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
     await waitForElement(() => rendered.getByText('default'))
 
     act(() => {
@@ -231,7 +267,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('error'))
     await waitForElement(() => rendered.getByText('Error test'))
@@ -257,7 +297,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('loading'))
     await waitForElement(() => rendered.getByText('error'))
@@ -294,7 +338,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('loading'))
     await waitForElement(() => rendered.getByText('error'))
@@ -306,6 +354,7 @@ describe('useQuery', () => {
   })
 
   it('should garbage collect queries without data immediately', async () => {
+    const queryCache = makeQueryCache()
     function Page() {
       const [filter, setFilter] = React.useState('')
       const { data } = useQuery(
@@ -324,7 +373,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider queryCache={queryCache}>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('update'))
 
@@ -368,7 +421,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('failureCount 1'))
     await waitForElement(() => rendered.getByText('status loading'))
@@ -385,6 +442,7 @@ describe('useQuery', () => {
 
   // See https://github.com/tannerlinsley/react-query/issues/195
   it('should not refetch immediately after a prefetch', async () => {
+    const queryCache = makeQueryCache()
     const queryFn = jest.fn()
     queryFn.mockImplementation(() => sleep(10))
 
@@ -404,7 +462,11 @@ describe('useQuery', () => {
     await queryCache.prefetchQuery('test', prefetchQueryFn)
     await queryCache.prefetchQuery('test', prefetchQueryFn)
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider queryCache={queryCache}>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('status success'))
 
@@ -436,7 +498,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('failureCount 1'))
     await waitForElement(() => rendered.getByText('failureCount 0'))
@@ -445,6 +511,7 @@ describe('useQuery', () => {
   // See https://github.com/tannerlinsley/react-query/issues/199
   it('should use prefetched data for dependent query', async () => {
     function Page() {
+      const queryCache = useQueryCache()
       const [key, setKey] = React.useState(false)
       const [isPrefetched, setPrefetched] = React.useState(false)
 
@@ -458,7 +525,7 @@ describe('useQuery', () => {
           setPrefetched(true)
         }
         prefetch()
-      }, [])
+      }, [ queryCache ])
 
       return (
         <div>
@@ -469,7 +536,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
     await waitForElement(() => rendered.getByText('isPrefetched'))
 
     fireEvent.click(rendered.getByText('setKey'))
@@ -492,7 +563,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Status: loading')
     await waitForElement(() => rendered.getByText('Status: success'))
@@ -520,7 +595,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Status: success')
     rendered.getByText('Data: no data')
@@ -554,7 +633,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('Status: success')
     rendered.getByText('Data: no data')
@@ -580,7 +663,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('data')
     expect(rendered.getByTestId('isFetching').textContent).toBe('false')
@@ -599,7 +686,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     rendered.getByText('0')
     expect(rendered.getByTestId('isFetching').textContent).toBe('false')
@@ -632,7 +723,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('initial'))
     fireEvent.click(rendered.getByText('setShouldFetch(false)'))
@@ -644,6 +739,7 @@ describe('useQuery', () => {
   it('it should support falsy queryKey in query object syntax', async () => {
     const queryFn = jest.fn()
     queryFn.mockImplementation(() => 'data')
+    const queryCache = makeQueryCache()
 
     function Page() {
       useQuery({
@@ -652,7 +748,11 @@ describe('useQuery', () => {
       })
       return null
     }
-    render(<Page />)
+    render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     const cachedQueries = Object.keys(queryCache.queries).length
     expect(queryFn).not.toHaveBeenCalled()
@@ -668,7 +768,7 @@ describe('useQuery', () => {
       useQuery({})
       return null
     }
-    expect(() => render(<Page />)).toThrowError(/queryKey|queryFn/)
+    expect(() => render(<ReactQueryCacheProvider><Page/></ReactQueryCacheProvider>)).toThrowError(/queryKey|queryFn/)
 
     console.error.mockRestore()
   })
@@ -686,7 +786,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('fetched data'))
     expect(rendered.getByTestId('isStale').textContent).toBe('true')
@@ -710,7 +814,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('fetched data'))
     expect(rendered.getByTestId('isStale').textContent).toBe('false')
@@ -729,7 +837,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('isFetching === false'))
   })
@@ -742,7 +854,13 @@ describe('useQuery', () => {
       return <div>{query.data}</div>
     }
 
-    const rendered = render(<Page />)
+    const queryCache = makeQueryCache()
+
+    const rendered = render(
+      <ReactQueryCacheProvider queryCache={queryCache}>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('fetched data'))
 
@@ -791,7 +909,11 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const rendered = render(
+      <ReactQueryCacheProvider>
+        <Page />
+      </ReactQueryCacheProvider>
+    )
 
     await waitForElement(() => rendered.getByText('status loading'))
     await waitForElement(() => rendered.getByText('status success'))

--- a/src/useBaseQuery.js
+++ b/src/useBaseQuery.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 //
 
-import { queryCache } from './queryCache'
+import { useQueryCache } from './queryCache'
 import { useConfigContext } from './config'
 import {
   useUid,
@@ -19,6 +19,8 @@ export function useBaseQuery(queryKey, queryVariables, queryFn, config = {}) {
     ...useConfigContext(),
     ...config,
   }
+
+  const queryCache = useQueryCache()
 
   const queryRef = React.useRef()
 

--- a/src/useIsFetching.js
+++ b/src/useIsFetching.js
@@ -1,8 +1,9 @@
 import React from 'react'
 
-import { queryCache } from './queryCache'
+import { useQueryCache } from './queryCache'
 
 export function useIsFetching() {
+  const queryCache = useQueryCache()
   const [state, setState] = React.useState({})
 
   React.useEffect(() => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -700,6 +700,20 @@ export interface QueryCache {
 export const queryCache: QueryCache
 
 /**
+ * a factory that creates a new query cache
+ */
+export function makeQueryCache(): QueryCache
+
+/**
+ * A hook that uses the query cache context
+ */
+export function useQueryCache(): QueryCache
+
+export const ReactQueryCacheProvider: React.ComponentType<{
+  queryCache?: QueryCache
+}>
+
+/**
  * A hook that returns the number of the quiries that your application is loading or fetching in the background
  * (useful for app-wide loading indicators).
  * @returns the number of the quiries that your application is currently loading or fetching in the background.


### PR DESCRIPTION
the query cache now comes from a context, meaning users can easily override and control the cache being used inside their application

see https://github.com/tannerlinsley/react-query/issues/460

this is a basic use case of creating an isolated cache for testing

in component:
```jsx
const MyComponent = () => {
  const queryCache = useQueryCache();

  const [ mutate ] = useMutation(someFn, {
    onSettled() {
      queryCache.refetchQueries('basket');
    }
  });
  return ( ... );
};
```

in unit test:
```jsx
import { makeQueryCache, QueryCacheProvider } from 'react-query';

const cache = makeQueryCache();
sinon.spy(cache, 'refetchQueries');


mount(
  <QueryCacheProvider queryCache={cache}>
    <MyComponent/>
  </QueryCacheProvider>
);

// ...

await invokeSomeMutation(); // after mutating, we should refetch the basket

expect(cache.refetchQueries).to.be.calledWith('basket');
```