### PR TITLE
feat: add support for bigint keys

### DIFF
--- a/packages/query-core/src/tests/utils.test.tsx
+++ b/packages/query-core/src/tests/utils.test.tsx
@@ -7,6 +7,7 @@ import {
   scheduleMicrotask,
   sleep,
   isPlainArray,
+  hashQueryKey
 } from '../utils'
 import { Mutation } from '../mutation'
 import { createQueryClient } from '../../../../tests/utils'
@@ -355,6 +356,14 @@ describe('core/utils', () => {
       expect(callback).not.toHaveBeenCalled()
       await sleep(0)
       expect(callback).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('hashQueryKey', () => {
+    it('should handle bigints gracefully', () => {
+      const keys = [123, 123n, BigInt("505")];
+      const hash = hashQueryKey(keys);
+      expect(hash).toBe("[123,\"123\",\"505\"]")
     })
   })
 })

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -272,10 +272,11 @@ export function hashQueryKey(queryKey: QueryKey): string {
       ? Object.keys(val)
           .sort()
           .reduce((result, key) => {
-            result[key] = val[key]
+            result[key] =
+              typeof val[key] === 'bigint' ? val[key].toString() : val[key]
             return result
           }, {} as any)
-      : val,
+      : typeof val === 'bigint' ? val.toString() : val,
   )
 }
 


### PR DESCRIPTION
Support bigint as keys within the default hashQueryKey function. 