### PR TITLE
docs: :memo: Update documentation to point to the new CDN link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ React Query is compatible with React v16.8+ and works with ReactDOM and React Na
 If you're not using a module bundler or package manager we also have a global ("UMD") build hosted on the [unpkg.com](https://unpkg.com) CDN. Simply add the following `<script>` tag to the bottom of your HTML file:
 
 ```html
-<script src="https://unpkg.com/react-query/dist/react-query.production.min.js"></script>
+<script src="https://unpkg.com/@tanstack/react-query@4/build/umd/index.production.js"></script>
 ```
 
 Once you've added this you will have access to the `window.ReactQuery` object and its exports.


### PR DESCRIPTION



# Changes:
Updated the documentation link from the old react-query to the new @tanstack/react-query
Old:
```md
<script src="https://unpkg.com/react-query/dist/react-query.production.min.js"></script>
```

New:
```md
<script src="https://unpkg.com/@tanstack/react-query@4/build/umd/index.production.js"></script>
```
In installation.md

# Related issues:
Fixes #3852 