### PR TITLE
Update useQuery.md

### DIFF
--- a/docs/reference/useQuery.md
+++ b/docs/reference/useQuery.md
@@ -175,6 +175,9 @@ const result = useQuery({
   - Optional
   - Defaults to `false`
   - If set, any previous `data` will be kept when fetching new data because the query key changed.
+- `isDataEqual: (oldData: TData | undefined, newData: TData) => boolean`
+  - Optional
+  - This function should return boolean indicating whether to use previous `data` (`true`) or new data (`false`) as a resolved data for the query.
 - `structuralSharing: boolean`
   - Optional
   - Defaults to `true`


### PR DESCRIPTION
Issue : #3813 (isDataEqual is not explained in Docs)

I added an explanation of the `isDataEqual` option.  

----
Now I know what this option does, but I don't know in what case this option will be useful (maybe performace?).

Would you please give me some source code link or explanation ?