### PR TITLE
fix: subpackage dependencies

### DIFF
--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -30,5 +30,8 @@
   "scripts": {
     "clean": "rm -rf ./build",
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src"
+  },
+  "dependencies": {
+    "@tanstack/react-query-persist-client": "^4.0.10"
   }
 }

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -32,6 +32,7 @@
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src"
   },
   "dependencies": {
+    "@tanstack/query-core": "^4.0.10",
     "broadcast-channel": "^3.4.1"
   }
 }

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -30,5 +30,8 @@
   "scripts": {
     "clean": "rm -rf ./build",
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src"
+  },
+  "dependencies": {
+    "@tanstack/react-query-persist-client": "^4.0.10"
   }
 }

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -23,13 +23,13 @@
     ".": {
       "development": {
         "types": "./build/lib/index.d.ts",
-        "require": "./build/lib/index.js",
-        "default": "./build/lib/index.mjs"
+        "import": "./build/lib/index.mjs",
+        "default": "./build/lib/index.js"
       },
       "default": {
         "types": "./build/lib/index.d.ts",
-        "require": "./build/lib/noop.js",
-        "default": "./build/lib/noop.mjs"
+        "import": "./build/lib/noop.mjs",
+        "default": "./build/lib/noop.js"
       }
     },
     "./production": {
@@ -44,7 +44,8 @@
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src"
   },
   "dependencies": {
-    "@tanstack/match-sorter-utils": "^8.0.0-alpha.82",
+    "@tanstack/match-sorter-utils": "^8.1.1",
+    "@tanstack/react-query": "^4.0.10",
     "@types/use-sync-external-store": "^0.0.3",
     "use-sync-external-store": "^1.2.0"
   }

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -30,5 +30,9 @@
   "scripts": {
     "clean": "rm -rf ./build",
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src"
+  },
+  "dependencies": {
+    "@tanstack/query-core": "^4.0.10",
+    "@tanstack/react-query": "^4.0.10"
   }
 }

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -47,7 +47,7 @@
     "react-error-boundary": "^3.1.4"
   },
   "dependencies": {
-    "@tanstack/query-core": "^4.0.0-beta.1",
+    "@tanstack/query-core": "^4.0.10",
     "@types/use-sync-external-store": "^0.0.3",
     "use-sync-external-store": "^1.2.0"
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -114,6 +114,7 @@ export default function rollup(options: RollupOptions): RollupOptions[] {
       entryFile: 'src/index.ts',
       globals: {
         react: 'React',
+        '@tanstack/query-core': 'QueryCore',
         '@tanstack/react-query': 'ReactQuery',
       },
     }),


### PR DESCRIPTION
This should allow for automatic deps install on sub packages. Currently when you try to install one of those, you might get an error about missing imports.

@TkDodo This should go to beta for pre-release