### PR TITLE
Add type:module property to package.json

### DIFF
--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tanstack/react-query-devtools",
+  "type": "module",
   "version": "4.0.10",
   "description": "TODO",
   "author": "tannerlinsley",


### PR DESCRIPTION
If the "--experimental-vm-modules" property is set, modules are processed with an error.

![image](https://user-images.githubusercontent.com/59764954/182678135-a4cb56a2-533b-46ce-ad61-17a8b114da4e.png)

Adding the property type: "module" solves this problem.