### PR TITLE
docs: add more detail to the loading status in useQuery

### DIFF
--- a/docs/reference/useQuery.md
+++ b/docs/reference/useQuery.md
@@ -198,8 +198,8 @@ const result = useQuery({
 
 - `status: String`
   - Will be:
-    - `loading` if there's no cached data and no query attempt was finished yet.
-    - `error` if the query attempt resulted in an error. The corresponding `error` property has the error received from the attempted fetch
+    - `loading` if there's no cached data and no query attempt was finished yet. Queries (including disabled ones) will start in `loading` state.
+    - `error` if the query attempt resulted in an error. The corresponding `error` property has the error received from the attempted fetch.
     - `success` if the query has received a response with no errors and is ready to display its data. The corresponding `data` property on the query is the data received from the successful fetch or if the query's `enabled` property is set to `false` and has not been fetched yet `data` is the first `initialData` supplied to the query on initialization.
 - `isLoading: boolean`
   - A derived boolean from the `status` variable above, provided for convenience.


### PR DESCRIPTION
Builds on top of https://github.com/TanStack/query/pull/4244

I think some more details in the useQuery docs for status would be helpful to those who miss the migration guide.