### PR TITLE
Fix Best of JS badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Hooks for fetching, caching and updating asynchronous data in React
     <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
   </a><a href="https://github.com/tannerlinsley/react-query/discussions">
   <img alt="Join the discussion on Github" src="https://img.shields.io/badge/Github%20Discussions%20%26%20Support-Chat%20now!-blue" />
-</a><a href="https://bestofjs.org/projects/react-query"><img alt="Best of JS" src="https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=tannerlinsley%2Freact-query%26since=daily" /></a><a href="https://github.com/tannerlinsley/react-query" target="\_parent">
+</a><a href="https://bestofjs.org/projects/react-query"><img alt="Best of JS" src="https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=TanStack%2Fquery%26since=daily" /></a><a href="https://github.com/tannerlinsley/react-query" target="\_parent">
   <img alt="" src="https://img.shields.io/github/stars/tannerlinsley/react-query.svg?style=social&label=Star" />
 </a><a href="https://twitter.com/tannerlinsley" target="\_parent">
   <img alt="" src="https://img.shields.io/twitter/follow/tannerlinsley.svg?style=social&label=Follow" />


### PR DESCRIPTION
Hello Tanner, this is Michael from [Best of JS](https://bestofjs.org/).

The badge that should display the number of stars added "since yesterday" currently displays nothing.

![image](https://user-images.githubusercontent.com/5546996/172997770-abcc3a13-bca1-4473-bc2e-817d179ff7cb.png)

The reason: the repo has moved from `tannerlinsley/react-query`.

This PR updates the repo location in the URL used to fetch data.

Keep up the great work! 😄 