### PR TITLE
fix: add "require" to "exports" in package.json of devtools

### DIFF
--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -22,6 +22,7 @@
     "development": {
       "default": "./build/esm/index.js"
     },
+    "require": "./build/cjs/packages/react-query-devtools/src/index.js",
     "default": "./build/esm/noop.js"
   },
   "scripts": {


### PR DESCRIPTION
Fresh NextJS project does not build after #3861 was merged. It looks like this is due to missing "require" path in "exports".

I'm not 100% sure why it is needed, but this suggestion from @satya164 seems to resolve the issue.

Repro: https://stackblitz.com/edit/nextjs-odbs3c

<img width="927" alt="image" src="https://user-images.githubusercontent.com/22678765/180036943-709a607c-b470-4112-8f90-6fe150be4a65.png">
