### PR TITLE
Rename query data generics from TData to TQueryFnData for consistency

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -102,31 +102,35 @@ export class QueryClient {
     return this.mutationCache.findAll({ ...filters, fetching: true }).length
   }
 
-  getQueryData<TData = unknown>(
+  getQueryData<TQueryFnData = unknown>(
     queryKey: QueryKey,
     filters?: QueryFilters
-  ): TData | undefined {
-    return this.queryCache.find<TData>(queryKey, filters)?.state.data
+  ): TQueryFnData | undefined {
+    return this.queryCache.find<TQueryFnData>(queryKey, filters)?.state.data
   }
 
-  getQueriesData<TData = unknown>(queryKey: QueryKey): [QueryKey, TData][]
-  getQueriesData<TData = unknown>(filters: QueryFilters): [QueryKey, TData][]
-  getQueriesData<TData = unknown>(
+  getQueriesData<TQueryFnData = unknown>(
+    queryKey: QueryKey
+  ): [QueryKey, TQueryFnData][]
+  getQueriesData<TQueryFnData = unknown>(
+    filters: QueryFilters
+  ): [QueryKey, TQueryFnData][]
+  getQueriesData<TQueryFnData = unknown>(
     queryKeyOrFilters: QueryKey | QueryFilters
-  ): [QueryKey, TData][] {
+  ): [QueryKey, TQueryFnData][] {
     return this.getQueryCache()
       .findAll(queryKeyOrFilters)
       .map(({ queryKey, state }) => {
-        const data = state.data as TData
+        const data = state.data as TQueryFnData
         return [queryKey, data]
       })
   }
 
-  setQueryData<TData>(
+  setQueryData<TQueryFnData>(
     queryKey: QueryKey,
-    updater: Updater<TData | undefined, TData>,
+    updater: Updater<TQueryFnData | undefined, TQueryFnData>,
     options?: SetDataOptions
-  ): TData {
+  ): TQueryFnData {
     const parsedOptions = parseQueryArgs(queryKey)
     const defaultedOptions = this.defaultQueryOptions(parsedOptions)
     return this.queryCache
@@ -134,38 +138,38 @@ export class QueryClient {
       .setData(updater, options)
   }
 
-  setQueriesData<TData>(
+  setQueriesData<TQueryFnData>(
     queryKey: QueryKey,
-    updater: Updater<TData | undefined, TData>,
+    updater: Updater<TQueryFnData | undefined, TQueryFnData>,
     options?: SetDataOptions
-  ): [QueryKey, TData][]
+  ): [QueryKey, TQueryFnData][]
 
-  setQueriesData<TData>(
+  setQueriesData<TQueryFnData>(
     filters: QueryFilters,
-    updater: Updater<TData | undefined, TData>,
+    updater: Updater<TQueryFnData | undefined, TQueryFnData>,
     options?: SetDataOptions
-  ): [QueryKey, TData][]
+  ): [QueryKey, TQueryFnData][]
 
-  setQueriesData<TData>(
+  setQueriesData<TQueryFnData>(
     queryKeyOrFilters: QueryKey | QueryFilters,
-    updater: Updater<TData | undefined, TData>,
+    updater: Updater<TQueryFnData | undefined, TQueryFnData>,
     options?: SetDataOptions
-  ): [QueryKey, TData][] {
+  ): [QueryKey, TQueryFnData][] {
     return notifyManager.batch(() =>
       this.getQueryCache()
         .findAll(queryKeyOrFilters)
         .map(({ queryKey }) => [
           queryKey,
-          this.setQueryData<TData>(queryKey, updater, options),
+          this.setQueryData<TQueryFnData>(queryKey, updater, options),
         ])
     )
   }
 
-  getQueryState<TData = unknown, TError = undefined>(
+  getQueryState<TQueryFnData = unknown, TError = undefined>(
     queryKey: QueryKey,
     filters?: QueryFilters
-  ): QueryState<TData, TError> | undefined {
-    return this.queryCache.find<TData, TError>(queryKey, filters)?.state
+  ): QueryState<TQueryFnData, TError> | undefined {
+    return this.queryCache.find<TQueryFnData, TError>(queryKey, filters)?.state
   }
 
   removeQueries(filters?: QueryFilters): void


### PR DESCRIPTION
Hey! Thank you for `react-query`. It makes my job a lot easier.

Recently we ran into some confusion about the expected return value from `getQueryData`. The existing return type is called `TData`:

https://github.com/tannerlinsley/react-query/blob/fc4671f0731d1dd757f9fd037fd8e6755b3393d1/src/core/queryClient.ts#L105-L110

However, looking at the type for `UseQueryOptions`, `TData` refers to the value after the `select` function has been applied. The type that's returned from `getQueryData` is called `TQueryFnData` in this context.

https://github.com/tannerlinsley/react-query/blob/fc4671f0731d1dd757f9fd037fd8e6755b3393d1/src/react/types.ts#L26-L31

This PR presents no changes in functionality, but it aligns the generics names between `UseQueryOptions` and `getQueryData`! Now when working with `UseQueryOptions`, the names will help indicate the value returned from `getQueryData`.

To illustrate further, you might write code like this if you're expecting `getQueryData` to return `TData`, but the types here are incorrect!

```tsx
type QueryOptions = UseQueryOptions<A, B, C>
type ExtractTData<P> = P extends UseQueryOptions<any, any, infer TData> ? TData : never;
type TData = ExtractTData<QueryOptions>

// ...

// `value` is not actually of type `TData`!
const value = queryClient.getQueryData<TData>(queryKey)
```