### PR TITLE
fix(react-query-devtools): support cjs in noop build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "test:jest:dev": "jest --config ./jest.config.ts --watch",
     "test:size": "npm run build && bundlewatch",
     "build": "rollup --config rollup.config.js && npm run typecheck",
-    "postbuild": "cp ./packages/react-query-devtools/src/noop.ts ./packages/react-query-devtools/build/esm/noop.js",
     "typecheck": "tsc -b",
     "watch": "concurrently --kill-others \"rollup --config rollup.config.js -w\" \"npm run typecheck -- --watch\" \"npm run test\"",
     "linkAll": "lerna exec 'npm run link' --parallel",

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -20,9 +20,13 @@
   ],
   "exports": {
     "development": {
+      "require": "./build/cjs/packages/react-query-devtools/src/noop.js",
       "default": "./build/esm/index.js"
     },
-    "default": "./build/esm/noop.js"
+    "default": {
+      "require": "./build/cjs/packages/react-query-devtools/src/index.js",
+      "default": "./build/esm/noop.js"
+    }
   },
   "scripts": {
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src",

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -20,11 +20,11 @@
   ],
   "exports": {
     "development": {
-      "require": "./build/cjs/packages/react-query-devtools/src/noop.js",
+      "require": "./build/cjs/packages/react-query-devtools/src/index.js",
       "default": "./build/esm/index.js"
     },
     "default": {
-      "require": "./build/cjs/packages/react-query-devtools/src/index.js",
+      "require": "./build/cjs/packages/react-query-devtools/src/noop.js",
       "default": "./build/esm/noop.js"
     }
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -87,6 +87,17 @@ export default function rollup(options: RollupOptions): RollupOptions[] {
       },
     }),
     ...buildConfigs({
+      name: 'react-query-devtools-noop',
+      packageDir: 'packages/react-query-devtools',
+      jsName: 'ReactQueryDevtools',
+      outputFile: 'react-query-devtools',
+      entryFile: 'src/noop.ts',
+      globals: {
+        react: 'React',
+        '@tanstack/react-query': 'ReactQuery',
+      },
+    }),
+    ...buildConfigs({
       name: 'react-query-persist-client',
       packageDir: 'packages/react-query-persist-client',
       jsName: 'ReactQueryPersistClient',


### PR DESCRIPTION
Just noticed that someone also made a PR #3883 . But we should export the noop version. 