### PR TITLE
refactor(examples): rewrite query keys to recommended standard

### DIFF
--- a/examples/react/rick-morty/src/Character.jsx
+++ b/examples/react/rick-morty/src/Character.jsx
@@ -17,7 +17,7 @@ import fetch from "./fetch";
 
 function Character() {
   const { characterId } = useParams();
-  const { status, data } = useQuery([`character-${characterId}`], () =>
+  const { status, data } = useQuery(["character", characterId], () =>
     fetch(`https://rickandmortyapi.com/api/character/${characterId}`)
   );
 
@@ -77,7 +77,7 @@ function Character() {
 }
 
 function Episode({ id }) {
-  const { data, status } = useQuery([`episode-${id}`], () =>
+  const { data, status } = useQuery(["episode", id], () =>
     fetch(`https://rickandmortyapi.com/api/episode/${id}`)
   );
 
@@ -97,7 +97,7 @@ function Episode({ id }) {
 }
 
 function Location({ id }) {
-  const { data, status } = useQuery([`location-${id}`], () =>
+  const { data, status } = useQuery(["location", id], () =>
     fetch(`https://rickandmortyapi.com/api/location/${id}`)
   );
 

--- a/examples/react/rick-morty/src/Episode.jsx
+++ b/examples/react/rick-morty/src/Episode.jsx
@@ -7,7 +7,7 @@ import fetch from "./fetch";
 
 function Episode() {
   const { episodeId } = useParams();
-  const { data, status } = useQuery([`episode-${episodeId}`], () =>
+  const { data, status } = useQuery(["episode", episodeId], () =>
     fetch(`https://rickandmortyapi.com/api/episode/${episodeId}`)
   );
 
@@ -30,7 +30,7 @@ function Episode() {
 }
 
 function Character({ id }) {
-  const { data, status } = useQuery([`character-${id}`], () =>
+  const { data, status } = useQuery(["character", id], () =>
     fetch(`https://rickandmortyapi.com/api/character/${id}`)
   );
 

--- a/examples/react/star-wars/src/Character.jsx
+++ b/examples/react/star-wars/src/Character.jsx
@@ -17,7 +17,7 @@ import fetch from "./fetch";
 
 function Character(props) {
   const characterId = props.match.params.characterId;
-  const { status, error, data } = useQuery([`character-${characterId}`], () =>
+  const { status, error, data } = useQuery(["character", characterId], () =>
     fetch(`https://swapi.dev/api/people/${characterId}/`)
   );
 
@@ -85,7 +85,7 @@ function Character(props) {
 
 function Film(props) {
   const { id } = props;
-  const { data, status, error } = useQuery([`film-${id}`], () =>
+  const { data, status } = useQuery(["film", id], () =>
     fetch(`https://swapi.dev/api/films/${id}/`)
   );
 
@@ -105,7 +105,7 @@ function Film(props) {
 
 function Homeworld(props) {
   const { id } = props;
-  const { data, status } = useQuery([`homeworld-${id}`], () =>
+  const { data, status } = useQuery(["homeworld", id], () =>
     fetch(`https://swapi.dev/api/planets/${id}/`)
   );
 

--- a/examples/react/star-wars/src/Film.jsx
+++ b/examples/react/star-wars/src/Film.jsx
@@ -7,7 +7,7 @@ import fetch from "./fetch";
 
 function Film(props) {
   const filmId = props.match.params.filmId;
-  const { data, status, error } = useQuery([`film-${filmId}`], () =>
+  const { data, status, error } = useQuery(["film", filmId], () =>
     fetch(`https://swapi.dev/api/films/${filmId}/`)
   );
 
@@ -35,7 +35,7 @@ function Film(props) {
 
 function Character(props) {
   const { id } = props;
-  const { data, status, error } = useQuery([`character-${id}`], () =>
+  const { data, status, error } = useQuery(["character", id], () =>
     fetch(`https://swapi.dev/api/people/${props.id}/`)
   );
 


### PR DESCRIPTION
This small PR rewrites some query keys from specific example apps to match the recommended standard in the docs.
There has not been a single mention of a query key that is made of a string literal for quite a while, so probably these few cases in the example apps are from old implementations and make sense to update them to the way the docs recommend shaping the query keys