### PR TITLE
Update method query observer base result

### DIFF
--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -25,6 +25,7 @@ const {
   isSuccess,
   refetch,
   remove,
+  update,
   status,
 } = useQuery(queryKey, queryFn?, {
   cacheTime,
@@ -246,3 +247,7 @@ const result = useQuery({
   - If `cancelRefetch` is `true`, then the current request will be cancelled before a new request is made
 - `remove: () => void`
   - A function to remove the query from the cache.
+- `update: (updater: TData | (oldData: TData | undefined) => TData) => void`
+  - A convenience function to optimistically update the query.
+  - It calls [`queryClient.setQueryData`](../reference/QueryClient#queryclientsetquerydata) internally with the key that was provided to the `useQuery` hook
+  - If its called without providing a query key to the `useQuery` hook, it will throw a warning in the console

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -1,4 +1,4 @@
-import { RefetchQueryFilters } from './types'
+import { RefetchQueryFilters, SetDataOptions } from './types'
 import {
   isServer,
   isValidTimeout,
@@ -99,6 +99,7 @@ export class QueryObserver<
   protected bindMethods(): void {
     this.remove = this.remove.bind(this)
     this.refetch = this.refetch.bind(this)
+    this.update = this.update.bind(this)
   }
 
   protected onSubscribe(): void {
@@ -309,6 +310,18 @@ export class QueryObserver<
       ...options,
       meta: { refetchPage: options?.refetchPage },
     })
+  }
+
+  update(updater: any, setDataOptions?: SetDataOptions | undefined) {
+    if (this?.options?.queryKey) {
+      return this.client.setQueryData(
+        this.options.queryKey,
+        updater,
+        setDataOptions
+      )
+    }
+
+    getLogger().warn('Called update on a query without queryKey being set')
   }
 
   fetchOptimistic(
@@ -604,6 +617,7 @@ export class QueryObserver<
       isStale: isStale(query, options),
       refetch: this.refetch,
       remove: this.remove,
+      update: this.update,
     }
 
     return result as QueryObserverResult<TData, TError>

--- a/src/core/tests/queryObserver.test.tsx
+++ b/src/core/tests/queryObserver.test.tsx
@@ -814,4 +814,18 @@ describe('queryObserver', () => {
 
     unsubscribe()
   })
+
+  test('optimistically update result after calling the update method', async () => {
+    const key = queryKey()
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => Promise.reject({ count: 1 }),
+    })
+
+    observer.update({ count: 2 })
+
+    expect(observer.getOptimisticResult(observer.options)).toMatchObject({
+      data: { count: 2 },
+    })
+  })
 })

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -346,6 +346,7 @@ export interface QueryObserverBaseResult<TData = unknown, TError = unknown> {
     options?: RefetchOptions & RefetchQueryFilters<TPageData>
   ) => Promise<QueryObserverResult<TData, TError>>
   remove: () => void
+  update: (updater: any, setDataOptions?: SetDataOptions | undefined) => void
   status: QueryStatus
 }
 

--- a/src/react/tests/useInfiniteQuery.test.tsx
+++ b/src/react/tests/useInfiniteQuery.test.tsx
@@ -95,6 +95,7 @@ describe('useInfiniteQuery', () => {
       isSuccess: false,
       refetch: expect.any(Function),
       remove: expect.any(Function),
+      update: expect.any(Function),
       status: 'loading',
     })
 
@@ -126,6 +127,7 @@ describe('useInfiniteQuery', () => {
       isSuccess: true,
       refetch: expect.any(Function),
       remove: expect.any(Function),
+      update: expect.any(Function),
       status: 'success',
     })
   })


### PR DESCRIPTION
The aim of this pr is to expose a convenience `update` function that has the query key in its closure scope and internally calls `queryClient.setQueryData(key, updater)`.

In many cases, there is a need to optimistically update query data inside the same component that calls `useQuery`, so instead of using `queryClient.setQueryData(key, updater)`, `update` comes preloaded with the right query key in its closure scope and internally calls `queryClient.setQueryData(key, updater)`.

So it allows for the following
```javascript
function MyComponent {
 const { update } = useQuery(key, ...);

 const issueApiRequest = (newValue) => {
   update(newValue);
   fetch(...);
 }
}

```

instead of
```javascript
function MyComponent {
 const { update } = useQuery(key, ...);
 const queryClient = useQueryClient();

 const issueApiRequest = (newValue) => {
   queryClient.setQueryData(key, newValue);
   fetch(...);
 }
}
```
