### PR TITLE
fix(types): fix MutateFunction

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -443,7 +443,7 @@ export type MutateFunction<
   TResult,
   TVariables,
   TError = Error
-> = undefined extends TVariables
+> = TVariables extends undefined
   ? (options?: MutateOptions<TResult, TVariables, TError>) => Promise<TResult>
   : (
       variables: TVariables,


### PR DESCRIPTION
TVariables now extends undefined to determine the return type of MutateFunction.

Fixes #661. When disableling [`--strictNullChecks`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#--strictnullchecks) `undefined` is always in every type's domain. `undefined extends TVariables` would always be true.