### PR TITLE
test(react): fix name(description) of test on refetchOnMount

### DIFF
--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -688,7 +688,7 @@ describe('useQuery', () => {
     expect(states[1]).toMatchObject({ data: 'test' })
   })
 
-  it('should fetch when refetchOnMount is false and data has been fetched already', async () => {
+  it('should not fetch when refetchOnMount is false and data has been fetched already', async () => {
     const key = queryKey()
     const states: UseQueryResult<string>[] = []
 


### PR DESCRIPTION
I think test `should fetch when refetchOnMount is false and data has been fetched already` is misspelled. 
The test name(description) seems to be the exact opposite of test code.

So I fixed it.