### PR TITLE
fix(types): add clear to QueryResultBase

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -286,6 +286,7 @@ export interface QueryResultBase<TResult, TError = Error> {
   query: object
   updatedAt: number
   refetch: ({ throwOnError }?: { throwOnError?: boolean }) => Promise<TResult>
+  clear: () => void
 }
 
 export interface QueryIdleResult<TResult, TError = Error>

--- a/types/test.ts
+++ b/types/test.ts
@@ -46,6 +46,8 @@ function simpleQuery() {
   querySimple.fetchMore // $ExpectError
 
   querySimple.canFetchMore // $ExpectType boolean | undefined
+  querySimple.clear // $ExpectType () => void
+  querySimple.clear() // $ExpectType void
   querySimple.data // $ExpectType string | undefined
   querySimple.error // $ExpectType Error | null
   querySimple.failureCount // $ExpectType number


### PR DESCRIPTION
Adds type for `clear()` on `QueryResultBase`

closes #692  