### PR TITLE
Update global suspense configuration in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,9 @@ Global configuration:
 import { ReactQueryConfigProvider } from 'react-query'
 
 const queryConfig = {
-  suspense: true,
+  shared: {
+    suspense: true,
+  }
 }
 
 function App() {


### PR DESCRIPTION
This updates the Suspense example in the readme to use the version 2 global configuration schema where suspense is no longer a top level config option.