### PR TITLE
fix: cjs devtools fallback

### DIFF
--- a/packages/react-query-devtools/cjs.fallback.js
+++ b/packages/react-query-devtools/cjs.fallback.js
@@ -1,0 +1,13 @@
+// This is the cjs fallback for bundlers that do not support exports.development conditional
+if (process.env.NODE_ENV !== 'development') {
+  module.exports = {
+    ReactQueryDevtools: function () {
+      return null
+    },
+    ReactQueryDevtoolsPanel: function () {
+      return null
+    },
+  }
+} else {
+  module.exports = require('./build/lib/index.js')
+}

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -17,6 +17,7 @@
   "files": [
     "build/lib/*",
     "build/umd/*",
+    "cjs.fallback.js",
     "src"
   ],
   "exports": {
@@ -29,7 +30,7 @@
       "default": {
         "types": "./build/lib/index.d.ts",
         "import": "./build/lib/noop.mjs",
-        "default": "./build/lib/noop.js"
+        "default": "./cjs.fallback.js"
       }
     },
     "./production": {


### PR DESCRIPTION
@TkDodo This is a potential fix for bundlers that does not support `development` conditional in `exports`
This will work only with `cjs`.

For `esm` i do not see any easy fix.