### PR TITLE
fix: Adding screenreader text to the DevTools open icon

### DIFF
--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -13,6 +13,7 @@ import {
 import { rankItem, compareItems } from '@tanstack/match-sorter-utils'
 import useLocalStorage from './useLocalStorage'
 import { useIsMounted } from './utils'
+import ScreenReader from './screenreader';
 
 import {
   Panel,
@@ -369,14 +370,9 @@ export function ReactQueryDevtools({
           }}
         >
           <Logo aria-hidden />
-          <span style={{
-            position: "absolute",
-            width: "0.1px",
-            height: "0.1px", 
-            overflow: "hidden",
-          }} className="screenreader">
+          <ScreenReader>
             Open React Query Devtools
-          </span>
+          </ScreenReader>
         </button>
       ) : null}
     </Container>
@@ -568,6 +564,9 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
               }}
             >
               <Logo aria-hidden />
+              <ScreenReader>
+                Close React Query Devtools
+              </ScreenReader>
             </button>
             <div
               style={{

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -369,6 +369,14 @@ export function ReactQueryDevtools({
           }}
         >
           <Logo aria-hidden />
+          <span style={{
+            position: "absolute",
+            width: "0.1px",
+            height: "0.1px", 
+            overflow: "hidden",
+          }} className="screenreader">
+            Open React Query Devtools
+          </span>
         </button>
       ) : null}
     </Container>

--- a/packages/react-query-devtools/src/screenreader.tsx
+++ b/packages/react-query-devtools/src/screenreader.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+export default function ScreenReader(children: React.ReactNode) {
+  return (
+    <span
+      style={{
+        position: "absolute",
+        width: "0.1px",
+        height: "0.1px", 
+        overflow: "hidden",
+      }}
+      className="screenreader"
+    >
+      {children}
+    </span>
+  )
+}


### PR DESCRIPTION
While testing our local site with our [accessibility testing tool](https://github.com/bbc/bbc-a11y), we recieved the following error:

```
✗ Main Dashboard
  * Forms: Labelling form controls: Fields must have labels or titles
    - Button has no text: //div[@id='ReactQueryDevtoolsPanel']/div[2]/div[1]/button
    - Button has no text: //main[@id='main-content']/aside/button
```

The issue is that not all screenreaders support aria values, and so this test is checking that buttons at least have a text value within them, which can be visibility hidden if so required.

To resolve this, this PR adds visually hidden text to the button.

TODO:

- [ ] I'm still working out if this is the best way of doing it (I haven't been through all of the code yet)
- [ ] I need to test this locally to ensure it meets the requirements.