### PR TITLE
enable externalHelpers for async-to-promise transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,14 @@
     ],
     "@babel/react"
   ],
-  "plugins": ["babel-plugin-transform-async-to-promises"],
+  "plugins": [
+    [
+      "babel-plugin-transform-async-to-promises",
+      {
+        externalHelpers: true
+      }
+    ]
+  ],
   "env": {
     "test": {
       "presets": [
@@ -22,7 +29,8 @@
             "exclude": ["@babel/plugin-transform-regenerator"]
           }
         ]
-      ]
+      ],
+      "plugins": ["babel-plugin-transform-async-to-promises"]
     }
   }
 }


### PR DESCRIPTION
This is something I noticed while evaluation `react-query` for use at my company. Several of the helpers from `babel-plugin-transform-async-to-promises` (`await()`, `async()`, `invoke()`, `catch()`, and `empty()`) are duplicated in the source code. Enabling the currently [undocumented](https://github.com/rpetrich/babel-plugin-transform-async-to-promises/pull/57) `externalHelpers` option will fix this duplication and save a few bytes. Thanks!
