### PR TITLE
Docs: Hide <kbd> Shortcuts for mobile/tablet breakpoints in Search

### DIFF
--- a/docs/src/components/Search.js
+++ b/docs/src/components/Search.js
@@ -69,7 +69,7 @@ export const Search = ({
             <path d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z" stroke="currentColor" fill="none" strokeWidth="2" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round"></path>
           </svg>
           Search docs
-          <span className="ml-auto">
+          <span className="hidden lg:block ml-auto">
             <kbd className="border border-gray-300 mr-1 bg-gray-100 align-middle p-0 inline-flex justify-center items-center  text-xs text-center mr-0 rounded group-hover:border-gray-300 transition duration-150 ease-in-out " style={{
             minWidth: '1.8em'
           }}>


### PR DESCRIPTION
These devices don't can't take advantage of shortcuts