### PR TITLE
feat(react-query): isLoading of type DefinedUseQueryResult is always false

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -425,11 +425,14 @@ export interface QueryObserverSuccessResult<TData = unknown, TError = unknown>
   status: 'success'
 }
 
-export type QueryObserverResult<TData = unknown, TError = unknown> =
-  | QueryObserverLoadingErrorResult<TData, TError>
-  | QueryObserverLoadingResult<TData, TError>
+export type DefinedQueryObserverResult<TData = unknown, TError = unknown> =
   | QueryObserverRefetchErrorResult<TData, TError>
   | QueryObserverSuccessResult<TData, TError>
+
+export type QueryObserverResult<TData = unknown, TError = unknown> =
+  | DefinedQueryObserverResult<TData, TError>
+  | QueryObserverLoadingErrorResult<TData, TError>
+  | QueryObserverLoadingResult<TData, TError>
 
 export interface InfiniteQueryObserverBaseResult<
   TData = unknown,

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -65,10 +65,10 @@ export type UseQueryResult<
   TError = unknown,
 > = UseBaseQueryResult<TData, TError>
 
-export type DefinedUseQueryResult<TData = unknown, TError = unknown> = Omit<
-  UseQueryResult<TData, TError>,
-  'data'
-> & { data: TData }
+export type DefinedUseQueryResult<
+  TData = unknown,
+  TError = unknown,
+> = UseQueryResult<TData, TError> & { data: TData; isLoading: false }
 
 export type UseInfiniteQueryResult<
   TData = unknown,

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -8,6 +8,7 @@ import {
   QueryKey,
   MutationObserverOptions,
   MutateFunction,
+  DefinedQueryObserverResult,
 } from '@tanstack/query-core'
 import type { QueryClient } from '@tanstack/query-core'
 
@@ -65,10 +66,15 @@ export type UseQueryResult<
   TError = unknown,
 > = UseBaseQueryResult<TData, TError>
 
+export type DefinedUseBaseQueryResult<
+  TData = unknown,
+  TError = unknown,
+> = DefinedQueryObserverResult<TData, TError>
+
 export type DefinedUseQueryResult<
   TData = unknown,
   TError = unknown,
-> = UseQueryResult<TData, TError> & { data: TData; isLoading: false }
+> = DefinedUseBaseQueryResult<TData, TError>
 
 export type UseInfiniteQueryResult<
   TData = unknown,


### PR DESCRIPTION
Since there is always cache data, the `isLoading` of type `DefinedUseQueryResult`  should be false. Besides, the `Omit` is not required.