### PR TITLE
fix(types): missing type definition for queryFnParamsFilter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -242,6 +242,7 @@ export interface BaseQueryOptions<TResult = unknown, TError = Error> {
   onSettled?: (data: TResult | undefined, error: TError | null) => void
   isDataEqual?: (oldData: unknown, newData: unknown) => boolean
   useErrorBoundary?: boolean
+  queryFnParamsFilter?: (args: any[]) => any[]
 }
 
 export interface QueryOptions<TResult, TError = Error>


### PR DESCRIPTION
Definition for `queryFnParamsFilter` is missing.