### PR TITLE
docs: fix typo in mutations guide

### DIFF
--- a/docs/guides/mutations.md
+++ b/docs/guides/mutations.md
@@ -182,7 +182,7 @@ mutate(todo, {
 ### Consecutive mutations
 There is a slight difference in handling `onSuccess`, `onError` and `onSettled` callbacks when it comes to consecutive mutations. When passed to the `mutate` function, they will be fired up only _once_ and only if the component is still mounted.  This is due to the fact that mutation observer is removed and resubscribed every time when the `mutate` function is called. On the contrary, `useMutation` handlers execute for each `mutate` call.
 
-> Be aware that most likely, `mutationFn` passed to `useMutation` is ansynchronous. In that case, the order in which mutations are fulfilled may differ from the order of `mutate` function calls.
+> Be aware that most likely, `mutationFn` passed to `useMutation` is asynchronous. In that case, the order in which mutations are fulfilled may differ from the order of `mutate` function calls.
 
 ```js
 useMutation(addTodo, {


### PR DESCRIPTION
Fixed a (very minor) typo in the mutations guide 

Thanks for everything you're doing, love the library! ❤️