### PR TITLE
fix(types): Add missing params for mutation types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2038,12 +2038,12 @@ const promise = mutate(variables, {
 - `onError: Function(err, variables, onMutateValue) => Promise | undefined`
   - Optional
   - This function will fire if the mutation encounters an error and will be passed the error.
-  - Fires after the `mutate`-level `onError` handerl (if it is defined)
+  - Fires after the `mutate`-level `onError` handler (if it is defined)
   - If a promise is returned, it will be awaited and resolved before proceeding
 - `onSettled: Function(data, error, variables, onMutateValue) => Promise | undefined`
   - Optional
   - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
-  - Fires after the `mutate`-level `onSettled` handerl (if it is defined)
+  - Fires after the `mutate`-level `onSettled` handler (if it is defined)
   - If a promise is returned, it will be awaited and resolved before proceeding
 - `throwOnError`
   - Defaults to `false`

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -500,7 +500,7 @@ export type MutateFunction<
   TError = Error
 > = undefined extends TVariables
   ? (options?: MutateOptions<TResult, TVariables, TError>) => Promise<TResult>
-  : (options?: MutateOptions<TResult, TVariables, TError>) => Promise<TResult>
+  : (variables: TVariables, options?: MutateOptions<TResult, TVariables, TError>) => Promise<TResult>
 
 export interface MutationResultBase<TResult, TError = Error> {
   status: 'idle' | 'loading' | 'error' | 'success'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -480,7 +480,11 @@ export type MutationFunction<TResults, TVariables, TError = Error> = (
 
 export interface MutateOptions<TResult, TVariables, TError = Error> {
   onSuccess?: (data: TResult, variables: TVariables) => Promise<void> | void
-  onError?: (error: TError, snapshotValue: unknown) => Promise<void> | void
+  onError?: (
+    error: TError,
+    snapshotValue: unknown,
+    onMutateValue: (variable: TVariables) => Promise<unknown> | unknown
+  ) => Promise<void> | void
   onSettled?: (
     data: undefined | TResult,
     error: TError | null,


### PR DESCRIPTION
The MutateFunction didn't accept variables when not undefined as expected