### PR TITLE
fix(setQueryData) unresolved promises

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -236,7 +236,7 @@ export function makeQueryCache() {
 
     if (!queries.length && typeof queryKey !== 'function') {
       queries = [
-        cache._buildQuery(queryKey, undefined, () => new Promise(noop), {
+        cache._buildQuery(queryKey, undefined, () => Promise.resolve(), {
           ...defaultConfigRef.current,
           ...config,
         }),

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -192,4 +192,15 @@ describe('queryCache', () => {
     expect(newQuery.state.markedForGarbageCollection).toBe(false)
     expect(newQuery.state.data).toBe('data')
   })
+
+  // this covers bug https://github.com/tannerlinsley/react-query/issues/639
+  test('setQueryData of not instatiated query uses a resolved promise as queryFn', async () => {
+    let promiseIsResolved = false
+    const queryCache = makeQueryCache()
+    const queryKey = 'notInstantiated'
+    queryCache.setQueryData(queryKey, "data")
+    await queryCache.refetchQueries(queryKey, { force: true });
+    promiseIsResolved = true
+    expect(promiseIsResolved).toBe(true)
+  })
 })


### PR DESCRIPTION
setQueryData(notInstantiatedQueryKey) now assigns Promise.resolve() instead of new Promise(noop) that caused a never ending promise en certain scenarios. Ref bug #639

EDIT
Forgot to mention that I went with `Promise.resolve` because in some other place we do `const promise = fn(...)` and if we simply make `fn` a `noop` then `promise` will be undefined and when we later do `promise.cancel` it will break. (typescript would help us in this case)

Here is where we access `promise.cancel` https://github.com/tannerlinsley/react-query/blob/1.x/src/queryCache.js#L375