### PR TITLE
feat types: pass a paramter to `setQueryData` and `getQueryData` to infer the type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -668,9 +668,9 @@ export interface QueryCache {
   }): Promise<TResult>
 
   getQueryData<T = unknown>(key: AnyQueryKey | string): T | undefined
-  setQueryData(
+  setQueryData<T = unknown>(
     key: AnyQueryKey | string,
-    dataOrUpdater: unknown | ((oldData: unknown | undefined) => unknown)
+    dataOrUpdater: T | ((oldData: T | undefined) => T)
   ): void
   refetchQueries(
     queryKeyOrPredicateFn:

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -667,7 +667,7 @@ export interface QueryCache {
     config?: PrefetchQueryOptions<TResult>
   }): Promise<TResult>
 
-  getQueryData(key: AnyQueryKey | string): unknown | undefined
+  getQueryData<T = unknown>(key: AnyQueryKey | string): T | undefined
   setQueryData(
     key: AnyQueryKey | string,
     dataOrUpdater: unknown | ((oldData: unknown | undefined) => unknown)

--- a/types/test.ts
+++ b/types/test.ts
@@ -6,6 +6,7 @@ import {
   useIsFetching,
   setConsole,
   ReactQueryProviderConfig,
+  queryCache,
 } from 'react-query'
 
 function simpleQuery() {

--- a/types/test.ts
+++ b/types/test.ts
@@ -6,7 +6,6 @@ import {
   useIsFetching,
   setConsole,
   ReactQueryProviderConfig,
-  queryCache,
 } from 'react-query'
 
 function simpleQuery() {


### PR DESCRIPTION
without this, one would have to cast the type  returned.