### PR TITLE
fix(react-query-persist-client): Make dependencies to peerDependencies

### DIFF
--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf ./build",
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@tanstack/query-core": "4.3.7",
     "@tanstack/react-query": "4.3.7"
   }


### PR DESCRIPTION
For yarn 3 pnp, having react-query as a normal dependencies causes it to be bundled multiple times. The query client set in react-query-persist-client is not visible for the normal useQuery imports from react-query. Setting react-query as a peerDependency instead fixes this issue.

Fixes #4161