### PR TITLE
Feature proposal: clearOnNoQuery option for usePaginatedQuery

### DIFF
--- a/src/tests/usePaginatedQuery.test.js
+++ b/src/tests/usePaginatedQuery.test.js
@@ -122,7 +122,7 @@ describe('usePaginatedQuery', () => {
     expect(rendered.getByTestId('status').textContent).not.toBe('loading')
   })
 
-  it('should clear resolvedData data while query is falsy and clearOnNoQuery option is set', async () => {
+  it('should clear resolvedData data when query is falsy', async () => {
     function Page() {
       const [searchTerm, setSearchTerm] = React.useState('')
       const [page, setPage] = React.useState(1)
@@ -131,8 +131,7 @@ describe('usePaginatedQuery', () => {
         async (queryName, searchTerm, page) => {
           await sleep(1)
           return `${searchTerm} ${page}`
-        },
-        { clearOnNoQuery: true }
+        }
       )
 
       return (

--- a/src/tests/usePaginatedQuery.test.js
+++ b/src/tests/usePaginatedQuery.test.js
@@ -121,4 +121,65 @@ describe('usePaginatedQuery', () => {
     expect(rendered.getByTestId('status').textContent).toBe('success')
     expect(rendered.getByTestId('status').textContent).not.toBe('loading')
   })
+
+  it('should clear resolvedData data while query is falsy and clearOnNoQuery option is set', async () => {
+    function Page() {
+      const [searchTerm, setSearchTerm] = React.useState('')
+      const [page, setPage] = React.useState(1)
+      const { resolvedData = 'undefined' } = usePaginatedQuery(
+        searchTerm && ['data', searchTerm, page],
+        async (queryName, searchTerm, page) => {
+          await sleep(1)
+          return `${searchTerm} ${page}`
+        },
+        { clearOnNoQuery: true }
+      )
+
+      return (
+        <div>
+          <h1 data-testid="title">Data {resolvedData}</h1>
+          <input
+            name="searchTerm"
+            placeholder="Enter a search term"
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.currentTarget.value)}
+          />
+          <button
+            onClick={() => {
+              setSearchTerm('')
+              setPage(1)
+            }}
+          >
+            clear
+          </button>
+          <button onClick={() => setPage(page + 1)}>next</button>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    fireEvent.change(rendered.getByPlaceholderText('Enter a search term'), {
+      target: { value: 'first-search' },
+    })
+    rendered.getByText('Data undefined')
+    await waitForElement(() => rendered.getByText('Data first-search 1'))
+
+    fireEvent.click(rendered.getByText('next'))
+    rendered.getByText('Data first-search 1')
+    await waitForElement(() => rendered.getByText('Data first-search 2'))
+
+    fireEvent.click(rendered.getByText('clear'))
+    rendered.getByText('Data undefined')
+
+    fireEvent.change(rendered.getByPlaceholderText('Enter a search term'), {
+      target: { value: 'second-search' },
+    })
+    rendered.getByText('Data undefined')
+    await waitForElement(() => rendered.getByText('Data second-search 1'))
+
+    fireEvent.click(rendered.getByText('next'))
+    rendered.getByText('Data second-search 1')
+    await waitForElement(() => rendered.getByText('Data second-search 2'))
+  })
 })

--- a/src/usePaginatedQuery.js
+++ b/src/usePaginatedQuery.js
@@ -10,7 +10,7 @@ export function usePaginatedQuery(...args) {
 
   const lastDataRef = React.useRef()
 
-  if (config.clearOnNoQuery && !queryKey) {
+  if (!queryKey) {
     lastDataRef.current = undefined
   }
 

--- a/src/usePaginatedQuery.js
+++ b/src/usePaginatedQuery.js
@@ -10,6 +10,10 @@ export function usePaginatedQuery(...args) {
 
   const lastDataRef = React.useRef()
 
+  if (config.clearOnNoQuery && !queryKey) {
+    lastDataRef.current = undefined
+  }
+
   // If latestData is set, don't use initialData
   if (typeof lastDataRef.current !== 'undefined') {
     delete config.initialData

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -389,7 +389,6 @@ export interface BaseQueryOptions {
   refetchIntervalInBackground?: boolean
   refetchOnWindowFocus?: boolean
   refetchOnMount?: boolean
-  clearOnNoQuery?: boolean
   onError?: (err: unknown) => void
   suspense?: boolean
   isDataEqual?: (oldData: unknown, newData: unknown) => boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -389,6 +389,7 @@ export interface BaseQueryOptions {
   refetchIntervalInBackground?: boolean
   refetchOnWindowFocus?: boolean
   refetchOnMount?: boolean
+  clearOnNoQuery?: boolean
   onError?: (err: unknown) => void
   suspense?: boolean
   isDataEqual?: (oldData: unknown, newData: unknown) => boolean


### PR DESCRIPTION
This PR adds a clearOnNoQuery option to usePaginatedQuery. When clearOnNoQuery is true resolvedData will clear if the query key is falsy.

I'm using usePaginatedQuery to provide the data for a search page with paginated results.

The issue I currently have is I want the results to clear when the search is cleared while still being able to paginate through the results. I set the query key to null when the search form is reset but the last searches results still in resolvedData.

The 2 workarounds that I've figured out before this PR are a bit hacky.
1. A special query key that immediately resolves to a special no results value
```js
const { resolvedData } = usePaginatedQuery(
  searchTerm ? ['search', searchTerm] : ['NO-SEARCH'],
  (queryKey) => {
    if (queryKey === 'NO-SEARCH') return Promise.resolve('NO-RESULTS')
  }
  // return real request
)
```
2. Perform the request in a results component that is only mounted when there a search value. I feel this mixes the logic with the display too much.