### PR TITLE
Feature/extended filters get query data

### DIFF
--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -168,12 +168,12 @@ The options for `prefetchInfiniteQuery` are exactly the same as those of [`fetch
 `getQueryData` is a synchronous function that can be used to get an existing query's cached data. If the query does not exist, `undefined` will be returned.
 
 ```tsx
-const data = queryClient.getQueryData(queryKey)
+const data = queryClient.getQueryData(queryKey| filters | queryOptions)
 ```
 
 **Options**
 
-- `queryKey?: QueryKey`: [Query Keys](../guides/query-keys)
+- `queryKey?: QueryKey`: [Query Keys](../guides/query-keys) | `filters: ExtendedQueryFilters`: [Query Filters](../guides/filters#query-filters) & [Query Options](../reference/useQuery)
 - `filters?: QueryFilters`: [Query Filters](../guides/filters#query-filters)
 
 **Returns**

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -165,7 +165,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
   }
 
   find<TQueryFnData = unknown, TError = unknown, TData = TQueryFnData>(
-    arg1: QueryKey,
+    arg1: QueryKey | QueryFilters,
     arg2?: QueryFilters,
   ): Query<TQueryFnData, TError, TData> | undefined {
     const [filters] = parseFilterArgs(arg1, arg2)

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -10,7 +10,6 @@ import {
   MutationFilters,
   functionalUpdate,
   ExtendedQueryFilters,
-  isQueryKey,
 } from './utils'
 import type {
   QueryClientConfig,
@@ -119,11 +118,7 @@ export class QueryClient {
     arg1: QueryKey | ExtendedQueryFilters<TData, any, TData, QueryKey>,
     arg2?: QueryFilters,
   ): TData | undefined {
-    if (isQueryKey(arg1))
-      return this.queryCache.find<TData>(arg1, arg2)?.state.data
-    if (arg1.queryKey)
-      return this.queryCache.find<TData>(arg1.queryKey, arg1)?.state.data
-    return undefined
+    return this.queryCache.find<TData>(arg1, arg2)?.state.data
   }
 
   getQueriesData<TData = unknown>(queryKey: QueryKey): [QueryKey, TData][]

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -9,6 +9,8 @@ import {
   hashQueryKeyByOptions,
   MutationFilters,
   functionalUpdate,
+  ExtendedQueryFilters,
+  isQueryKey,
 } from './utils'
 import type {
   QueryClientConfig,
@@ -107,10 +109,21 @@ export class QueryClient {
   }
 
   getQueryData<TData = unknown>(
+    filters: ExtendedQueryFilters<TData, any, TData, QueryKey>,
+  ): TData | undefined
+  getQueryData<TData = unknown>(
     queryKey: QueryKey,
     filters?: QueryFilters,
+  ): TData | undefined
+  getQueryData<TData = unknown>(
+    arg1: QueryKey | ExtendedQueryFilters<TData, any, TData, QueryKey>,
+    arg2?: QueryFilters,
   ): TData | undefined {
-    return this.queryCache.find<TData>(queryKey, filters)?.state.data
+    if (isQueryKey(arg1))
+      return this.queryCache.find<TData>(arg1, arg2)?.state.data
+    if (arg1.queryKey)
+      return this.queryCache.find<TData>(arg1.queryKey, arg1)?.state.data
+    return undefined
   }
 
   getQueriesData<TData = unknown>(queryKey: QueryKey): [QueryKey, TData][]

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -471,11 +471,14 @@ describe('queryClient', () => {
     test('should return the query data with stale filter', () => {
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], 'bar')
-      expect(queryClient.getQueryData([key, 'id'], { stale: false })).toBe(
-        'bar',
-      )
       expect(
-        queryClient.getQueryData({ queryKey: [key, 'id'], stale: false }),
+        queryClient.getQueryData<string>([key, 'id'], { stale: false }),
+      ).toBe('bar')
+      expect(
+        queryClient.getQueryData<string>({
+          queryKey: [key, 'id'],
+          stale: false,
+        }),
       ).toBe('bar')
     })
 
@@ -485,7 +488,7 @@ describe('queryClient', () => {
       expect(
         queryClient.getQueryData({
           queryKey: [key, 'id'],
-          queryFn: async () => 1,
+          queryFn: async () => 'foo',
           cacheTime: 1000,
           retry: false,
         }),

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -454,17 +454,55 @@ describe('queryClient', () => {
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], 'bar')
       expect(queryClient.getQueryData([key, 'id'])).toBe('bar')
+      expect(queryClient.getQueryData({ queryKey: [key, 'id'] })).toBe('bar')
+    })
+
+    test('should return the query data with inactive filter', () => {
+      const key = queryKey()
+      queryClient.setQueryData([key, 'id'], 'bar')
+      expect(queryClient.getQueryData([key, 'id'], { type: 'inactive' })).toBe(
+        'bar',
+      )
+      expect(
+        queryClient.getQueryData({ queryKey: [key, 'id'], type: 'inactive' }),
+      ).toBe('bar')
+    })
+
+    test('should return the query data with stale filter', () => {
+      const key = queryKey()
+      queryClient.setQueryData([key, 'id'], 'bar')
+      expect(queryClient.getQueryData([key, 'id'], { stale: false })).toBe(
+        'bar',
+      )
+      expect(
+        queryClient.getQueryData({ queryKey: [key, 'id'], stale: false }),
+      ).toBe('bar')
+    })
+
+    test('should return the query data even with query options', () => {
+      const key = queryKey()
+      queryClient.setQueryData([key, 'id'], 'bar')
+      expect(
+        queryClient.getQueryData({
+          queryKey: [key, 'id'],
+          queryFn: async () => 1,
+          cacheTime: 1000,
+          retry: false,
+        }),
+      ).toBe('bar')
     })
 
     test('should return undefined if the query is not found', () => {
       const key = queryKey()
       expect(queryClient.getQueryData(key)).toBeUndefined()
+      expect(queryClient.getQueryData({ queryKey: key })).toBeUndefined()
     })
 
     test('should match exact by default', () => {
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], 'bar')
       expect(queryClient.getQueryData([key])).toBeUndefined()
+      expect(queryClient.getQueryData({ queryKey: [key] })).toBeUndefined()
     })
   })
 

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -45,7 +45,9 @@ export interface ExtendedQueryFilters<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > extends Omit<QueryFilters, 'queryKey'>,
-    QueryOptions<TQueryFnData, TError, TData, TQueryKey> {}
+    Omit<QueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey'> {
+  queryKey: TQueryKey
+}
 
 export interface MutationFilters {
   /**

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -39,6 +39,14 @@ export interface QueryFilters {
   fetchStatus?: FetchStatus
 }
 
+export interface ExtendedQueryFilters<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> extends Omit<QueryFilters, 'queryKey'>,
+    QueryOptions<TQueryFnData, TError, TData, TQueryKey> {}
+
 export interface MutationFilters {
   /**
    * Match mutation key exactly


### PR DESCRIPTION
Hello @TkDodo @tannerlinsley ,

This PR is following this discussion :  
https://twitter.com/ecyrbedev/status/1571561333992079363

Consider the following pattern :  
![image](https://user-images.githubusercontent.com/633115/191081622-68d0f439-2500-4bfc-9500-0f5e45a0bc41.png)


The idea is now that people are using the factory pattern to create keys and `useQueryOptions` in general, it might be helpful to be consistent for every function and allow to pass directly the result of the factory to all functions.

People might want to have everywhere the same ability to pass the factory result like they do for :  
- useQuery
- useInfiniteQuery
- fetchQuery

This PR add this possibility to : 
- getQueryData

Might also need to do it on (i can improve this PR upon agreement, after fixing details) :  
- getQueriesData

The solution i took is to be backward compatible with current `getQueryData`, but also allow to pass only one parameter that would be the filter + ignore the additionnal parameters.

For this i added an `ExtendedQueryFilters` :  
```ts
export interface ExtendedQueryFilters<
  TQueryFnData = unknown,
  TError = unknown,
  TData = TQueryFnData,
  TQueryKey extends QueryKey = QueryKey,
> extends Omit<QueryFilters, 'queryKey'>,
    Omit<QueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey'> {
  queryKey: TQueryKey
}
```
```ts
getQueryData<TData = unknown>(
    filters:  ExtendedQueryFilters,
  ): TData | undefined
``` 
