### PR TITLE
fix(devtools): make sure that sort function is properly read from localStorage

### DIFF
--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -577,14 +577,12 @@ describe('ReactQueryDevtools', () => {
       initialIsOpen: true,
     })
 
-    const filterInput: HTMLInputElement = screen.getByLabelText(
-      /Filter by queryhash/i
-    )
+    const filterInput: HTMLInputElement =
+      screen.getByLabelText(/Filter by queryhash/i)
     expect(filterInput.value).toEqual('')
 
-    const sortCombobox: HTMLSelectElement = screen.getByLabelText(
-      /Sort queries/i
-    )
+    const sortCombobox: HTMLSelectElement =
+      screen.getByLabelText(/Sort queries/i)
     expect(sortCombobox.value).toEqual(Object.keys(sortFns)[0])
 
     expect(screen.getByRole('button', { name: /Asc/i })).toBeInTheDocument()
@@ -597,7 +595,7 @@ describe('ReactQueryDevtools', () => {
     localStorage.setItem('reactQueryDevtoolsSortDesc', 'true')
     localStorage.setItem(
       'reactQueryDevtoolsSortFn',
-      JSON.stringify(Object.keys(sortFns)[1])
+      JSON.stringify(Object.keys(sortFns)[1]),
     )
 
     const { queryClient } = createQueryClient()
@@ -619,9 +617,8 @@ describe('ReactQueryDevtools', () => {
       initialIsOpen: true,
     })
 
-    const sortCombobox: HTMLSelectElement = screen.getByLabelText(
-      /Sort queries/i
-    )
+    const sortCombobox: HTMLSelectElement =
+      screen.getByLabelText(/Sort queries/i)
     expect(sortCombobox.value).toEqual(Object.keys(sortFns)[1])
 
     expect(screen.getByRole('button', { name: /Desc/i })).toBeInTheDocument()
@@ -649,9 +646,8 @@ describe('ReactQueryDevtools', () => {
       initialIsOpen: true,
     })
 
-    const filterInput: HTMLInputElement = screen.getByLabelText(
-      /Filter by queryhash/i
-    )
+    const filterInput: HTMLInputElement =
+      screen.getByLabelText(/Filter by queryhash/i)
     expect(filterInput.value).toEqual('posts')
   })
 

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -587,7 +587,7 @@ describe('ReactQueryDevtools', () => {
     )
     expect(sortCombobox.value).toEqual(Object.keys(sortFns)[0])
 
-    screen.getByRole('button', { name: /Asc/i })
+    expect(screen.getByRole('button', { name: /Asc/i })).toBeInTheDocument()
 
     const detailsPanel = screen.queryByText(/Query Details/i)
     expect(detailsPanel).not.toBeInTheDocument()
@@ -624,7 +624,7 @@ describe('ReactQueryDevtools', () => {
     )
     expect(sortCombobox.value).toEqual(Object.keys(sortFns)[1])
 
-    screen.getByRole('button', { name: /Desc/i })
+    expect(screen.getByRole('button', { name: /Desc/i })).toBeInTheDocument()
   })
 
   it('should initialize filter value with one stored in localstorage', () => {

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -384,7 +384,7 @@ const getStatusRank = (q: Query) =>
     ? 2
     : 1
 
-const sortFns: Record<string, (a: Query, b: Query) => number> = {
+export const sortFns: Record<string, (a: Query, b: Query) => number> = {
   'Status > Last Updated': (a, b) =>
     getStatusRank(a) === getStatusRank(b)
       ? (sortFns['Last Updated']?.(a, b) as number)
@@ -440,12 +440,6 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
   )
 
   const sortFn = React.useMemo(() => sortFns[sort as string], [sort])
-
-  React[isServer ? 'useEffect' : 'useLayoutEffect'](() => {
-    if (!sortFn) {
-      setSort(Object.keys(sortFns)[0] as string)
-    }
-  }, [setSort, sortFn])
 
   const queriesCount = useSubscribeToQueryCache(
     queryCache,


### PR DESCRIPTION
Fix for: [#3639: DevTools doesn't remember the sort function](https://github.com/TanStack/query/issues/3639)

[This effect](https://github.com/TanStack/query/blob/19d755cb875056e34ac09d2a7aedeaf05632ebf3/src/devtools/devtools.tsx#L445-L449) is causing the problem. Good news is that it's also completely unneeded as it's doubling what's already done [via useLocalStorage](https://github.com/TanStack/query/blob/19d755cb875056e34ac09d2a7aedeaf05632ebf3/src/devtools/devtools.tsx#L431-L434). And if the runs after (which it usually does), it disregards the value that's read by `useLocalStorage` hook - which is exactly what causes the bug.

This is easily fixable by simply removing the effect.