### PR TITLE
feat: make `data` defined when `suspense` is `true`

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.types.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.types.test.tsx
@@ -155,3 +155,402 @@ describe('initialData', () => {
     })
   })
 })
+
+describe('suspense', () => {
+  describe('Config object overload', () => {
+    it('TData should always be defined when suspense is true', () => {
+      doNotExecute(() => {
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is false', () => {
+      doNotExecute(() => {
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is NOT provided', () => {
+      doNotExecute(() => {
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is true and enabled is provided', () => {
+      doNotExecute(() => {
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key overload', () => {
+    it('TData should always be defined when suspense is true', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is false', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is NOT defined', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is true and enabled is provided', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key and func', () => {
+    it('TData should always be defined when suspense is true', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(
+          ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is false', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(
+          ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: false,
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is NOT defined', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(['key'], () => {
+          return {
+            wow: true,
+          }
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is true and enabled is provided', () => {
+      doNotExecute(() => {
+        const { data } = useQuery(
+          ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+            enabled: false,
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+})
+
+describe('suspense with initialData', () => {
+  describe('Config object overload', () => {
+    it('TData should always be defined when suspense is enabled conditionally and initialData is provided as an object', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: {
+            wow: true,
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should always be defined when suspense is enabled conditionally and initialData is provided as a function which ALWAYS returns the data', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: () => ({
+            wow: true,
+          }),
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally and initialData is NOT provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally and initialData is provided as a function which can return undefined', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = useQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: () => undefined as { wow: boolean } | undefined,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key overload', () => {
+    it('TData should always be defined when suspense is enabled conditionally and initialData is provided', () => {
+      const getEnabled = () => true
+
+      doNotExecute(() => {
+        const { data } = useQuery(['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: {
+            wow: true,
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally and initialData is NOT provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = useQuery(['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key and func', () => {
+    it('TData should always be defined when suspense is enabled conditionally and initialData is provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = useQuery(
+          ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+            enabled: getEnabled(),
+            initialData: {
+              wow: true,
+            },
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally and initialData is NOT provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = useQuery(
+          ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+            enabled: getEnabled(),
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+})

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -17,6 +17,46 @@ export function useQuery<
 >(
   options: Omit<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'suspense' | 'enabled' | 'initialData'
+  > & { suspense: true; enabled: boolean; initialData?: () => undefined },
+): UseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'suspense' | 'enabled' | 'initialData'
+  > & {
+    suspense: true
+    enabled: boolean
+    initialData?: TQueryFnData | (() => TQueryFnData)
+  },
+): DefinedUseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'suspense'
+  > & { suspense: true },
+): DefinedUseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
     'initialData'
   > & { initialData?: () => undefined },
 ): UseQueryResult<TData, TError>
@@ -41,6 +81,49 @@ export function useQuery<
 >(
   options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): UseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'suspense' | 'enabled' | 'initialData'
+  > & { suspense: true; enabled: boolean; initialData?: () => undefined },
+): UseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'suspense' | 'enabled' | 'initialData'
+  > & {
+    suspense: true
+    enabled: boolean
+    initialData: TQueryFnData | (() => TQueryFnData)
+  },
+): DefinedUseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'suspense'
+  > & { suspense: true },
+): DefinedUseQueryResult<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -80,6 +163,52 @@ export function useQuery<
     'queryKey'
   >,
 ): UseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'suspense' | 'enabled' | 'initialData'
+  > & { suspense: true; enabled: boolean; initialData?: () => undefined },
+): UseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'suspense' | 'enabled' | 'initialData'
+  > & {
+    suspense: true
+    enabled: boolean
+    initialData: TQueryFnData | (() => TQueryFnData)
+  },
+): DefinedUseQueryResult<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'suspense'
+  > & { suspense: true },
+): DefinedUseQueryResult<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,

--- a/packages/solid-query/src/__tests__/createQuery.types.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.types.test.tsx
@@ -158,3 +158,405 @@ describe('initialData', () => {
     })
   })
 })
+
+describe('suspense', () => {
+  describe('Config object overload', () => {
+    it('TData should always be defined when suspense is true', () => {
+      doNotExecute(() => {
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is false', () => {
+      doNotExecute(() => {
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is NOT provided', () => {
+      doNotExecute(() => {
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is true and enabled is provided', () => {
+      doNotExecute(() => {
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key overload', () => {
+    it('TData should always be defined when suspense is true', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(() => ['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is false', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(() => ['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is NOT defined', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(() => ['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is true and enabled is provided', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(() => ['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: false,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key and func', () => {
+    it('TData should always be defined when suspense is true', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(
+          () => ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is false', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(
+          () => ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: false,
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is NOT defined', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(
+          () => ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is true and enabled is provided', () => {
+      doNotExecute(() => {
+        const { data } = createQuery(
+          () => ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+            enabled: false,
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+})
+
+describe('suspense with initialData', () => {
+  describe('Config object overload', () => {
+    it('TData should always be defined when suspense is enabled conditionally initialData is provided as an object', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: {
+            wow: true,
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should always be defined when suspense is enabled conditionally initialData is provided as a function which ALWAYS returns the data', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: () => ({
+            wow: true,
+          }),
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally initialData is NOT provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally initialData is provided as a function which can return undefined', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery({
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: () => undefined as { wow: boolean } | undefined,
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key overload', () => {
+    it('TData should always be defined when suspense is enabled conditionally initialData is provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery(() => ['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+          initialData: {
+            wow: true,
+          },
+        })
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally initialData is NOT provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery(() => ['key'], {
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          suspense: true,
+          enabled: getEnabled(),
+        })
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+
+  describe('Query key and func', () => {
+    it('TData should always be defined when suspense is enabled conditionally initialData is provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery(
+          () => ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+            enabled: getEnabled(),
+            initialData: {
+              wow: true,
+            },
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should have undefined in the union when suspense is enabled conditionally initialData is NOT provided', () => {
+      doNotExecute(() => {
+        const getEnabled = () => true
+
+        const { data } = createQuery(
+          () => ['key'],
+          () => {
+            return {
+              wow: true,
+            }
+          },
+          {
+            suspense: true,
+            enabled: getEnabled(),
+          },
+        )
+
+        const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+          true
+        return result
+      })
+    })
+  })
+})

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -24,6 +24,43 @@ export function createQuery<
 >(
   options: Omit<
     CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'suspense' | 'enabled' | 'initialData'
+  > & { suspense: true; enabled: boolean; initialData?: () => undefined },
+): CreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  options: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'suspense' | 'enabled' | 'initialData'
+  > & {
+    suspense: true
+    enabled: boolean
+    initialData?: TQueryFnData | (() => TQueryFnData)
+  },
+): DefinedCreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  options: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'suspense'
+  > & { suspense: true },
+): DefinedCreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  options: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
     'initialData'
   > & {
     initialData?: () => undefined
@@ -50,6 +87,46 @@ export function createQuery<
 >(
   options: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): CreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'suspense' | 'enabled' | 'initialData'
+  > & { suspense: true; enabled: boolean; initialData?: () => undefined },
+): CreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'suspense' | 'enabled' | 'initialData'
+  > & {
+    suspense: true
+    enabled: boolean
+    initialData?: TQueryFnData | (() => TQueryFnData)
+  },
+): DefinedCreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'suspense'
+  > & { suspense: true },
+): DefinedCreateQueryResult<TData, TError>
 export function createQuery<
   TQueryFnData = unknown,
   TError = unknown,
@@ -86,6 +163,49 @@ export function createQuery<
     'queryKey'
   >,
 ): CreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, ReturnType<TQueryKey>>,
+  options: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'suspense' | 'enabled' | 'initialData'
+  > & { suspense: true; enabled: boolean; initialData?: () => undefined },
+): CreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, ReturnType<TQueryKey>>,
+  options: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'suspense' | 'enabled' | 'initialData'
+  > & {
+    suspense: true
+    enabled: boolean
+    initialData?: TQueryFnData | (() => TQueryFnData)
+  },
+): DefinedCreateQueryResult<TData, TError>
+export function createQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, ReturnType<TQueryKey>>,
+  options: Omit<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'suspense'
+  > & { suspense: true },
+): DefinedCreateQueryResult<TData, TError>
 export function createQuery<
   TQueryFnData = unknown,
   TError = unknown,


### PR DESCRIPTION
This PR adds the overloads to `useQuery` that makes `data` be defined if `{ suspense: true }` is defined in the options