### PR TITLE
fix(examples): Import ReactQueryDevtools from correct package

### DIFF
--- a/examples/load-more-infinite-scroll/pages/index.js
+++ b/examples/load-more-infinite-scroll/pages/index.js
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import axios from 'axios'
 
 import { useInfiniteQuery } from 'react-query'
-import { ReactQueryDevtools } from 'react-query'
+import { ReactQueryDevtools } from 'react-query-devtools'
 
 //
 

--- a/examples/pagination/pages/index.js
+++ b/examples/pagination/pages/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import axios from 'axios'
 import { usePaginatedQuery, queryCache } from 'react-query'
-import { ReactQueryDevtools } from 'react-query'
+import { ReactQueryDevtools } from 'react-query-devtools'
 
 function Todos() {
   const [page, setPage] = React.useState(0)


### PR DESCRIPTION
While browsing through the docs I've noticed that the `pagination` example is broken (can't be build): https://codesandbox.io/s/github/tannerlinsley/react-query/tree/master/examples/pagination

The `load-more-infinite-scroll` was affected by the very same issue, which have been fixed with this PR too: https://codesandbox.io/s/github/tannerlinsley/react-query/tree/master/examples/load-more-infinite-scroll

As far as I could tell (coming off a very, very long day...) these were the only examples that were broken.