### PR TITLE
Fixed incorrect syntax in QueryCache docs

### DIFF
--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -19,7 +19,7 @@ const queryCache = new QueryCache({
   }
 })
 
-const query = queryCache.find('posts')
+const query = queryCache.find(['posts'])
 ```
 
 Its available methods are:
@@ -71,7 +71,7 @@ const query = queryCache.find(queryKey)
 > Note: This is not typically needed for most applications, but can come in handy when needing more information about a query in rare scenarios
 
 ```tsx
-const queries = queryCache.findAll(queryKey)
+const queries = queryCache.findAll([queryKey])
 ```
 
 **Options**


### PR DESCRIPTION
The QueryCache docs were showing to find data in the queryCache by using a string in the find method. That is incorrect as in react query v4, keys are arrays only.