### PR TITLE
fix: remove browser entry, fix umd size

### DIFF
--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -10,10 +10,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
+  "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -10,10 +10,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
+  "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -10,10 +10,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
+  "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -10,10 +10,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
+  "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -10,16 +10,10 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
+  "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
   "browser": "build/lib/index.js",
-  "types": "build/lib/index.d.ts",
-  "files": [
-    "build/lib/*",
-    "build/umd/*",
-    "cjs.fallback.js",
-    "src"
-  ],
   "exports": {
     ".": {
       "development": {
@@ -40,6 +34,12 @@
     },
     "./package.json": "./package.json"
   },
+  "files": [
+    "build/lib/*",
+    "build/umd/*",
+    "cjs.fallback.js",
+    "src"
+  ],
   "scripts": {
     "clean": "rm -rf ./build",
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src"

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -13,7 +13,6 @@
   "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
-  "browser": "build/lib/index.js",
   "exports": {
     ".": {
       "development": {

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -10,10 +10,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
+  "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -10,10 +10,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
+  "types": "build/lib/index.d.ts",
   "module": "build/lib/index.mjs",
   "main": "build/lib/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -81,6 +81,7 @@ export default function rollup(options: RollupOptions): RollupOptions[] {
       entryFile: 'src/index.ts',
       globals: {
         react: 'React',
+        'react-dom': 'ReactDOM',
         '@tanstack/query-core': 'QueryCore',
       },
     }),

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -84,6 +84,7 @@ export default function rollup(options: RollupOptions): RollupOptions[] {
         'react-dom': 'ReactDOM',
         '@tanstack/query-core': 'QueryCore',
       },
+      bundleUMDGlobals: ['@tanstack/query-core'],
     }),
     ...buildConfigs({
       name: 'react-query-devtools',
@@ -129,9 +130,16 @@ function buildConfigs(opts: {
   outputFile: string
   entryFile: string
   globals: Record<string, string>
+  // This option allows to bundle specified dependencies for umd build
+  bundleUMDGlobals?: string[]
 }): RollupOptions[] {
   const input = path.resolve(opts.packageDir, opts.entryFile)
   const externalDeps = Object.keys(opts.globals)
+
+  const bundleUMDGlobals = opts.bundleUMDGlobals || []
+  const umdExternal = externalDeps.filter(
+    (external) => !bundleUMDGlobals.includes(external),
+  )
 
   const external = (moduleName) => externalDeps.includes(moduleName)
   const banner = createBanner(opts.name)
@@ -146,7 +154,7 @@ function buildConfigs(opts: {
     globals: opts.globals,
   }
 
-  return [esm(options), cjs(options), umdDev(options), umdProd(options)]
+  return [esm(options), cjs(options), umdDev({...options, external: umdExternal}), umdProd({...options, external: umdExternal})]
 }
 
 function esm({ input, packageDir, external, banner }: Options): RollupOptions {


### PR DESCRIPTION
@TkDodo
This should fix:
- some bundlers picking up `browser` entry in package.json (`umd` build instead of `cjs` or `esm`)
- unusual size of `react-query`, due to missing rollup global definition for react-dom

This won't fix:
- bundlers that support `exports`, but does not support `development/production` conditionals (https://webpack.js.org/guides/package-exports/#optimizations)
  This might be the case as those conditionals were mostly proposed by `webpack`.
  We could potentially overcome this by linking `exports/./default/default` not to `noop.js`, but to intermediate `js` file that conditionally require devtools based on `NODE_ENV`, like in the v3.
  This however i would like to test separately.

Previous beta release also have a side effect that `react-query` UMD build does not contain `query-core` UMD build and therefore is smaller. Is that something we should fix to be bundled together?

--

I would like to get this as a beta pre-release to test it out.