### PR TITLE
Docs: update mutate options description

### DIFF
--- a/docs/reference/useMutation.md
+++ b/docs/reference/useMutation.md
@@ -97,7 +97,7 @@ mutate(variables, {
   - `variables: TVariables`
     - Optional
     - The variables object to pass to the `mutationFn`.
-  - Remaining options extend the same options described above in the `useMutation` hook.
+  - The remaining options extend the same options described above in the `useMutation` hook. The difference is that if the `onSuccess`, `onError` or `onSettled` callback returns a promise, it will not be awaited before the mutation is resolved.
   - If you make multiple requests, `onSuccess` will fire only after the latest call you've made.
 - `mutateAsync: (variables: TVariables, { onSuccess, onSettled, onError }) => Promise<TData>`
   - Similar to `mutate` but returns a promise which can be awaited.

--- a/docs/reference/useMutation.md
+++ b/docs/reference/useMutation.md
@@ -97,7 +97,7 @@ mutate(variables, {
   - `variables: TVariables`
     - Optional
     - The variables object to pass to the `mutationFn`.
-  - `onSuccess: (data: TData, variables: TVariables, context: TContext | undefined) => void`
+  - `onSuccess: (data: TData, variables: TVariables, context: TContext) => void`
     - Optional
     - This function will fire when the mutation is successful and will be passed the mutation's result.
     - Void function, the returned value will be ignored

--- a/docs/reference/useMutation.md
+++ b/docs/reference/useMutation.md
@@ -97,7 +97,18 @@ mutate(variables, {
   - `variables: TVariables`
     - Optional
     - The variables object to pass to the `mutationFn`.
-  - The remaining options extend the same options described above in the `useMutation` hook. The difference is that if the `onSuccess`, `onError` or `onSettled` callback returns a promise, it will not be awaited before the mutation is resolved.
+  - `onSuccess: (data: TData, variables: TVariables, context: TContext | undefined) => void`
+    - Optional
+    - This function will fire when the mutation is successful and will be passed the mutation's result.
+    - Void function, the returned value will be ignored
+  - `onError: (err: TError, variables: TVariables, context: TContext | undefined) => void`
+    - Optional
+    - This function will fire if the mutation encounters an error and will be passed the error.
+    - Void function, the returned value will be ignored
+  - `onSettled: (data: TData | undefined, error: TError | null, variables: TVariables, context: TContext | undefined) => void`
+    - Optional
+    - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
+    - Void function, the returned value will be ignored
   - If you make multiple requests, `onSuccess` will fire only after the latest call you've made.
 - `mutateAsync: (variables: TVariables, { onSuccess, onSettled, onError }) => Promise<TData>`
   - Similar to `mutate` but returns a promise which can be awaited.

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -579,19 +579,19 @@ export interface MutateOptions<
   onSuccess?: (
     data: TData,
     variables: TVariables,
-    context: TContext,
-  ) => Promise<unknown> | unknown
+    context: TContext | undefined,
+  ) => void
   onError?: (
     error: TError,
     variables: TVariables,
     context: TContext | undefined,
-  ) => Promise<unknown> | unknown
+  ) => void
   onSettled?: (
     data: TData | undefined,
     error: TError | null,
     variables: TVariables,
     context: TContext | undefined,
-  ) => Promise<unknown> | unknown
+  ) => void
 }
 
 export type MutateFunction<

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -579,7 +579,7 @@ export interface MutateOptions<
   onSuccess?: (
     data: TData,
     variables: TVariables,
-    context: TContext | undefined,
+    context: TContext,
   ) => void
   onError?: (
     error: TError,

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -576,11 +576,7 @@ export interface MutateOptions<
   TVariables = void,
   TContext = unknown,
 > {
-  onSuccess?: (
-    data: TData,
-    variables: TVariables,
-    context: TContext,
-  ) => void
+  onSuccess?: (data: TData, variables: TVariables, context: TContext) => void
   onError?: (
     error: TError,
     variables: TVariables,


### PR DESCRIPTION
Hey, in [`useMutation` options docs](https://tanstack.com/query/v4/docs/reference/useMutation) description for `onSuccess`, `onError`  and  `onSettled` says 

> If a promise is returned, it will be awaited and resolved before proceeding

So in this example, the mutation will wait for the promise in `onSuccess` to be resolved before changing mutation status and data

```tsx
{
  const { data, isLoading } = useMutation(
    () => {
      /**Some async stuff */
    },
    {
      onSuccess: () => {
        /** Will wait to be resolved before changing the mutation status */
        return delay(5000);
      },
    }
  );
}
```

It also says in `mutate` options 

> Remaining options extend the same options described above in the useMutation hook.

But if used like this the promise will not be awaited

```tsx
  const { data, isLoading, mutate } = useMutation(() => {
    /**Some async stuff */
  });

  mutate(undefined, {
    onSuccess: () => {
      /** Will NOT wait to be resolved before changing the mutation status */
      return delay(5000);
    },
  });
```

As I understand, this is intended behavior, so I want to update the docs to clarify this. 

