### PR TITLE
feat(react-query): type of `DefinedUseQueryResult.isLoading` is always false

### DIFF
--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -67,8 +67,8 @@ export type UseQueryResult<
 
 export type DefinedUseQueryResult<TData = unknown, TError = unknown> = Omit<
   UseQueryResult<TData, TError>,
-  'data'
-> & { data: TData }
+  'data' | 'isLoading'
+> & { data: TData, isLoading: false }
 
 export type UseInfiniteQueryResult<
   TData = unknown,


### PR DESCRIPTION
Since the `DefinedUseQueryResult` is used with `initialData`, there is always cached data. I think the  `isLoading` should always be false.