### PR TITLE
fix(devtools): stop devtools explorer from un-expanding when data is fetched

### DIFF
--- a/src/devtools/Explorer.tsx
+++ b/src/devtools/Explorer.tsx
@@ -67,7 +67,7 @@ type Entry = {
 }
 
 type RendererProps = {
-  handleEntry: (entry: Entry) => JSX.Element,
+  handleEntry: (entry: Entry) => JSX.Element
   label?: string
   value: unknown
   subEntries: Entry[]
@@ -126,9 +126,7 @@ export const DefaultRenderer: Renderer = ({
           </ExpandButton>
           {expanded ? (
             subEntryPages.length === 1 ? (
-              <SubEntries>
-                {subEntries.map(handleEntry)}
-              </SubEntries>
+              <SubEntries>{subEntries.map(handleEntry)}</SubEntries>
             ) : (
               <SubEntries>
                 {subEntryPages.map((entries, index) => (
@@ -147,9 +145,7 @@ export const DefaultRenderer: Renderer = ({
                         {index * pageSize + pageSize - 1}]
                       </LabelButton>
                       {expandedPages.includes(index) ? (
-                        <SubEntries>
-                          {entries.map(handleEntry)}
-                        </SubEntries>
+                        <SubEntries>{entries.map(handleEntry)}</SubEntries>
                       ) : null}
                     </Entry>
                   </div>
@@ -240,8 +236,14 @@ export default function Explorer({
   const subEntryPages = chunkArray(subEntries, pageSize)
 
   return renderer({
-    handleEntry: (entry) => (
-      <Explorer key={entry.label} value={value} renderer={renderer} {...rest} {...entry} />
+    handleEntry: entry => (
+      <Explorer
+        key={entry.label}
+        value={value}
+        renderer={renderer}
+        {...rest}
+        {...entry}
+      />
     ),
     type,
     subEntries,

--- a/src/devtools/Explorer.tsx
+++ b/src/devtools/Explorer.tsx
@@ -67,7 +67,7 @@ type Entry = {
 }
 
 type RendererProps = {
-  HandleEntry: HandleEntryComponent
+  handleEntry: (entry: Entry) => JSX.Element,
   label?: string
   value: unknown
   subEntries: Entry[]
@@ -101,7 +101,7 @@ export function chunkArray<T>(array: T[], size: number): T[][] {
 type Renderer = (props: RendererProps) => JSX.Element
 
 export const DefaultRenderer: Renderer = ({
-  HandleEntry,
+  handleEntry,
   label,
   value,
   subEntries = [],
@@ -127,9 +127,7 @@ export const DefaultRenderer: Renderer = ({
           {expanded ? (
             subEntryPages.length === 1 ? (
               <SubEntries>
-                {subEntries.map(entry => (
-                  <HandleEntry key={entry.label} entry={entry} />
-                ))}
+                {subEntries.map(handleEntry)}
               </SubEntries>
             ) : (
               <SubEntries>
@@ -150,9 +148,7 @@ export const DefaultRenderer: Renderer = ({
                       </LabelButton>
                       {expandedPages.includes(index) ? (
                         <SubEntries>
-                          {entries.map(entry => (
-                            <HandleEntry key={entry.label} entry={entry} />
-                          ))}
+                          {entries.map(handleEntry)}
                         </SubEntries>
                       ) : null}
                     </Entry>
@@ -170,8 +166,6 @@ export const DefaultRenderer: Renderer = ({
     </Entry>
   )
 }
-
-type HandleEntryComponent = (props: { entry: Entry }) => JSX.Element
 
 type ExplorerProps = Partial<RendererProps> & {
   renderer?: Renderer
@@ -246,8 +240,8 @@ export default function Explorer({
   const subEntryPages = chunkArray(subEntries, pageSize)
 
   return renderer({
-    HandleEntry: ({ entry }) => (
-      <Explorer value={value} renderer={renderer} {...rest} {...entry} />
+    handleEntry: (entry) => (
+      <Explorer key={entry.label} value={value} renderer={renderer} {...rest} {...entry} />
     ),
     type,
     subEntries,

--- a/src/devtools/tests/Explorer.test.tsx
+++ b/src/devtools/tests/Explorer.test.tsx
@@ -39,7 +39,7 @@ describe('Explorer', () => {
           pageSize={10}
           expanded={false}
           subEntryPages={[[{ label: 'A lovely label' }]]}
-          HandleEntry={() => <></>}
+          handleEntry={() => <></>}
           value={undefined}
           subEntries={[]}
           type="string"


### PR DESCRIPTION
Fixes #3681 

Reverts the change in #2949 from function `handleEntry` to component `HandleEntry`, but keeps the added types.
I'm not actually sure why that fixes the un-expanding, but it does.