### PR TITLE
Properly type useInfiniteQuery to respect the select result

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     "titleBar.inactiveBackground": "#00da63", // change this color!
     "titleBar.activeForeground": "#ffffff", // change this color!
     "titleBar.inactiveForeground": "#ffffff" // change this color!
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/core/infiniteQueryBehavior.ts
+++ b/src/core/infiniteQueryBehavior.ts
@@ -11,8 +11,9 @@ import { getAbortController } from './utils'
 export function infiniteQueryBehavior<
   TQueryFnData,
   TError,
-  TData
->(): QueryBehavior<TQueryFnData, TError, InfiniteData<TData>> {
+  TData,
+  SData
+>(): QueryBehavior<TQueryFnData, TError, InfiniteData<TData, SData>> {
   return {
     onFetch: context => {
       context.fetchFn = () => {

--- a/src/core/infiniteQueryObserver.ts
+++ b/src/core/infiniteQueryObserver.ts
@@ -18,33 +18,34 @@ import {
 } from './infiniteQueryBehavior'
 import { Query } from './query'
 
-type InfiniteQueryObserverListener<TData, TError> = (
-  result: InfiniteQueryObserverResult<TData, TError>
+type InfiniteQueryObserverListener<TData, TError, SData> = (
+  result: InfiniteQueryObserverResult<TData, TError, SData>
 ) => void
 
 export class InfiniteQueryObserver<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  SData = unknown
 > extends QueryObserver<
   TQueryFnData,
   TError,
-  InfiniteData<TData>,
+  InfiniteData<TData, SData>,
   InfiniteData<TQueryData>
 > {
   // Type override
   subscribe!: (
-    listener?: InfiniteQueryObserverListener<TData, TError>
+    listener?: InfiniteQueryObserverListener<TData, TError, SData>
   ) => () => void
 
   // Type override
-  getCurrentResult!: () => InfiniteQueryObserverResult<TData, TError>
+  getCurrentResult!: () => InfiniteQueryObserverResult<TData, TError, SData>
 
   // Type override
   protected fetch!: (
     fetchOptions?: ObserverFetchOptions
-  ) => Promise<InfiniteQueryObserverResult<TData, TError>>
+  ) => Promise<InfiniteQueryObserverResult<TData, TError, SData>>
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(
@@ -53,7 +54,8 @@ export class InfiniteQueryObserver<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      SData
     >
   ) {
     super(client, options)
@@ -70,7 +72,8 @@ export class InfiniteQueryObserver<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      SData
     >,
     notifyOptions?: NotifyOptions
   ): void {
@@ -88,19 +91,21 @@ export class InfiniteQueryObserver<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      SData
     >
-  ): InfiniteQueryObserverResult<TData, TError> {
+  ): InfiniteQueryObserverResult<TData, TError, SData> {
     options.behavior = infiniteQueryBehavior()
     return super.getOptimisticResult(options) as InfiniteQueryObserverResult<
       TData,
-      TError
+      TError,
+      SData
     >
   }
 
   fetchNextPage(
     options?: FetchNextPageOptions
-  ): Promise<InfiniteQueryObserverResult<TData, TError>> {
+  ): Promise<InfiniteQueryObserverResult<TData, TError, SData>> {
     return this.fetch({
       // TODO consider removing `?? true` in future breaking change, to be consistent with `refetch` API (see https://github.com/tannerlinsley/react-query/issues/2617)
       cancelRefetch: options?.cancelRefetch ?? true,
@@ -113,7 +118,7 @@ export class InfiniteQueryObserver<
 
   fetchPreviousPage(
     options?: FetchPreviousPageOptions
-  ): Promise<InfiniteQueryObserverResult<TData, TError>> {
+  ): Promise<InfiniteQueryObserverResult<TData, TError, SData>> {
     return this.fetch({
       // TODO consider removing `?? true` in future breaking change, to be consistent with `refetch` API (see https://github.com/tannerlinsley/react-query/issues/2617)
       cancelRefetch: options?.cancelRefetch ?? true,
@@ -130,9 +135,10 @@ export class InfiniteQueryObserver<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      SData
     >
-  ): InfiniteQueryObserverResult<TData, TError> {
+  ): InfiniteQueryObserverResult<TData, TError, SData> {
     const { state } = query
     const result = super.createResult(query, options)
     return {

--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -405,7 +405,13 @@ export class QueryClient {
     SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
-    options: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+    options: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<InfiniteData<TData, SData>>
   fetchInfiniteQuery<
     TQueryFnData = unknown,
@@ -415,7 +421,13 @@ export class QueryClient {
     TQueryKey extends QueryKey = QueryKey
   >(
     queryKey: TQueryKey,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+    options?: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<InfiniteData<TData, SData>>
   fetchInfiniteQuery<
     TQueryFnData = unknown,
@@ -426,7 +438,13 @@ export class QueryClient {
   >(
     queryKey: TQueryKey,
     queryFn: QueryFunction<TQueryFnData, TQueryKey>,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+    options?: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<InfiniteData<TData, SData>>
   fetchInfiniteQuery<
     TQueryFnData,
@@ -437,11 +455,29 @@ export class QueryClient {
   >(
     arg1:
       | TQueryKey
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
+      | FetchInfiniteQueryOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          SData,
+          TQueryKey
+        >,
     arg2?:
       | QueryFunction<TQueryFnData, TQueryKey>
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
-    arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+      | FetchInfiniteQueryOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          SData,
+          TQueryKey
+        >,
+    arg3?: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<InfiniteData<TData>> {
     const parsedOptions = parseQueryArgs(arg1, arg2, arg3)
     parsedOptions.behavior = infiniteQueryBehavior<
@@ -460,7 +496,13 @@ export class QueryClient {
     SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
-    options: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+    options: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<void>
   prefetchInfiniteQuery<
     TQueryFnData = unknown,
@@ -470,7 +512,13 @@ export class QueryClient {
     TQueryKey extends QueryKey = QueryKey
   >(
     queryKey: TQueryKey,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+    options?: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<void>
   prefetchInfiniteQuery<
     TQueryFnData = unknown,
@@ -481,7 +529,13 @@ export class QueryClient {
   >(
     queryKey: TQueryKey,
     queryFn: QueryFunction<TQueryFnData, TQueryKey>,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+    options?: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<void>
   prefetchInfiniteQuery<
     TQueryFnData,
@@ -492,11 +546,29 @@ export class QueryClient {
   >(
     arg1:
       | TQueryKey
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
+      | FetchInfiniteQueryOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          SData,
+          TQueryKey
+        >,
     arg2?:
       | QueryFunction<TQueryFnData, TQueryKey>
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
-    arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+      | FetchInfiniteQueryOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          SData,
+          TQueryKey
+        >,
+    arg3?: FetchInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      SData,
+      TQueryKey
+    >
   ): Promise<void> {
     return this.fetchInfiniteQuery(arg1 as any, arg2 as any, arg3)
       .then(noop)

--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -402,48 +402,53 @@ export class QueryClient {
     TQueryFnData = unknown,
     TError = unknown,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
-    options: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-  ): Promise<InfiniteData<TData>>
+    options: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+  ): Promise<InfiniteData<TData, SData>>
   fetchInfiniteQuery<
     TQueryFnData = unknown,
     TError = unknown,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
     queryKey: TQueryKey,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-  ): Promise<InfiniteData<TData>>
+    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+  ): Promise<InfiniteData<TData, SData>>
   fetchInfiniteQuery<
     TQueryFnData = unknown,
     TError = unknown,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
     queryKey: TQueryKey,
     queryFn: QueryFunction<TQueryFnData, TQueryKey>,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-  ): Promise<InfiniteData<TData>>
+    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
+  ): Promise<InfiniteData<TData, SData>>
   fetchInfiniteQuery<
     TQueryFnData,
     TError,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
     arg1:
       | TQueryKey
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
     arg2?:
       | QueryFunction<TQueryFnData, TQueryKey>
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-    arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
+    arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
   ): Promise<InfiniteData<TData>> {
     const parsedOptions = parseQueryArgs(arg1, arg2, arg3)
     parsedOptions.behavior = infiniteQueryBehavior<
       TQueryFnData,
       TError,
-      TData
+      TData,
+      SData
     >()
     return this.fetchQuery(parsedOptions)
   }
@@ -452,42 +457,46 @@ export class QueryClient {
     TQueryFnData = unknown,
     TError = unknown,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
-    options: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+    options: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
   ): Promise<void>
   prefetchInfiniteQuery<
     TQueryFnData = unknown,
     TError = unknown,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
     queryKey: TQueryKey,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
   ): Promise<void>
   prefetchInfiniteQuery<
     TQueryFnData = unknown,
     TError = unknown,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
     queryKey: TQueryKey,
     queryFn: QueryFunction<TQueryFnData, TQueryKey>,
-    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
   ): Promise<void>
   prefetchInfiniteQuery<
     TQueryFnData,
     TError,
     TData = TQueryFnData,
+    SData = unknown,
     TQueryKey extends QueryKey = QueryKey
   >(
     arg1:
       | TQueryKey
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
     arg2?:
       | QueryFunction<TQueryFnData, TQueryKey>
-      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-    arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>,
+    arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, SData, TQueryKey>
   ): Promise<void> {
     return this.fetchInfiniteQuery(arg1 as any, arg2 as any, arg3)
       .then(noop)

--- a/src/core/tests/queryClient.test.tsx
+++ b/src/core/tests/queryClient.test.tsx
@@ -440,6 +440,7 @@ describe('queryClient', () => {
           StrictData,
           any,
           StrictData,
+          any,
           StrictQueryKey
         >(key, fetchFn)
       ).resolves.toEqual(data)
@@ -476,6 +477,7 @@ describe('queryClient', () => {
         StrictData,
         any,
         StrictData,
+        any,
         StrictQueryKey
       >(key, fetchFn)
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -43,10 +43,10 @@ export type GetNextPageParamFunction<TQueryFnData = unknown> = (
   allPages: TQueryFnData[]
 ) => unknown
 
-export interface InfiniteData<TData> {
+export type InfiniteData<TData, SData = unknown> = {
   pages: TData[]
   pageParams: unknown[]
-}
+} & SData
 
 export type QueryMeta = Record<string, unknown>
 
@@ -242,11 +242,12 @@ export interface InfiniteQueryObserverOptions<
   TError = unknown,
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey
+  SData = unknown,
+  TQueryKey extends QueryKey = QueryKey,
 > extends QueryObserverOptions<
     TQueryFnData,
     TError,
-    InfiniteData<TData>,
+    InfiniteData<TData, SData>,
     InfiniteData<TQueryData>,
     TQueryKey
   > {}
@@ -268,11 +269,12 @@ export interface FetchInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey
+  SData = unknown,
+  TQueryKey extends QueryKey = QueryKey,
 > extends FetchQueryOptions<
     TQueryFnData,
     TError,
-    InfiniteData<TData>,
+    InfiniteData<TData, SData>,
     TQueryKey
   > {}
 
@@ -427,14 +429,15 @@ export type QueryObserverResult<TData = unknown, TError = unknown> =
 
 export interface InfiniteQueryObserverBaseResult<
   TData = unknown,
-  TError = unknown
-> extends QueryObserverBaseResult<InfiniteData<TData>, TError> {
+  TError = unknown,
+  SData = unknown
+> extends QueryObserverBaseResult<InfiniteData<TData, SData>, TError> {
   fetchNextPage: (
     options?: FetchNextPageOptions
-  ) => Promise<InfiniteQueryObserverResult<TData, TError>>
+  ) => Promise<InfiniteQueryObserverResult<TData, TError, SData>>
   fetchPreviousPage: (
     options?: FetchPreviousPageOptions
-  ) => Promise<InfiniteQueryObserverResult<TData, TError>>
+  ) => Promise<InfiniteQueryObserverResult<TData, TError, SData>>
   hasNextPage?: boolean
   hasPreviousPage?: boolean
   isFetchingNextPage: boolean
@@ -443,8 +446,9 @@ export interface InfiniteQueryObserverBaseResult<
 
 export interface InfiniteQueryObserverIdleResult<
   TData = unknown,
-  TError = unknown
-> extends InfiniteQueryObserverBaseResult<TData, TError> {
+  TError = unknown,
+  SData = unknown
+> extends InfiniteQueryObserverBaseResult<TData, TError, SData> {
   data: undefined
   error: null
   isError: false
@@ -458,8 +462,9 @@ export interface InfiniteQueryObserverIdleResult<
 
 export interface InfiniteQueryObserverLoadingResult<
   TData = unknown,
-  TError = unknown
-> extends InfiniteQueryObserverBaseResult<TData, TError> {
+  TError = unknown,
+  SData = unknown
+> extends InfiniteQueryObserverBaseResult<TData, TError, SData> {
   data: undefined
   error: null
   isError: false
@@ -473,8 +478,9 @@ export interface InfiniteQueryObserverLoadingResult<
 
 export interface InfiniteQueryObserverLoadingErrorResult<
   TData = unknown,
-  TError = unknown
-> extends InfiniteQueryObserverBaseResult<TData, TError> {
+  TError = unknown,
+  SData = unknown
+> extends InfiniteQueryObserverBaseResult<TData, TError, SData> {
   data: undefined
   error: TError
   isError: true
@@ -488,9 +494,10 @@ export interface InfiniteQueryObserverLoadingErrorResult<
 
 export interface InfiniteQueryObserverRefetchErrorResult<
   TData = unknown,
-  TError = unknown
-> extends InfiniteQueryObserverBaseResult<TData, TError> {
-  data: InfiniteData<TData>
+  TError = unknown,
+  SData = unknown
+> extends InfiniteQueryObserverBaseResult<TData, TError, SData> {
+  data: InfiniteData<TData, SData>
   error: TError
   isError: true
   isIdle: false
@@ -503,9 +510,10 @@ export interface InfiniteQueryObserverRefetchErrorResult<
 
 export interface InfiniteQueryObserverSuccessResult<
   TData = unknown,
-  TError = unknown
-> extends InfiniteQueryObserverBaseResult<TData, TError> {
-  data: InfiniteData<TData>
+  TError = unknown,
+  SData = unknown
+> extends InfiniteQueryObserverBaseResult<TData, TError, SData> {
+  data: InfiniteData<TData, SData>
   error: null
   isError: false
   isIdle: false
@@ -516,12 +524,12 @@ export interface InfiniteQueryObserverSuccessResult<
   status: 'success'
 }
 
-export type InfiniteQueryObserverResult<TData = unknown, TError = unknown> =
-  | InfiniteQueryObserverIdleResult<TData, TError>
-  | InfiniteQueryObserverLoadingErrorResult<TData, TError>
-  | InfiniteQueryObserverLoadingResult<TData, TError>
-  | InfiniteQueryObserverRefetchErrorResult<TData, TError>
-  | InfiniteQueryObserverSuccessResult<TData, TError>
+export type InfiniteQueryObserverResult<TData = unknown, TError = unknown, SData = unknown> =
+  | InfiniteQueryObserverIdleResult<TData, TError, SData>
+  | InfiniteQueryObserverLoadingErrorResult<TData, TError, SData>
+  | InfiniteQueryObserverLoadingResult<TData, TError, SData>
+  | InfiniteQueryObserverRefetchErrorResult<TData, TError, SData>
+  | InfiniteQueryObserverSuccessResult<TData, TError, SData>
 
 export type MutationKey = string | readonly unknown[]
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -243,7 +243,7 @@ export interface InfiniteQueryObserverOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   SData = unknown,
-  TQueryKey extends QueryKey = QueryKey,
+  TQueryKey extends QueryKey = QueryKey
 > extends QueryObserverOptions<
     TQueryFnData,
     TError,
@@ -270,7 +270,7 @@ export interface FetchInfiniteQueryOptions<
   TError = unknown,
   TData = TQueryFnData,
   SData = unknown,
-  TQueryKey extends QueryKey = QueryKey,
+  TQueryKey extends QueryKey = QueryKey
 > extends FetchQueryOptions<
     TQueryFnData,
     TError,
@@ -524,7 +524,11 @@ export interface InfiniteQueryObserverSuccessResult<
   status: 'success'
 }
 
-export type InfiniteQueryObserverResult<TData = unknown, TError = unknown, SData = unknown> =
+export type InfiniteQueryObserverResult<
+  TData = unknown,
+  TError = unknown,
+  SData = unknown
+> =
   | InfiniteQueryObserverIdleResult<TData, TError, SData>
   | InfiniteQueryObserverLoadingErrorResult<TData, TError, SData>
   | InfiniteQueryObserverLoadingResult<TData, TError, SData>

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -41,12 +41,14 @@ export interface UseInfiniteQueryOptions<
   TError = unknown,
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey
+  SData = unknown,
+  TQueryKey extends QueryKey = QueryKey,
 > extends InfiniteQueryObserverOptions<
     TQueryFnData,
     TError,
     TData,
     TQueryData,
+    SData,
     TQueryKey
   > {}
 
@@ -62,8 +64,9 @@ export type UseQueryResult<
 
 export type UseInfiniteQueryResult<
   TData = unknown,
-  TError = unknown
-> = InfiniteQueryObserverResult<TData, TError>
+  TError = unknown,
+  SData = unknown
+> = InfiniteQueryObserverResult<TData, TError, SData>
 
 export interface UseMutationOptions<
   TData = unknown,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -42,7 +42,7 @@ export interface UseInfiniteQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   SData = unknown,
-  TQueryKey extends QueryKey = QueryKey,
+  TQueryKey extends QueryKey = QueryKey
 > extends InfiniteQueryObserverOptions<
     TQueryFnData,
     TError,

--- a/src/react/useInfiniteQuery.ts
+++ b/src/react/useInfiniteQuery.ts
@@ -11,6 +11,7 @@ export function useInfiniteQuery<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
+  SData = unknown,
   TQueryKey extends QueryKey = QueryKey
 >(
   options: UseInfiniteQueryOptions<
@@ -18,13 +19,15 @@ export function useInfiniteQuery<
     TError,
     TData,
     TQueryFnData,
+    SData,
     TQueryKey
   >
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<TData, TError, SData>
 export function useInfiniteQuery<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
+  SData = unknown,
   TQueryKey extends QueryKey = QueryKey
 >(
   queryKey: TQueryKey,
@@ -34,15 +37,17 @@ export function useInfiniteQuery<
       TError,
       TData,
       TQueryFnData,
+      SData,
       TQueryKey
     >,
     'queryKey'
   >
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<TData, TError, SData>
 export function useInfiniteQuery<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
+  SData = unknown,
   TQueryKey extends QueryKey = QueryKey
 >(
   queryKey: TQueryKey,
@@ -53,15 +58,17 @@ export function useInfiniteQuery<
       TError,
       TData,
       TQueryFnData,
+      SData,
       TQueryKey
     >,
     'queryKey' | 'queryFn'
   >
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<TData, TError, SData>
 export function useInfiniteQuery<
   TQueryFnData,
   TError,
   TData = TQueryFnData,
+  SData = unknown,
   TQueryKey extends QueryKey = QueryKey
 >(
   arg1:
@@ -71,6 +78,7 @@ export function useInfiniteQuery<
         TError,
         TData,
         TQueryFnData,
+        SData,
         TQueryKey
       >,
   arg2?:
@@ -80,6 +88,7 @@ export function useInfiniteQuery<
         TError,
         TData,
         TQueryFnData,
+        SData,
         TQueryKey
       >,
   arg3?: UseInfiniteQueryOptions<
@@ -87,12 +96,14 @@ export function useInfiniteQuery<
     TError,
     TData,
     TQueryFnData,
+    SData,
     TQueryKey
   >
-): UseInfiniteQueryResult<TData, TError> {
+): UseInfiniteQueryResult<TData, TError, SData> {
   const options = parseQueryArgs(arg1, arg2, arg3)
   return useBaseQuery(
     options,
     InfiniteQueryObserver as typeof QueryObserver
-  ) as UseInfiniteQueryResult<TData, TError>
+  ) as UseInfiniteQueryResult<TData, TError, SData>
 }
+

--- a/src/react/useInfiniteQuery.ts
+++ b/src/react/useInfiniteQuery.ts
@@ -106,4 +106,3 @@ export function useInfiniteQuery<
     InfiniteQueryObserver as typeof QueryObserver
   ) as UseInfiniteQueryResult<TData, TError, SData>
 }
-


### PR DESCRIPTION
Test: https://codesandbox.io/s/tannerlinsley-react-query-forked-gw8jm2?file=/src/index.tsx

Currently the type returned by `useInfiniteQuery` is not honoring the result of the `select` function.  This is due to the fact that it is wrapped at one point in `InfiniteData<TData>` which strips the context once it is passed to the `Query` which doesn't have any wrapping. 

The solution was to allow `InfiniteData` to have two parameters, one would be the normal `TData` and the other is a type parameter `SData` which represents the result of the select fn.  This way it doesn't strip the context and can store both.  The SData ends up taking precedence, but rules do still exist:

- Select must return a compatible type to `InfiniteData<TData>` (it must have a pages and pagesParams property and both must be arrays, but they can be made a diff type if needed). 
- Any extra keys can be returned on top of those keys and the type is automatically inferred.

Such that:

```ts
type FetchResult = {
  totalPages: number;
  page: number;
  items: {
    n: number;
  }[];
};

async function exampleFetch(page: number): Promise<FetchResult> {
  return {
    totalPages: 50,
    page,
    items: [{ n: page + 1 }, { n: page + 2 }, { n: page + 3 }],
  };
}

/*

function transformResult(data: InfiniteData<FetchResult>) {
  return {
    ...data,
    items: data.pages.flatMap(x => x.items),
  };
}

export function useExampleInfiniteQuery() {
  const result = useInfiniteQuery({
    queryKey: ['example'],
    queryFn: ({ pageParam = 1 }) => exampleFetch(pageParam),
    getNextPageParam: (lastPage: FetchResult) =>
      lastPage.page === lastPage.totalPages ? undefined : lastPage.page + 1,
    getPreviousPageParam: () => undefined,
    select: useCallback(data => transformResult(data), []),
  });
  
  // correct
  const data: InfiniteData<FetchResult, {
    items: {
        n: number;
    }[];
  }> | undefined = result.data

  return result.data?.items;
}
```

<img width="274" alt="image" src="https://user-images.githubusercontent.com/15365418/169220360-2b1a3dfe-de36-4c85-b631-cd229a339ba1.png">

It also allows overwriting the `pages` and `pagesParams` keys, but it will error if the return transformation does not include them and they must be arrays.

So:

```ts
// @ts-expect-error - type must have pages and pageParams arrays
function transformResult(data: InfiniteData<FetchResult>) {
  return {
    items: data.pages.flatMap(x => x.items),
  };
}


/*
InfiniteData<never, {
    pages: never[];
    pageParams: never[];
    items: {
        n: number;
    }[];
}>
*/
function transformResult(data: InfiniteData<FetchResult>) {
  return {
    pages: [],
    pageParams: [],
    items: data.pages.flatMap(x => x.items),
  };
}

/*
InfiniteData<number, {
    pages: number[];
    pageParams: number[];
    items: {
        n: number;
    }[];
}>
*/
function transformResult(data: InfiniteData<FetchResult>) {
  return {
    pages: [1, 2, 3],
    pageParams: [1, 2, 3],
    items: data.pages.flatMap(x => x.items),
  };
}
```


closes #3065