### PR TITLE
docs(community): add query key factory community contribution

### DIFF
--- a/docs/community/lukemorales-query-key-factory.md
+++ b/docs/community/lukemorales-query-key-factory.md
@@ -1,0 +1,92 @@
+---
+id: lukemorales-query-key-factory
+title: Query Key Factory
+---
+
+Typesafe query key management with auto-completion features. Focus on writing and invalidating queries without the hassle of remembering how you've set up a key for a specific query!
+
+
+## Installation
+You can install Query Key Factory via [NPM](https://www.npmjs.com/package/@lukemorales/query-key-factory).
+
+```bash
+$ npm i @lukemorales/query-key-factory
+# or
+$ yarn add @lukemorales/query-key-factory
+```
+
+
+## Quick start
+Start by defining the query keys for your app:
+
+### Declare everything in a single file
+```ts
+import { createQueryKeyStore } from '@lukemorales/query-key-factory'
+
+export const queryKeys = createQueryKeyStore({
+  users: null,
+  todos: {
+    completed: null,
+    search: (query: string, limit = 15) => [query, limit],
+    byId: (productId: string) => ({ productId }),
+  },
+})
+```
+
+### Fine-grained declaration by features
+```ts
+import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory'
+
+// my-api/users.ts
+export const usersKeys = createQueryKeys('users')
+
+// my-api/todos.ts
+export const todosKeys = createQueryKeys('todos', {
+  completed: null,
+  search: (query: string, limit = 15) => [query, limit],
+  byId: (productId: string) => ({ productId }),
+})
+
+// my-api/index.ts
+export const queryKeys = mergeQueryKeys(usersKeys, todosKeys)
+```
+
+Use throughout your codebase as the single source for writing the query keys for your cache management:
+```tsx
+import { queryKeys, completeTodo, fetchSingleTodo } from '../my-api'
+
+export function Todo({ todoId }) {
+  const queryClient = useQueryClient()
+
+  const query = useQuery(queryKeys.todos.byId(todoId), fetchSingleTodo)
+
+  const mutation = useMutation(completeTodo, {
+    onSuccess: () => {
+      // Invalidate and refetch
+      queryClient.invalidateQueries(queryKeys.todos.completed)
+    },
+  })
+
+  return (
+    <div>
+      <h1>
+        {query.data?.title}
+      </h1>
+
+      <p>
+        {query.data?.description}
+      </p>
+
+      <button
+        onClick={() => {
+          mutation.mutate({ todoId })
+        }}
+      >
+        Complete Todo
+      </button>
+    </div>
+  )
+}
+```
+
+Check the complete documentation on [GitHub](https://github.com/lukemorales/query-key-factory).

--- a/docs/config.json
+++ b/docs/config.json
@@ -210,6 +210,10 @@
         {
           "label": "TkDodo's Blog",
           "to": "community/tkdodos-blog"
+        },
+        {
+          "label": "Query Key Factory",
+          "to": "community/lukemorales-query-key-factory"
         }
       ]
     },

--- a/docs/guides/query-keys.md
+++ b/docs/guides/query-keys.md
@@ -70,5 +70,5 @@ function Todos({ todoId }) {
 
 ## Further reading
 
-For tips on organizing Query Keys in larger applications, have a look at [Effective React Query Keys](../community/tkdodos-blog#8-effective-react-query-keys) from
+For tips on organizing Query Keys in larger applications, have a look at [Effective React Query Keys](../community/tkdodos-blog#8-effective-react-query-keys) and check the [Query Key Factory Package](../community/lukemorales-query-key-factory) from
 the Community Resources.


### PR DESCRIPTION
Hey Tanner and TkDodo, here's the PR adding the Query Key Factory package to the Community section on Docs.

I tried to make the examples as less prone to changes as possible, as well as match the examples already provided in the docs (using todos, same patterns, code style etc).

Please let me know if you'd like for me to make any changes.