### PR TITLE
Fix fetch abort example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1138,7 +1138,7 @@ const query = useQuery('todos', () => {
   })
 
   // Cancel the request if React Query calls the `promise.cancel` method
-  promise.cancel = controller.abort
+  promise.cancel = () => controller.abort()
 
   return promise
 })


### PR DESCRIPTION
**Very minor tweak to the README:**

Passing `controller.abort` directly as a callback breaks the "this" function context.