### PR TITLE
TS make arg of mutation->onError rollback optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -405,7 +405,7 @@ export interface MutateOptions<TResult, TVariables, TError = Error> {
   onError?: (
     error: TError,
     snapshotValue: unknown,
-    onMutateValue: (variable: TVariables) => Promise<unknown> | unknown
+    onMutateValue: (variable?: TVariables) => Promise<unknown> | unknown
   ) => Promise<void> | void
   onSettled?: (
     data: undefined | TResult,


### PR DESCRIPTION
Hi Tanner,

I was gonna open an issue, but then i thought maybe I send PR since it's a small change.

Following the optimistic UI update section [Updating a list of todos when adding a new todo](https://github.com/tannerlinsley/react-query#updating-a-list-of-todos-when-adding-a-new-todo) in TS app, it seems that the type definition for the `rollback` function expects a mandatory parameter (variable) to be passed when it, _I think_, it should be optional (since the example in the docs doesn't pass anything to `rollback()`).


**To Reproduce**

- Check the linting error on line 26 in this [codesandbox](https://codesandbox.io/s/hardcore-greider-bydvq?file=/src/useApi.ts)


**Expected behavior**
No linting error about missing required 1 argument.

**Screenshots**

<img width="868" alt="Screen Shot 2020-06-29 at 3 33 58 pm" src="https://user-images.githubusercontent.com/13101565/85994063-73572700-ba21-11ea-84f7-b849a6cff8b0.png">

