### PR TITLE
Already checked in line 566.

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -615,13 +615,11 @@ export class QueryClient {
       )
       // It is ok not having defaults, but it is error prone to have more than 1 default for a given key
       if (matchingDefaults.length > 1) {
-        if (process.env.NODE_ENV !== 'production') {
-          this.logger.error(
-            `[QueryClient] Several mutation defaults match with key '${JSON.stringify(
-              mutationKey,
-            )}'. The first matching mutation defaults are used. Please check how mutation defaults are registered. Order does matter here. cf. https://react-query.tanstack.com/reference/QueryClient#queryclientsetmutationdefaults.`,
-          )
-        }
+        this.logger.error(
+          `[QueryClient] Several mutation defaults match with key '${JSON.stringify(
+            mutationKey,
+          )}'. The first matching mutation defaults are used. Please check how mutation defaults are registered. Order does matter here. cf. https://react-query.tanstack.com/reference/QueryClient#queryclientsetmutationdefaults.`,
+        )
       }
     }
 

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -570,13 +570,11 @@ export class QueryClient {
       )
       // It is ok not having defaults, but it is error prone to have more than 1 default for a given key
       if (matchingDefaults.length > 1) {
-        if (process.env.NODE_ENV !== 'production') {
-          this.logger.error(
-            `[QueryClient] Several query defaults match with key '${JSON.stringify(
-              queryKey,
-            )}'. The first matching query defaults are used. Please check how query defaults are registered. Order does matter here. cf. https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydefaults.`,
-          )
-        }
+        this.logger.error(
+          `[QueryClient] Several query defaults match with key '${JSON.stringify(
+            queryKey,
+          )}'. The first matching query defaults are used. Please check how query defaults are registered. Order does matter here. cf. https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydefaults.`,
+        )
       }
     }
 


### PR DESCRIPTION
(╯°□°)╯︵ ┻━┻

Typescript doesn't like it when we are checking if we're on production twice. First we check at Line 566 `if (process.env.NODE_ENV !== 'production') {` and then again @ line 573. 

```Failed to compile.

../../node_modules/@tanstack/query-core/src/queryClient.ts:573:13
Type error: This condition will always return 'true' since the types '"development" | "test"' and '"production"' have no overlap.
```

Simple fix 🥇 