### PR TITLE
run terser plugin for react-query.min.mjs bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default [
       sourcemap: true,
     },
     external,
-    plugins: [resolve(), babel(), commonJS(), externalDeps()],
+    plugins: [resolve(), babel(), commonJS(), externalDeps(), terser()],
   },
   {
     input: 'src/index.js',


### PR DESCRIPTION
I noticed that the published [react.query.min.mjs](https://unpkg.com/browse/react-query@1.4.3/dist/react-query.min.mjs) file is not actually minified so I added the `terser()` plugin for that rollup bundle. Thanks!