### PR TITLE
Fix the npm installation snippet

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ or a good ol' `<script>` via
 ### NPM
 
 ```bash
-$ npm i @tanstack/react-query
+$ npm i react-query
 ```
 
 React Query is compatible with React v16.8+ and works with ReactDOM and React Native.


### PR DESCRIPTION
The `@tanstack/react-query` is not found and npm ended with to 404.