### PR TITLE
docs: stabilise query client in quick start guide

### DIFF
--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -23,9 +23,13 @@ import { getTodos, postTodo } from '../my-api'
 const queryClient = new QueryClient()
 
 function App() {
+
+  //Stabilise the client between renders
+  const [client] = useState(queryClient)
+
   return (
     // Provide the client to your App
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={client}>
       <Todos />
     </QueryClientProvider>
   )


### PR DESCRIPTION
This caused me some pain when initially learning react query. HMR would break when I added functionality like error toasts to the global onError handlers. I figure wrapping the query client in a useState hook would be sensible default. 