### PR TITLE
chore: force type import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
     "react/jsx-key": ["error", { "checkFragmentShorthand": true }],
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/packages/query-async-storage-persister/src/index.ts
+++ b/packages/query-async-storage-persister/src/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   PersistedClient,
   Persister,
   Promisable,

--- a/packages/query-core/src/infiniteQueryObserver.ts
+++ b/packages/query-core/src/infiniteQueryObserver.ts
@@ -8,17 +8,14 @@ import type {
   QueryKey,
 } from './types'
 import type { QueryClient } from './queryClient'
-import {
-  NotifyOptions,
-  ObserverFetchOptions,
-  QueryObserver,
-} from './queryObserver'
+import type { NotifyOptions, ObserverFetchOptions } from './queryObserver'
+import { QueryObserver } from './queryObserver'
 import {
   hasNextPage,
   hasPreviousPage,
   infiniteQueryBehavior,
 } from './infiniteQueryBehavior'
-import { Query } from './query'
+import type { Query } from './query'
 
 type InfiniteQueryObserverListener<TData, TError> = (
   result: InfiniteQueryObserverResult<TData, TError>,

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -1,10 +1,12 @@
 import type { MutationOptions, MutationStatus, MutationMeta } from './types'
 import type { MutationCache } from './mutationCache'
 import type { MutationObserver } from './mutationObserver'
-import { defaultLogger, Logger } from './logger'
+import type { Logger } from './logger'
+import { defaultLogger } from './logger'
 import { notifyManager } from './notifyManager'
 import { Removable } from './removable'
-import { canFetch, Retryer, createRetryer } from './retryer'
+import type { Retryer } from './retryer'
+import { canFetch, createRetryer } from './retryer'
 
 // TYPES
 

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -1,9 +1,11 @@
-import { MutationObserver } from './mutationObserver'
+import type { MutationObserver } from './mutationObserver'
 import type { MutationOptions } from './types'
 import type { QueryClient } from './queryClient'
 import { notifyManager } from './notifyManager'
-import { Action, Mutation, MutationState } from './mutation'
-import { matchMutation, MutationFilters, noop } from './utils'
+import type { Action, MutationState } from './mutation'
+import { Mutation } from './mutation'
+import type { MutationFilters } from './utils'
+import { matchMutation, noop } from './utils'
 import { Subscribable } from './subscribable'
 
 // TYPES

--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -1,4 +1,5 @@
-import { Action, getDefaultState, Mutation } from './mutation'
+import type { Action, Mutation } from './mutation'
+import { getDefaultState } from './mutation'
 import { notifyManager } from './notifyManager'
 import type { QueryClient } from './queryClient'
 import { Subscribable } from './subscribable'

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -6,7 +6,8 @@ import type {
   DefaultedQueryObserverOptions,
 } from './types'
 import type { QueryClient } from './queryClient'
-import { NotifyOptions, QueryObserver } from './queryObserver'
+import type { NotifyOptions } from './queryObserver'
+import { QueryObserver } from './queryObserver'
 import { Subscribable } from './subscribable'
 
 type QueriesObserverListener = (result: QueryObserverResult[]) => void

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -12,9 +12,11 @@ import type {
 } from './types'
 import type { QueryCache } from './queryCache'
 import type { QueryObserver } from './queryObserver'
-import { defaultLogger, Logger } from './logger'
+import type { Logger } from './logger'
+import { defaultLogger } from './logger'
 import { notifyManager } from './notifyManager'
-import { Retryer, isCancelledError, canFetch, createRetryer } from './retryer'
+import type { Retryer } from './retryer'
+import { isCancelledError, canFetch, createRetryer } from './retryer'
 import { Removable } from './removable'
 
 // TYPES

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -1,15 +1,12 @@
-import {
-  QueryFilters,
-  hashQueryKeyByOptions,
-  matchQuery,
-  parseFilterArgs,
-} from './utils'
-import { Action, Query, QueryState } from './query'
+import type { QueryFilters } from './utils'
+import { hashQueryKeyByOptions, matchQuery, parseFilterArgs } from './utils'
+import type { Action, QueryState } from './query'
+import { Query } from './query'
 import type { QueryKey, QueryOptions } from './types'
 import { notifyManager } from './notifyManager'
 import type { QueryClient } from './queryClient'
 import { Subscribable } from './subscribable'
-import { QueryObserver } from './queryObserver'
+import type { QueryObserver } from './queryObserver'
 
 // TYPES
 

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -1,13 +1,11 @@
+import type { QueryFilters, Updater, MutationFilters } from './utils'
 import {
-  QueryFilters,
-  Updater,
   hashQueryKey,
   noop,
   parseFilterArgs,
   parseQueryArgs,
   partialMatchKey,
   hashQueryKeyByOptions,
-  MutationFilters,
   functionalUpdate,
 } from './utils'
 import type {
@@ -38,8 +36,9 @@ import { focusManager } from './focusManager'
 import { onlineManager } from './onlineManager'
 import { notifyManager } from './notifyManager'
 import { infiniteQueryBehavior } from './infiniteQueryBehavior'
-import { CancelOptions, DefaultedQueryObserverOptions } from './types'
-import { defaultLogger, Logger } from './logger'
+import type { CancelOptions, DefaultedQueryObserverOptions } from './types'
+import type { Logger } from './logger'
+import { defaultLogger } from './logger'
 
 // TYPES
 

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -1,4 +1,4 @@
-import { DefaultedQueryObserverOptions, RefetchPageFilters } from './types'
+import type { DefaultedQueryObserverOptions, RefetchPageFilters } from './types'
 import {
   isServer,
   isValidTimeout,

--- a/packages/query-core/src/retryer.ts
+++ b/packages/query-core/src/retryer.ts
@@ -1,7 +1,7 @@
 import { focusManager } from './focusManager'
 import { onlineManager } from './onlineManager'
 import { sleep } from './utils'
-import { CancelOptions, NetworkMode } from './types'
+import type { CancelOptions, NetworkMode } from './types'
 
 // TYPES
 

--- a/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
@@ -1,10 +1,9 @@
 import { waitFor } from '@testing-library/react'
 import type {
   QueryClient,
-  InfiniteQueryObserverResult} from '@tanstack/query-core';
-import {
-  InfiniteQueryObserver
+  InfiniteQueryObserverResult,
 } from '@tanstack/query-core'
+import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { createQueryClient, queryKey } from './utils'
 
 describe('InfiniteQueryBehavior', () => {

--- a/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
@@ -1,8 +1,9 @@
 import { waitFor } from '@testing-library/react'
-import {
+import type {
   QueryClient,
-  InfiniteQueryObserver,
-  InfiniteQueryObserverResult,
+  InfiniteQueryObserverResult} from '@tanstack/query-core';
+import {
+  InfiniteQueryObserver
 } from '@tanstack/query-core'
 import { createQueryClient, queryKey } from './utils'
 

--- a/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
@@ -1,5 +1,5 @@
 import { createQueryClient, queryKey, sleep } from './utils'
-import type { QueryClient} from '..';
+import type { QueryClient } from '..'
 import { InfiniteQueryObserver } from '..'
 
 describe('InfiniteQueryObserver', () => {

--- a/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
@@ -1,5 +1,6 @@
 import { createQueryClient, queryKey, sleep } from './utils'
-import { QueryClient, InfiniteQueryObserver } from '..'
+import type { QueryClient} from '..';
+import { InfiniteQueryObserver } from '..'
 
 describe('InfiniteQueryObserver', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/mutationObserver.test.tsx
+++ b/packages/query-core/src/tests/mutationObserver.test.tsx
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/react'
 import { createQueryClient, sleep } from './utils'
-import { QueryClient, MutationObserver } from '..'
+import type { QueryClient} from '..';
+import { MutationObserver } from '..'
 
 describe('mutationObserver', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/mutationObserver.test.tsx
+++ b/packages/query-core/src/tests/mutationObserver.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react'
 import { createQueryClient, sleep } from './utils'
-import type { QueryClient} from '..';
+import type { QueryClient } from '..'
 import { MutationObserver } from '..'
 
 describe('mutationObserver', () => {

--- a/packages/query-core/src/tests/mutations.test.tsx
+++ b/packages/query-core/src/tests/mutations.test.tsx
@@ -1,6 +1,6 @@
-import { QueryClient } from '..'
+import type { QueryClient } from '..'
 import { createQueryClient, executeMutation, queryKey, sleep } from './utils'
-import { MutationState } from '../mutation'
+import type { MutationState } from '../mutation'
 import { MutationObserver } from '../mutationObserver'
 
 describe('mutations', () => {

--- a/packages/query-core/src/tests/queriesObserver.test.tsx
+++ b/packages/query-core/src/tests/queriesObserver.test.tsx
@@ -1,12 +1,13 @@
 import { waitFor } from '@testing-library/react'
 import { sleep, queryKey, createQueryClient, mockLogger } from './utils'
-import {
+import type {
   QueryClient,
+  QueryObserverResult} from '..';
+import {
   QueriesObserver,
-  QueryObserverResult,
   QueryObserver,
 } from '..'
-import { QueryKey } from '..'
+import type { QueryKey } from '..'
 
 describe('queriesObserver', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/queriesObserver.test.tsx
+++ b/packages/query-core/src/tests/queriesObserver.test.tsx
@@ -1,12 +1,7 @@
 import { waitFor } from '@testing-library/react'
 import { sleep, queryKey, createQueryClient, mockLogger } from './utils'
-import type {
-  QueryClient,
-  QueryObserverResult} from '..';
-import {
-  QueriesObserver,
-  QueryObserver,
-} from '..'
+import type { QueryClient, QueryObserverResult } from '..'
+import { QueriesObserver, QueryObserver } from '..'
 import type { QueryKey } from '..'
 
 describe('queriesObserver', () => {

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -9,13 +9,9 @@ import type {
   QueryCache,
   QueryClient,
   QueryFunctionContext,
-  QueryObserverResult} from '..';
-import {
-  QueryObserver,
-  isCancelledError,
-  isError,
-  onlineManager
+  QueryObserverResult,
 } from '..'
+import { QueryObserver, isCancelledError, isError, onlineManager } from '..'
 import { waitFor } from '@testing-library/react'
 
 describe('query', () => {

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -5,15 +5,16 @@ import {
   mockLogger,
   createQueryClient,
 } from './utils'
-import {
+import type {
   QueryCache,
   QueryClient,
+  QueryFunctionContext,
+  QueryObserverResult} from '..';
+import {
   QueryObserver,
   isCancelledError,
   isError,
-  onlineManager,
-  QueryFunctionContext,
-  QueryObserverResult,
+  onlineManager
 } from '..'
 import { waitFor } from '@testing-library/react'
 

--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -1,5 +1,5 @@
 import { sleep, queryKey, createQueryClient } from './utils'
-import type { QueryClient } from '..';
+import type { QueryClient } from '..'
 import { QueryCache } from '..'
 import type { Query } from '.././query'
 

--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -1,6 +1,7 @@
 import { sleep, queryKey, createQueryClient } from './utils'
-import { QueryCache, QueryClient } from '..'
-import { Query } from '.././query'
+import type { QueryClient } from '..';
+import { QueryCache } from '..'
+import type { Query } from '.././query'
 
 describe('queryCache', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -2,13 +2,14 @@ import { waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import { sleep, queryKey, mockLogger, createQueryClient } from './utils'
-import {
-  InfiniteQueryObserver,
+import type {
   QueryCache,
   QueryClient,
   QueryFunction,
-  QueryObserver,
-  QueryObserverOptions,
+  QueryObserverOptions} from '..';
+import {
+  InfiniteQueryObserver,
+  QueryObserver
 } from '..'
 import { focusManager, onlineManager } from '..'
 

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -6,11 +6,9 @@ import type {
   QueryCache,
   QueryClient,
   QueryFunction,
-  QueryObserverOptions} from '..';
-import {
-  InfiniteQueryObserver,
-  QueryObserver
+  QueryObserverOptions,
 } from '..'
+import { InfiniteQueryObserver, QueryObserver } from '..'
 import { focusManager, onlineManager } from '..'
 
 describe('queryClient', () => {

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -5,10 +5,11 @@ import {
   mockLogger,
   createQueryClient,
 } from './utils'
-import {
+import type {
   QueryClient,
+  QueryObserverResult} from '..';
+import {
   QueryObserver,
-  QueryObserverResult,
   focusManager,
 } from '..'
 

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -5,13 +5,8 @@ import {
   mockLogger,
   createQueryClient,
 } from './utils'
-import type {
-  QueryClient,
-  QueryObserverResult} from '..';
-import {
-  QueryObserver,
-  focusManager,
-} from '..'
+import type { QueryClient, QueryObserverResult } from '..'
+import { QueryObserver, focusManager } from '..'
 
 describe('queryObserver', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/utils.ts
+++ b/packages/query-core/src/tests/utils.ts
@@ -1,10 +1,7 @@
 import { act } from '@testing-library/react'
 
-import {
-  MutationOptions,
-  QueryClient,
-  QueryClientConfig,
-} from '@tanstack/query-core'
+import type { MutationOptions, QueryClientConfig } from '@tanstack/query-core'
+import { QueryClient } from '@tanstack/query-core'
 import * as utils from '../utils'
 
 export function createQueryClient(config?: QueryClientConfig): QueryClient {

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -4,7 +4,7 @@ import type { RetryValue, RetryDelayValue } from './retryer'
 import type { QueryFilters, QueryTypeFilter } from './utils'
 import type { QueryCache } from './queryCache'
 import type { MutationCache } from './mutationCache'
-import { Logger } from './logger'
+import type { Logger } from './logger'
 
 export type QueryKey = readonly unknown[]
 

--- a/packages/query-sync-storage-persister/.eslintrc
+++ b/packages/query-sync-storage-persister/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "project": "./tsconfig.lint.json",
+    "project": "packages/query-sync-storage-persister/tsconfig.lint.json",
     "sourceType": "module"
   }
 }

--- a/packages/query-sync-storage-persister/.eslintrc
+++ b/packages/query-sync-storage-persister/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "project": "packages/query-sync-storage-persister/tsconfig.lint.json",
+    "project": "./tsconfig.lint.json",
     "sourceType": "module"
   }
 }

--- a/packages/query-sync-storage-persister/src/index.ts
+++ b/packages/query-sync-storage-persister/src/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   PersistedClient,
   Persister,
   PersistRetryer,

--- a/packages/react-query-devtools/.eslintrc
+++ b/packages/react-query-devtools/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "project": "./tsconfig.lint.json",
+    "project": "packages/react-query-devtools/tsconfig.lint.json",
     "sourceType": "module"
   }
 }

--- a/packages/react-query-devtools/.eslintrc
+++ b/packages/react-query-devtools/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "project": "packages/react-query-devtools/tsconfig.lint.json",
+    "project": "./tsconfig.lint.json",
     "sourceType": "module"
   }
 }

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -2,7 +2,8 @@ import * as React from 'react'
 import { fireEvent, screen, waitFor, act } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary'
 import '@testing-library/jest-dom'
-import { useQuery, QueryClient } from '@tanstack/react-query'
+import type { QueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query'
 import { sortFns } from '../utils'
 import {
   getByTextContent,

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { fireEvent, screen, waitFor, act } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary'
 import '@testing-library/jest-dom'
-import type { QueryClient } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
 import { sortFns } from '../utils'
 import {

--- a/packages/react-query-devtools/src/__tests__/utils.tsx
+++ b/packages/react-query-devtools/src/__tests__/utils.tsx
@@ -1,4 +1,4 @@
-import { MatcherFunction } from '@testing-library/dom/types/matches'
+import type { MatcherFunction } from '@testing-library/dom/types/matches'
 import { render } from '@testing-library/react'
 import * as React from 'react'
 import { ReactQueryDevtools } from '../devtools'

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
-import {
-  useQueryClient,
-  onlineManager,
-  notifyManager,
+import type {
   QueryCache,
   QueryClient,
   QueryKey as QueryKeyType,
   ContextOptions,
+} from '@tanstack/react-query'
+import {
+  useQueryClient,
+  onlineManager,
+  notifyManager,
 } from '@tanstack/react-query'
 import { rankItem, compareItems } from '@tanstack/match-sorter-utils'
 import useLocalStorage from './useLocalStorage'

--- a/packages/react-query-devtools/src/utils.ts
+++ b/packages/react-query-devtools/src/utils.ts
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import type { Query } from '@tanstack/react-query'
 
-import { Theme, useTheme } from './theme'
+import type { Theme } from './theme'
+import { useTheme } from './theme'
 import useMediaQuery from './useMediaQuery'
 
 type StyledComponent<T> = T extends 'button'

--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react'
 
-import type { PersistQueryClientOptions } from './persist';
+import type { PersistQueryClientOptions } from './persist'
 import { persistQueryClient } from './persist'
-import type {
-  QueryClientProviderProps} from '@tanstack/react-query';
-import {
-  QueryClientProvider,
-  IsRestoringProvider,
-} from '@tanstack/react-query'
+import type { QueryClientProviderProps } from '@tanstack/react-query'
+import { QueryClientProvider, IsRestoringProvider } from '@tanstack/react-query'
 
 export type PersistQueryClientProviderProps = QueryClientProviderProps & {
   persistOptions: Omit<PersistQueryClientOptions, 'queryClient'>

--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 
-import { persistQueryClient, PersistQueryClientOptions } from './persist'
+import type { PersistQueryClientOptions } from './persist';
+import { persistQueryClient } from './persist'
+import type {
+  QueryClientProviderProps} from '@tanstack/react-query';
 import {
   QueryClientProvider,
-  QueryClientProviderProps,
   IsRestoringProvider,
 } from '@tanstack/react-query'
 

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react'
 import { render, waitFor } from '@testing-library/react'
 
+import type {
+  UseQueryResult,
+  DefinedUseQueryResult} from '@tanstack/react-query';
 import {
   QueryClient,
   useQuery,
-  UseQueryResult,
-  useQueries,
-  DefinedUseQueryResult,
+  useQueries
 } from '@tanstack/react-query'
 import { createQueryClient, mockLogger, queryKey, sleep } from './utils'
-import { PersistedClient, Persister, persistQueryClientSave } from '../persist'
+import type { PersistedClient, Persister} from '../persist';
+import { persistQueryClientSave } from '../persist'
 import { PersistQueryClientProvider } from '../PersistQueryClientProvider'
 
 const createMockPersister = (): Persister => {

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -3,14 +3,11 @@ import { render, waitFor } from '@testing-library/react'
 
 import type {
   UseQueryResult,
-  DefinedUseQueryResult} from '@tanstack/react-query';
-import {
-  QueryClient,
-  useQuery,
-  useQueries
+  DefinedUseQueryResult,
 } from '@tanstack/react-query'
+import { QueryClient, useQuery, useQueries } from '@tanstack/react-query'
 import { createQueryClient, mockLogger, queryKey, sleep } from './utils'
-import type { PersistedClient, Persister} from '../persist';
+import type { PersistedClient, Persister } from '../persist'
 import { persistQueryClientSave } from '../persist'
 import { PersistQueryClientProvider } from '../PersistQueryClientProvider'
 

--- a/packages/react-query-persist-client/src/__tests__/persist.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/persist.test.tsx
@@ -1,10 +1,6 @@
 import { createQueryClient, sleep } from './utils'
-import type {
-  PersistedClient,
-  Persister} from '../persist';
-import {
-  persistQueryClientSubscribe,
-} from '../persist'
+import type { PersistedClient, Persister } from '../persist'
+import { persistQueryClientSubscribe } from '../persist'
 
 const createMockPersister = (): Persister => {
   let storedState: PersistedClient | undefined

--- a/packages/react-query-persist-client/src/__tests__/persist.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/persist.test.tsx
@@ -1,7 +1,8 @@
 import { createQueryClient, sleep } from './utils'
-import {
+import type {
   PersistedClient,
-  Persister,
+  Persister} from '../persist';
+import {
   persistQueryClientSubscribe,
 } from '../persist'
 

--- a/packages/react-query-persist-client/src/__tests__/utils.ts
+++ b/packages/react-query-persist-client/src/__tests__/utils.ts
@@ -1,6 +1,7 @@
 import { act } from '@testing-library/react'
 
-import { QueryClient, QueryClientConfig } from '@tanstack/query-core'
+import type { QueryClientConfig } from '@tanstack/query-core'
+import { QueryClient } from '@tanstack/query-core'
 
 export function createQueryClient(config?: QueryClientConfig): QueryClient {
   jest.spyOn(console, 'error').mockImplementation(() => undefined)

--- a/packages/react-query-persist-client/src/persist.ts
+++ b/packages/react-query-persist-client/src/persist.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   QueryClient,
-  dehydrate,
   DehydratedState,
   DehydrateOptions,
   HydrateOptions,
-  hydrate,
 } from '@tanstack/query-core'
+import { dehydrate, hydrate } from '@tanstack/query-core'
 
 export type Promisable<T> = T | PromiseLike<T>
 

--- a/packages/react-query-persist-client/src/retryStrategies.ts
+++ b/packages/react-query-persist-client/src/retryStrategies.ts
@@ -1,4 +1,4 @@
-import { PersistedClient } from './persist'
+import type { PersistedClient } from './persist'
 
 export type PersistRetryer = (props: {
   persistedClient: PersistedClient

--- a/packages/react-query/src/Hydrate.tsx
+++ b/packages/react-query/src/Hydrate.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 
-import { hydrate, HydrateOptions } from '@tanstack/query-core'
+import type { HydrateOptions } from '@tanstack/query-core';
+import { hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
-import { ContextOptions } from './types'
+import type { ContextOptions } from './types'
 
 export function useHydrate(
   state: unknown,

--- a/packages/react-query/src/Hydrate.tsx
+++ b/packages/react-query/src/Hydrate.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import type { HydrateOptions } from '@tanstack/query-core';
+import type { HydrateOptions } from '@tanstack/query-core'
 import { hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type { ContextOptions } from './types'

--- a/packages/react-query/src/QueryClientProvider.tsx
+++ b/packages/react-query/src/QueryClientProvider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
-import { QueryClient } from '@tanstack/query-core'
-import { ContextOptions } from './types'
+import type { QueryClient } from '@tanstack/query-core'
+import type { ContextOptions } from './types'
 
 declare global {
   interface Window {

--- a/packages/react-query/src/__tests__/suspense.test.tsx
+++ b/packages/react-query/src/__tests__/suspense.test.tsx
@@ -3,15 +3,13 @@ import { ErrorBoundary } from 'react-error-boundary'
 import * as React from 'react'
 
 import { createQueryClient, queryKey, renderWithClient, sleep } from './utils'
-import type {
-  UseInfiniteQueryResult,
-  UseQueryResult} from '..';
+import type { UseInfiniteQueryResult, UseQueryResult } from '..'
 import {
   QueryCache,
   QueryErrorResetBoundary,
   useInfiniteQuery,
   useQuery,
-  useQueryErrorResetBoundary
+  useQueryErrorResetBoundary,
 } from '..'
 
 describe("useQuery's in Suspense mode", () => {

--- a/packages/react-query/src/__tests__/suspense.test.tsx
+++ b/packages/react-query/src/__tests__/suspense.test.tsx
@@ -3,14 +3,15 @@ import { ErrorBoundary } from 'react-error-boundary'
 import * as React from 'react'
 
 import { createQueryClient, queryKey, renderWithClient, sleep } from './utils'
+import type {
+  UseInfiniteQueryResult,
+  UseQueryResult} from '..';
 import {
   QueryCache,
   QueryErrorResetBoundary,
   useInfiniteQuery,
-  UseInfiniteQueryResult,
   useQuery,
-  useQueryErrorResetBoundary,
-  UseQueryResult,
+  useQueryErrorResetBoundary
 } from '..'
 
 describe("useQuery's in Suspense mode", () => {

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -9,12 +9,13 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
-import {
+import type {
   InfiniteData,
-  QueryCache,
   QueryFunctionContext,
-  useInfiniteQuery,
-  UseInfiniteQueryResult,
+  UseInfiniteQueryResult} from '..';
+import {
+  QueryCache,
+  useInfiniteQuery
 } from '..'
 
 interface Result {

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -12,11 +12,9 @@ import {
 import type {
   InfiniteData,
   QueryFunctionContext,
-  UseInfiniteQueryResult} from '..';
-import {
-  QueryCache,
-  useInfiniteQuery
+  UseInfiniteQueryResult,
 } from '..'
+import { QueryCache, useInfiniteQuery } from '..'
 
 interface Result {
   items: number[]

--- a/packages/react-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/react-query/src/__tests__/useIsFetching.test.tsx
@@ -9,7 +9,7 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
-import type { QueryClient} from '..';
+import type { QueryClient } from '..'
 import { QueryCache, useIsFetching, useQuery } from '..'
 
 describe('useIsFetching', () => {

--- a/packages/react-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/react-query/src/__tests__/useIsFetching.test.tsx
@@ -9,7 +9,8 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
-import { QueryCache, QueryClient, useIsFetching, useQuery } from '..'
+import type { QueryClient} from '..';
+import { QueryCache, useIsFetching, useQuery } from '..'
 
 describe('useIsFetching', () => {
   // See https://github.com/tannerlinsley/react-query/issues/105

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -3,8 +3,9 @@ import '@testing-library/jest-dom'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
-import { MutationCache, QueryCache, QueryClient, useMutation } from '..'
-import { UseMutationResult } from '../types'
+import type { QueryClient} from '..';
+import { MutationCache, QueryCache, useMutation } from '..'
+import type { UseMutationResult } from '../types'
 import {
   createQueryClient,
   mockNavigatorOnLine,

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
-import type { QueryClient} from '..';
+import type { QueryClient } from '..'
 import { MutationCache, QueryCache, useMutation } from '..'
 import type { UseMutationResult } from '../types'
 import {

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -12,18 +12,19 @@ import {
   renderWithClient,
   sleep,
 } from './utils'
-import {
-  QueriesObserver,
-  QueryCache,
+import type {
   QueryClient,
   QueryFunction,
   QueryKey,
   QueryObserverResult,
-  useQueries,
   UseQueryOptions,
-  UseQueryResult,
+  UseQueryResult} from '..';
+import {
+  QueriesObserver,
+  QueryCache,
+  useQueries
 } from '..'
-import { QueryFunctionContext } from '@tanstack/query-core'
+import type { QueryFunctionContext } from '@tanstack/query-core'
 
 describe('useQueries', () => {
   const queryCache = new QueryCache()

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -18,12 +18,9 @@ import type {
   QueryKey,
   QueryObserverResult,
   UseQueryOptions,
-  UseQueryResult} from '..';
-import {
-  QueriesObserver,
-  QueryCache,
-  useQueries
+  UseQueryResult,
 } from '..'
+import { QueriesObserver, QueryCache, useQueries } from '..'
 import type { QueryFunctionContext } from '@tanstack/query-core'
 
 describe('useQueries', () => {

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -13,14 +13,15 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
-import {
+import type {
   DefinedUseQueryResult,
-  QueryCache,
   QueryFunction,
   QueryFunctionContext,
-  useQuery,
   UseQueryOptions,
-  UseQueryResult,
+  UseQueryResult} from '..';
+import {
+  QueryCache,
+  useQuery
 } from '..'
 import { ErrorBoundary } from 'react-error-boundary'
 

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -18,11 +18,9 @@ import type {
   QueryFunction,
   QueryFunctionContext,
   UseQueryOptions,
-  UseQueryResult} from '..';
-import {
-  QueryCache,
-  useQuery
+  UseQueryResult,
 } from '..'
+import { QueryCache, useQuery } from '..'
 import { ErrorBoundary } from 'react-error-boundary'
 
 describe('useQuery', () => {

--- a/packages/react-query/src/__tests__/utils.tsx
+++ b/packages/react-query/src/__tests__/utils.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react'
 import { act, render } from '@testing-library/react'
-import type {
-  ContextOptions,
-  QueryClientConfig,
-  MutationOptions} from '..';
-import {
-  QueryClient,
-  QueryClientProvider
-} from '..'
+import type { ContextOptions, QueryClientConfig, MutationOptions } from '..'
+import { QueryClient, QueryClientProvider } from '..'
 import * as utils from '@tanstack/query-core'
 
 export function renderWithClient(

--- a/packages/react-query/src/__tests__/utils.tsx
+++ b/packages/react-query/src/__tests__/utils.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import { act, render } from '@testing-library/react'
+import type {
+  ContextOptions,
+  QueryClientConfig,
+  MutationOptions} from '..';
 import {
   QueryClient,
-  ContextOptions,
-  QueryClientProvider,
-  QueryClientConfig,
-  MutationOptions,
+  QueryClientProvider
 } from '..'
 import * as utils from '@tanstack/query-core'
 

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import {
+import type * as React from 'react'
+import type {
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
   MutationObserverResult,

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 
-import { QueryKey, notifyManager, QueryObserver } from '@tanstack/query-core'
+import type { QueryKey, QueryObserver } from '@tanstack/query-core'
+import { notifyManager } from '@tanstack/query-core'
 import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import { useQueryClient } from './QueryClientProvider'
-import { UseBaseQueryOptions } from './types'
+import type { UseBaseQueryOptions } from './types'
 import { shouldThrowError } from './utils'
 import { useIsRestoring } from './isRestoring'
 

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   QueryObserver,
-  InfiniteQueryObserver,
   QueryFunction,
   QueryKey,
-  parseQueryArgs,
 } from '@tanstack/query-core'
-import { UseInfiniteQueryOptions, UseInfiniteQueryResult } from './types'
+import { InfiniteQueryObserver, parseQueryArgs } from '@tanstack/query-core'
+import type { UseInfiniteQueryOptions, UseInfiniteQueryResult } from './types'
 import { useBaseQuery } from './useBaseQuery'
 
 // HOOK

--- a/packages/react-query/src/useIsFetching.ts
+++ b/packages/react-query/src/useIsFetching.ts
@@ -1,13 +1,9 @@
 import * as React from 'react'
-import {
-  QueryKey,
-  notifyManager,
-  parseFilterArgs,
-  QueryFilters,
-} from '@tanstack/query-core'
+import type { QueryKey, QueryFilters } from '@tanstack/query-core'
+import { notifyManager, parseFilterArgs } from '@tanstack/query-core'
 
 import { useSyncExternalStore } from './useSyncExternalStore'
-import { ContextOptions } from './types'
+import type { ContextOptions } from './types'
 import { useQueryClient } from './QueryClientProvider'
 
 interface Options extends ContextOptions {}

--- a/packages/react-query/src/useIsMutating.ts
+++ b/packages/react-query/src/useIsMutating.ts
@@ -1,13 +1,9 @@
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 
-import {
-  notifyManager,
-  MutationKey,
-  MutationFilters,
-  parseMutationFilterArgs,
-} from '@tanstack/query-core'
-import { ContextOptions } from './types'
+import type { MutationKey, MutationFilters } from '@tanstack/query-core'
+import { notifyManager, parseMutationFilterArgs } from '@tanstack/query-core'
+import type { ContextOptions } from './types'
 import { useQueryClient } from './QueryClientProvider'
 
 interface Options extends ContextOptions {}

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -1,15 +1,14 @@
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 
+import type { MutationFunction, MutationKey } from '@tanstack/query-core'
 import {
   notifyManager,
   parseMutationArgs,
   MutationObserver,
-  MutationFunction,
-  MutationKey,
 } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
-import {
+import type {
   UseMutateFunction,
   UseMutationOptions,
   UseMutationResult,

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -1,14 +1,10 @@
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 
-import {
-  QueryKey,
-  QueryFunction,
-  notifyManager,
-  QueriesObserver,
-} from '@tanstack/query-core'
+import type { QueryKey, QueryFunction } from '@tanstack/query-core'
+import { notifyManager, QueriesObserver } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
-import { UseQueryOptions, UseQueryResult } from './types'
+import type { UseQueryOptions, UseQueryResult } from './types'
 import { useIsRestoring } from './isRestoring'
 
 // This defines the `UseQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -1,10 +1,10 @@
-import {
-  parseQueryArgs,
-  QueryFunction,
-  QueryKey,
-  QueryObserver,
-} from '@tanstack/query-core'
-import { DefinedUseQueryResult, UseQueryOptions, UseQueryResult } from './types'
+import type { QueryFunction, QueryKey } from '@tanstack/query-core'
+import { parseQueryArgs, QueryObserver } from '@tanstack/query-core'
+import type {
+  DefinedUseQueryResult,
+  UseQueryOptions,
+  UseQueryResult,
+} from './types'
 import { useBaseQuery } from './useBaseQuery'
 
 // HOOK


### PR DESCRIPTION
if someone enables 'preserveValueImports' and 'isolatedModules' in tsconfig.json, it won't throw errors now.