### PR TITLE
fix(docs): fix branch name bug

### DIFF
--- a/docs/src/pages/overview.md
+++ b/docs/src/pages/overview.md
@@ -44,7 +44,7 @@ On a more technical note, React Query will likely:
 
 In the example below, you can see React Query in its most basic and simple form being used to fetch the GitHub stats for the React Query GitHub project itself:
 
-[Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/master/examples/simple)
+[Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/simple)
 
 ```js
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query'


### PR DESCRIPTION
The renaming of the "master" branch to "main" branch broke all sandbox links. This PR fixed all Sandbox links :)