### PR TITLE
fix: reintroduce production export

### DIFF
--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -18,6 +18,11 @@
       "import": "./build/lib/index.mjs",
       "default": "./build/lib/index.js"
     },
+    "./production": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.prod.mjs",
+      "default": "./build/lib/index.prod.js"
+    },
     "./build/lib/index.prod.js": {
       "types": "./build/lib/index.d.ts",
       "import": "./build/lib/index.prod.mjs",


### PR DESCRIPTION
@TkDodo For this to work, you need to have a proper TS version (>= 4.7) and chnage `moduleResolution` to `NodeNext`