### PR TITLE
Extend type description of useQuery's onSuccess

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -165,7 +165,7 @@ export interface QueryObserverOptions<
    */
   notifyOnChangePropsExclusions?: Array<keyof InfiniteQueryObserverResult>
   /**
-   * This callback will fire any time the query successfully fetches new data.
+   * This callback will fire any time the query successfully fetches new data or the cache is updated via `setQueryData`.
    */
   onSuccess?: (data: TData) => void
   /**


### PR DESCRIPTION
If you look [at the docs](https://react-query.tanstack.com/reference/useQuery), you can see the `onSuccess` is not only called when a query successfully fetches new data, but also when you programmatically call `setQueryData`. This change adds the second part to the description of useQuery's type.