### PR TITLE
Change docs code-snippet types to tsx

### DIFF
--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -21,7 +21,7 @@ $ yarn add @tanstack/react-query-devtools
 
 You can import the devtools like this:
 
-```js
+```tsx
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 ```
 
@@ -33,7 +33,7 @@ Floating Mode will mount the devtools as a fixed, floating element in your app a
 
 Place the following code as high in your React app as you can. The closer it is to the root of the page, the better it will work!
 
-```js
+```tsx
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 function App() {
@@ -66,7 +66,7 @@ function App() {
 
 Embedded Mode will embed the devtools as a regular component in your application. You can style it however you'd like after that!
 
-```js
+```tsx
 import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools'
 
 function App() {

--- a/docs/guides/background-fetching-indicators.md
+++ b/docs/guides/background-fetching-indicators.md
@@ -5,7 +5,7 @@ title: Background Fetching Indicators
 
 A query's `status === 'loading'` state is sufficient enough to show the initial hard-loading state for a query, but sometimes you may want to display an additional indicator that a query is refetching in the background. To do this, queries also supply you with an `isFetching` boolean that you can use to show that it's in a fetching state, regardless of the state of the `status` variable:
 
-```js
+```tsx
 function Todos() {
   const { status, data: todos, error, isFetching } = useQuery(
     'todos',
@@ -34,7 +34,7 @@ function Todos() {
 
 In addition to individual query loading states, if you would like to show a global loading indicator when **any** queries are fetching (including in the background), you can use the `useIsFetching` hook:
 
-```js
+```tsx
 import { useIsFetching } from '@tanstack/react-query'
 
 function GlobalLoadingIndicator() {

--- a/docs/guides/custom-logger.md
+++ b/docs/guides/custom-logger.md
@@ -5,7 +5,7 @@ title: Custom Logger
 
 If you want to change how information is logged by React Query, you can set a custom logger when creating a `QueryClient`.
 
-```js
+```tsx
 const queryClient = new QueryClient({
   logger: {
     log: (...args) => {

--- a/docs/guides/default-query-function.md
+++ b/docs/guides/default-query-function.md
@@ -5,7 +5,7 @@ title: Default Query Function
 
 If you find yourself wishing for whatever reason that you could just share the same query function for your entire app and just use query keys to identify what it should fetch, you can do that by providing a **default query function** to React Query:
 
-```js
+```tsx
 // Define a default query function that will receive the query key
 const defaultQueryFn = async ({ queryKey }) => {
   const { data } = await axios.get(`https://jsonplaceholder.typicode.com${queryKey[0]}`);

--- a/docs/guides/dependent-queries.md
+++ b/docs/guides/dependent-queries.md
@@ -5,7 +5,7 @@ title: Dependent Queries
 
 Dependent (or serial) queries depend on previous ones to finish before they can execute. To achieve this, it's as easy as using the `enabled` option to tell a query when it is ready to run:
 
-```js
+```tsx
 // Get the user
 const { data: user } = useQuery(['user', email], getUserByEmail)
 
@@ -24,21 +24,21 @@ const { status, fetchStatus, data: projects } = useQuery(
 
 The `projects` query will start in:
 
-```js
+```tsx
 status: 'loading'
 fetchStatus: 'idle'
 ```
 
 As soon as the `user` is available, the `projects` query will be `enabled` and will then transition to:
 
-```js
+```tsx
 status: 'loading'
 fetchStatus: 'fetching'
 ```
 
 Once we have the projects, it will go to:
 
-```js
+```tsx
 status: 'success'
 fetchStatus: 'idle'
 ```

--- a/docs/guides/disabling-queries.md
+++ b/docs/guides/disabling-queries.md
@@ -16,7 +16,7 @@ When `enabled` is `false`:
 - The query will ignore query client `invalidateQueries` and `refetchQueries` calls that would normally result in the query refetching.
 - `refetch` returned from `useQuery` can be used to manually trigger the query to fetch.
 
-```jsx
+```tsxx
 function Todos() {
   const {
     isLoading,
@@ -65,7 +65,7 @@ Permanently disabling a query opts out of many great features that react-query h
 
 The enabled option can not only be used to permenantly disable a query, but also to enable / disable it at a later time. A good example would be a filter form where you only want to fire off the first request once the user has entered a filter value:
 
-```jsx
+```tsxx
 function Todos() {
   const [filter, setFilter] = React.useState('')
 

--- a/docs/guides/does-this-replace-client-state.md
+++ b/docs/guides/does-this-replace-client-state.md
@@ -18,7 +18,7 @@ For a vast majority of applications, the truly **globally accessible client stat
 
 Here we have some "global" state being managed by a global state library:
 
-```js
+```tsx
 const globalState = {
   projects,
   teams,
@@ -31,7 +31,7 @@ const globalState = {
 
 Currently, the global state manager is caching 4 types of server-state: `projects`, `teams`, `tasks`, and `users`. If we were to move these server-state assets to React Query, our remaining global state would look more like this:
 
-```js
+```tsx
 const globalState = {
   themeMode,
   sidebarStatus,

--- a/docs/guides/filters.md
+++ b/docs/guides/filters.md
@@ -9,7 +9,7 @@ Some methods within React Query accept a `QueryFilters` or `MutationFilters` obj
 
 A query filter is an object with certain conditions to match a query with:
 
-```js
+```tsx
 // Cancel all queries
 await queryClient.cancelQueries()
 
@@ -47,7 +47,7 @@ A query filter object supports the following properties:
 
 A mutation filter is an object with certain conditions to match a mutation with:
 
-```js
+```tsx
 // Get the number of all fetching mutations
 await queryClient.isMutating()
 

--- a/docs/guides/infinite-queries.md
+++ b/docs/guides/infinite-queries.md
@@ -22,7 +22,7 @@ When using `useInfiniteQuery`, you'll notice a few things are different:
 
 Let's assume we have an API that returns pages of `projects` 3 at a time based on a `cursor` index along with a cursor that can be used to fetch the next group of projects:
 
-```js
+```tsx
 fetch('/api/projects?cursor=0')
 // { data: [...], nextCursor: 3}
 fetch('/api/projects?cursor=3')
@@ -41,7 +41,7 @@ With this information, we can create a "Load More" UI by:
 
 > Note: It's very important you do not call `fetchNextPage` with arguments unless you want them to override the `pageParam` data returned from the `getNextPageParam` function. e.g. Do not do this: `<button onClick={fetchNextPage} />` as this would send the onClick event to the `fetchNextPage` function.
 
-```js
+```tsx
 import { useInfiniteQuery } from '@tanstack/react-query'
 
 function Projects() {
@@ -99,7 +99,7 @@ When an infinite query becomes `stale` and needs to be refetched, each group is 
 
 If you only want to actively refetch a subset of all pages, you can pass the `refetchPage` function to `refetch` returned from `useInfiniteQuery`.
 
-```js
+```tsx
 const { refetch } = useInfiniteQuery(['projects'], fetchProjects, {
   getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
 })
@@ -120,7 +120,7 @@ The function is executed for each page, and only pages where this function retur
 
 By default, the variable returned from `getNextPageParam` will be supplied to the query function, but in some cases, you may want to override this. You can pass custom variables to the `fetchNextPage` function which will override the default variable like so:
 
-```js
+```tsx
 function Projects() {
   const fetchProjects = ({ pageParam = 0 }) =>
     fetch('/api/projects?cursor=' + pageParam)
@@ -145,7 +145,7 @@ function Projects() {
 
 Bi-directional lists can be implemented by using the `getPreviousPageParam`, `fetchPreviousPage`, `hasPreviousPage` and `isFetchingPreviousPage` properties and functions.
 
-```js
+```tsx
 useInfiniteQuery(['projects'], fetchProjects, {
   getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
   getPreviousPageParam: (firstPage, pages) => firstPage.prevCursor,
@@ -156,7 +156,7 @@ useInfiniteQuery(['projects'], fetchProjects, {
 
 Sometimes you may want to show the pages in reversed order. If this is case, you can use the `select` option:
 
-```js
+```tsx
 useInfiniteQuery(['projects'], fetchProjects, {
   select: data => ({
     pages: [...data.pages].reverse(),
@@ -169,7 +169,7 @@ useInfiniteQuery(['projects'], fetchProjects, {
 
 Manually removing first page:
 
-```js
+```tsx
 queryClient.setQueryData(['projects'], data => ({
   pages: data.pages.slice(1),
   pageParams: data.pageParams.slice(1),
@@ -178,7 +178,7 @@ queryClient.setQueryData(['projects'], data => ({
 
 Manually removing a single value from an individual page:
 
-```js
+```tsx
 const newPagesArray = oldPagesArray?.pages.map((page) =>
   page.filter((val) => val.id !== updatedId)
 ) ?? []

--- a/docs/guides/initial-query-data.md
+++ b/docs/guides/initial-query-data.md
@@ -17,7 +17,7 @@ There may be times when you already have the initial data for a query available 
 
 > IMPORTANT: `initialData` is persisted to the cache, so it is not recommended to provide placeholder, partial or incomplete data to this option and instead use `placeholderData`
 
-```js
+```tsx
 function Todos() {
   const result = useQuery(['todos'], () => fetch('/todos'), {
     initialData: initialTodos,
@@ -31,7 +31,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
 - If you configure your query observer with `initialData`, and no `staleTime` (the default `staleTime: 0`), the query will immediately refetch when it mounts:
 
-  ```js
+  ```tsx
   function Todos() {
     // Will show initialTodos immediately, but also immediately refetch todos after mount
     const result = useQuery(['todos'], () => fetch('/todos'), {
@@ -42,7 +42,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
 - If you configure your query observer with `initialData` and a `staleTime` of `1000` ms, the data will be considered fresh for that same amount of time, as if it was just fetched from your query function.
 
-  ```js
+  ```tsx
   function Todos() {
     // Show initialTodos immediately, but won't refetch until another interaction event is encountered after 1000 ms
     const result = useQuery(['todos'], () => fetch('/todos'), {
@@ -53,7 +53,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
   ```
 
 - So what if your `initialData` isn't totally fresh? That leaves us with the last configuration that is actually the most accurate and uses an option called `initialDataUpdatedAt`. This option allows you to pass a numeric JS timestamp in milliseconds of when the initialData itself was last updated, e.g. what `Date.now()` provides. Take note that if you have a unix timestamp, you'll need to convert it to a JS timestamp by multiplying it by `1000`.
-  ```js
+  ```tsx
   function Todos() {
     // Show initialTodos immediately, but won't refetch until another interaction event is encountered after 1000 ms
     const result = useQuery(['todos'], () => fetch('/todos'), {
@@ -72,7 +72,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
 If the process for accessing a query's initial data is intensive or just not something you want to perform on every render, you can pass a function as the `initialData` value. This function will be executed only once when the query is initialized, saving you precious memory and/or CPU:
 
-```js
+```tsx
 function Todos() {
   const result = useQuery(['todos'], () => fetch('/todos'), {
     initialData: () => {
@@ -86,7 +86,7 @@ function Todos() {
 
 In some circumstances, you may be able to provide the initial data for a query from the cached result of another. A good example of this would be searching the cached data from a todos list query for an individual todo item, then using that as the initial data for your individual todo query:
 
-```js
+```tsx
 function Todo({ todoId }) {
   const result = useQuery(['todo', todoId], () => fetch('/todos'), {
     initialData: () => {
@@ -101,7 +101,7 @@ function Todo({ todoId }) {
 
 Getting initial data from the cache means the source query you're using to look up the initial data from is likely old, but `initialData`. Instead of using an artificial `staleTime` to keep your query from refetching immediately, it's suggested that you pass the source query's `dataUpdatedAt` to `initialDataUpdatedAt`. This provides the query instance with all the information it needs to determine if and when the query needs to be refetched, regardless of initial data being provided.
 
-```js
+```tsx
 function Todo({ todoId }) {
   const result = useQuery(['todo', todoId], () => fetch(`/todos/${todoId}`), {
     initialData: () =>
@@ -116,7 +116,7 @@ function Todo({ todoId }) {
 
 If the source query you're using to look up the initial data from is old, you may not want to use the cached data at all and just fetch from the server. To make this decision easier, you can use the `queryClient.getQueryState` method instead to get more information about the source query, including a `state.dataUpdatedAt` timestamp you can use to decide if the query is "fresh" enough for your needs:
 
-```js
+```tsx
 function Todo({ todoId }) {
   const result = useQuery(['todo', todoId], () => fetch(`/todos/${todoId}`), {
     initialData: () => {

--- a/docs/guides/invalidations-from-mutations.md
+++ b/docs/guides/invalidations-from-mutations.md
@@ -7,13 +7,13 @@ Invalidating queries is only half the battle. Knowing **when** to invalidate the
 
 For example, assume we have a mutation to post a new todo:
 
-```js
+```tsx
 const mutation = useMutation(postTodo)
 ```
 
 When a successful `postTodo` mutation happens, we likely want all `todos` queries to get invalidated and possibly refetched to show the new todo item. To do this, you can use `useMutation`'s `onSuccess` options and the `client`'s `invalidateQueries` function:
 
-```js
+```tsx
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 const queryClient = useQueryClient()

--- a/docs/guides/migrating-to-react-query-3.md
+++ b/docs/guides/migrating-to-react-query-3.md
@@ -38,7 +38,7 @@ This has some benefits:
 
 When creating a `new QueryClient()`, a `QueryCache` and `MutationCache` are automatically created for you if you don't supply them.
 
-```js
+```tsx
 import { QueryClient } from 'react-query'
 
 const queryClient = new QueryClient()
@@ -50,7 +50,7 @@ Default options for queries and mutations can now be specified in `QueryClient`:
 
 **Notice that it's now defaultOptions instead of defaultConfig**
 
-```js
+```tsx
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -65,7 +65,7 @@ const queryClient = new QueryClient({
 
 The `QueryClientProvider` component is now used to connect a `QueryClient` to your application:
 
-```js
+```tsx
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 const queryClient = new QueryClient()
@@ -87,7 +87,7 @@ It's been a long time coming, but it's finally gone :)
 
 The new `QueryClient.prefetchQuery()` function is async, but **does not return the data from the query**. If you require the data, use the new `QueryClient.fetchQuery()` function
 
-```js
+```tsx
 // Prefetch a query:
 await queryClient.prefetchQuery('posts', fetchPosts)
 
@@ -126,7 +126,7 @@ It returns the provided `queryClient` for its component tree and shouldn't need 
 
 Inline functions are now the suggested way of passing parameters to your query functions:
 
-```js
+```tsx
 // Old
 useQuery(['post', id], (_key, id) => fetchPost(id))
 
@@ -136,7 +136,7 @@ useQuery(['post', id], () => fetchPost(id))
 
 If you still insist on not using inline functions, you can use the newly passed `QueryFunctionContext`:
 
-```js
+```tsx
 useQuery(['post', id], context => fetchPost(context.queryKey[1]))
 ```
 
@@ -144,7 +144,7 @@ useQuery(['post', id], context => fetchPost(context.queryKey[1]))
 
 They were previously added as the last query key parameter in your query function, but this proved to be difficult for some patterns
 
-```js
+```tsx
 // Old
 useInfiniteQuery(['posts'], (_key, pageParam = 0) => fetchPosts(pageParam))
 
@@ -156,7 +156,7 @@ useInfiniteQuery(['posts'], ({ pageParam = 0 }) => fetchPosts(pageParam))
 
 The new `keepPreviousData` options is available for both `useQuery` and `useInfiniteQuery` and will have the same "lagging" effect on your data:
 
-```js
+```tsx
 import { useQuery } from 'react-query'
 
 function Page({ page }) {
@@ -182,7 +182,7 @@ The `useInfiniteQuery()` interface has changed to fully support bi-directional i
 
 One direction:
 
-```js
+```tsx
 const {
   data,
   fetchNextPage,
@@ -199,7 +199,7 @@ const {
 
 Both directions:
 
-```js
+```tsx
 const {
   data,
   fetchNextPage,
@@ -220,7 +220,7 @@ const {
 
 One direction reversed:
 
-```js
+```tsx
 const {
   data,
   fetchNextPage,
@@ -243,7 +243,7 @@ const {
 
 This allows for easier manipulation of the data and the page params, like, for example, removing the first page of data along with it's params:
 
-```js
+```tsx
 queryClient.setQueryData(['projects'], data => ({
   pages: data.pages.slice(1),
   pageParams: data.pageParams.slice(1),
@@ -254,7 +254,7 @@ queryClient.setQueryData(['projects'], data => ({
 
 Though the old way gave us warm fuzzy feelings of when we first discovered `useState` for the first time, they didn't last long. Now the mutation return is a single object.
 
-```js
+```tsx
 // Old:
 const [mutate, { status, reset }] = useMutation()
 
@@ -273,7 +273,7 @@ Because of this the `mutate` function is now split into a `mutate` and `mutateAs
 
 The `mutate` function can be used when using callbacks:
 
-```js
+```tsx
 const { mutate } = useMutation(addTodo)
 
 mutate('todo', {
@@ -291,7 +291,7 @@ mutate('todo', {
 
 The `mutateAsync` function can be used when using async/await:
 
-```js
+```tsx
 const { mutateAsync } = useMutation(addTodo)
 
 try {
@@ -306,7 +306,7 @@ try {
 
 ### The object syntax for useQuery now uses a collapsed config:
 
-```js
+```tsx
 // Old:
 useQuery({
   queryKey: 'posts',
@@ -354,7 +354,7 @@ With these new options it is possible to configure when a component should re-re
 
 Only re-render when the `data` or `error` properties change:
 
-```js
+```tsx
 import { useQuery } from 'react-query'
 
 function User() {
@@ -367,7 +367,7 @@ function User() {
 
 Prevent re-render when the `isStale` property changes:
 
-```js
+```tsx
 import { useQuery } from 'react-query'
 
 function User() {
@@ -388,7 +388,7 @@ Because data and errors can be present at the same time, the `updatedAt` propert
 
 ### `setConsole()` has been replaced by the new `setLogger()` function
 
-```js
+```tsx
 import { setLogger } from 'react-query'
 
 // Log with Sentry
@@ -406,7 +406,7 @@ setLogger(winston.createLogger())
 
 To prevent showing error screens in React Native when a query fails it was necessary to manually change the Console:
 
-```js
+```tsx
 import { setConsole } from 'react-query'
 
 setConsole({
@@ -455,7 +455,7 @@ const { data, status } = useQuery(['post', id], () => fetchPost(id))
 
 The `useQuery` and `useInfiniteQuery` hooks now have a `select` option to select or transform parts of the query result.
 
-```js
+```tsx
 import { useQuery } from 'react-query'
 
 function User() {
@@ -472,7 +472,7 @@ Set the `notifyOnChangeProps` option to `['data', 'error']` to only re-render wh
 
 Wish you could run `useQuery` in a loop? The rules of hooks say no, but with the new `useQueries()` hook, you can!
 
-```js
+```tsx
 import { useQueries } from 'react-query'
 
 function Overview() {
@@ -492,7 +492,7 @@ function Overview() {
 
 By default React Query will not retry a mutation on error, but it is possible with the `retry` option:
 
-```js
+```tsx
 const mutation = useMutation(addTodo, {
   retry: 3,
 })
@@ -508,7 +508,7 @@ Mutations can now be persisted to storage and resumed at a later point. More inf
 
 A `QueryObserver` can be used to create and/or watch a query:
 
-```js
+```tsx
 const observer = new QueryObserver(queryClient, { queryKey: 'posts' })
 
 const unsubscribe = observer.subscribe(result => {
@@ -521,7 +521,7 @@ const unsubscribe = observer.subscribe(result => {
 
 A `InfiniteQueryObserver` can be used to create and/or watch an infinite query:
 
-```js
+```tsx
 const observer = new InfiniteQueryObserver(queryClient, {
   queryKey: 'posts',
   queryFn: fetchPosts,
@@ -539,7 +539,7 @@ const unsubscribe = observer.subscribe(result => {
 
 A `QueriesObserver` can be used to create and/or watch multiple queries:
 
-```js
+```tsx
 const observer = new QueriesObserver(queryClient, [
   { queryKey: ['post', 1], queryFn: fetchPost },
   { queryKey: ['post', 2], queryFn: fetchPost },
@@ -555,7 +555,7 @@ const unsubscribe = observer.subscribe(result => {
 
 The `QueryClient.setQueryDefaults()` method can be used to set default options for specific queries:
 
-```js
+```tsx
 queryClient.setQueryDefaults(['posts'], { queryFn: fetchPosts })
 
 function Component() {
@@ -567,7 +567,7 @@ function Component() {
 
 The `QueryClient.setMutationDefaults()` method can be used to set default options for specific mutations:
 
-```js
+```tsx
 queryClient.setMutationDefaults(['addPost'], { mutationFn: addPost })
 
 function Component() {
@@ -579,7 +579,7 @@ function Component() {
 
 The `useIsFetching()` hook now accepts filters which can be used to for example only show a spinner for certain type of queries:
 
-```js
+```tsx
 const fetches = useIsFetching(['posts'])
 ```
 
@@ -587,7 +587,7 @@ const fetches = useIsFetching(['posts'])
 
 The core of React Query is now fully separated from React, which means it can also be used standalone or in other frameworks. Use the `react-query/core` entry point to only import the core functionality:
 
-```js
+```tsx
 import { QueryClient } from 'react-query/core'
 ```
 

--- a/docs/guides/migrating-to-react-query-4.md
+++ b/docs/guides/migrating-to-react-query-4.md
@@ -109,7 +109,7 @@ In order to make bailing out of updates possible by returning `undefined`, we ha
 
 Further, it is an easy bug to produce `Promise<void>` by adding logging in the queryFn:
 
-```js
+```tsx
 useQuery(['key'], () => axios.get(url).then(result => console.log(result.data)))
 ```
 
@@ -121,7 +121,7 @@ Please read the [New Features announcement](#proper-offline-support) about onlin
 
 Even though React Query is an Async State Manager that can be used for anything that produces a Promise, it is most often used for data fetching in combination with data fetching libraries. That is why, per default, queries and mutations will be `paused` if there is no network connection. If you want to opt-in to the previous behavior, you can globally set `networkMode: offlineFirst` for both queries and mutations:
 
-```js
+```tsx
 new QueryClient({
   defaultOptions: {
     queries: {
@@ -388,7 +388,7 @@ React Query defaults to "tracking" query properties, which should give you a nic
 
 When using the [functional updater form of setQueryData](../reference/QueryClient#queryclientsetquerydata), you can now bail out of the update by returning `undefined`. This is helpful if `undefined` is given to you as `previousValue`, which means that currently, no cached entry exists and you don't want to / cannot create one, like in the example of toggling a todo:
 
-```js
+```tsx
 queryClient.setQueryData(['todo', id], previousTodo =>
   previousTodo ? { ...previousTodo, done: true } : undefined
 )

--- a/docs/guides/mutations.md
+++ b/docs/guides/mutations.md
@@ -7,7 +7,7 @@ Unlike queries, mutations are typically used to create/update/delete data or per
 
 Here's an example of a mutation that adds a new todo to the server:
 
-```js
+```tsx
 function App() {
   const mutation = useMutation(newTodo => {
     return axios.post('/todos', newTodo)
@@ -57,7 +57,7 @@ Even with just variables, mutations aren't all that special, but when used with 
 
 > IMPORTANT: The `mutate` function is an asynchronous function, which means you cannot use it directly in an event callback in **React 16 and earlier**. If you need to access the event in `onSubmit` you need to wrap `mutate` in another function. This is due to [React event pooling](https://reactjs.org/docs/legacy-event-pooling.html).
 
-```js
+```tsx
 // This will not work in React 16 and earlier
 const CreateTodo = () => {
   const mutation = useMutation(event => {
@@ -86,7 +86,7 @@ const CreateTodo = () => {
 
 It's sometimes the case that you need to clear the `error` or `data` of a mutation request. To do this, you can use the `reset` function to handle this:
 
-```js
+```tsx
 const CreateTodo = () => {
   const [title, setTitle] = useState('')
   const mutation = useMutation(createTodo)
@@ -117,7 +117,7 @@ const CreateTodo = () => {
 
 `useMutation` comes with some helper options that allow quick and easy side-effects at any stage during the mutation lifecycle. These come in handy for both [invalidating and refetching queries after mutations](./invalidations-from-mutations) and even [optimistic updates](./optimistic-updates)
 
-```js
+```tsx
 useMutation(addTodo, {
   onMutate: variables => {
     // A mutation is about to happen!
@@ -140,7 +140,7 @@ useMutation(addTodo, {
 
 When returning a promise in any of the callback functions it will first be awaited before the next callback is called:
 
-```js
+```tsx
 useMutation(addTodo, {
   onSuccess: async () => {
     console.log("I'm first!")
@@ -153,7 +153,7 @@ useMutation(addTodo, {
 
 You might find that you want to **trigger additional callbacks** beyond the ones defined on `useMutation` when calling `mutate`. This can be used to trigger component-specific side effects. To do that, you can provide any of the same callback options to the `mutate` function after your mutation variable. Supported overrides include: `onSuccess`, `onError` and `onSettled`. Please keep in mind that those additional callbacks won't run if your component unmounts _before_ the mutation finishes.
 
-```js
+```tsx
 useMutation(addTodo, {
   onSuccess: (data, variables, context) => {
     // I will fire first
@@ -184,7 +184,7 @@ There is a slight difference in handling `onSuccess`, `onError` and `onSettled` 
 
 > Be aware that most likely, `mutationFn` passed to `useMutation` is asynchronous. In that case, the order in which mutations are fulfilled may differ from the order of `mutate` function calls.
 
-```js
+```tsx
 useMutation(addTodo, {
   onSuccess: (data, error, variables, context) => {
     // Will be called 3 times
@@ -205,7 +205,7 @@ useMutation(addTodo, {
 
 Use `mutateAsync` instead of `mutate` to get a promise which will resolve on success or throw on an error. This can for example be used to compose side effects.
 
-```js
+```tsx
 const mutation = useMutation(addTodo)
 
 try {
@@ -222,7 +222,7 @@ try {
 
 By default React Query will not retry a mutation on error, but it is possible with the `retry` option:
 
-```js
+```tsx
 const mutation = useMutation(addTodo, {
   retry: 3,
 })
@@ -234,7 +234,7 @@ If mutations fail because the device is offline, they will be retried in the sam
 
 Mutations can be persisted to storage if needed and resumed at a later point. This can be done with the hydration functions:
 
-```js
+```tsx
 const queryClient = new QueryClient()
 
 // Define the "addTodo" mutation
@@ -285,7 +285,7 @@ If you persist offline mutations with the [persistQueryClient plugin](../plugins
 
 This is a technical limitation. When persisting to an external storage, only the state of mutations is persisted, as functions cannot be serialized. After hydration, the component that triggeres the mutation might not be mounted, so calling `resumePausedMutations` might yield an error: `No mutationFn found`.
 
-```js
+```tsx
 const persister = createSyncStoragePersister({
   storage: window.localStorage,
 })

--- a/docs/guides/optimistic-updates.md
+++ b/docs/guides/optimistic-updates.md
@@ -9,7 +9,7 @@ To do this, `useMutation`'s `onMutate` handler option allows you to return a val
 
 ## Updating a list of todos when adding a new todo
 
-```js
+```tsx
 const queryClient = useQueryClient()
 
 useMutation(updateTodo, {
@@ -40,7 +40,7 @@ useMutation(updateTodo, {
 
 ## Updating a single todo
 
-```js
+```tsx
 useMutation(updateTodo, {
   // When mutate is called:
   onMutate: async newTodo => {
@@ -72,7 +72,7 @@ useMutation(updateTodo, {
 
 You can also use the `onSettled` function in place of the separate `onError` and `onSuccess` handlers if you wish:
 
-```js
+```tsx
 useMutation(updateTodo, {
   // ...
   onSettled: (newTodo, error, variables, context) => {

--- a/docs/guides/paginated-queries.md
+++ b/docs/guides/paginated-queries.md
@@ -5,7 +5,7 @@ title: Paginated / Lagged Queries
 
 Rendering paginated data is a very common UI pattern and in React Query, it "just works" by including the page information in the query key:
 
-```js
+```tsx
 const result = useQuery(['projects', page], fetchProjects)
 ```
 
@@ -23,7 +23,7 @@ Consider the following example where we would ideally want to increment a pageIn
 - When the new data arrives, the previous `data` is seamlessly swapped to show the new data.
 - `isPreviousData` is made available to know what data the query is currently providing you
 
-```js
+```tsx
 function Todos() {
   const [page, setPage] = React.useState(0)
 

--- a/docs/guides/parallel-queries.md
+++ b/docs/guides/parallel-queries.md
@@ -9,7 +9,7 @@ title: Parallel Queries
 
 When the number of parallel queries does not change, there is **no extra effort** to use parallel queries. Just use any number of React Query's `useQuery` and `useInfiniteQuery` hooks side-by-side!
 
-```js
+```tsx
 function App () {
   // The following queries will execute in parallel
   const usersQuery = useQuery(['users'], fetchUsers)
@@ -27,7 +27,7 @@ If the number of queries you need to execute is changing from render to render, 
 
 `useQueries` accepts an **options object** with a **queries key** whose value is an **array of query objects**. It returns an **array of query results**:
 
-```js
+```tsx
 function App({ users }) {
   const userQueries = useQueries({
     queries: users.map(user => {

--- a/docs/guides/placeholder-query-data.md
+++ b/docs/guides/placeholder-query-data.md
@@ -18,7 +18,7 @@ There are a few ways to supply placeholder data for a query to the cache before 
 
 ## Placeholder Data as a Value
 
-```js
+```tsx
 function Todos() {
   const result = useQuery(['todos'], () => fetch('/todos'), {
     placeholderData: placeholderTodos,
@@ -30,7 +30,7 @@ function Todos() {
 
 If the process for accessing a query's placeholder data is intensive or just not something you want to perform on every render, you can memoize the value or pass a memoized function as the `placeholderData` value:
 
-```js
+```tsx
 function Todos() {
   const placeholderData = useMemo(() => generateFakeTodos(), [])
   const result = useQuery(['todos'], () => fetch('/todos'), { placeholderData })
@@ -41,7 +41,7 @@ function Todos() {
 
 In some circumstances, you may be able to provide the placeholder data for a query from the cached result of another. A good example of this would be searching the cached data from a blog post list query for a preview version of the post, then using that as the placeholder data for your individual post query:
 
-```js
+```tsx
 function Todo({ blogPostId }) {
   const result = useQuery(['blogPost', blogPostId], () => fetch(`/blogPosts/${blogPostId}`), {
     placeholderData: () => {

--- a/docs/guides/prefetching.md
+++ b/docs/guides/prefetching.md
@@ -5,7 +5,7 @@ title: Prefetching
 
 If you're lucky enough, you may know enough about what your users will do to be able to prefetch the data they need before it's needed! If this is the case, you can use the `prefetchQuery` method to prefetch the results of a query to be placed into the cache:
 
-```js
+```tsx
 const prefetchTodos = async () => {
   // The results of this query will be cached like a normal query
   await queryClient.prefetchQuery(['todos'], fetchTodos)
@@ -20,6 +20,6 @@ const prefetchTodos = async () => {
 
 Alternatively, if you already have the data for your query synchronously available, you don't need to prefetch it. You can just use the [Query Client's `setQueryData` method](../reference/QueryClient#queryclientsetquerydata) to directly add or update a query's cached result by key.
 
-```js
+```tsx
 queryClient.setQueryData(['todos'], todos)
 ```

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -14,7 +14,7 @@ To subscribe to a query in your components or custom hooks, call the `useQuery` 
   - Resolves the data, or
   - Throws an error
 
-```js
+```tsx
 import { useQuery } from '@tanstack/react-query'
 
 function App() {
@@ -26,7 +26,7 @@ The **unique key** you provide is used internally for refetching, caching, and s
 
 The query results returned by `useQuery` contains all of the information about the query that you'll need for templating and any other usage of the data:
 
-```js
+```tsx
 const result = useQuery(['todos'], fetchTodoList)
 ```
 
@@ -43,7 +43,7 @@ Beyond those primary states, more information is available depending on the stat
 
 For **most** queries, it's usually sufficient to check for the `isLoading` state, then the `isError` state, then finally, assume that the data is available and render the successful state:
 
-```js
+```tsx
 function Todos() {
   const { isLoading, isError, data, error } = useQuery(['todos'], fetchTodoList)
 
@@ -68,7 +68,7 @@ function Todos() {
 
 If booleans aren't your thing, you can always use the `status` state as well:
 
-```js
+```tsx
 function Todos() {
   const { status, data, error } = useQuery(['todos'], fetchTodoList)
 

--- a/docs/guides/query-cancellation.md
+++ b/docs/guides/query-cancellation.md
@@ -19,7 +19,7 @@ However, if you consume the `AbortSignal` or attach a `cancel` function to your 
 
 ## Using `fetch`
 
-```js
+```tsx
 const query = useQuery(['todos'], async ({ signal }) => {
   const todosResponse = await fetch('/todos', {
     // Pass the signal to one fetch
@@ -43,7 +43,7 @@ const query = useQuery(['todos'], async ({ signal }) => {
 
 ### Using `axios` [v0.22.0+](https://github.com/axios/axios/releases/tag/v0.22.0)
 
-```js
+```tsx
 import axios from 'axios'
 
 const query = useQuery(['todos'], ({ signal }) =>
@@ -56,7 +56,7 @@ const query = useQuery(['todos'], ({ signal }) =>
 
 ### Using an `axios` version less than v0.22.0
 
-```js
+```tsx
 import axios from 'axios'
 
 const query = useQuery(['todos'], ({ signal }) => {
@@ -80,7 +80,7 @@ const query = useQuery(['todos'], ({ signal }) => {
 
 ## Using `XMLHttpRequest`
 
-```js
+```tsx
 const query = useQuery(['todos'], ({ signal }) => {
   return new Promise((resolve, reject) => {
     var oReq = new XMLHttpRequest()
@@ -101,7 +101,7 @@ const query = useQuery(['todos'], ({ signal }) => {
 
 An `AbortSignal` can be set in the client `request` method.
 
-```js
+```tsx
 const client = new GraphQLClient(endpoint)
 
 const query = useQuery('todos', ({ signal }) => {
@@ -113,7 +113,7 @@ const query = useQuery('todos', ({ signal }) => {
 
 An `AbortSignal` can be set in the `GraphQLClient` constructor.
 
-```js
+```tsx
 const query = useQuery(['todos'], ({ signal }) => {
   const client = new GraphQLClient(endpoint, {
     signal,
@@ -126,7 +126,7 @@ const query = useQuery(['todos'], ({ signal }) => {
 
 You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries(key)`, which will cancel the query and revert it back to its previous state. If `promise.cancel` is available, or you have consumed the `signal` passed to the query function, React Query will additionally also cancel the Promise.
 
-```js
+```tsx
 const query = useQuery(['todos'], async ({ signal }) => {
   const resp = await fetch('/todos', { signal })
   return resp.json()
@@ -150,7 +150,7 @@ To integrate with this feature, attach a `cancel` function to the promise return
 
 ## Using `axios` with `cancel` function
 
-```js
+```tsx
 import axios from 'axios'
 
 const query = useQuery(['todos'], () => {
@@ -174,7 +174,7 @@ const query = useQuery(['todos'], () => {
 
 ## Using `fetch` with `cancel` function
 
-```js
+```tsx
 const query = useQuery(['todos'], () => {
   // Create a new AbortController instance for this request
   const controller = new AbortController()

--- a/docs/guides/query-functions.md
+++ b/docs/guides/query-functions.md
@@ -7,7 +7,7 @@ A query function can be literally any function that **returns a promise**. The p
 
 All of the following are valid query function configurations:
 
-```js
+```tsx
 useQuery(['todos'], fetchAllTodos)
 useQuery(['todos', todoId], () => fetchTodoById(todoId))
 useQuery(['todos', todoId], async () => {
@@ -21,7 +21,7 @@ useQuery(['todos', todoId], ({ queryKey }) => fetchTodoById(queryKey[1]))
 
 For React Query to determine a query has errored, the query function **must throw**. Any error that is thrown in the query function will be persisted on the `error` state of the query.
 
-```js
+```tsx
 const { error } = useQuery(['todos', todoId], async () => {
   if (somethingGoesWrong) {
     throw new Error('Oh no!')
@@ -35,7 +35,7 @@ const { error } = useQuery(['todos', todoId], async () => {
 
 While most utilities like `axios` or `graphql-request` automatically throw errors for unsuccessful HTTP calls, some utilities like `fetch` do not throw errors by default. If that's the case, you'll need to throw them on your own. Here is a simple way to do that with the popular `fetch` API:
 
-```js
+```tsx
 useQuery(['todos', todoId], async () => {
   const response = await fetch('/todos/' + todoId)
   if (!response.ok) {
@@ -49,7 +49,7 @@ useQuery(['todos', todoId], async () => {
 
 Query keys are not just for uniquely identifying the data you are fetching, but are also conveniently passed into your query function as part of the QueryFunctionContext. While not always necessary, this makes it possible to extract your query functions if needed:
 
-```js
+```tsx
 function Todos({ status, page }) {
   const result = useQuery(['todos', { status, page }], fetchTodoList)
 }
@@ -79,7 +79,7 @@ The `QueryFunctionContext` is the object passed to each query function. It consi
 
 Anywhere the `[queryKey, queryFn, config]` signature is supported throughout React Query's API, you can also use an object to express the same configuration:
 
-```js
+```tsx
 import { useQuery } from '@tanstack/react-query'
 
 useQuery({

--- a/docs/guides/query-invalidation.md
+++ b/docs/guides/query-invalidation.md
@@ -5,7 +5,7 @@ title: Query Invalidation
 
 Waiting for queries to become stale before they are fetched again doesn't always work, especially when you know for a fact that a query's data is out of date because of something the user has done. For that purpose, the `QueryClient` has an `invalidateQueries` method that lets you intelligently mark queries as stale and potentially refetch them too!
 
-```js
+```tsx
 // Invalidate every query in the cache
 queryClient.invalidateQueries()
 // Invalidate every query with a key that starts with `todos`
@@ -25,7 +25,7 @@ When using APIs like `invalidateQueries` and `removeQueries` (and others that su
 
 In this example, we can use the `todos` prefix to invalidate any queries that start with `todos` in their query key:
 
-```js
+```tsx
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 // Get QueryClient from the context
@@ -40,7 +40,7 @@ const todoListQuery = useQuery(['todos', { page: 1 }], fetchTodoList)
 
 You can even invalidate queries with specific variables by passing a more specific query key to the `invalidateQueries` method:
 
-```js
+```tsx
 queryClient.invalidateQueries(['todos', { type: 'done' }])
 
 // The query below will be invalidated
@@ -52,7 +52,7 @@ const todoListQuery = useQuery(['todos'], fetchTodoList)
 
 The `invalidateQueries` API is very flexible, so even if you want to **only** invalidate `todos` queries that don't have any more variables or subkeys, you can pass an `exact: true` option to the `invalidateQueries` method:
 
-```js
+```tsx
 queryClient.invalidateQueries(['todos'], { exact: true })
 
 // The query below will be invalidated
@@ -64,7 +64,7 @@ const todoListQuery = useQuery(['todos', { type: 'done' }], fetchTodoList)
 
 If you find yourself wanting **even more** granularity, you can pass a predicate function to the `invalidateQueries` method. This function will receive each `Query` instance from the query cache and allow you to return `true` or `false` for whether you want to invalidate that query:
 
-```js
+```tsx
 queryClient.invalidateQueries({
   predicate: query =>
     query.queryKey[0] === 'todos' && query.queryKey[1]?.version >= 10,

--- a/docs/guides/query-keys.md
+++ b/docs/guides/query-keys.md
@@ -12,7 +12,7 @@ The simplest form of a key is an array with constants values. This format is use
 - Generic List/Index resources
 - Non-hierarchical resources
 
-```js
+```tsx
 // A list of todos
 useQuery(['todos'], ...)
 
@@ -29,7 +29,7 @@ When a query needs more information to uniquely describe its data, you can use a
 - Queries with additional parameters
   - It's common to pass an object of additional options
 
-```js
+```tsx
 // An individual todo
 useQuery(['todo', 5], ...)
 
@@ -44,7 +44,7 @@ useQuery(['todos', { type: 'done' }], ...)
 
 This means that no matter the order of keys in objects, all of the following queries are considered equal:
 
-```js
+```tsx
 useQuery(['todos', { status, page }], ...)
 useQuery(['todos', { page, status }], ...)
 useQuery(['todos', { page, status, other: undefined }], ...)
@@ -52,7 +52,7 @@ useQuery(['todos', { page, status, other: undefined }], ...)
 
 The following query keys, however, are not equal. Array item order matters!
 
-```js
+```tsx
 useQuery(['todos', status, page], ...)
 useQuery(['todos', page, status], ...)
 useQuery(['todos', undefined, page, status], ...)
@@ -62,7 +62,7 @@ useQuery(['todos', undefined, page, status], ...)
 
 Since query keys uniquely describe the data they are fetching, they should include any variables you use in your query function that **change**. For example:
 
-```js
+```tsx
 function Todos({ todoId }) {
   const result = useQuery(['todos', todoId], () => fetchTodoById(todoId))
 }

--- a/docs/guides/query-retries.md
+++ b/docs/guides/query-retries.md
@@ -12,7 +12,7 @@ You can configure retries both on a global level and an individual query level.
 - Setting `retry = true` will infinitely retry failing requests.
 - Setting `retry = (failureCount, error) => ...` allows for custom logic based on why the request failed.
 
-```js
+```tsx
 import { useQuery } from '@tanstack/react-query'
 
 // Make a specific query retry a certain number of times
@@ -27,7 +27,7 @@ By default, retries in React Query do not happen immediately after a request fai
 
 The default `retryDelay` is set to double (starting at `1000`ms) with each attempt, but not exceed 30 seconds:
 
-```js
+```tsx
 // Configure for all queries
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
@@ -46,7 +46,7 @@ function App() {
 
 Though it is not recommended, you can obviously override the `retryDelay` function/integer in both the Provider and individual query options. If set to an integer instead of a function the delay will always be the same amount of time:
 
-```js
+```tsx
 const result = useQuery(['todos'], fetchTodoList, {
   retryDelay: 1000, // Will always wait 1000ms to retry, regardless of how many retries
 })

--- a/docs/guides/ssr.md
+++ b/docs/guides/ssr.md
@@ -24,7 +24,7 @@ React Query supports both of these forms of pre-rendering regardless of what pla
 
 Together with Next.js's [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation) or [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering), you can pass the data you fetch in either method to `useQuery`'s' `initialData` option. From React Query's perspective, these integrate in the same way, `getStaticProps` is shown below:
 
-```js
+```tsx
 export async function getStaticProps() {
   const posts = await getPosts()
   return { props: { posts } }
@@ -53,7 +53,7 @@ To support caching queries on the server and set up hydration:
 - Wrap your app component with `<QueryClientProvider>` and pass it the client instance
 - Wrap your app component with `<Hydrate>` and pass it the `dehydratedState` prop from `pageProps`
 
-```js
+```tsx
 // _app.jsx
 import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
@@ -76,7 +76,7 @@ Now you are ready to prefetch some data in your pages with either [`getStaticPro
 - Prefetch the data using the clients `prefetchQuery` method and wait for it to complete
 - Use `dehydrate` to dehydrate the query cache and pass it to the page via the `dehydratedState` prop. This is the same prop that the cache will be picked up from in your `_app.js`
 
-```js
+```tsx
 // pages/posts.jsx
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 
@@ -130,7 +130,7 @@ This guide is at-best, a high level overview of how SSR with React Query should 
 
 > SECURITY NOTE: Serializing data with `JSON.stringify` can put you at risk for XSS-vulnerabilities, [this blog post explains why and how to solve it](https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0)
 
-```js
+```tsx
 import { dehydrate, Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 async function handleRequest (req, res) {
@@ -167,7 +167,7 @@ async function handleRequest (req, res) {
 - Create a new `QueryClient` instance
 - Render your app with the client provider and also **using the dehydrated state. This is extremely important! You must render both server and client using the same dehydrated state to ensure hydration on the client produces the exact same markup as the server.**
 
-```js
+```tsx
 import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const dehydratedState = window.__REACT_QUERY_STATE__

--- a/docs/guides/suspense.md
+++ b/docs/guides/suspense.md
@@ -9,7 +9,7 @@ React Query can also be used with React's new Suspense for Data Fetching API's. 
 
 Global configuration:
 
-```js
+```tsx
 // Configure for all queries
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
@@ -32,7 +32,7 @@ function Root() {
 
 Query configuration:
 
-```js
+```tsx
 import { useQuery } from '@tanstack/react-query'
 
 // Enable for an individual query
@@ -51,7 +51,7 @@ Query errors can be reset with the `QueryErrorResetBoundary` component or with t
 
 When using the component it will reset any query errors within the boundaries of the component:
 
-```js
+```tsx
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 
@@ -76,7 +76,7 @@ const App: React.FC = () => (
 
 When using the hook it will reset any query errors within the closest `QueryErrorResetBoundary`. If there is no boundary defined it will reset them globally:
 
-```js
+```tsx
 import { useQueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 

--- a/docs/guides/updates-from-mutation-responses.md
+++ b/docs/guides/updates-from-mutation-responses.md
@@ -5,7 +5,7 @@ title: Updates from Mutation Responses
 
 When dealing with mutations that **update** objects on the server, it's common for the new object to be automatically returned in the response of the mutation. Instead of refetching any queries for that item and wasting a network call for data we already have, we can take advantage of the object returned by the mutation function and update the existing query with the new data immediately using the [Query Client's `setQueryData`](../reference/QueryClient#queryclientsetquerydata) method:
 
-```js
+```tsx
 const queryClient = useQueryClient()
 
 const mutation = useMutation(editTodo, {
@@ -27,7 +27,7 @@ const { status, data, error } = useQuery(['todo', { id: 5 }], fetchTodoById)
 You might want to tie the `onSuccess` logic into a reusable mutation, for that you can
 create a custom hook like this:
 
-```js
+```tsx
 const useMutateTodo = () => {
   const queryClient = useQueryClient()
 

--- a/docs/guides/window-focus-refetching.md
+++ b/docs/guides/window-focus-refetching.md
@@ -7,7 +7,7 @@ If a user leaves your application and returns to stale data, **React Query autom
 
 #### Disabling Globally
 
-```js
+```tsx
 //
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -24,7 +24,7 @@ function App() {
 
 #### Disabling Per-Query
 
-```js
+```tsx
 useQuery(['todos'], fetchTodos, { refetchOnWindowFocus: false })
 ```
 
@@ -32,7 +32,7 @@ useQuery(['todos'], fetchTodos, { refetchOnWindowFocus: false })
 
 In rare circumstances, you may want to manage your own window focus events that trigger React Query to revalidate. To do this, React Query provides a `focusManager.setEventListener` function that supplies you the callback that should be fired when the window is focused and allows you to set up your own events. When calling `focusManager.setEventListener`, the previously set handler is removed (which in most cases will be the default handler) and your new handler is used instead. For example, this is the default handler:
 
-```js
+```tsx
 focusManager.setEventListener(handleFocus => {
   // Listen to visibilitychange and focus
   if (typeof window !== 'undefined' && window.addEventListener) {
@@ -52,7 +52,7 @@ focusManager.setEventListener(handleFocus => {
 
 A great use-case for replacing the focus handler is that of iframe events. Iframes present problems with detecting window focus by both double-firing events and also firing false-positive events when focusing or using iframes within your app. If you experience this, you should use an event handler that ignores these events as much as possible. I recommend [this one](https://gist.github.com/tannerlinsley/1d3a2122332107fcd8c9cc379be10d88)! It can be set up in the following way:
 
-```js
+```tsx
 import { focusManager } from '@tanstack/react-query'
 import onWindowFocus from './onWindowFocus' // The gist above
 
@@ -63,7 +63,7 @@ focusManager.setEventListener(onWindowFocus) // Boom!
 
 Instead of event listeners on `window`, React Native provides focus information through the [`AppState` module](https://reactnative.dev/docs/appstate#app-states). You can use the `AppState` "change" event to trigger an update when the app state changes to "active":
 
-```js
+```tsx
 import { AppState } from 'react-native'
 import { focusManager } from '@tanstack/react-query'
 
@@ -80,7 +80,7 @@ focusManager.setEventListener(handleFocus => {
 
 ## Managing focus state
 
-```js
+```tsx
 import { focusManager } from '@tanstack/react-query'
 
 // Override the default focus state

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -46,7 +46,7 @@ In the example below, you can see React Query in its most basic and simple form 
 
 [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/simple)
 
-```js
+```tsx
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
 
 const queryClient = new QueryClient()

--- a/docs/plugins/createAsyncStoragePersister.md
+++ b/docs/plugins/createAsyncStoragePersister.md
@@ -47,7 +47,7 @@ Retries work the same as for a [SyncStoragePersister](./createSyncStoragePersist
 
 Call this function to create an asyncStoragePersister that you can use later with `persistQueryClient`.
 
-```js
+```tsx
 createAsyncStoragePersister(options: CreateAsyncStoragePersisterOptions)
 ```
 
@@ -79,7 +79,7 @@ interface AsyncStorage {
 
 The default options are:
 
-```js
+```tsx
 {
   key = `REACT_QUERY_OFFLINE_CACHE`,
   throttleTime = 1000,

--- a/docs/plugins/createSyncStoragePersister.md
+++ b/docs/plugins/createSyncStoragePersister.md
@@ -55,7 +55,7 @@ Per default, no retry will occur. You can use one of the predefined strategies t
 - `removeOldestQuery`
   - will return a new `PersistedClient` with the oldest query removed.
 
-```js
+```tsx
 const localStoragePersister = createSyncStoragePersister({
   storage: window.localStorage,
   retry: removeOldestQuery
@@ -68,7 +68,7 @@ const localStoragePersister = createSyncStoragePersister({
 
 Call this function to create a syncStoragePersister that you can use later with `persistQueryClient`.
 
-```js
+```tsx
 createSyncStoragePersister(options: CreateSyncStoragePersisterOptions)
 ```
 
@@ -94,7 +94,7 @@ interface CreateSyncStoragePersisterOptions {
 
 The default options are:
 
-```js
+```tsx
 {
   key = `REACT_QUERY_OFFLINE_CACHE`,
   throttleTime = 1000,
@@ -107,7 +107,7 @@ The default options are:
 There is a limit to the amount of data which can be stored in `localStorage`.
 If you need to store more data in `localStorage`, you can override the `serialize` and `deserialize` functions to compress and decrompress the data using a library like [lz-string](https://github.com/pieroxy/lz-string/).
 
-```js
+```tsx
 import { QueryClient } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client'
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'

--- a/docs/plugins/persistQueryClient.md
+++ b/docs/plugins/persistQueryClient.md
@@ -164,7 +164,7 @@ However, restoring is asynchronous, because all persisters are async by nature, 
 
 Further, if you subscribe to changes outside of the React component lifecycle, you have no way of unsubscribing:
 
-```js
+```tsx
 // 🚨 never unsubscribes from syncing
 persistQueryClient({
   queryClient,
@@ -179,7 +179,7 @@ ReactDOM.createRoot(rootElement).render(<App />)
 
 For this use-case, you can use the `PersistQueryClientProvider`. It will make sure to subscribe / unsubscribe correctly according to the React component lifecycle, and it will also make sure that queries will not start fetching while we are still restoring. Queries will still render though, they will just be put into `fetchingState: 'idle'` until data has been restored. Then, they will refetch unless the restored data is _fresh_ enough, and _initialData_ will also be respected. It can be used _instead of_ the normal [QueryClientProvider](../reference/QueryClientProvider):
 
-```jsx
+```tsxx
 
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -9,7 +9,7 @@ This example very briefly illustrates the 3 core concepts of React Query:
 - [Mutations](./guides/mutations)
 - [Query Invalidation](./guides/query-invalidation)
 
-```js
+```tsx
 import {
   useQuery,
   useMutation,

--- a/docs/reference/InfiniteQueryObserver.md
+++ b/docs/reference/InfiniteQueryObserver.md
@@ -7,7 +7,7 @@ title: InfiniteQueryObserver
 
 The `InfiniteQueryObserver` can be used to observe and switch between infinite queries.
 
-```js
+```tsx
 const observer = new InfiniteQueryObserver(queryClient, {
   queryKey: ['posts'],
   queryFn: fetchPosts,

--- a/docs/reference/MutationCache.md
+++ b/docs/reference/MutationCache.md
@@ -7,7 +7,7 @@ The `MutationCache` is the storage for mutations.
 
 **Normally, you will not interact with the MutationCache directly and instead use the `QueryClient`.**
 
-```js
+```tsx
 import { MutationCache } from '@tanstack/react-query'
 
 const mutationCache = new MutationCache({
@@ -51,7 +51,7 @@ The `onError`, `onSuccess` and `onMutate` callbacks on the MutationCache can be 
 
 > Note: This is not typically needed for most applications, but can come in handy when needing more information about a mutation in rare scenarios
 
-```js
+```tsx
 const mutations = mutationCache.getAll()
 ```
 
@@ -64,7 +64,7 @@ const mutations = mutationCache.getAll()
 
 The `subscribe` method can be used to subscribe to the mutation cache as a whole and be informed of safe/known updates to the cache like mutation states changing or mutations being updated, added or removed.
 
-```js
+```tsx
 const callback = event => {
   console.log(event.type, event.mutation)
 }
@@ -86,6 +86,6 @@ const unsubscribe = mutationCache.subscribe(callback)
 
 The `clear` method can be used to clear the cache entirely and start fresh.
 
-```js
+```tsx
 mutationCache.clear()
 ```

--- a/docs/reference/QueriesObserver.md
+++ b/docs/reference/QueriesObserver.md
@@ -7,7 +7,7 @@ title: QueriesObserver
 
 The `QueriesObserver` can be used to observe multiple queries.
 
-```js
+```tsx
 const observer = new QueriesObserver(queryClient, [
   { queryKey: ['post', 1], queryFn: fetchPost },
   { queryKey: ['post', 2], queryFn: fetchPost },

--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -7,7 +7,7 @@ The `QueryCache` is the storage mechanism for React Query. It stores all the dat
 
 **Normally, you will not interact with the QueryCache directly and instead use the `QueryClient` for a specific cache.**
 
-```js
+```tsx
 import { QueryCache } from '@tanstack/react-query'
 
 const queryCache = new QueryCache({
@@ -50,7 +50,7 @@ The `onError` and `onSuccess` callbacks on the QueryCache can be used to handle 
 
 > Note: This is not typically needed for most applications, but can come in handy when needing more information about a query in rare scenarios (eg. Looking at the query.state.dataUpdatedAt timestamp to decide whether a query is fresh enough to be used as an initial value)
 
-```js
+```tsx
 const query = queryCache.find(queryKey)
 ```
 
@@ -70,7 +70,7 @@ const query = queryCache.find(queryKey)
 
 > Note: This is not typically needed for most applications, but can come in handy when needing more information about a query in rare scenarios
 
-```js
+```tsx
 const queries = queryCache.findAll(queryKey)
 ```
 
@@ -88,7 +88,7 @@ const queries = queryCache.findAll(queryKey)
 
 The `subscribe` method can be used to subscribe to the query cache as a whole and be informed of safe/known updates to the cache like query states changing or queries being updated, added or removed
 
-```js
+```tsx
 const callback = event => {
   console.log(event.type, event.query)
 }
@@ -110,6 +110,6 @@ const unsubscribe = queryCache.subscribe(callback)
 
 The `clear` method can be used to clear the cache entirely and start fresh.
 
-```js
+```tsx
 queryCache.clear()
 ```

--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -7,7 +7,7 @@ title: QueryClient
 
 The `QueryClient` can be used to interact with a cache:
 
-```js
+```tsx
 import { QueryClient } from '@tanstack/react-query'
 
 const queryClient = new QueryClient({
@@ -74,7 +74,7 @@ If the query exists and the data is not invalidated or older than the given `sta
 
 > The difference between using `fetchQuery` and `setQueryData` is that `fetchQuery` is async and will ensure that duplicate requests for this query are not created with `useQuery` instances for the same query are rendered while the data is fetching.
 
-```js
+```tsx
 try {
   const data = await queryClient.fetchQuery(queryKey, queryFn)
 } catch (error) {
@@ -84,7 +84,7 @@ try {
 
 Specify a `staleTime` to only fetch when the data is older than a certain amount of time:
 
-```js
+```tsx
 try {
   const data = await queryClient.fetchQuery(queryKey, queryFn, {
     staleTime: 10000,
@@ -106,7 +106,7 @@ The options for `fetchQuery` are exactly the same as those of [`useQuery`](./use
 
 `fetchInfiniteQuery` is similar to `fetchQuery` but can be used to fetch and cache an infinite query.
 
-```js
+```tsx
 try {
   const data = await queryClient.fetchInfiniteQuery(queryKey, queryFn)
   console.log(data.pages)
@@ -127,13 +127,13 @@ The options for `fetchInfiniteQuery` are exactly the same as those of [`fetchQue
 
 `prefetchQuery` is an asynchronous method that can be used to prefetch a query before it is needed or rendered with `useQuery` and friends. The method works the same as `fetchQuery` except that it will not throw or return any data.
 
-```js
+```tsx
 await queryClient.prefetchQuery(queryKey, queryFn)
 ```
 
 You can even use it with a default queryFn in your config!
 
-```js
+```tsx
 await queryClient.prefetchQuery(queryKey)
 ```
 
@@ -150,7 +150,7 @@ The options for `prefetchQuery` are exactly the same as those of [`fetchQuery`](
 
 `prefetchInfiniteQuery` is similar to `prefetchQuery` but can be used to prefetch and cache an infinite query.
 
-```js
+```tsx
 await queryClient.prefetchInfiniteQuery(queryKey, queryFn)
 ```
 
@@ -167,7 +167,7 @@ The options for `prefetchInfiniteQuery` are exactly the same as those of [`fetch
 
 `getQueryData` is a synchronous function that can be used to get an existing query's cached data. If the query does not exist, `undefined` will be returned.
 
-```js
+```tsx
 const data = queryClient.getQueryData(queryKey)
 ```
 
@@ -185,7 +185,7 @@ const data = queryClient.getQueryData(queryKey)
 
 `getQueriesData` is a synchronous function that can be used to get the cached data of multiple queries. Only queries that match the passed queryKey or queryFilter will be returned. If there are no matching queries, an empty array will be returned.
 
-```js
+```tsx
 const data = queryClient.getQueriesData(queryKey | filters)
 ```
 
@@ -212,7 +212,7 @@ This distinction is more a "convenience" for ts devs that know which structure w
 
 > The difference between using `setQueryData` and `fetchQuery` is that `setQueryData` is sync and assumes that you already synchronously have the data available. If you need to fetch the data asynchronously, it's suggested that you either refetch the query key or use `fetchQuery` to handle the asynchronous fetch.
 
-```js
+```tsx
 queryClient.setQueryData(queryKey, updater)
 ```
 
@@ -225,7 +225,7 @@ queryClient.setQueryData(queryKey, updater)
 
 **Using an updater value**
 
-```js
+```tsx
 setQueryData(queryKey, newData)
 ```
 
@@ -235,7 +235,7 @@ If the value is `undefined`, the query data is not updated.
 
 For convenience in syntax, you can also pass an updater function which receives the current data value and returns the new one:
 
-```js
+```tsx
 setQueryData(queryKey, oldData => newData)
 ```
 
@@ -245,7 +245,7 @@ If the updater function returns `undefined`, the query data will not be updated.
 
 `getQueryState` is a synchronous function that can be used to get an existing query's state. If the query does not exist, `undefined` will be returned.
 
-```js
+```tsx
 const state = queryClient.getQueryState(queryKey)
 console.log(state.dataUpdatedAt)
 ```
@@ -259,7 +259,7 @@ console.log(state.dataUpdatedAt)
 
 `setQueriesData` is a synchronous function that can be used to immediately update cached data of multiple queries by using filter function or partially matching the query key. Only queries that match the passed queryKey or queryFilter will be updated - no new cache entries will be created. Under the hood, [`setQueryData`](#queryclientsetquerydata) is called for each query.
 
-```js
+```tsx
 queryClient.setQueriesData(queryKey | filters, updater)
 ```
 
@@ -278,7 +278,7 @@ The `invalidateQueries` method can be used to invalidate and refetch single or m
 - If you **do not want active queries to refetch**, and simply be marked as invalid, you can use the `refetchType: 'none'` option.
 - If you **want inactive queries to refetch** as well, use the `refetchTye: 'all'` option
 
-```js
+```tsx
 await queryClient.invalidateQueries(['posts'], {
   exact,
   refetchType: 'active',
@@ -312,7 +312,7 @@ The `refetchQueries` method can be used to refetch queries based on certain cond
 
 Examples:
 
-```js
+```tsx
 // refetch all queries:
 await queryClient.refetchQueries()
 
@@ -351,7 +351,7 @@ The `cancelQueries` method can be used to cancel outgoing queries based on their
 
 This is most useful when performing optimistic updates since you will likely need to cancel any outgoing query refetches so they don't clobber your optimistic update when they resolve.
 
-```js
+```tsx
 await queryClient.cancelQueries(['posts'], { exact: true })
 ```
 
@@ -368,7 +368,7 @@ This method does not return anything
 
 The `removeQueries` method can be used to remove queries from the cache based on their query keys or any other functionally accessible property/state of the query.
 
-```js
+```tsx
 queryClient.removeQueries(queryKey, { exact: true })
 ```
 
@@ -392,7 +392,7 @@ subscribers &mdash; and reset the query to its pre-loaded state &mdash; unlike
 `invalidateQueries`. If a query has `initialData`, the query's data will be
 reset to that. If a query is active, it will be refetched.
 
-```js
+```tsx
 queryClient.resetQueries(queryKey, { exact: true })
 ```
 
@@ -419,7 +419,7 @@ This method returns a promise that resolves when all active queries have been re
 
 This `isFetching` method returns an `integer` representing how many queries, if any, in the cache are currently fetching (including background-fetching, loading new pages, or loading more infinite query results)
 
-```js
+```tsx
 if (queryClient.isFetching()) {
   console.log('At least one query is fetching!')
 }
@@ -440,7 +440,7 @@ This method returns the number of fetching queries.
 
 This `isMutating` method returns an `integer` representing how many mutations, if any, in the cache are currently fetching.
 
-```js
+```tsx
 if (queryClient.isMutating()) {
   console.log('At least one mutation is fetching!')
 }
@@ -459,7 +459,7 @@ This method returns the number of fetching mutations.
 
 The `getLogger` method returns the logger which have been set when creating the client.
 
-```js
+```tsx
 const logger = queryClient.getLogger()
 ```
 
@@ -467,7 +467,7 @@ const logger = queryClient.getLogger()
 
 The `getDefaultOptions` method returns the default options which have been set when creating the client or with `setDefaultOptions`.
 
-```js
+```tsx
 const defaultOptions = queryClient.getDefaultOptions()
 ```
 
@@ -475,7 +475,7 @@ const defaultOptions = queryClient.getDefaultOptions()
 
 The `setDefaultOptions` method can be used to dynamically set the default options for this queryClient. Previously defined default options will be overwritten.
 
-```js
+```tsx
 queryClient.setDefaultOptions({
   queries: {
     staleTime: Infinity,
@@ -487,7 +487,7 @@ queryClient.setDefaultOptions({
 
 The `getQueryDefaults` method returns the default options which have been set for specific queries:
 
-```js
+```tsx
 const defaultOptions = queryClient.getQueryDefaults(['posts'])
 ```
 
@@ -498,7 +498,7 @@ const defaultOptions = queryClient.getQueryDefaults(['posts'])
 
 `setQueryDefaults` can be used to set default options for specific queries:
 
-```js
+```tsx
 queryClient.setQueryDefaults(['posts'], { queryFn: fetchPosts })
 
 function Component() {
@@ -518,7 +518,7 @@ function Component() {
 
 The `getMutationDefaults` method returns the default options which have been set for specific mutations:
 
-```js
+```tsx
 const defaultOptions = queryClient.getMutationDefaults(['addPost'])
 ```
 
@@ -526,7 +526,7 @@ const defaultOptions = queryClient.getMutationDefaults(['addPost'])
 
 `setMutationDefaults` can be used to set default options for specific mutations:
 
-```js
+```tsx
 queryClient.setMutationDefaults(['addPost'], { mutationFn: addPost })
 
 function Component() {
@@ -545,7 +545,7 @@ function Component() {
 
 The `getQueryCache` method returns the query cache this client is connected to.
 
-```js
+```tsx
 const queryCache = queryClient.getQueryCache()
 ```
 
@@ -553,7 +553,7 @@ const queryCache = queryClient.getQueryCache()
 
 The `getMutationCache` method returns the mutation cache this client is connected to.
 
-```js
+```tsx
 const mutationCache = queryClient.getMutationCache()
 ```
 
@@ -561,7 +561,7 @@ const mutationCache = queryClient.getMutationCache()
 
 The `clear` method clears all connected caches.
 
-```js
+```tsx
 queryClient.clear()
 ```
 
@@ -569,6 +569,6 @@ queryClient.clear()
 
 Can be used to resume mutations that have been paused because there was no network connection.
 
-```js
+```tsx
 queryClient.resumePausedMutations()
 ```

--- a/docs/reference/QueryClientProvider.md
+++ b/docs/reference/QueryClientProvider.md
@@ -5,7 +5,7 @@ title: QueryClientProvider
 
 Use the `QueryClientProvider` component to connect and provide a `QueryClient` to your application:
 
-```js
+```tsx
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const queryClient = new QueryClient()

--- a/docs/reference/QueryErrorResetBoundary.md
+++ b/docs/reference/QueryErrorResetBoundary.md
@@ -5,7 +5,7 @@ title: QueryErrorResetBoundary
 
 When using **suspense** or **useErrorBoundaries** in your queries, you need a way to let queries know that you want to try again when re-rendering after some error occurred. With the `QueryErrorResetBoundary` component you can reset any query errors within the boundaries of the component.
 
-```js
+```tsx
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 

--- a/docs/reference/QueryObserver.md
+++ b/docs/reference/QueryObserver.md
@@ -7,7 +7,7 @@ title: QueryObserver
 
 The `QueryObserver` can be used to observe and switch between queries.
 
-```js
+```tsx
 const observer = new QueryObserver(queryClient, { queryKey: ['posts'] })
 
 const unsubscribe = observer.subscribe(result => {

--- a/docs/reference/focusManager.md
+++ b/docs/reference/focusManager.md
@@ -17,7 +17,7 @@ Its available methods are:
 
 `setEventListener` can be used to set a custom event listener:
 
-```js
+```tsx
 import { focusManager } from '@tanstack/react-query'
 
 focusManager.setEventListener(handleFocus => {
@@ -39,7 +39,7 @@ focusManager.setEventListener(handleFocus => {
 
 `setFocused` can be used to manually set the focus state. Set `undefined` to fallback to the default focus check.
 
-```js
+```tsx
 import { focusManager } from '@tanstack/react-query'
 
 // Set focused
@@ -60,6 +60,6 @@ focusManager.setFocused(undefined)
 
 `isFocused` can be used to get the current focus state.
 
-```js
+```tsx
 const isFocused = focusManager.isFocused()
 ```

--- a/docs/reference/hydration.md
+++ b/docs/reference/hydration.md
@@ -7,7 +7,7 @@ title: hydration
 
 `dehydrate` creates a frozen representation of a `cache` that can later be hydrated with `Hydrate`, `useHydrate`, or `hydrate`. This is useful for passing prefetched queries from server to client or persisting queries to localStorage or other persistent locations. It only includes currently successful queries by default.
 
-```js
+```tsx
 import { dehydrate } from '@tanstack/react-query'
 
 const dehydratedState = dehydrate(queryClient, {
@@ -50,7 +50,7 @@ const dehydratedState = dehydrate(queryClient, {
 
 Some storage systems (such as browser [Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API)) require values to be JSON serializable. If you need to dehydrate values that are not automatically serializable to JSON (like `Error` or `undefined`), you have to serialize them for yourself. Since only successful queries are included per default, to also include `Errors`, you have to provide `shouldDehydrateQuery`, e.g.:
 
-```js
+```tsx
 // server
 const state = dehydrate(client, { shouldDehydrateQuery: () => true }) // to also include Errors
 const serializedState = mySerialize(state) // transform Error instances to objects
@@ -64,7 +64,7 @@ hydrate(client, state)
 
 `hydrate` adds a previously dehydrated state into a `cache`.
 
-```js
+```tsx
 import { hydrate } from '@tanstack/react-query'
 
 hydrate(queryClient, dehydratedState, options)
@@ -95,7 +95,7 @@ If the queries included in dehydration already exist in the queryCache, `hydrate
 
 `useHydrate` adds a previously dehydrated state into the `queryClient` that would be returned by `useQueryClient()`. If the client already contains data, the new queries will be intelligently merged based on update timestamp.
 
-```jsx
+```tsxx
 import { useHydrate } from '@tanstack/react-query'
 
 useHydrate(dehydratedState, options)
@@ -117,7 +117,7 @@ useHydrate(dehydratedState, options)
 
 `Hydrate` wraps `useHydrate` into component. Can be useful when you need hydrate in class component or need hydrate on same level where `QueryClientProvider` rendered.
 
-```js
+```tsx
 import { Hydrate } from '@tanstack/react-query'
 
 function App() {

--- a/docs/reference/onlineManager.md
+++ b/docs/reference/onlineManager.md
@@ -17,7 +17,7 @@ Its available methods are:
 
 `setEventListener` can be used to set a custom event listener:
 
-```js
+```tsx
 import NetInfo from '@react-native-community/netinfo'
 import { onlineManager } from '@tanstack/react-query'
 
@@ -32,7 +32,7 @@ onlineManager.setEventListener(setOnline => {
 
 `setOnline` can be used to manually set the online state. Set `undefined` to fallback to the default online check.
 
-```js
+```tsx
 import { onlineManager } from '@tanstack/react-query'
 
 // Set to online
@@ -53,6 +53,6 @@ onlineManager.setOnline(undefined)
 
 `isOnline` can be used to get the current online state.
 
-```js
+```tsx
 const isOnline = onlineManager.isOnline()
 ```

--- a/docs/reference/useInfiniteQuery.md
+++ b/docs/reference/useInfiniteQuery.md
@@ -3,7 +3,7 @@ id: useInfiniteQuery
 title: useInfiniteQuery
 ---
 
-```js
+```tsx
 const {
   fetchNextPage,
   fetchPreviousPage,

--- a/docs/reference/useIsFetching.md
+++ b/docs/reference/useIsFetching.md
@@ -5,7 +5,7 @@ title: useIsFetching
 
 `useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or fetching in the background (useful for app-wide loading indicators).
 
-```js
+```tsx
 import { useIsFetching } from '@tanstack/react-query'
 // How many queries are fetching?
 const isFetching = useIsFetching()

--- a/docs/reference/useIsMutating.md
+++ b/docs/reference/useIsMutating.md
@@ -5,7 +5,7 @@ title: useIsMutating
 
 `useIsMutating` is an optional hook that returns the `number` of mutations that your application is fetching (useful for app-wide loading indicators).
 
-```js
+```tsx
 import { useIsMutating } from '@tanstack/react-query'
 // How many mutations are fetching?
 const isMutating = useIsMutating()

--- a/docs/reference/useMutation.md
+++ b/docs/reference/useMutation.md
@@ -3,7 +3,7 @@ id: useMutation
 title: useMutation
 ---
 
-```js
+```tsx
 const {
   data,
   error,

--- a/docs/reference/useQueries.md
+++ b/docs/reference/useQueries.md
@@ -5,7 +5,7 @@ title: useQueries
 
 The `useQueries` hook can be used to fetch a variable number of queries:
 
-```js
+```tsx
 const results = useQueries({
   queries: [
     { queryKey: ['post', 1], queryFn: fetchPost, staleTime: Infinity},

--- a/docs/reference/useQuery.md
+++ b/docs/reference/useQuery.md
@@ -3,7 +3,7 @@ id: useQuery
 title: useQuery
 ---
 
-```js
+```tsx
 const {
   data,
   dataUpdatedAt,

--- a/docs/reference/useQueryClient.md
+++ b/docs/reference/useQueryClient.md
@@ -5,7 +5,7 @@ title: useQueryClient
 
 The `useQueryClient` hook returns the current `QueryClient` instance.
 
-```js
+```tsx
 import { useQueryClient } from '@tanstack/react-query'
 
 const queryClient = useQueryClient()

--- a/docs/reference/useQueryErrorResetBoundary.md
+++ b/docs/reference/useQueryErrorResetBoundary.md
@@ -5,7 +5,7 @@ title: useQueryErrorResetBoundary
 
 This hook will reset any query errors within the closest `QueryErrorResetBoundary`. If there is no boundary defined it will reset them globally:
 
-```js
+```tsx
 import { useQueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 


### PR DESCRIPTION
The tanstack.com site shows the code-snippets as `bash` as a fallback,
as js is not expected as a language type. (see
[here](https://github.com/TanStack/tanstack.com/blob/main/app/components/CodeBlock.tsx)
for allowed language types).

In addition to allowing JS as a snippet type (https://github.com/TanStack/tanstack.com/pull/17),
changing the documentation to be `tsx` ensures that syntax
highlighting and the language type appears correct.