### PR TITLE
fix(setQueryData). When there is no previous instance of the query it tries to create a new one but the type signature was incorrect

### DIFF
--- a/src/core/queryCache.js
+++ b/src/core/queryCache.js
@@ -241,7 +241,7 @@ export function makeQueryCache({ frozen = isServer, defaultConfig } = {}) {
     let query = queryCache.getQuery(queryKey)
 
     if (!query) {
-      query = queryCache.buildQuery(queryKey, () => new Promise(noop), config)
+      query = queryCache.buildQuery(queryKey, config)
     }
 
     query.setData(updater)

--- a/src/core/tests/queryCache.test.js
+++ b/src/core/tests/queryCache.test.js
@@ -122,7 +122,7 @@ describe('queryCache', () => {
 
     await waitFor(
       () => expect(queryCache.getQuery('key').state.isStale).toEqual(true),
-      { timeout: 100, interval: 5 }
+      { timeout: 110, interval: 5 }
     )
   })
 


### PR DESCRIPTION
The 2.x version of this reported bug https://github.com/tannerlinsley/react-query/issues/639

While I was trying to reproduce the reported bug in the 2.x branch I realized that the bug was not present
due to a incorrect function call to `buildQuery` in the problematic code (problematic respect to the code).

I fixed that and left the queryFn to be `undefined` to avoid going into the problem condition as explained in the bug.
had to fix tests too.



Bonus:
- have you considered slowly migrating to Typescript? this sort of bug will never happen in typescript (although is minor) and I know from experience that the dev experience is greatly enhanced.
- is there any particular reason you have defined the `makeQuery` as a function instead of as a class?
- is there any particular reason `queryCache` is modeled as an object with methods and attributes instead of a class and an instance?  The both seem like central "entities" in the library that are instantiated more than once, so they fit the class/instance model pretty well, and with the new syntax they became pretty powerful.

The last two seem like a good use case for classes that could improve the code a little bit.

Respectfully 
Fran