### PR TITLE
docs: query keys consistency

### DIFF
--- a/docs/adapters/react-query.md
+++ b/docs/adapters/react-query.md
@@ -12,7 +12,7 @@ import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-quer
 const queryClient = new QueryClient()
 
 function Example() {
-  const query = useQuery('todos', fetchTodos)
+  const query = useQuery(['todos'], fetchTodos)
 
   return (
     <div>

--- a/docs/guides/background-fetching-indicators.md
+++ b/docs/guides/background-fetching-indicators.md
@@ -8,7 +8,7 @@ A query's `status === 'loading'` state is sufficient enough to show the initial 
 ```tsx
 function Todos() {
   const { status, data: todos, error, isFetching } = useQuery(
-    'todos',
+    ['todos'],
     fetchTodos
   )
 

--- a/docs/guides/query-cancellation.md
+++ b/docs/guides/query-cancellation.md
@@ -100,7 +100,7 @@ An `AbortSignal` can be set in the client `request` method.
 ```tsx
 const client = new GraphQLClient(endpoint)
 
-const query = useQuery('todos', ({ signal }) => {
+const query = useQuery(['todos'], ({ signal }) => {
   client.request({ document: query, signal })
 })
 ```


### PR DESCRIPTION
Keeping consistency in which query keys need to be an array.