### PR TITLE
feat(ssr): support SSR in Deno

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -72,7 +72,7 @@ export type QueryStatusFilter = 'all' | 'active' | 'inactive' | 'none'
 
 // UTILS
 
-export const isServer = typeof window === 'undefined'
+export const isServer = typeof window === 'undefined' || 'Deno' in window
 
 export function noop(): undefined {
   return undefined

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -72,7 +72,10 @@ export type QueryStatusFilter = 'all' | 'active' | 'inactive' | 'none'
 
 // UTILS
 
-export const isServer = typeof window === 'undefined' || 'Deno' in window
+export const isServer =
+  typeof window === 'undefined' ||
+  // @ts-expect-error
+  !!(window.Deno && Deno.version && Deno.version.deno)
 
 export function noop(): undefined {
   return undefined


### PR DESCRIPTION
I use react-query in Deno:

```tsx
import { QueryClient, QueryClientProvider, useQuery } from 'https://esm.sh/react-query';

const queryClient = new QueryClient();

export default function App() {
  return (
    <QueryClientProvider client={queryClient}>
      <Example />
    </QueryClientProvider>
  );
}

function Example() {
  const { isLoading, data } = useQuery('repoData', () => Promise.resolve({ name: 'foo' }));

  if (isLoading) return 'Loading...';

  return <div>{data.name}</div>;
}
```

It output a warning:

> This browser doesn't support requestAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills
> This browser doesn't support cancelAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills