### PR TITLE
fix: do not suspend on subsequent page loads

### DIFF
--- a/src/usePaginatedQuery.js
+++ b/src/usePaginatedQuery.js
@@ -39,12 +39,14 @@ export function usePaginatedQuery(...args) {
     status = 'success'
   }
 
-  handleSuspense(query)
-
-  return {
+  const paginatedQuery = {
     ...query,
     resolvedData,
     latestData,
     status,
   }
+
+  handleSuspense(paginatedQuery)
+
+  return paginatedQuery
 }


### PR DESCRIPTION
As described in #503, `usePaginatedQuery` shouldn't suspend during subsequent page loads, but it currently does.

`handleSuspense` suspend on `status === 'loading'`.
`usePaginatedQuery` changes returned `status` from `'loading'` to `'success'` if `resolvedData` is available, but passes to `handleSuspense` an object that contains old `status` value.

This PR fixes this by passing the object with updated `status` to `handleSuspense`.