### PR TITLE
docs: correct broken hyperlinks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ React Query exports a set of hooks that address these issues. Out of the box, Re
 <details>
 <summary>Inspiration & Hat-Tipping</summary>
 <br />
+  
 A big thanks to both [Draqula](https://github.com/vadimdemedes/draqula) for inspiring a lot of React Query's original API and documentation and also [Vercel's SWR](https://github.com/zeit/swr) and its creators for inspiring even further customizations and examples. You all rock!
 
 </details>


### PR DESCRIPTION
Thanks a lot for your work with `react-query`!

I noticed that GitHub's markdown parser didn't correctly render the hyperlinks in the README.md - this is the fix for it! Probably one of the easiest PRs ☺️

Here is a rich diff of the changes:

![image](https://user-images.githubusercontent.com/13087421/85584971-3205f680-b672-11ea-949a-b3707c8b7d40.png)
