### PR TITLE
docs(queryCache): illustrate how to use the `getQueries` function to find most recent queries

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -70,6 +70,16 @@ export function makeQueryCache() {
 
   cache.getQueryData = queryKey => cache.getQuery(queryKey)?.state.data
 
+  cache.getLatestQueryData = partialKey => {
+    const query = findQueries(partialKey).reduce(
+      function(prev, current) {
+        return prev.state.updatedAt > current.state.updatedAt ? prev : current
+      },
+      { state: { updatedAt: 0 } }
+    )
+    return query.state.data
+  }
+
   cache.removeQueries = (predicate, { exact } = {}) => {
     const foundQueries = findQueries(predicate, { exact })
 

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -141,6 +141,24 @@ describe('queryCache', () => {
     expect(data).toEqual(['data1', 'data2'])
   })
 
+  test('getLatestQueryData returns the latest data from a partial match query key', async () => {
+    const fetchData1 = () => Promise.resolve('data1')
+    const fetchData2 = () => Promise.resolve('data2')
+    await queryCache.prefetchQuery(['data', { page: 1 }], fetchData1)
+    await queryCache.prefetchQuery(['data', { page: 2 }], fetchData2)
+    const latestQueryData = queryCache.getLatestQueryData('data')
+    expect(latestQueryData).toBe('data2')
+  })
+
+  test("getLatestQueryData returns undefined if a partial key doesn't find a query", async () => {
+    const fetchData1 = () => Promise.resolve('data1')
+    const fetchData2 = () => Promise.resolve('data2')
+    await queryCache.prefetchQuery(['data', { page: 1 }], fetchData1)
+    await queryCache.prefetchQuery(['data', { page: 2 }], fetchData2)
+    const latestQueryData = queryCache.getLatestQueryData('differentData')
+    expect(latestQueryData).toBe(undefined)
+  })
+
   test('stale timeout dispatch is not called if query is no longer in the query cache', async () => {
     const queryKey = 'key'
     const fetchData = () => Promise.resolve('data')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -692,6 +692,7 @@ export interface QueryCache {
   ): Promise<void>
   getQuery(queryKey: AnyQueryKey): CachedQuery<unknown> | undefined
   getQueries(queryKey: AnyQueryKey): Array<CachedQuery<unknown>>
+  getLatestQueryData<T = unknown>(key: AnyQueryKey | string): T | undefined
   isFetching: number
   subscribe(callback: (queryCache: QueryCache) => void): () => void
   clear(): Array<CachedQuery<unknown>>


### PR DESCRIPTION
Provide a way to get the latest query by a partial query key match. Get the latest data when you don't know the full query key due to a large parameter object, i.e. complicated filters.