### PR TITLE
docs: Update "Pass a falsy query key" section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ To do this, you can use the following 2 approaches:
 
 ### Pass a falsy query key
 
-If a query isn't ready to be requested yet, just pass a falsy value as the query key or as an item in the query key:
+If a query isn't ready to be requested yet, just pass a falsy value as the query key:
 
 ```js
 // Get the user


### PR DESCRIPTION
The docs have been updated to remove the deprecated option to supply falsey items in the key, but this section in the README.md was not updated. This PR make the update!