### PR TITLE
fix(queryObserver): allow refetch interval in service worker (#4018)

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -364,7 +364,8 @@ export class QueryObserver<
     this.currentRefetchInterval = nextInterval
 
     if (
-      isServer ||
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      !globalThis.setInterval ||
       this.options.enabled === false ||
       !isValidTimeout(this.currentRefetchInterval) ||
       this.currentRefetchInterval === 0
@@ -372,7 +373,7 @@ export class QueryObserver<
       return
     }
 
-    this.refetchIntervalId = setInterval(() => {
+    this.refetchIntervalId = globalThis.setInterval(() => {
       if (
         this.options.refetchIntervalInBackground ||
         focusManager.isFocused()


### PR DESCRIPTION
Resolves discussion in #4018 

Note: The use of `// eslint-disable-next-line` is an intentional choice. The lint rule `@typescript-eslint/no-unnecessary-condition` works when typing is known. In this case `globalThis` is scoped to `NodeJS`'s global namespace and therefore has the typings for only one environment of `globalThis`. It's a weird case which is why I put the ignore for this line only consistent with other uses of ignoring `no-unnecessary-condition`