### PR TITLE
Missing QueryClientProvider import in example.

### DIFF
--- a/docs/adapters/react-query.md
+++ b/docs/adapters/react-query.md
@@ -7,7 +7,7 @@ The `react-query` package offers a 1st-class API for using TanStack Query via Re
 ## Example
 
 ```tsx
-import { QueryClient, useQuery } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
 
 const queryClient = new QueryClient()
 


### PR DESCRIPTION
Plenty examples that aren't working - I'll work my way through and get them sorted where I see them.