### PR TITLE
feat(useQuery): allow callback format for `enabled` option in useQuery

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -112,7 +112,7 @@ export interface QueryObserverOptions<
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
    * Defaults to `true`.
    */
-  enabled?: boolean
+  enabled?: boolean | ((query: Query<TQueryFnData, TError, TQueryData, TQueryKey>) => boolean)
   /**
    * The time in milliseconds after data is considered stale.
    * If set to `Infinity`, the data will never be considered stale.


### PR DESCRIPTION
Add support for using a callback in the `enabled` option, to allow queries to decide whether they should be refetched depending on the query. This saves the need to use predicates in invalidate calls.

There are no breaking changes introduced by this feature.

**I have not yet tested this, nor written unit tests**