### PR TITLE
chore: allow to dispatch publish with tag override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,13 @@ name: ci
 concurrency:
   group: publish-${{ github.github.base_ref }}
   cancel-in-progress: true
-on: [push]
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: override release tag
+        required: false
+  push:
 jobs:
   test-and-publish:
     if: github.repository == 'TanStack/query' && github.event_name != 'pull_request'
@@ -28,3 +34,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG: ${{ inputs.tag }}


### PR DESCRIPTION
Allows to manually dispatch publish workflow, while also giving ability to override `tag`.
This is useful for `minor` or `patch` pre-releases, when we want to first test some functionality before releasing it as a regular version.

1. merge changes that you want to test to `beta` branch (ideally should be in sync with `main`)
2. trigger workflow manually from the [actions](https://github.com/TanStack/query/actions) tab overriding `tag` to a version higher with suffix. Ex `v4.0.11-beta.0` and branch to `beta` (available only to maintainers)