### PR TITLE
Fix react-query package types import path

### DIFF
--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -13,7 +13,7 @@
   "module": "build/esm/index.js",
   "main": "build/cjs/react-query/src/index.js",
   "browser": "build/umd/index.production.js",
-  "types": "build/types/packages/query-core/src/index.d.ts",
+  "types": "build/types/packages/react-query/src/index.d.ts",
   "sideEffects": [
     "lib/index.js",
     "lib/index.mjs",


### PR DESCRIPTION
There was a typo in react-query `package.json` that pointed to query-core types instead of react-query types. Tagging @tannerlinsley : I've seen your releases today and this bug was included in the v4.