### PR TITLE
chore(devtools): Add peerDependencies

### DIFF
--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -36,5 +36,8 @@
     "@tanstack/match-sorter-utils": "^8.0.0-alpha.82",
     "@types/use-sync-external-store": "^0.0.3",
     "use-sync-external-store": "^1.2.0"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^4.0.0"
   }
 }


### PR DESCRIPTION
react-query-devtools gives the following error when using _yarn berry workspace_.
And you can check it out at https://github.com/doinki/react-query

![Screenshot from 2022-08-09 10-57-44](https://user-images.githubusercontent.com/90969158/183548379-4674a7db-d84d-4ea8-b0c0-3df17bdd7a7f.png)

```yml
packageExtensions:
  '@tanstack/react-query-devtools@*':
    peerDependencies:
      '@tanstack/react-query': '^4.0.0'
```

But can fix this error by adding packageExtentions to .yarnrc.yml