### PR TITLE
New MutationResultPair type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -393,7 +393,9 @@ export function useMutation<
 >(
   mutationFn: MutationFunction<TResult, TVariables, TError, TSnapshot>,
   mutationOptions?: MutationOptions<TResult, TVariables, TError, TSnapshot>
-): [
+): MutationResultPair<TResult, TVariables, TError>
+
+export type MutationResultPair<TResult, TVariables, TError> = [
   MutateFunction<TResult, TVariables, TError>,
   MutationResult<TResult, TError>
 ]


### PR DESCRIPTION
This change just assigns a generic type to the array returned by `useMutation`. This is helpful when creating hooks which wrap `useMutation` because it helps avoid such verbose types (repeating `TResult` and `TError` twice).

**Before**:

```ts
export default function useUpdateAccount(): [
  MutateFunction<AccountResult, Account, Error>,
  MutationResult<AccountResult, Error>
] {
    return useMutation<AccountResult, Account, Error>(...);
}
```

**After**:

```ts
export default function useUpdateAccount(): MutationResultPair<AccountResult, Account, Error> {
    return useMutation<AccountResult, Account, Error>(...);
}
```

I'm not convinced that I chose the best name, especially since `MutationResult` already exists, but I really couldn't think of anything else.