### PR TITLE
docs(setFocusHandler): React Native Example

### DIFF
--- a/docs/src/pages/docs/guides/window-focus-refetching.md
+++ b/docs/src/pages/docs/guides/window-focus-refetching.md
@@ -47,3 +47,22 @@ import onWindowFocus from './onWindowFocus' // The gist above
 
 setFocusHandler(onWindowFocus) // Boom!
 ```
+
+## Managing Focus in React Native
+
+Instead of event listeners on `window`, React Native provides focus information through the [`AppState` module](https://reactnative.dev/docs/appstate#app-states). You can use the `AppState` "change" event to trigger an update when the app state changes to "active":
+
+```js
+import { setFocusHandler } from 'react-query';
+import { AppState } from 'react-native';
+
+setFocusHandler((handleFocus) => {
+  const handleAppStateChange = (appState) => {
+    if (appState === 'active') {
+      handleFocus();
+    }
+  };
+  AppState.addEventListener('change', handleAppStateChange);
+  return () => AppState.removeEventListener('change', handleAppStateChange);
+});
+```


### PR DESCRIPTION
This docs addition adds a snippet to replicate the default behavior of react-query's window focus handling for React Native apps.

EDIT: My apologies, I didn't see the discussion question topic about this until searching in the repo just now. https://github.com/tannerlinsley/react-query/discussions/296#discussioncomment-2312 

That said, I think this is still focused enough to warrant a mention in the docs themselves? The library cherniavskii mentions does basically this exact thing plus a helpful amount more, but assumes the user is using React Navigation. I could update the text to suggest that as well.