### PR TITLE
docs: fix the typo in persistQueryClient.md

### DIFF
--- a/docs/plugins/persistQueryClient.md
+++ b/docs/plugins/persistQueryClient.md
@@ -175,7 +175,7 @@ persistQueryClient({
 ReactDOM.createRoot(rootElement).render(<App />)
 ```
 
-### PeristQueryClientProvider
+### PersistQueryClientProvider
 
 For this use-case, you can use the `PersistQueryClientProvider`. It will make sure to subscribe / unsubscribe correctly according to the React component lifecycle, and it will also make sure that queries will not start fetching while we are still restoring. Queries will still render though, they will just be put into `fetchingState: 'idle'` until data has been restored. Then, they will refetch unless the restored data is _fresh_ enough, and _initialData_ will also be respected. It can be used _instead of_ the normal [QueryClientProvider](../reference/QueryClientProvider):
 


### PR DESCRIPTION
Update subtitle `PeristQueryClientProvider` to `PersistQueryClientProvider`.