### PR TITLE
fix(types): queryCache.getQueries

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -614,7 +614,14 @@ export interface QueryCache {
     { exact }?: { exact?: boolean }
   ): void
   getQuery(queryKey: AnyQueryKey): CachedQuery<unknown> | undefined
-  getQueries(queryKey: AnyQueryKey): Array<CachedQuery<unknown>>
+  getQueries(
+    queryKeyOrPredicateFn:
+      | AnyQueryKey
+      | string
+      | boolean
+      | ((query: CachedQuery<unknown>) => boolean),
+    { exact }?: { exact?: boolean }
+  ): Array<CachedQuery<unknown>>
   cancelQueries(
     queryKeyOrPredicateFn:
       | AnyQueryKey

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -540,7 +540,7 @@ export interface CachedQuery<T, TError = unknown> {
 
 export type QueryKey<TKey> = TKey | false | null | undefined
 
-type QueryKeyOrPredicateFn =
+export type QueryKeyOrPredicateFn =
   | AnyQueryKey
   | string
   | boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -540,6 +540,12 @@ export interface CachedQuery<T, TError = unknown> {
 
 export type QueryKey<TKey> = TKey | false | null | undefined
 
+type QueryKeyOrPredicateFn =
+  | AnyQueryKey
+  | string
+  | boolean
+  | ((query: CachedQuery<unknown>) => boolean)
+
 export interface QueryCache {
   prefetchQuery<TResult, TKey extends AnyQueryKey, TError = Error>(
     queryKey: QueryKey<TKey>,
@@ -580,9 +586,9 @@ export interface QueryCache {
     prefetch?: PrefetchQueryOptions
   }): Promise<TResult>
 
-  getQueryData<T = unknown>(key: AnyQueryKey | string): T | undefined
+  getQueryData<T = unknown>(key: QueryKeyOrPredicateFn): T | undefined
   setQueryData<TResult, TError = Error>(
-    key: AnyQueryKey | string,
+    queryKeyOrPredicateFn: QueryKeyOrPredicateFn,
     dataOrUpdater:
       | TResult
       | undefined
@@ -590,10 +596,7 @@ export interface QueryCache {
     config?: SetQueryDataQueryOptions<TResult, TError>
   ): void
   invalidateQueries<TResult>(
-    queryKeyOrPredicateFn:
-      | AnyQueryKey
-      | string
-      | ((query: CachedQuery<unknown>) => boolean),
+    queryKeyOrPredicateFn: QueryKeyOrPredicateFn,
     {
       exact,
       throwOnError,
@@ -607,26 +610,16 @@ export interface QueryCache {
     }
   ): Promise<TResult>
   removeQueries(
-    queryKeyOrPredicateFn:
-      | AnyQueryKey
-      | string
-      | ((query: CachedQuery<unknown>) => boolean),
+    queryKeyOrPredicateFn: QueryKeyOrPredicateFn,
     { exact }?: { exact?: boolean }
   ): void
-  getQuery(queryKey: AnyQueryKey): CachedQuery<unknown> | undefined
+  getQuery(queryKeyOrPredicateFn: QueryKeyOrPredicateFn): CachedQuery<unknown> | undefined
   getQueries(
-    queryKeyOrPredicateFn:
-      | AnyQueryKey
-      | string
-      | boolean
-      | ((query: CachedQuery<unknown>) => boolean),
+    queryKeyOrPredicateFn: QueryKeyOrPredicateFn,
     { exact }?: { exact?: boolean }
   ): Array<CachedQuery<unknown>>
   cancelQueries(
-    queryKeyOrPredicateFn:
-      | AnyQueryKey
-      | string
-      | ((query: CachedQuery<unknown>) => boolean),
+    queryKeyOrPredicateFn: QueryKeyOrPredicateFn,
     { exact }?: { exact?: boolean }
   ): void
   isFetching: number

--- a/types/test.ts
+++ b/types/test.ts
@@ -37,6 +37,14 @@ function prefetchQuery() {
   })
 }
 
+function getQueries() {
+  queryCache.getQueries(['queryKey']);
+  queryCache.getQueries('queryKey');
+  queryCache.getQueries(true);
+  queryCache.getQueries((query) => true);
+}
+
+
 function simpleQuery() {
   // Query - simple case
   const querySimple = useQuery<string, 'todos'>('todos', () =>

--- a/types/test.ts
+++ b/types/test.ts
@@ -44,7 +44,6 @@ function getQueries() {
   queryCache.getQueries((query) => true);
 }
 
-
 function simpleQuery() {
   // Query - simple case
   const querySimple = useQuery<string, 'todos'>('todos', () =>

--- a/types/test.ts
+++ b/types/test.ts
@@ -37,6 +37,27 @@ function prefetchQuery() {
   })
 }
 
+function getQueryData() {
+  queryCache.getQueryData(['queryKey']);
+  queryCache.getQueryData('queryKey');
+  queryCache.getQueryData(true);
+  queryCache.getQueryData((query) => true);
+}
+
+function setQueryData() {
+  queryCache.setQueryData(['queryKey'], ['data']);
+  queryCache.setQueryData('queryKey', ['data']);
+  queryCache.setQueryData(true, ['data']);
+  queryCache.setQueryData((query) => true, ['data']);
+}
+
+function getQuery() {
+  queryCache.getQuery(['queryKey']);
+  queryCache.getQuery('queryKey');
+  queryCache.getQuery(true);
+  queryCache.getQuery((query) => true);
+}
+
 function getQueries() {
   queryCache.getQueries(['queryKey']);
   queryCache.getQueries('queryKey');


### PR DESCRIPTION
There were some missing types in the getQueries method's type definitions. I copied the parameter types from the other methods that allow `AnyQueryKey | string | function`, and added `boolean` as it looks like that's also a possible parameter type, looking at the implementation.