### PR TITLE
Update link to the `network-mode` page

### DIFF
--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -98,7 +98,7 @@ TypeScript will also narrow the type of `data` correctly if you've checked for `
 In addition to the `status` field, the `result` object, you will also get an additional `fetchStatus`property with the following options:
 
 - `fetchStatus === 'fetching'` - The query is currently fetching.
-- `fetchStatus === 'paused'` - The query wanted to fetch, but it is paused. Read more about this in the [Network Mode](./network-mode) guide.
+- `fetchStatus === 'paused'` - The query wanted to fetch, but it is paused. Read more about this in the [Network Mode](https://tanstack.com/query/v4/docs/guides/network-mode) guide.
 - `fetchStatus === 'idle'` - The query is not doing anything at the moment.
 
 ### Why two different states?

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -5,7 +5,7 @@ title: Queries
 
 ## Query Basics
 
-A query is a declarative dependency on an asynchronous source of data that is tied to a **unique key**. A query can be used with any Promise based method (including GET and POST methods) to fetch data from a server. If your method modifies data on the server, we recommend using [Mutations](https://react-query.tanstack.com/docs/guides/mutations) instead.
+A query is a declarative dependency on an asynchronous source of data that is tied to a **unique key**. A query can be used with any Promise based method (including GET and POST methods) to fetch data from a server. If your method modifies data on the server, we recommend using [Mutations](../guides/mutations) instead.
 
 To subscribe to a query in your components or custom hooks, call the `useQuery` hook with at least:
 
@@ -98,7 +98,7 @@ TypeScript will also narrow the type of `data` correctly if you've checked for `
 In addition to the `status` field, the `result` object, you will also get an additional `fetchStatus`property with the following options:
 
 - `fetchStatus === 'fetching'` - The query is currently fetching.
-- `fetchStatus === 'paused'` - The query wanted to fetch, but it is paused. Read more about this in the [Network Mode](https://tanstack.com/query/v4/docs/guides/network-mode) guide.
+- `fetchStatus === 'paused'` - The query wanted to fetch, but it is paused. Read more about this in the [Network Mode](../guides/network-mode) guide.
 - `fetchStatus === 'idle'` - The query is not doing anything at the moment.
 
 ### Why two different states?


### PR DESCRIPTION
The present link is a 404.
https://tanstack.com/query/v4/docs/guides/network-mode