### PR TITLE
fix: Adding screenreader text to the DevTools open icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,8 +101,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -121,8 +121,8 @@
       "name": "@tanstack/query-example-react-basic",
       "version": "0.0.1",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -136,8 +136,8 @@
       "name": "@tanstack/query-example-react-basic-graphql-request",
       "version": "0.0.1",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "graphql": "^15.3.0",
         "graphql-request": "^3.1.0",
         "react": "^18.0.0",
@@ -168,28 +168,6 @@
       "peerDependencies": {
         "vite": "^3.0.0"
       }
-    },
-    "examples/react/basic-graphql-request/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "examples/react/basic-graphql-request/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/basic-graphql-request/node_modules/magic-string": {
       "version": "0.26.2",
@@ -242,26 +220,6 @@
         "node": ">=0.10.0"
       }
     },
-    "examples/react/basic-graphql-request/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "examples/react/basic-graphql-request/node_modules/vite": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -307,10 +265,10 @@
       "name": "@tanstack/query-example-react-basic-typescript",
       "version": "0.0.1",
       "dependencies": {
-        "@tanstack/query-sync-storage-persister": "4.0.10",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
-        "@tanstack/react-query-persist-client": "4.0.10",
+        "@tanstack/query-sync-storage-persister": "4.2.1",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
+        "@tanstack/react-query-persist-client": "4.2.1",
         "axios": "^0.26.1",
         "broadcast-channel": "^3.4.1",
         "react": "^18.0.0",
@@ -399,34 +357,12 @@
         "vite": "^3.0.0"
       }
     },
-    "examples/react/basic/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "examples/react/basic/node_modules/axios": {
       "version": "0.21.4",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
-    },
-    "examples/react/basic/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/basic/node_modules/magic-string": {
       "version": "0.26.2",
@@ -477,26 +413,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "examples/react/basic/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "examples/react/basic/node_modules/vite": {
@@ -566,8 +482,8 @@
       "name": "@tanstack/query-example-react-default-query-function",
       "version": "0.0.1",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.26.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -597,28 +513,6 @@
       "peerDependencies": {
         "vite": "^3.0.0"
       }
-    },
-    "examples/react/default-query-function/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "examples/react/default-query-function/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/default-query-function/node_modules/magic-string": {
       "version": "0.26.2",
@@ -669,26 +563,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "examples/react/default-query-function/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "examples/react/default-query-function/node_modules/vite": {
@@ -752,8 +626,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -774,8 +648,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "ky": "^0.23.0",
         "ky-universal": "^0.8.2",
         "next": "12.2.2",
@@ -790,11 +664,11 @@
       "name": "@tanstack/query-example-react-offline",
       "version": "0.0.1",
       "dependencies": {
-        "@tanstack/query-sync-storage-persister": "4.0.10",
+        "@tanstack/query-sync-storage-persister": "4.2.1",
         "@tanstack/react-location": "^3.7.0",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
-        "@tanstack/react-query-persist-client": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
+        "@tanstack/react-query-persist-client": "4.2.1",
         "ky": "^0.30.0",
         "msw": "^0.39.2",
         "react": "^18.0.0",
@@ -826,28 +700,6 @@
       "peerDependencies": {
         "vite": "^3.0.0"
       }
-    },
-    "examples/react/offline/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "examples/react/offline/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/offline/node_modules/ky": {
       "version": "0.30.0",
@@ -908,26 +760,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "examples/react/offline/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "examples/react/offline/node_modules/vite": {
@@ -991,8 +823,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@types/node": "14.14.14",
         "@types/react": "^18.0.15",
         "axios": "^0.21.1",
@@ -1019,8 +851,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -1039,8 +871,8 @@
       "name": "@tanstack/query-example-react-playground",
       "version": "0.0.1",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -1069,28 +901,6 @@
       "peerDependencies": {
         "vite": "^3.0.0"
       }
-    },
-    "examples/react/playground/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "examples/react/playground/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/playground/node_modules/magic-string": {
       "version": "0.26.2",
@@ -1143,26 +953,6 @@
         "node": ">=0.10.0"
       }
     },
-    "examples/react/playground/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "examples/react/playground/node_modules/vite": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -1209,8 +999,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -1232,8 +1022,8 @@
         "@react-native-community/netinfo": "6.0.2",
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.0.2",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "expo": "~43.0.2",
         "expo-constants": "~12.1.3",
         "expo-status-bar": "~1.1.0",
@@ -1328,8 +1118,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@material-ui/core": "^4.9.7",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router": "^5.1.2",
@@ -1360,28 +1150,6 @@
       "peerDependencies": {
         "vite": "^3.0.0"
       }
-    },
-    "examples/react/rick-morty/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "examples/react/rick-morty/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/rick-morty/node_modules/magic-string": {
       "version": "0.26.2",
@@ -1434,26 +1202,6 @@
         "node": ">=0.10.0"
       }
     },
-    "examples/react/rick-morty/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "examples/react/rick-morty/node_modules/vite": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -1499,8 +1247,8 @@
       "name": "@tanstack/query-example-react-simple",
       "version": "0.0.1",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.26.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -1530,28 +1278,6 @@
       "peerDependencies": {
         "vite": "^3.0.0"
       }
-    },
-    "examples/react/simple/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "examples/react/simple/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/simple/node_modules/magic-string": {
       "version": "0.26.2",
@@ -1604,26 +1330,6 @@
         "node": ">=0.10.0"
       }
     },
-    "examples/react/simple/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "examples/react/simple/node_modules/vite": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.2.tgz",
@@ -1670,8 +1376,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@material-ui/core": "^4.9.7",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router": "^5.1.2",
@@ -1702,28 +1408,6 @@
       "peerDependencies": {
         "vite": "^3.0.0"
       }
-    },
-    "examples/react/star-wars/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "examples/react/star-wars/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/star-wars/node_modules/magic-string": {
       "version": "0.26.2",
@@ -1776,26 +1460,6 @@
         "node": ">=0.10.0"
       }
     },
-    "examples/react/star-wars/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "examples/react/star-wars/node_modules/vite": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -1841,8 +1505,8 @@
       "name": "@tanstack/query-example-react-suspense",
       "version": "1.0.0",
       "dependencies": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -1874,34 +1538,12 @@
         "vite": "^3.0.0"
       }
     },
-    "examples/react/suspense/node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "examples/react/suspense/node_modules/axios": {
       "version": "0.21.4",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
-    },
-    "examples/react/suspense/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "examples/react/suspense/node_modules/magic-string": {
       "version": "0.26.2",
@@ -1967,26 +1609,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "examples/react/suspense/node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "examples/react/suspense/node_modules/vite": {
@@ -4416,6 +4038,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -4434,6 +4057,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.16.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -4447,6 +4071,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4454,6 +4079,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -5321,6 +4947,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.0",
@@ -5333,6 +4960,7 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hutson/parse-repository-url": {
@@ -5996,7 +5624,7 @@
     },
     "node_modules/@jest/types": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6011,7 +5639,7 @@
     },
     "node_modules/@jest/types/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6025,7 +5653,7 @@
     },
     "node_modules/@jest/types/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6040,7 +5668,7 @@
     },
     "node_modules/@jest/types/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6051,12 +5679,12 @@
     },
     "node_modules/@jest/types/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/types/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6064,7 +5692,7 @@
     },
     "node_modules/@jest/types/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11732,7 +11360,7 @@
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -12442,6 +12070,7 @@
     },
     "node_modules/acorn": {
       "version": "7.4.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -12567,6 +12196,7 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17086,6 +16716,7 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1"
@@ -17671,6 +17302,7 @@
     },
     "node_modules/eslint": {
       "version": "7.32.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -18334,6 +17966,7 @@
     },
     "node_modules/eslint/node_modules/@babel/code-frame": {
       "version": "7.12.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
@@ -18341,6 +17974,7 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -18354,6 +17988,7 @@
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -18368,6 +18003,7 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -18378,10 +18014,12 @@
     },
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -18394,6 +18032,7 @@
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -18404,6 +18043,7 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "5.1.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -18415,6 +18055,7 @@
     },
     "node_modules/eslint/node_modules/eslint-utils": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
@@ -18428,6 +18069,7 @@
     },
     "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -18435,6 +18077,7 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
@@ -18442,6 +18085,7 @@
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.16.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -18455,6 +18099,7 @@
     },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18462,6 +18107,7 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -18469,6 +18115,7 @@
     },
     "node_modules/eslint/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -18479,6 +18126,7 @@
     },
     "node_modules/eslint/node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18486,6 +18134,7 @@
     },
     "node_modules/eslint/node_modules/semver": {
       "version": "7.3.7",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -18499,6 +18148,7 @@
     },
     "node_modules/eslint/node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -18509,6 +18159,7 @@
     },
     "node_modules/eslint/node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18516,6 +18167,7 @@
     },
     "node_modules/eslint/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18526,6 +18178,7 @@
     },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -18536,6 +18189,7 @@
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -18546,6 +18200,7 @@
     },
     "node_modules/eslint/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -18559,10 +18214,12 @@
     },
     "node_modules/eslint/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/espree": {
       "version": "7.3.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^7.4.0",
@@ -20065,6 +19722,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -20175,6 +19833,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -20186,6 +19845,7 @@
     },
     "node_modules/flatted": {
       "version": "3.2.6",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/flatten": {
@@ -21755,6 +21415,7 @@
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inflight": {
@@ -23841,7 +23502,7 @@
     },
     "node_modules/jest-get-type": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -23849,7 +23510,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -23874,7 +23535,7 @@
     },
     "node_modules/jest-haste-map/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23882,7 +23543,7 @@
     },
     "node_modules/jest-haste-map/node_modules/jest-worker": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -23895,7 +23556,7 @@
     },
     "node_modules/jest-haste-map/node_modules/supports-color": {
       "version": "8.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -24222,7 +23883,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -24230,7 +23891,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -24263,7 +23924,7 @@
     },
     "node_modules/jest-resolve/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -24277,7 +23938,7 @@
     },
     "node_modules/jest-resolve/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -24292,7 +23953,7 @@
     },
     "node_modules/jest-resolve/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -24303,12 +23964,12 @@
     },
     "node_modules/jest-resolve/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-resolve/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24316,7 +23977,7 @@
     },
     "node_modules/jest-resolve/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -24654,7 +24315,7 @@
     },
     "node_modules/jest-serializer": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -24814,7 +24475,7 @@
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -24830,7 +24491,7 @@
     },
     "node_modules/jest-util/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -24844,7 +24505,7 @@
     },
     "node_modules/jest-util/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -24859,12 +24520,12 @@
     },
     "node_modules/jest-util/node_modules/ci-info": {
       "version": "3.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-util/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -24875,12 +24536,12 @@
     },
     "node_modules/jest-util/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-util/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24888,7 +24549,7 @@
     },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -24899,7 +24560,7 @@
     },
     "node_modules/jest-validate": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -24915,7 +24576,7 @@
     },
     "node_modules/jest-validate/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -24929,7 +24590,7 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -24940,7 +24601,7 @@
     },
     "node_modules/jest-validate/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -24955,7 +24616,7 @@
     },
     "node_modules/jest-validate/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -24966,12 +24627,12 @@
     },
     "node_modules/jest-validate/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24979,7 +24640,7 @@
     },
     "node_modules/jest-validate/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -26235,6 +25896,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -26606,6 +26268,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.omit": {
@@ -26645,6 +26308,7 @@
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.unescape": {
@@ -30207,6 +29871,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -32020,6 +31685,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -32070,7 +31736,7 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -32083,7 +31749,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -32094,7 +31760,7 @@
     },
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/process": {
@@ -37425,6 +37091,7 @@
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -37758,7 +37425,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -38316,6 +37983,7 @@
     },
     "node_modules/serialize-javascript": {
       "version": "4.0.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -39665,6 +39333,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -39930,6 +39599,7 @@
     },
     "node_modules/table": {
       "version": "6.8.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
@@ -39944,6 +39614,7 @@
     },
     "node_modules/table/node_modules/ajv": {
       "version": "8.11.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -39958,6 +39629,7 @@
     },
     "node_modules/table/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -39971,6 +39643,7 @@
     },
     "node_modules/table/node_modules/astral-regex": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -39978,6 +39651,7 @@
     },
     "node_modules/table/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -39988,10 +39662,12 @@
     },
     "node_modules/table/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/table/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -39999,10 +39675,12 @@
     },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/table/node_modules/slice-ansi": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -40018,6 +39696,7 @@
     },
     "node_modules/table/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -40173,22 +39852,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/terser": {
-      "version": "4.4.2",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/terser-webpack-plugin": {
@@ -40354,11 +40017,6 @@
     "node_modules/terser-webpack-plugin/node_modules/y18n": {
       "version": "4.0.3",
       "license": "ISC"
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -40715,6 +40373,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -41196,6 +40855,7 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
@@ -41441,7 +41101,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "nan": "^2.12.1"
@@ -41617,42 +41276,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=10.4"
-      }
-    },
-    "node_modules/webpack": {
-      "version": "4.41.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
-        "watchpack": "^1.6.0",
-        "webpack-sources": "^1.4.1"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=6.11.5"
       }
     },
     "node_modules/webpack-dev-middleware": {
@@ -42279,327 +41902,6 @@
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
       }
-    },
-    "node_modules/webpack/node_modules/acorn": {
-      "version": "6.4.2",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/braces": {
-      "version": "2.3.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/cacache": {
-      "version": "12.0.4",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "4.0.3",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/fill-range": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack/node_modules/find-up": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/is-number": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack/node_modules/locate-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack/node_modules/make-dir": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack/node_modules/micromatch": {
-      "version": "3.1.10",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/p-locate": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack/node_modules/rimraf": {
-      "version": "2.7.1",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.2",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "figgy-pudding": "^3.5.1"
-      }
-    },
-    "node_modules/webpack/node_modules/terser-webpack-plugin": {
-      "version": "1.4.5",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^4.0.0",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/watchpack": {
-      "version": "1.7.5",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
-      },
-      "optionalDependencies": {
-        "chokidar": "^3.4.1",
-        "watchpack-chokidar2": "^2.0.1"
-      }
-    },
-    "node_modules/webpack/node_modules/y18n": {
-      "version": "4.0.3",
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -43288,7 +42590,7 @@
     },
     "packages/query-async-storage-persister": {
       "name": "@tanstack/query-async-storage-persister",
-      "version": "4.0.10",
+      "version": "4.2.1",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -43310,7 +42612,7 @@
     },
     "packages/query-broadcast-client-experimental": {
       "name": "@tanstack/query-broadcast-client-experimental",
-      "version": "4.0.10",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "broadcast-channel": "^4.14.0"
@@ -43350,7 +42652,7 @@
     },
     "packages/query-core": {
       "name": "@tanstack/query-core",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -43359,7 +42661,7 @@
     },
     "packages/query-sync-storage-persister": {
       "name": "@tanstack/query-sync-storage-persister",
-      "version": "4.0.10",
+      "version": "4.2.1",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -43368,7 +42670,7 @@
     },
     "packages/react-query": {
       "name": "@tanstack/react-query",
-      "version": "4.1.3",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^4.0.0-beta.1",
@@ -43400,7 +42702,7 @@
     },
     "packages/react-query-devtools": {
       "name": "@tanstack/react-query-devtools",
-      "version": "4.0.10",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/match-sorter-utils": "^8.0.0-alpha.82",
@@ -43419,7 +42721,7 @@
     },
     "packages/react-query-persist-client": {
       "name": "@tanstack/react-query-persist-client",
-      "version": "4.0.10",
+      "version": "4.2.1",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -44803,6 +44105,7 @@
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
@@ -44817,15 +44120,18 @@
       "dependencies": {
         "globals": {
           "version": "13.16.0",
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
         },
         "ignore": {
-          "version": "4.0.6"
+          "version": "4.0.6",
+          "dev": true
         },
         "type-fest": {
-          "version": "0.20.2"
+          "version": "0.20.2",
+          "dev": true
         }
       }
     },
@@ -45431,6 +44737,7 @@
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
+      "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.0",
         "debug": "^4.1.1",
@@ -45438,7 +44745,8 @@
       }
     },
     "@humanwhocodes/object-schema": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -45879,7 +45187,7 @@
     },
     "@jest/types": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -45890,14 +45198,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -45905,22 +45213,22 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "devOptional": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "devOptional": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -47834,8 +47142,7 @@
       }
     },
     "@material-ui/types": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "@material-ui/utils": {
       "version": "4.11.3",
@@ -48200,8 +47507,7 @@
     },
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
@@ -48869,8 +48175,7 @@
       }
     },
     "@react-native-community/netinfo": {
-      "version": "6.0.2",
-      "requires": {}
+      "version": "6.0.2"
     },
     "@react-native/assets": {
       "version": "1.0.0"
@@ -48900,8 +48205,7 @@
       }
     },
     "@react-navigation/elements": {
-      "version": "1.3.4",
-      "requires": {}
+      "version": "1.3.4"
     },
     "@react-navigation/native": {
       "version": "6.0.11",
@@ -49220,8 +48524,8 @@
     "@tanstack/query-example-react-basic": {
       "version": "file:examples/react/basic",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "axios": "^0.21.1",
         "react": "^18.0.0",
@@ -49244,27 +48548,11 @@
             "react-refresh": "^0.14.0"
           }
         },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "axios": {
           "version": "0.21.4",
           "requires": {
             "follow-redirects": "^1.14.0"
           }
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "magic-string": {
           "version": "0.26.2",
@@ -49298,20 +48586,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -49330,8 +48604,8 @@
     "@tanstack/query-example-react-basic-graphql-request": {
       "version": "file:examples/react/basic-graphql-request",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "graphql": "^15.3.0",
         "graphql-request": "^3.1.0",
@@ -49355,22 +48629,6 @@
             "react-refresh": "^0.14.0"
           }
         },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "magic-string": {
           "version": "0.26.2",
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
@@ -49403,20 +48661,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -49438,10 +48682,10 @@
         "@rescripts/cli": "^0.0.11",
         "@rescripts/rescript-use-babel-config": "^0.0.8",
         "@rescripts/rescript-use-eslint-config": "^0.0.9",
-        "@tanstack/query-sync-storage-persister": "4.0.10",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
-        "@tanstack/react-query-persist-client": "4.0.10",
+        "@tanstack/query-sync-storage-persister": "4.2.1",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
+        "@tanstack/react-query-persist-client": "4.2.1",
         "@types/react": "^17.0.3",
         "@types/react-dom": "^17.0.3",
         "axios": "^0.26.1",
@@ -49486,16 +48730,15 @@
         },
         "eslint-config-prettier": {
           "version": "8.5.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
     "@tanstack/query-example-react-default-query-function": {
       "version": "file:examples/react/default-query-function",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "axios": "^0.26.1",
         "react": "^18.0.0",
@@ -49517,22 +48760,6 @@
             "magic-string": "^0.26.2",
             "react-refresh": "^0.14.0"
           }
-        },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "magic-string": {
           "version": "0.26.2",
@@ -49566,20 +48793,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -49598,8 +48811,8 @@
     "@tanstack/query-example-react-load-more-infinite-scroll": {
       "version": "file:examples/react/load-more-infinite-scroll",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -49619,8 +48832,8 @@
     "@tanstack/query-example-react-nextjs": {
       "version": "file:examples/react/nextjs",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "ky": "^0.23.0",
         "ky-universal": "^0.8.2",
         "next": "12.2.2",
@@ -49633,11 +48846,11 @@
     "@tanstack/query-example-react-offline": {
       "version": "file:examples/react/offline",
       "requires": {
-        "@tanstack/query-sync-storage-persister": "4.0.10",
+        "@tanstack/query-sync-storage-persister": "4.2.1",
         "@tanstack/react-location": "^3.7.0",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
-        "@tanstack/react-query-persist-client": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
+        "@tanstack/react-query-persist-client": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "ky": "^0.30.0",
         "msw": "^0.39.2",
@@ -49661,22 +48874,6 @@
             "magic-string": "^0.26.2",
             "react-refresh": "^0.14.0"
           }
-        },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "ky": {
           "version": "0.30.0"
@@ -49713,20 +48910,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -49745,8 +48928,8 @@
     "@tanstack/query-example-react-optimistic-updates-typescript": {
       "version": "file:examples/react/optimistic-updates-typescript",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@types/node": "14.14.14",
         "@types/react": "^18.0.15",
         "axios": "^0.21.1",
@@ -49771,8 +48954,8 @@
     "@tanstack/query-example-react-pagination": {
       "version": "file:examples/react/pagination",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -49791,8 +48974,8 @@
     "@tanstack/query-example-react-playground": {
       "version": "file:examples/react/playground",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -49813,22 +48996,6 @@
             "magic-string": "^0.26.2",
             "react-refresh": "^0.14.0"
           }
-        },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "magic-string": {
           "version": "0.26.2",
@@ -49862,20 +49029,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -49894,8 +49047,8 @@
     "@tanstack/query-example-react-prefetching": {
       "version": "file:examples/react/prefetching",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -49920,8 +49073,8 @@
         "@react-native-community/netinfo": "6.0.2",
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.0.2",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@types/react-native": "~0.64.3",
         "babel-plugin-module-resolver": "^4.1.0",
         "eslint": "^7.32.0",
@@ -49981,8 +49134,8 @@
     "@tanstack/query-example-react-refetch-interval": {
       "version": "file:examples/react/auto-refetching",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "axios": "^0.21.1",
         "isomorphic-unfetch": "3.0.0",
         "next": "12.2.2",
@@ -50002,8 +49155,8 @@
       "version": "file:examples/react/rick-morty",
       "requires": {
         "@material-ui/core": "^4.9.7",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -50026,22 +49179,6 @@
             "magic-string": "^0.26.2",
             "react-refresh": "^0.14.0"
           }
-        },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "magic-string": {
           "version": "0.26.2",
@@ -50075,20 +49212,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -50107,8 +49230,8 @@
     "@tanstack/query-example-react-simple": {
       "version": "file:examples/react/simple",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "axios": "^0.26.1",
         "react": "^18.0.0",
@@ -50131,22 +49254,6 @@
             "react-refresh": "^0.14.0"
           }
         },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "magic-string": {
           "version": "0.26.2",
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
@@ -50179,20 +49286,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.2.tgz",
@@ -50212,8 +49305,8 @@
       "version": "file:examples/react/star-wars",
       "requires": {
         "@material-ui/core": "^4.9.7",
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -50237,22 +49330,6 @@
             "react-refresh": "^0.14.0"
           }
         },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "magic-string": {
           "version": "0.26.2",
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
@@ -50285,20 +49362,6 @@
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
         },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "vite": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
@@ -50317,8 +49380,8 @@
     "@tanstack/query-example-react-suspense": {
       "version": "file:examples/react/suspense",
       "requires": {
-        "@tanstack/react-query": "4.1.3",
-        "@tanstack/react-query-devtools": "4.0.10",
+        "@tanstack/react-query": "4.2.1",
+        "@tanstack/react-query-devtools": "4.2.1",
         "@vitejs/plugin-react": "^2.0.0",
         "axios": "^0.21.1",
         "react": "^18.0.0",
@@ -50342,27 +49405,11 @@
             "react-refresh": "^0.14.0"
           }
         },
-        "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "axios": {
           "version": "0.21.4",
           "requires": {
             "follow-redirects": "^1.14.0"
           }
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "magic-string": {
           "version": "0.26.2",
@@ -50403,20 +49450,6 @@
           "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
           "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
           "dev": true
-        },
-        "terser": {
-          "version": "5.14.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
         },
         "vite": {
           "version": "3.0.4",
@@ -50917,7 +49950,7 @@
     },
     "@types/yargs": {
       "version": "16.0.4",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -51399,11 +50432,11 @@
       }
     },
     "acorn": {
-      "version": "7.4.1"
+      "version": "7.4.1",
+      "dev": true
     },
     "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "requires": {}
+      "version": "4.0.0"
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -51414,8 +50447,7 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.2",
-      "requires": {}
+      "version": "5.3.2"
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -51462,12 +50494,10 @@
       }
     },
     "ajv-errors": {
-      "version": "1.0.1",
-      "requires": {}
+      "version": "1.0.1"
     },
     "ajv-keywords": {
-      "version": "3.5.2",
-      "requires": {}
+      "version": "3.5.2"
     },
     "alphanum-sort": {
       "version": "1.0.2"
@@ -51476,7 +50506,8 @@
       "version": "1.4.10"
     },
     "ansi-colors": {
-      "version": "4.1.3"
+      "version": "4.1.3",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -51806,8 +50837,7 @@
       }
     },
     "babel-core": {
-      "version": "7.0.0-bridge.0",
-      "requires": {}
+      "version": "7.0.0-bridge.0"
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -51942,8 +50972,7 @@
       }
     },
     "babel-plugin-named-asset-import": {
-      "version": "0.3.8",
-      "requires": {}
+      "version": "0.3.8"
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -54516,6 +53545,7 @@
     },
     "enquirer": {
       "version": "2.3.6",
+      "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -54832,6 +53862,7 @@
     },
     "eslint": {
       "version": "7.32.0",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -54877,18 +53908,21 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -54896,15 +53930,18 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "cross-spawn": {
           "version": "7.0.3",
+          "dev": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -54912,10 +53949,12 @@
           }
         },
         "escape-string-regexp": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "eslint-scope": {
           "version": "5.1.1",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^4.1.1"
@@ -54923,77 +53962,93 @@
         },
         "eslint-utils": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           },
           "dependencies": {
             "eslint-visitor-keys": {
-              "version": "1.3.0"
+              "version": "1.3.0",
+              "dev": true
             }
           }
         },
         "eslint-visitor-keys": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "dev": true
         },
         "globals": {
           "version": "13.16.0",
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "ignore": {
-          "version": "4.0.6"
+          "version": "4.0.6",
+          "dev": true
         },
         "lru-cache": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "path-key": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "dev": true
         },
         "semver": {
           "version": "7.3.7",
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "shebang-command": {
           "version": "2.0.0",
+          "dev": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.1",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
           "version": "7.2.0",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "type-fest": {
-          "version": "0.20.2"
+          "version": "0.20.2",
+          "dev": true
         },
         "which": {
           "version": "2.0.2",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
@@ -55013,13 +54068,11 @@
     },
     "eslint-config-standard": {
       "version": "14.1.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-standard-jsx": {
       "version": "8.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-standard-react": {
       "version": "9.2.0",
@@ -55030,8 +54083,7 @@
     },
     "eslint-import-resolver-alias": {
       "version": "1.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -55310,8 +54362,7 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react-native": {
       "version": "3.11.0",
@@ -55336,8 +54387,7 @@
     },
     "eslint-plugin-standard": {
       "version": "4.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-restricted-globals": {
       "version": "0.2.0",
@@ -55368,6 +54418,7 @@
     },
     "espree": {
       "version": "7.3.1",
+      "dev": true,
       "requires": {
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.3.1",
@@ -55650,8 +54701,7 @@
       }
     },
     "expo-application": {
-      "version": "4.0.2",
-      "requires": {}
+      "version": "4.0.2"
     },
     "expo-asset": {
       "version": "8.4.6",
@@ -55820,8 +54870,7 @@
     },
     "expo-error-recovery": {
       "version": "3.0.5",
-      "optional": true,
-      "requires": {}
+      "optional": true
     },
     "expo-file-system": {
       "version": "13.0.3",
@@ -55968,8 +55017,7 @@
       }
     },
     "expo-keep-awake": {
-      "version": "10.0.2",
-      "requires": {}
+      "version": "10.0.2"
     },
     "expo-modules-autolinking": {
       "version": "0.3.4",
@@ -56338,6 +55386,7 @@
     },
     "file-entry-cache": {
       "version": "6.0.1",
+      "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -56409,13 +55458,15 @@
     },
     "flat-cache": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "3.2.6"
+      "version": "3.2.6",
+      "dev": true
     },
     "flatten": {
       "version": "1.0.3"
@@ -56902,8 +55953,7 @@
       }
     },
     "goober": {
-      "version": "2.1.10",
-      "requires": {}
+      "version": "2.1.10"
     },
     "graceful-fs": {
       "version": "4.2.10"
@@ -57464,7 +56514,8 @@
       "version": "1.0.1"
     },
     "infer-owner": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -58820,11 +57871,11 @@
     },
     "jest-get-type": {
       "version": "27.5.1",
-      "devOptional": true
+      "dev": true
     },
     "jest-haste-map": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@jest/types": "^27.5.1",
         "@types/graceful-fs": "^4.1.2",
@@ -58843,11 +57894,11 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "devOptional": true
+          "dev": true
         },
         "jest-worker": {
           "version": "27.5.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "@types/node": "*",
             "merge-stream": "^2.0.0",
@@ -58856,7 +57907,7 @@
         },
         "supports-color": {
           "version": "8.1.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -59059,16 +58110,15 @@
       }
     },
     "jest-pnp-resolver": {
-      "version": "1.2.2",
-      "requires": {}
+      "version": "1.2.2"
     },
     "jest-regex-util": {
       "version": "27.5.1",
-      "devOptional": true
+      "dev": true
     },
     "jest-resolve": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@jest/types": "^27.5.1",
         "chalk": "^4.0.0",
@@ -59084,14 +58134,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -59099,22 +58149,22 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "devOptional": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "devOptional": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -59344,7 +58394,7 @@
     },
     "jest-serializer": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "graceful-fs": "^4.2.9"
@@ -59451,7 +58501,7 @@
     },
     "jest-util": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@jest/types": "^27.5.1",
         "@types/node": "*",
@@ -59463,14 +58513,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -59478,26 +58528,26 @@
         },
         "ci-info": {
           "version": "3.3.2",
-          "devOptional": true
+          "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "devOptional": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "devOptional": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -59506,7 +58556,7 @@
     },
     "jest-validate": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@jest/types": "^27.5.1",
         "camelcase": "^6.2.0",
@@ -59518,18 +58568,18 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "camelcase": {
           "version": "6.3.0",
-          "devOptional": true
+          "dev": true
         },
         "chalk": {
           "version": "4.1.2",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -59537,22 +58587,22 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "devOptional": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "devOptional": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -60429,6 +59479,7 @@
     },
     "levn": {
       "version": "0.4.1",
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -60700,7 +59751,8 @@
       "version": "4.1.2"
     },
     "lodash.merge": {
-      "version": "4.6.2"
+      "version": "4.6.2",
+      "dev": true
     },
     "lodash.omit": {
       "version": "4.5.0"
@@ -60731,7 +59783,8 @@
       "version": "4.1.1"
     },
     "lodash.truncate": {
-      "version": "4.4.2"
+      "version": "4.4.2",
+      "dev": true
     },
     "lodash.unescape": {
       "version": "4.0.1"
@@ -62575,8 +61628,7 @@
         "use-sync-external-store": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
-          "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
-          "requires": {}
+          "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ=="
         }
       }
     },
@@ -63209,6 +62261,7 @@
     },
     "optionator": {
       "version": "0.9.1",
+      "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -64447,7 +63500,8 @@
       }
     },
     "prelude-ls": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "prettier": {
       "version": "2.7.1",
@@ -64472,7 +63526,7 @@
     },
     "pretty-format": {
       "version": "27.5.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -64481,11 +63535,11 @@
       "dependencies": {
         "ansi-styles": {
           "version": "5.2.0",
-          "devOptional": true
+          "dev": true
         },
         "react-is": {
           "version": "17.0.2",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -65177,8 +64231,7 @@
       }
     },
     "react-intersection-observer": {
-      "version": "8.34.0",
-      "requires": {}
+      "version": "8.34.0"
     },
     "react-is": {
       "version": "16.8.6"
@@ -65546,8 +64599,7 @@
       }
     },
     "react-native-iphone-x-helper": {
-      "version": "1.3.1",
-      "requires": {}
+      "version": "1.3.1"
     },
     "react-native-paper": {
       "version": "4.9.2",
@@ -65590,8 +64642,7 @@
       }
     },
     "react-native-safe-area-context": {
-      "version": "3.3.2",
-      "requires": {}
+      "version": "3.3.2"
     },
     "react-native-screens": {
       "version": "3.8.0",
@@ -66439,8 +65490,7 @@
           }
         },
         "eslint-plugin-react-hooks": {
-          "version": "1.7.0",
-          "requires": {}
+          "version": "1.7.0"
         },
         "eslint-utils": {
           "version": "1.4.3",
@@ -67779,8 +66829,7 @@
           }
         },
         "ts-pnp": {
-          "version": "1.1.2",
-          "requires": {}
+          "version": "1.1.2"
         },
         "tslib": {
           "version": "1.14.1"
@@ -68273,7 +67322,8 @@
       }
     },
     "regexpp": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "dev": true
     },
     "regexpu-core": {
       "version": "5.1.0",
@@ -68483,7 +67533,7 @@
     },
     "resolve.exports": {
       "version": "1.1.0",
-      "devOptional": true
+      "dev": true
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -68839,6 +67889,7 @@
     },
     "serialize-javascript": {
       "version": "4.0.0",
+      "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -69794,7 +68845,8 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "strong-log-transformer": {
       "version": "2.1.0",
@@ -69826,8 +68878,7 @@
     "styled-jsx": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "requires": {}
+      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ=="
     },
     "stylehacks": {
       "version": "4.0.3",
@@ -69851,8 +68902,7 @@
       "version": "3.5.4"
     },
     "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "requires": {}
+      "version": "0.0.10"
     },
     "sucrase": {
       "version": "3.23.0",
@@ -69963,6 +69013,7 @@
     },
     "table": {
       "version": "6.8.0",
+      "dev": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -69973,6 +69024,7 @@
       "dependencies": {
         "ajv": {
           "version": "8.11.0",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -69982,30 +69034,37 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "astral-regex": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "dev": true
         },
         "json-schema-traverse": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         },
         "slice-ansi": {
           "version": "4.0.0",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "astral-regex": "^2.0.0",
@@ -70014,6 +69073,7 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
@@ -70110,21 +69170,6 @@
       "requires": {
         "ansi-escapes": "^4.2.1",
         "supports-hyperlinks": "^2.0.0"
-      }
-    },
-    "terser": {
-      "version": "4.4.2",
-      "peer": true,
-      "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "peer": true
-        }
       }
     },
     "terser-webpack-plugin": {
@@ -70470,6 +69515,7 @@
     },
     "type-check": {
       "version": "0.4.0",
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -70719,12 +69765,10 @@
       "version": "3.1.1"
     },
     "use-subscription": {
-      "version": "1.1.1",
-      "requires": {}
+      "version": "1.1.1"
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "utif": {
       "version": "2.0.1",
@@ -70771,7 +69815,8 @@
       "version": "3.4.0"
     },
     "v8-compile-cache": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -70955,7 +70000,6 @@
         "fsevents": {
           "version": "1.2.13",
           "optional": true,
-          "peer": true,
           "requires": {
             "bindings": "^1.5.0",
             "nan": "^2.12.1"
@@ -71085,267 +70129,6 @@
     "webidl-conversions": {
       "version": "6.1.0",
       "dev": true
-    },
-    "webpack": {
-      "version": "4.41.2",
-      "peer": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
-        "watchpack": "^1.6.0",
-        "webpack-sources": "^1.4.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.4.2",
-          "peer": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "peer": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "peer": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "cacache": {
-          "version": "12.0.4",
-          "peer": true,
-          "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
-          }
-        },
-        "chownr": {
-          "version": "1.1.4",
-          "peer": true
-        },
-        "eslint-scope": {
-          "version": "4.0.3",
-          "peer": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "peer": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "peer": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "2.1.0",
-          "peer": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^2.0.0",
-            "pkg-dir": "^3.0.0"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "peer": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "peer": true
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "peer": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "peer": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "peer": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "peer": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "peer": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "peer": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "peer": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "peer": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "peer": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "peer": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "ssri": {
-          "version": "6.0.2",
-          "peer": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1"
-          }
-        },
-        "terser-webpack-plugin": {
-          "version": "1.4.5",
-          "peer": true,
-          "requires": {
-            "cacache": "^12.0.2",
-            "find-cache-dir": "^2.1.0",
-            "is-wsl": "^1.1.0",
-            "schema-utils": "^1.0.0",
-            "serialize-javascript": "^4.0.0",
-            "source-map": "^0.6.1",
-            "terser": "^4.1.2",
-            "webpack-sources": "^1.4.0",
-            "worker-farm": "^1.7.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "peer": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        },
-        "watchpack": {
-          "version": "1.7.5",
-          "peer": true,
-          "requires": {
-            "chokidar": "^3.4.1",
-            "graceful-fs": "^4.1.2",
-            "neo-async": "^2.5.0",
-            "watchpack-chokidar2": "^2.0.1"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "peer": true
-        }
-      }
     },
     "webpack-dev-middleware": {
       "version": "3.7.0",
@@ -72136,8 +70919,7 @@
       }
     },
     "ws": {
-      "version": "7.5.8",
-      "requires": {}
+      "version": "7.5.8"
     },
     "xcode": {
       "version": "3.0.1",

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -540,7 +540,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
               }}
             >
               <Logo aria-hidden />
-              <ScreenReader text="Open React Query Devtools" />
+              <ScreenReader text="Close React Query Devtools" />
             </button>
             <div
               style={{

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -12,6 +12,7 @@ import {
 import { rankItem, compareItems } from '@tanstack/match-sorter-utils'
 import useLocalStorage from './useLocalStorage'
 import { sortFns, useIsMounted } from './utils'
+import ScreenReader from './screenreader'
 
 import {
   Panel,
@@ -368,6 +369,7 @@ export function ReactQueryDevtools({
           }}
         >
           <Logo aria-hidden />
+          <ScreenReader text="Open React Query Devtools" />
         </button>
       ) : null}
     </Container>
@@ -538,6 +540,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
               }}
             >
               <Logo aria-hidden />
+              <ScreenReader text="Open React Query Devtools" />
             </button>
             <div
               style={{

--- a/packages/react-query-devtools/src/screenreader.tsx
+++ b/packages/react-query-devtools/src/screenreader.tsx
@@ -9,7 +9,6 @@ export default function ScreenReader({ text }: { text: string }) {
         height: '0.1px',
         overflow: 'hidden',
       }}
-      className="screenreader"
     >
       {text}
     </span>

--- a/packages/react-query-devtools/src/screenreader.tsx
+++ b/packages/react-query-devtools/src/screenreader.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+export default function ScreenReader({ text }: { text: string }) {
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        width: '0.1px',
+        height: '0.1px',
+        overflow: 'hidden',
+      }}
+      className="screenreader"
+    >
+      {text}
+    </span>
+  )
+}


### PR DESCRIPTION
> Recreated from https://github.com/TanStack/query/pull/3854

While testing our local site with our [accessibility testing tool](https://github.com/bbc/bbc-a11y), we recieved the following error:

```
✗ Main Dashboard
  * Forms: Labelling form controls: Fields must have labels or titles
    - Button has no text: //div[@id='ReactQueryDevtoolsPanel']/div[2]/div[1]/button
    - Button has no text: //main[@id='main-content']/aside/button
```

The issue is that not all screenreaders support aria values, and so this test is checking that buttons at least have a text value within them, which can be visibility hidden if so required.

To resolve this, this PR adds visually hidden text to the button.