### PR TITLE
Update code example to use v4 convention

### DIFF
--- a/docs/guides/ssr.md
+++ b/docs/guides/ssr.md
@@ -83,7 +83,7 @@ import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 export async function getStaticProps() {
   const queryClient = new QueryClient()
 
-  await queryClient.prefetchQuery('posts', getPosts)
+  await queryClient.prefetchQuery(['posts'], getPosts)
 
   return {
     props: {


### PR DESCRIPTION
When using the example code I got the following error in the terminal:
```
As of v4, queryKey needs to be an Array. If you are using a string like 'repoData', please change it to an Array, e.g. ['repoData']
```

That makes me think this code example in particular got outdated when v4 was released.