### PR TITLE
docs(migration-guide): multiline codemod commands

### DIFF
--- a/docs/guides/migrating-to-react-query-4.md
+++ b/docs/guides/migrating-to-react-query-4.md
@@ -28,18 +28,17 @@ You can easily apply it by using one (or both) of the following commands:
 If you want to run it against `.js` or `.jsx` files, please use the command below:
 
 ```
-npx jscodeshift ./path/to/src/
-  --extensions=js,jsx
+npx jscodeshift ./path/to/src/ \
+  --extensions=js,jsx \
   --transform=./node_modules/@tanstack/react-query/codemods/v4/replace-import-specifier.js
-  
 ```
 
 If you want to run it against `.ts` or `.tsx` files, please use the command below:
 
 ```
-npx jscodeshift ./path/to/src/
-  --extensions=ts,tsx
-  --parser=tsx
+npx jscodeshift ./path/to/src/ \
+  --extensions=ts,tsx \
+  --parser=tsx \
   --transform=./node_modules/@tanstack/react-query/codemods/v4/replace-import-specifier.js
 ```
 
@@ -73,17 +72,17 @@ You can easily apply it by using one (or both) of the following commands:
 If you want to run it against `.js` or `.jsx` files, please use the command below:
 
 ```
-npx jscodeshift ./path/to/src/
-  --extensions=js,jsx
+npx jscodeshift ./path/to/src/ \
+  --extensions=js,jsx \
   --transform=./node_modules/@tanstack/react-query/codemods/v4/key-transformation.js
 ```
 
 If you want to run it against `.ts` or `.tsx` files, please use the command below:
 
 ```
-npx jscodeshift ./path/to/src/
-  --extensions=ts,tsx
-  --parser=tsx
+npx jscodeshift ./path/to/src/ \
+  --extensions=ts,tsx \
+  --parser=tsx \
   --transform=./node_modules/@tanstack/react-query/codemods/v4/key-transformation.js
 ```
 


### PR DESCRIPTION
I suggest adding backslashes to the codemod commands which makes them easier to copy-paste.

I was having trouble executing the commands before I realized my shell was ignoring half of the command because of the newline characters.

Hoping this change could be helpful to others following the migration guide.
