### PR TITLE
fix: Adding screenreader text to the dev tools offline mock button

### DIFF
--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -651,6 +651,13 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
                           </>
                         )}
                       </svg>
+                      <ScreenReader
+                        text={
+                          isMockOffline
+                            ? 'Restore offline mock'
+                            : 'Mock offline behavior'
+                        }
+                      />
                     </Button>
                   </>
                 ) : null}


### PR DESCRIPTION
This PR comes after this recent PR for adding screenreader text to the open/close button:

https://github.com/TanStack/query/pull/4063

In this PR, I'm adding screenreader text to the offline mock button, which I must not have noticed in my previous PR, and a new version of our a11y testing tool seems to pick it up, when our old tool did not (sorry about that).