### PR TITLE
feat: Add move devtools select menu

### DIFF
--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -59,6 +59,9 @@ function App() {
 - `position?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
   - Defaults to `bottom-left`
   - The position of the React Query logo to open and close the devtools panel
+- `panelPosition?: "top" | "bottom" | "left" | "right"`
+  - Defaults to `bottom`
+  - The position of the React Query devtools panel
 - `context?: React.Context<QueryClient | undefined>`
   - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
@@ -87,3 +90,7 @@ Use these options to style the dev tools.
   - The standard React style object used to style a component with inline styles
 - `className: string`
   - The standard React className property used to style a component with classes
+- `showCloseButton?: boolean`
+  - Show a close button inside the devtools panel
+- `closeButtonProps: PropsObject`
+  - Use this to add props to the close button. For example, you can add `className`, `style` (merge and override default style), `onClick` (extend default handler), etc.

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -763,4 +763,103 @@ describe('ReactQueryDevtools', () => {
       consoleErrorMock.mockRestore()
     })
   })
+
+  it('should render a menu to select panel position', async () => {
+    const { queryClient } = createQueryClient()
+
+    function Page() {
+      const { data = 'default' } = useQuery(['check'], async () => 'test')
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    renderWithClient(queryClient, <Page />, {
+      initialIsOpen: true,
+    })
+
+    const positionSelect = (await screen.findByLabelText(
+      'Panel position'
+    )) as HTMLSelectElement
+
+    expect(positionSelect.value).toBe('bottom')
+  })
+
+  it(`should render the panel to the left if panelPosition is set to 'left'`, async () => {
+    const { queryClient } = createQueryClient()
+
+    function Page() {
+      const { data = 'default' } = useQuery(['check'], async () => 'test')
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    renderWithClient(queryClient, <Page />, {
+      initialIsOpen: true,
+      panelPosition: 'left',
+    })
+
+    const positionSelect = (await screen.findByLabelText(
+      'Panel position'
+    )) as HTMLSelectElement
+
+    expect(positionSelect.value).toBe('left')
+
+    const panel = (await screen.getByLabelText(
+      'React Query Devtools Panel'
+    )) as HTMLDivElement
+
+    expect(panel.style.left).toBe('0px')
+    expect(panel.style.width).toBe('500px')
+    expect(panel.style.height).toBe('100vh')
+  })
+
+  it('should change the panel position if user select different option from the menu', async () => {
+    const { queryClient } = createQueryClient()
+
+    function Page() {
+      const { data = 'default' } = useQuery(['check'], async () => 'test')
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    renderWithClient(queryClient, <Page />, {
+      initialIsOpen: true,
+    })
+
+    const positionSelect = (await screen.findByLabelText(
+      'Panel position'
+    )) as HTMLSelectElement
+
+    expect(positionSelect.value).toBe('bottom')
+
+    const panel = (await screen.getByLabelText(
+      'React Query Devtools Panel'
+    )) as HTMLDivElement
+
+    expect(panel.style.bottom).toBe('0px')
+    expect(panel.style.height).toBe('500px')
+    expect(panel.style.width).toBe('100%')
+
+    await act(async () => {
+      fireEvent.change(positionSelect, { target: { value: 'right' } })
+    })
+
+    expect(positionSelect.value).toBe('right')
+
+    expect(panel.style.right).toBe('0px')
+    expect(panel.style.width).toBe('500px')
+    expect(panel.style.height).toBe('100vh')
+  })
 })

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -23,6 +23,7 @@ import {
   getSidedProp,
   useIsomorphicEffect,
   isServer,
+  defaultPanelSize,
 } from './utils'
 
 import {
@@ -140,13 +141,13 @@ export function ReactQueryDevtools({
     'reactQueryDevtoolsOpen',
     initialIsOpen,
   )
-  const [devtoolsHeight, setDevtoolsHeight] = useLocalStorage<number | null>(
+  const [devtoolsHeight, setDevtoolsHeight] = useLocalStorage<number>(
     'reactQueryDevtoolsHeight',
-    null,
+    defaultPanelSize,
   )
-  const [devtoolsWidth, setDevtoolsWidth] = useLocalStorage<number | null>(
+  const [devtoolsWidth, setDevtoolsWidth] = useLocalStorage<number>(
     'reactQueryDevtoolsWidth',
-    null,
+    defaultPanelSize,
   )
 
   const [panelPosition = 'bottom', setPanelPosition] = useLocalStorage<Side>(
@@ -184,16 +185,14 @@ export function ReactQueryDevtools({
           (panelPosition === 'right'
             ? startX - moveEvent.clientX
             : moveEvent.clientX - startX)
-        // directly apply the style to the dom element for a smother animation
-        // hint: we sync state to localStorage which makes resize sluggish if we relied on it instead of direct dom access
-        panelElement.style.width = `${newSize}px`
+        setDevtoolsWidth(newSize)
       } else {
         newSize =
           height +
           (panelPosition === 'bottom'
             ? startY - moveEvent.clientY
             : moveEvent.clientY - startY)
-        panelElement.style.height = `${newSize}px`
+        setDevtoolsHeight(newSize)
       }
 
       if (newSize < minPanelSize) {
@@ -205,14 +204,7 @@ export function ReactQueryDevtools({
 
     const unsub = () => {
       if (isResizing) {
-        // save the new size to localStorage
-        if (isVertical) {
-          setDevtoolsWidth(newSize)
-        } else {
-          setDevtoolsHeight(newSize)
-        }
         setIsResizing(false)
-        newSize = 0
       }
 
       document.removeEventListener('mousemove', run, false)

--- a/packages/react-query-devtools/src/utils.ts
+++ b/packages/react-query-devtools/src/utils.ts
@@ -99,12 +99,18 @@ export function styled<T extends keyof HTMLElementTagNameMap>(
     },
   )
 }
+/**
+ * Resolves to useEffect when "window" is not in scope and useLayoutEffect in the browser
+ */
+export const useIsomorphicEffect = isServer
+  ? React.useEffect
+  : React.useLayoutEffect
 
 export function useIsMounted() {
   const mountedRef = React.useRef(false)
   const isMounted = React.useCallback(() => mountedRef.current, [])
 
-  React[isServer ? 'useEffect' : 'useLayoutEffect'](() => {
+  useIsomorphicEffect(() => {
     mountedRef.current = true
     return () => {
       mountedRef.current = false
@@ -123,4 +129,159 @@ export const displayValue = (value: unknown) => {
   const newValue = typeof value === 'bigint' ? `${value.toString()}n` : value
 
   return JSON.stringify(newValue, name)
+}
+
+export const minPanelSize = 70
+export const defaultPanelSize = 500
+export const sides: Record<Side, Side> = {
+  top: 'bottom',
+  bottom: 'top',
+  left: 'right',
+  right: 'left',
+}
+
+export type Corner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+export type Side = 'left' | 'right' | 'top' | 'bottom'
+/**
+ * Check if the given side is vertical (left/right)
+ */
+export function isVerticalSide(side: Side) {
+  return ['left', 'right'].includes(side)
+}
+/**
+ * Get the opposite side, eg 'left' => 'right'. 'top' => 'bottom', etc
+ */
+export function getOppositeSide(side: Side): Side {
+  return sides[side]
+}
+/**
+ * Given as css prop it will return a sided css prop based on a given side
+ * Example given `border` and `right` it return `borderRight`
+ */
+export function getSidedProp<T extends string>(prop: T, side: Side) {
+  return `${prop}${
+    side.charAt(0).toUpperCase() + side.slice(1)
+  }` as `${T}${Capitalize<Side>}`
+}
+
+export interface SidePanelStyleOptions {
+  /**
+   * Position of the panel
+   * Defaults to 'bottom'
+   */
+  position?: Side
+  /**
+   * Staring height for the panel, it is set if the position is horizontal eg 'top' or 'bottom'
+   * Defaults to 500
+   */
+  height?: React.CSSProperties['height'] | null
+  /**
+   * Staring width for the panel, it is set if the position is vertical eg 'left' or 'right'
+   * Defaults to 500
+   */
+  width?: React.CSSProperties['width'] | null
+  /**
+   * RQ devtools theme
+   */
+  devtoolsTheme: Theme
+  /**
+   * Sets the correct transition and visibility styles
+   */
+  isOpen?: boolean
+  /**
+   * If the panel is resizing set to true to apply the correct transition styles
+   */
+  isResizing?: boolean
+  /**
+   * Extra panel style passed by the user
+   */
+  panelStyle?: React.CSSProperties
+}
+
+export function getSidePanelStyle({
+  position = 'bottom',
+  height: devtoolsHeight,
+  width: devtoolsWidth,
+  devtoolsTheme,
+  isOpen,
+  isResizing,
+  panelStyle,
+}: SidePanelStyleOptions): React.CSSProperties {
+  const oppositeSide = getOppositeSide(position)
+  const borderSide = getSidedProp('border', oppositeSide)
+  const isVertical = isVerticalSide(position)
+
+  return {
+    ...panelStyle,
+    position: 'fixed',
+    [position]: 0,
+    [borderSide]: `1px solid ${devtoolsTheme.gray}`,
+    transformOrigin: oppositeSide,
+    boxShadow: '0 0 20px rgba(0,0,0,.3)',
+    zIndex: 99999,
+    // visibility will be toggled after transitions, but set initial state here
+    visibility: isOpen ? 'visible' : 'hidden',
+    ...(isResizing
+      ? {
+          transition: `none`,
+        }
+      : { transition: `all .2s ease` }),
+    ...(isOpen
+      ? {
+          opacity: 1,
+          pointerEvents: 'all',
+          transform: isVertical
+            ? `translateX(0) scale(1)`
+            : `translateY(0) scale(1)`,
+        }
+      : {
+          opacity: 0,
+          pointerEvents: 'none',
+          transform: isVertical
+            ? `translateX(15px) scale(1.02)`
+            : `translateY(15px) scale(1.02)`,
+        }),
+    ...(isVertical
+      ? {
+          top: 0,
+          height: '100vh',
+          maxWidth: '90%',
+          width: devtoolsWidth ?? defaultPanelSize,
+        }
+      : {
+          left: 0,
+          width: '100%',
+          maxHeight: '90%',
+          height: devtoolsHeight ?? defaultPanelSize,
+        }),
+  }
+}
+
+/**
+ * Get resize handle style based on a given side
+ */
+export function getResizeHandleStyle(
+  position: Side = 'bottom'
+): React.CSSProperties {
+  const isVertical = isVerticalSide(position)
+  const oppositeSide = getOppositeSide(position)
+  const marginSide = getSidedProp('margin', oppositeSide)
+
+  return {
+    position: 'absolute',
+    cursor: isVertical ? 'col-resize' : 'row-resize',
+    zIndex: 100000,
+    [oppositeSide]: 0,
+    [marginSide]: `-4px`,
+    ...(isVertical
+      ? {
+          top: 0,
+          height: '100%',
+          width: '4px',
+        }
+      : {
+          width: '100%',
+          height: '4px',
+        }),
+  }
 }

--- a/packages/react-query-devtools/src/utils.ts
+++ b/packages/react-query-devtools/src/utils.ts
@@ -174,12 +174,12 @@ export interface SidePanelStyleOptions {
    * Staring height for the panel, it is set if the position is horizontal eg 'top' or 'bottom'
    * Defaults to 500
    */
-  height?: React.CSSProperties['height'] | null
+  height?: number
   /**
    * Staring width for the panel, it is set if the position is vertical eg 'left' or 'right'
    * Defaults to 500
    */
-  width?: React.CSSProperties['width'] | null
+  width?: number
   /**
    * RQ devtools theme
    */
@@ -200,8 +200,8 @@ export interface SidePanelStyleOptions {
 
 export function getSidePanelStyle({
   position = 'bottom',
-  height: devtoolsHeight,
-  width: devtoolsWidth,
+  height,
+  width,
   devtoolsTheme,
   isOpen,
   isResizing,
@@ -246,13 +246,19 @@ export function getSidePanelStyle({
           top: 0,
           height: '100vh',
           maxWidth: '90%',
-          width: devtoolsWidth ?? defaultPanelSize,
+          width:
+            typeof width === 'number' && width >= minPanelSize
+              ? width
+              : defaultPanelSize,
         }
       : {
           left: 0,
           width: '100%',
           maxHeight: '90%',
-          height: devtoolsHeight ?? defaultPanelSize,
+          height:
+            typeof height === 'number' && height >= minPanelSize
+              ? height
+              : defaultPanelSize,
         }),
   }
 }


### PR DESCRIPTION
Added the option to move devtools to one of these sides `left`,  `right`, `top`, and `bottom` and refactored the code to accommodate the new capability

closes https://github.com/TanStack/query/issues/2994 