### PR TITLE
fix: clear cache timeouts

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -520,10 +520,7 @@ export function makeQueryCache() {
     query.clear = () => {
       clearTimeout(query.staleTimeout)
       clearTimeout(query.cacheTimeout)
-      if (query.cancelQueries) {
-        query.cancelQueries()
-      }
-      query.cancelled = cancelledError
+      query.cancel()
     }
 
     return query

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -84,6 +84,7 @@ export function makeQueryCache() {
   }
 
   cache.clear = () => {
+    Object.values(cache.queries).forEach(query => query.clear())
     cache.queries = {}
     notifyGlobalListeners()
   }
@@ -514,6 +515,15 @@ export function makeQueryCache() {
       // Schedule a fresh invalidation!
       clearTimeout(query.staleTimeout)
       query.scheduleStaleTimeout()
+    }
+
+    query.clear = () => {
+      clearTimeout(query.staleTimeout)
+      clearTimeout(query.cacheTimeout)
+      if (query.cancelQueries) {
+        query.cancelQueries()
+      }
+      query.cancelled = cancelledError
     }
 
     return query

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -593,6 +593,7 @@ export interface CachedQuery<T> {
   setData(
     dataOrUpdater: unknown | ((oldData: unknown | undefined) => unknown)
   ): void
+  clear(): void
 }
 
 export interface QueryCache {
@@ -701,7 +702,7 @@ export interface QueryCache {
   ): void
   isFetching: number
   subscribe(callback: (queryCache: QueryCache) => void): () => void
-  clear(): Array<CachedQuery<unknown>>
+  clear(): void
 }
 
 export const queryCache: QueryCache


### PR DESCRIPTION
calling queryCache.clear() was empting the queries object but not tearing any of them down
this commit adds a clear method to the individual queries, which cancels timeouts and promises
queryCache.clear now loops through the queries and clears each one
I've also update the return type of queryCache.clear as it doesn't actually return anything

I've not added any tests as this is a very intermittent problem and I wasn't entirely sure if I could reliably reproduce the warnings. All existing tests still pass

this should solve https://github.com/tannerlinsley/react-query/issues/432 and unblock https://github.com/tannerlinsley/react-query/pull/476