### PR TITLE
feat(query-core): log queryKey in createRetryer

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -452,7 +452,13 @@ export class Query<
       abort: abortController?.abort.bind(abortController),
       onSuccess: (data) => {
         if (typeof data === 'undefined') {
-          onError(new Error('Query data cannot be undefined') as any)
+          onError(
+            new Error(
+              `Query data cannot be undefined - affected query key: ${JSON.stringify(
+                this.queryKey,
+              )}`,
+            ) as any,
+          )
           return
         }
 

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -454,9 +454,7 @@ export class Query<
         if (typeof data === 'undefined') {
           onError(
             new Error(
-              `Query data cannot be undefined - affected query key: ${JSON.stringify(
-                this.queryKey,
-              )}`,
+              `Query data cannot be undefined - query key in question: ${this.queryHash}`,
             ) as any,
           )
           return

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -454,7 +454,7 @@ export class Query<
         if (typeof data === 'undefined') {
           onError(
             new Error(
-              `Query data cannot be undefined - query key in question: ${this.queryHash}`,
+              `Query data cannot be undefined - affected query key: ${this.queryHash}`,
             ) as any,
           )
           return

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -816,7 +816,11 @@ describe('query', () => {
 
     await sleep(10)
 
-    const error = new Error('Query data cannot be undefined')
+    const error = new Error(
+      `Query data cannot be undefined - affected query key: ${
+        observer.getCurrentQuery().queryHash
+      }`,
+    )
 
     expect(observerResult).toMatchObject({
       isError: true,


### PR DESCRIPTION
@TkDodo As per our chat on Discord, I made a small change in the error that throws in `createRetryer`'s `onSuccess` callback if the fetched data turns out to be `undefined`. The error now includes the affected `queryKey` - I have confirmed this in my personal project and successfully resolved the issue I had that way.

Open to any suggestions.

Thanks!