### PR TITLE
don't schedule garbage collection unnecessarily

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -308,6 +308,7 @@ export function makeQueryCache({ frozen = isServer, defaultConfig } = {}) {
     }
 
     query.scheduleGarbageCollection = () => {
+      if (!queryCache.queries[query.queryHash]) return
       if (query.config.cacheTime === Infinity) {
         return
       }


### PR DESCRIPTION
This doesn't actually fix the issue I'm looking into, but I did notice that this timeout is scheduled even when the query is cleared and I *think* it shouldn't be. If we do need to garbage collect something, that should happen in `clear` I think.

Feel free to ignore this PR. This is just a drive-by note more than a real contribution.