### PR TITLE
docs: update react native app focus instructions

### DIFF
--- a/docs/guides/window-focus-refetching.md
+++ b/docs/guides/window-focus-refetching.md
@@ -67,15 +67,17 @@ Instead of event listeners on `window`, React Native provides focus information 
 import { AppState } from 'react-native'
 import { focusManager } from '@tanstack/react-query'
 
-focusManager.setEventListener(handleFocus => {
-  const subscription = AppState.addEventListener('change', state => {
-    handleFocus(state === 'active')
-  })
-
-  return () => {
-    subscription.remove()
+function onAppStateChange(status: AppStateStatus) {
+  if (Platform.OS !== 'web') {
+    focusManager.setFocused(status === 'active')
   }
-})
+}
+
+useEffect(() => {
+  const subscription = AppState.addEventListener('change', onAppStateChange)
+
+  return () => subscription.remove()
+}, [])
 ```
 
 ## Managing focus state

--- a/docs/react-native.md
+++ b/docs/react-native.md
@@ -27,9 +27,10 @@ onlineManager.setEventListener(setOnline => {
 
 ## Refetch on App focus
 
-In React Native you have to use React Query `focusManager` to refetch when the App is focused.
+Instead of event listeners on `window`, React Native provides focus information through the [`AppState` module](https://reactnative.dev/docs/appstate#app-states). You can use the `AppState` "change" event to trigger an update when the app state changes to "active":
 
 ```ts
+import { AppState } from 'react-native'
 import { focusManager } from '@tanstack/react-query'
 
 function onAppStateChange(status: AppStateStatus) {


### PR DESCRIPTION
As stated in the issue raised here: https://github.com/TanStack/query/issues/4135. There is an inconsistency with the instructions provided on how to refetch on app focus.

The change contained in this PR addresses the inconsistency and updates the documentation to provide a single way to implement this functionality.