### PR TITLE
Optimizing by memoizing the `<QueryClientProvider>` component using `React.memo` 🚀 

### DIFF
--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -12,7 +12,7 @@ export type PersistQueryClientProviderProps = QueryClientProviderProps & {
   onSuccess?: () => void
 }
 
-export const PersistQueryClientProvider = ({
+export const PersistQueryClientProvider = React.memo(({
   client,
   children,
   persistOptions,
@@ -52,4 +52,4 @@ export const PersistQueryClientProvider = ({
       <IsRestoringProvider value={isRestoring}>{children}</IsRestoringProvider>
     </QueryClientProvider>
   )
-}
+})

--- a/packages/react-query/src/Hydrate.tsx
+++ b/packages/react-query/src/Hydrate.tsx
@@ -30,7 +30,7 @@ export interface HydrateProps {
   children?: React.ReactNode
 }
 
-export const Hydrate = ({ children, options, state }: HydrateProps) => {
+export const Hydrate = React.memo(({ children, options, state }: HydrateProps) => {
   useHydrate(state, options)
   return children as React.ReactElement
-}
+})

--- a/packages/react-query/src/QueryClientProvider.tsx
+++ b/packages/react-query/src/QueryClientProvider.tsx
@@ -67,7 +67,7 @@ export type QueryClientProviderProps =
   | QueryClientProviderPropsWithContext
   | QueryClientProviderPropsWithContextSharing
 
-export const QueryClientProvider = ({
+export const QueryClientProvider = React.memo(({
   client,
   children,
   context,
@@ -87,4 +87,4 @@ export const QueryClientProvider = ({
       <Context.Provider value={client}>{children}</Context.Provider>
     </QueryClientSharingContext.Provider>
   )
-}
+})

--- a/packages/react-query/src/QueryErrorResetBoundary.tsx
+++ b/packages/react-query/src/QueryErrorResetBoundary.tsx
@@ -34,11 +34,11 @@ export const useQueryErrorResetBoundary = () =>
 
 export interface QueryErrorResetBoundaryProps {
   children:
-    | ((value: QueryErrorResetBoundaryValue) => React.ReactNode)
-    | React.ReactNode
+  | ((value: QueryErrorResetBoundaryValue) => React.ReactNode)
+  | React.ReactNode
 }
 
-export const QueryErrorResetBoundary = ({
+export const QueryErrorResetBoundary = React.memo(({
   children,
 }: QueryErrorResetBoundaryProps) => {
   const [value] = React.useState(() => createValue())
@@ -49,4 +49,4 @@ export const QueryErrorResetBoundary = ({
         : children}
     </QueryErrorResetBoundaryContext.Provider>
   )
-}
+})


### PR DESCRIPTION
Memoizing `<QueryClientProvider>` and some other `react-query` components using `React.memo` which might improve the performance of that components :)

For more info please refer [the documentation](https://reactjs.org/docs/react-api.html#reactmemo).
_Extremely sorry, if I made any mistakes :(_