### PR TITLE
docs: make examples point to v3 instead of main

### DIFF
--- a/docs/src/pages/examples/auto-refetching.mdx
+++ b/docs/src/pages/examples/auto-refetching.mdx
@@ -6,11 +6,11 @@ toc: false
 
 This example works best when ran locally so you can open 2 separate browsers or tabs at the same time and interact between them.
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/auto-refetching)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/auto-refetching)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/auto-refetching)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/auto-refetching)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/auto-refetching?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/auto-refetching?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: auto-refetching"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/basic-graphql-request.mdx
+++ b/docs/src/pages/examples/basic-graphql-request.mdx
@@ -4,11 +4,11 @@ title: Basic w/ GraphQL-Request
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/basic-graphql-request)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/basic-graphql-request)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/basic-graphql-request)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/basic-graphql-request)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/basic-graphql-request?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/basic-graphql-request?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: basic-graphql-request"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/basic.mdx
+++ b/docs/src/pages/examples/basic.mdx
@@ -4,11 +4,11 @@ title: Basic
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/basic)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/basic)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/basic)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/basic)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/basic?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/basic?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: basic"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/custom-hooks.mdx
+++ b/docs/src/pages/examples/custom-hooks.mdx
@@ -4,11 +4,11 @@ title: Custom Hooks
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/custom-hooks)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/custom-hooks)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/custom-hooks)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/custom-hooks)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/custom-hooks?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/custom-hooks?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: custom-hooks"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/default-query-function.mdx
+++ b/docs/src/pages/examples/default-query-function.mdx
@@ -4,11 +4,11 @@ title: Default Query Function
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/default-query-function)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/default-query-function)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/default-query-function)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/default-query-function)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/default-query-function?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/default-query-function?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: default-query-function"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/focus-refetching.mdx
+++ b/docs/src/pages/examples/focus-refetching.mdx
@@ -4,11 +4,11 @@ title: Focus Refetching
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/focus-refetching)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/focus-refetching)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/focus-refetching)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/focus-refetching)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/focus-refetching?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/focus-refetching?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: focus-refetching"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/load-more-infinite-scroll.mdx
+++ b/docs/src/pages/examples/load-more-infinite-scroll.mdx
@@ -4,11 +4,11 @@ title: Load More / Infinite Scroll
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/load-more-infinite-scroll)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/load-more-infinite-scroll)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/load-more-infinite-scroll)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/load-more-infinite-scroll)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/load-more-infinite-scroll?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/load-more-infinite-scroll?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: load-more-infinite-scroll"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/nextjs.mdx
+++ b/docs/src/pages/examples/nextjs.mdx
@@ -4,11 +4,11 @@ title: Nextjs SSG
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/nextjs)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/nextjs)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/nextjs)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/nextjs)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/nextjs?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/nextjs?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: nextjs"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/optimistic-updates-typescript.mdx
+++ b/docs/src/pages/examples/optimistic-updates-typescript.mdx
@@ -4,11 +4,11 @@ title: Optimistic Updates in TypeScript
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/optimistic-updates-typescript)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/optimistic-updates-typescript)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/optimistic-updates-typescript)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/optimistic-updates-typescript)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/optimistic-updates-typescript?autoresize=1&fontsize=14&module=%2Fpages%2Findex.tsx&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/optimistic-updates-typescript?autoresize=1&fontsize=14&module=%2Fpages%2Findex.tsx&theme=dark"
   title="tannerlinsley/react-query: optimistic-updates-typescript"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/optimistic-updates.mdx
+++ b/docs/src/pages/examples/optimistic-updates.mdx
@@ -4,11 +4,11 @@ title: Optimistic Updates
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/optimistic-updates)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/optimistic-updates)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/optimistic-updates)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/optimistic-updates)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/optimistic-updates?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/optimistic-updates?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: optimistic-updates"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/pagination.mdx
+++ b/docs/src/pages/examples/pagination.mdx
@@ -4,11 +4,11 @@ title: Pagination
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/pagination)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/pagination)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/pagination)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/pagination)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/pagination?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/pagination?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: pagination"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/playground.mdx
+++ b/docs/src/pages/examples/playground.mdx
@@ -4,11 +4,11 @@ title: Playground
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/playground)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/playground)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/playground)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/playground)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/playground?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/playground?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: playground"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/prefetching.mdx
+++ b/docs/src/pages/examples/prefetching.mdx
@@ -4,11 +4,11 @@ title: Prefetching
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/prefetching)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/prefetching)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/prefetching)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/prefetching)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/prefetching?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/prefetching?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: prefetching"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/react-native.mdx
+++ b/docs/src/pages/examples/react-native.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 - [Open the Snack](https://snack.expo.dev/@arnaudbzn/react-query-basic-example)
-- [TypeScript version in the repo](https://github.com/tannerlinsley/react-query/tree/main/examples/react-native)
+- [TypeScript version in the repo](https://github.com/tannerlinsley/react-query/tree/v3/examples/react-native)
 
 <iframe
   src="https://snack.expo.dev/@arnaudbzn/react-query-basic-example"

--- a/docs/src/pages/examples/rick-morty.mdx
+++ b/docs/src/pages/examples/rick-morty.mdx
@@ -4,11 +4,11 @@ title: Rick & Morty
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/rick-morty)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/rick-morty)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/rick-morty)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/rick-morty)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/rick-morty?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/rick-morty?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: rick-morty"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/simple.mdx
+++ b/docs/src/pages/examples/simple.mdx
@@ -4,11 +4,11 @@ title: Simple
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/simple)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/simple)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/simple)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/simple)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/simple?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/simple?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: basic"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/star-wars.mdx
+++ b/docs/src/pages/examples/star-wars.mdx
@@ -4,11 +4,11 @@ title: Star Wars
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/star-wars)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/star-wars)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/star-wars)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/star-wars)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/star-wars?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/star-wars?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: star-wars"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/examples/suspense.mdx
+++ b/docs/src/pages/examples/suspense.mdx
@@ -4,11 +4,11 @@ title: Suspense
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/suspense)
-- [View Source](https://github.com/tannerlinsley/react-query/tree/main/examples/suspense)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/suspense)
+- [View Source](https://github.com/tannerlinsley/react-query/tree/v3/examples/suspense)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/suspense?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/suspense?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-query: suspense"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/docs/src/pages/guides/suspense.md
+++ b/docs/src/pages/guides/suspense.md
@@ -39,7 +39,7 @@ import { useQuery } from 'react-query'
 useQuery(queryKey, queryFn, { suspense: true })
 ```
 
-When using suspense mode, `status` states and `error` objects are not needed and are then replaced by usage of the `React.Suspense` component (including the use of the `fallback` prop and React error boundaries for catching errors). Please read the [Resetting Error Boundaries](#resetting-error-boundaries) and look at the [Suspense Example](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/suspense) for more information on how to set up suspense mode.
+When using suspense mode, `status` states and `error` objects are not needed and are then replaced by usage of the `React.Suspense` component (including the use of the `fallback` prop and React error boundaries for catching errors). Please read the [Resetting Error Boundaries](#resetting-error-boundaries) and look at the [Suspense Example](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/suspense) for more information on how to set up suspense mode.
 
 In addition to queries behaving differently in suspense mode, mutations also behave a bit differently. By default, instead of supplying the `error` variable when a mutation fails, it will be thrown during the next render of the component it's used in and propagate to the nearest error boundary, similar to query errors. If you wish to disable this, you can set the `useErrorBoundary` option to `false`. If you wish that errors are not thrown at all, you can set the `throwOnError` option to `false` as well!
 

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -289,7 +289,7 @@ const Home = ({ sponsors }) => {
         <section className="bg-gray-900 body-font">
           <div className="container max-w-7xl px-4  mx-auto -mt-72 relative">
             <iframe
-              src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/main/examples/basic?autoresize=1&fontsize=16&theme=dark"
+              src="https://codesandbox.io/embed/github/tannerlinsley/react-query/tree/v3/examples/basic?autoresize=1&fontsize=16&theme=dark"
               title="tannerlinsley/react-query: basic"
               sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
               className="shadow-2xl"

--- a/docs/src/pages/overview.md
+++ b/docs/src/pages/overview.md
@@ -44,7 +44,7 @@ On a more technical note, React Query will likely:
 
 In the example below, you can see React Query in its most basic and simple form being used to fetch the GitHub stats for the React Query GitHub project itself:
 
-[Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/main/examples/simple)
+[Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/v3/examples/simple)
 
 ```js
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query'


### PR DESCRIPTION
make examples point to v3 instead of main