### PR TITLE
docs: add react query kit community contribution

### DIFF
--- a/docs/community/liaoliao666-react-query-kit.md
+++ b/docs/community/liaoliao666-react-query-kit.md
@@ -9,8 +9,8 @@ title: React Query Kit
 
 - Make `queryKey` strongly related with `queryFn`
 - Manage `queryKey` in a type-safe way
-- Generate quickly a custom ReactQuery hook
-- Make `queryClient`'s operations more clearly associated with which custom ReactQuery hook
+- Generate a custom ReactQuery hook quickly
+- Make `queryClient`'s operations clearly associated with custom ReactQuery hooks
 - Set defaultOptions for custom ReactQuery hooks easier and clearer
 
 ## Installation

--- a/docs/community/liaoliao666-react-query-kit.md
+++ b/docs/community/liaoliao666-react-query-kit.md
@@ -3,7 +3,7 @@ id: liaoliao666-react-query-kit
 title: React Query Kit
 ---
 
-🕊️ A toolkit for ReactQuery that make ReactQuery hooks reusable and typesafe
+🕊️ A toolkit for ReactQuery that makes ReactQuery hooks reusable and typesafe
 
 ## what do you benefit from it
 

--- a/docs/community/liaoliao666-react-query-kit.md
+++ b/docs/community/liaoliao666-react-query-kit.md
@@ -1,0 +1,77 @@
+---
+id: liaoliao666-react-query-kit
+title: React Query Kit
+---
+
+🕊️ A toolkit for ReactQuery that make ReactQuery hooks reusable and typesafe
+
+## what do you benefit from it
+
+- Make `queryKey` strongly related with `queryFn`
+- Manage `queryKey` in a type-safe way
+- Generate quickly a custom ReactQuery hook
+- Make `queryClient`'s operations more clearly associated with which custom ReactQuery hook
+- Set defaultOptions for custom ReactQuery hooks easier and clearer
+
+## Installation
+
+This module is distributed via [NPM](https://www.npmjs.com/package/react-query-kit) and
+should be installed as one of your project's `dependencies`:
+
+```bash
+$ npm i react-query-kit
+# or
+$ yarn add react-query-kit
+```
+
+## Quick start with nextjs
+
+[CodeSandbox](https://codesandbox.io/s/example-react-query-kit-nextjs-uldl88)
+
+```ts
+import { QueryClient, dehydrate } from '@tanstack/react-query'
+import { createQuery } from 'react-query-kit'
+
+type Response = { title: string; content: string }
+type Variables = { id: number }
+
+const usePost = createQuery<Response, Variables, Error>({
+  primaryKey: '/posts',
+  queryFn: ({ queryKey: [primaryKey, variables] }) => {
+    // primaryKey equals to '/posts'
+    return fetch(`${primaryKey}/${variables.id}`).then(res => res.json())
+  },
+  suspense: true
+})
+
+const variables = { id: 1 }
+
+export default function Page() {
+  // queryKey equals to ['/posts', { id: 1 }]
+  const { data } = usePost({ variables, suspense: true })
+
+  return (
+    <div>
+      <div>{data?.title}</div>
+      <div>{data?.content}</div>
+    </div>
+  )
+}
+
+console.log(usePost.getKey()) //  ['/posts']
+console.log(usePost.getKey(variables)) //  ['/posts', { id: 1 }]
+
+export async function getStaticProps() {
+  const queryClient = new QueryClient()
+
+  await queryClient.prefetchQuery(usePost.getKey(variables), usePost.queryFn)
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  }
+}
+```
+
+Check the complete documentation on [GitHub](https://github.com/liaoliao666/react-query-kit).


### PR DESCRIPTION
this PR is for adding `react-query-kit` package to the docs.

I recently wrote this package to get rid of the tedious management of `queryKey` and make `queryKey` strongly related to `queryFn`.

Maybe some people would like to use it.