### PR TITLE
fix(core): added in timer and interval id checks before clearing

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -211,8 +211,10 @@ export class Query<
   }
 
   private clearGcTimeout() {
-    clearTimeout(this.gcTimeout)
-    this.gcTimeout = undefined
+    if (this.gcTimeout) {
+      clearTimeout(this.gcTimeout)
+      this.gcTimeout = undefined
+    }
   }
 
   private optionalRemove() {

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -440,7 +440,7 @@ export class QueryObserver<
   }
 
   private clearRefetchInterval(): void {
-    if (this.refetchIntervalId) { 
+    if (this.refetchIntervalId) {
       clearInterval(this.refetchIntervalId)
       this.refetchIntervalId = undefined
     }

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -433,13 +433,17 @@ export class QueryObserver<
   }
 
   private clearStaleTimeout(): void {
-    clearTimeout(this.staleTimeoutId)
-    this.staleTimeoutId = undefined
+    if (this.staleTimeoutId) {
+      clearTimeout(this.staleTimeoutId)
+      this.staleTimeoutId = undefined
+    }
   }
 
   private clearRefetchInterval(): void {
-    clearInterval(this.refetchIntervalId)
-    this.refetchIntervalId = undefined
+    if (this.refetchIntervalId) { 
+      clearInterval(this.refetchIntervalId)
+      this.refetchIntervalId = undefined
+    }
   }
 
   protected createResult(


### PR DESCRIPTION
[`clearInterval` and `clearTimeout` are expensive to run](https://jsbench.me/mjl4ybxzwe/1) and should only be ran if there is for sure an id to be cleared. This PR adds the checks in as discussed in #3756 