### PR TITLE
feat(useQuery): enable the `throwOnError` option of `useQuery.refetch`

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -58,6 +58,10 @@ export interface FetchMoreOptions {
   previous: boolean
 }
 
+export interface RefetchOptions {
+  throwOnError?: boolean;
+}
+
 export enum ActionType {
   Failed = 'Failed',
   MarkStale = 'MarkStale',
@@ -224,12 +228,12 @@ export class Query<TResult, TError> {
     )
   }
 
-  async refetch(options?: { throwOnError?: boolean }): Promise<TResult | undefined> {
+  async refetch(options?: RefetchOptions): Promise<TResult | undefined> {
     try {
       return await this.fetch()
     } catch (error) {
       if (options?.throwOnError === true) {
-        return Promise.reject(error);
+        throw error;
       }
       Console.error(error)
     }

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -1,6 +1,6 @@
 import { getStatusProps, isServer, isDocumentVisible, Console } from './utils'
 import type { QueryResult, QueryObserverConfig } from './types'
-import type { Query, QueryState, Action, FetchMoreOptions } from './query'
+import type { Query, QueryState, Action, FetchMoreOptions, RefetchOptions } from './query'
 
 export type UpdateListener<TResult, TError> = (
   result: QueryResult<TResult, TError>
@@ -86,7 +86,7 @@ export class QueryObserver<TResult, TError> {
     return this.currentQuery.clear()
   }
 
-  async refetch(options?: { throwOnError?: boolean }): Promise<TResult | undefined> {
+  async refetch(options?: RefetchOptions): Promise<TResult | undefined> {
     this.currentQuery.updateConfig(this.config)
     return this.currentQuery.refetch(options)
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-import type { Query, FetchMoreOptions } from './query'
+import type { Query, FetchMoreOptions, RefetchOptions } from './query';
 import type { QueryCache } from './queryCache'
 
 export type QueryKey =
@@ -160,7 +160,7 @@ export interface QueryResultBase<TResult, TError = unknown> {
   isStale: boolean
   isSuccess: boolean
   query: Query<TResult, TError>
-  refetch: (options?: { throwOnError?: boolean }) => Promise<TResult | undefined>
+  refetch: (options?: RefetchOptions) => Promise<TResult | undefined>
   status: QueryStatus
   updatedAt: number
 }


### PR DESCRIPTION
Enables the `throwOnError` configuration option for `useQuery.refetch` that has as of yet only been present in the documentation but not in the code.
Also returns the result of the fetch for consistency.

Relates to: #903 #843