### PR TITLE
fix: serve esm.js for webpack 4

### DIFF
--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -12,6 +12,7 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
+  "module": "build/lib/index.esm.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -12,6 +12,7 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
+  "module": "build/lib/index.esm.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -12,6 +12,7 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
+  "module": "build/lib/index.esm.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -12,6 +12,7 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
+  "module": "build/lib/index.esm.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -12,6 +12,7 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
+  "module": "build/lib/index.esm.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -12,6 +12,7 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
+  "module": "build/lib/index.esm.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -12,6 +12,7 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
+  "module": "build/lib/index.esm.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -187,7 +187,7 @@ function buildConfigs(opts: {
     forceBundle: opts.forceBundle || false,
   }
 
-  let builds = [esm(options), cjs(options)]
+  let builds = [mjs(options), esm(options), cjs(options)]
 
   if (!opts.skipUmdBuild) {
     builds = builds.concat([
@@ -199,7 +199,7 @@ function buildConfigs(opts: {
   return builds
 }
 
-function esm({
+function mjs({
   input,
   packageDir,
   external,
@@ -222,6 +222,46 @@ function esm({
     banner,
     preserveModules: true,
     entryFileNames: '[name].mjs',
+  }
+
+  return {
+    // ESM
+    external,
+    input,
+    output: forceBundle ? bundleOutput : normalOutput,
+    plugins: [
+      svelte(),
+      babelPlugin,
+      commonJS(),
+      nodeResolve({ extensions: ['.ts', '.tsx', '.native.ts'] }),
+      forceDevEnv ? forceEnvPlugin('development') : undefined,
+    ],
+  }
+}
+
+function esm({
+  input,
+  packageDir,
+  external,
+  banner,
+  outputFile,
+  forceDevEnv,
+  forceBundle,
+}: Options): RollupOptions {
+  const bundleOutput: OutputOptions = {
+    format: 'esm',
+    file: `${packageDir}/build/lib/${outputFile}.esm.js`,
+    sourcemap: true,
+    banner,
+  }
+
+  const normalOutput: OutputOptions = {
+    format: 'esm',
+    dir: `${packageDir}/build/lib`,
+    sourcemap: true,
+    banner,
+    preserveModules: true,
+    entryFileNames: '[name].esm.js',
   }
 
   return {


### PR DESCRIPTION
@TkDodo Quick check:
- scripts v4
![scipts4](https://user-images.githubusercontent.com/28151934/190710444-cea57e6c-b61c-457b-9048-1810bc042ca5.jpg)
- scripts 5
![scripts5](https://user-images.githubusercontent.com/28151934/190710499-2455f71b-e03a-4966-b5db-ac68d9d541ee.jpg)

Both seems to work

![bundle](https://user-images.githubusercontent.com/28151934/190710832-ddd51777-df4e-43c6-ad3e-2d8596ae1ac9.jpg)

Could you please check with react-native 🙏 

Fixes: https://github.com/TanStack/query/issues/4155
