### PR TITLE
Add questions

### DIFF
--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -29,7 +29,7 @@ export function useBaseQuery<
   >,
   Observer: typeof QueryObserver,
 ) {
-  // Duc - we need to call create a queryClient and reuse it
+  // Duc - we need to create a queryClient and reuse it per query
 
   // { context: options.context }
   // Duc - why do we need context here?
@@ -115,6 +115,10 @@ export function useBaseQuery<
   )
 
   // Duc - update observer option if consumer options are changed
+  // Duc - need to find a good API to for angular life cycle
+  // Duc - a good canidate is provide options as BehaviorSubject
+  // Duc - consumer will subject this subject whenever options are update
+  // Duc - angular bindings should listen for changes and update observer options
   React.useEffect(() => {
     // Do not notify on updates because of changes in the options because
     // these changes should already be reflected in the optimistic result.

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -29,6 +29,9 @@ export function useBaseQuery<
   >,
   Observer: typeof QueryObserver,
 ) {
+  // Duc - we need to call create a queryClient and reuse it
+
+  // { context: options.context }
   // Duc - why do we need context here?
   // Duc - how to implement this behavior in angular
   // Duc - FROM the document: Required, but only if no default query function has been defined See Default Query Function for more information.
@@ -38,7 +41,7 @@ export function useBaseQuery<
   // Duc - skip this in MVP
   const isRestoring = useIsRestoring()
   // Duc - SKIP: since angular does not have ErrorBoundary
-  const errorResetBoundary = useQueryErrorResetBoundary()
+  // const errorResetBoundary = useQueryErrorResetBoundary()
   const defaultedOptions = queryClient.defaultQueryOptions(options)
 
   // Make sure results are optimistically set in fetching state before subscribing or updating options
@@ -78,10 +81,10 @@ export function useBaseQuery<
   }
 
   // Duc - SKIP: since angular does not have ErrorBoundary
-  ensurePreventErrorBoundaryRetry(defaultedOptions, errorResetBoundary)
+  // ensurePreventErrorBoundaryRetry(defaultedOptions, errorResetBoundary)
 
   // Duc - SKIP: since angular does not have ErrorBoundary
-  useClearResetErrorBoundary(errorResetBoundary)
+  // useClearResetErrorBoundary(errorResetBoundary)
 
   // Duc - create an observer for this query one time
   // and reuse it
@@ -103,7 +106,8 @@ export function useBaseQuery<
       (onStoreChange) =>
         isRestoring
           ? () => undefined
-          : observer.subscribe(notifyManager.batchCalls(onStoreChange)),
+          : // Duc - call unsubcribe on destroy
+            observer.subscribe(notifyManager.batchCalls(onStoreChange)),
       [observer, isRestoring],
     ),
     () => observer.getCurrentResult(),
@@ -120,38 +124,38 @@ export function useBaseQuery<
   // Duc - is this react specific suspense logic?
   // Duc - I guess we don't need this for Angular
   // Handle suspense
-  if (
-    defaultedOptions.suspense &&
-    result.isLoading &&
-    result.isFetching &&
-    !isRestoring
-  ) {
-    throw observer
-      .fetchOptimistic(defaultedOptions)
-      .then(({ data }) => {
-        defaultedOptions.onSuccess?.(data as TData)
-        defaultedOptions.onSettled?.(data, null)
-      })
-      .catch((error) => {
-        errorResetBoundary.clearReset()
-        defaultedOptions.onError?.(error)
-        defaultedOptions.onSettled?.(undefined, error)
-      })
-  }
+  // if (
+  //   defaultedOptions.suspense &&
+  //   result.isLoading &&
+  //   result.isFetching &&
+  //   !isRestoring
+  // ) {
+  //   throw observer
+  //     .fetchOptimistic(defaultedOptions)
+  //     .then(({ data }) => {
+  //       defaultedOptions.onSuccess?.(data as TData)
+  //       defaultedOptions.onSettled?.(data, null)
+  //     })
+  //     .catch((error) => {
+  //       errorResetBoundary.clearReset()
+  //       defaultedOptions.onError?.(error)
+  //       defaultedOptions.onSettled?.(undefined, error)
+  //     })
+  // }
 
   // Duc - is this react specific suspense logic?
   // Duc - I guess we don't need this for Angular
   // Handle error boundary
-  if (
-    getHasError({
-      result,
-      errorResetBoundary,
-      useErrorBoundary: defaultedOptions.useErrorBoundary,
-      query: observer.getCurrentQuery(),
-    })
-  ) {
-    throw result.error
-  }
+  // if (
+  //   getHasError({
+  //     result,
+  //     errorResetBoundary,
+  //     useErrorBoundary: defaultedOptions.useErrorBoundary,
+  //     query: observer.getCurrentQuery(),
+  //   })
+  // ) {
+  //   throw result.error
+  // }
 
   // Handle result property usage tracking
   return !defaultedOptions.notifyOnChangeProps

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -29,16 +29,25 @@ export function useBaseQuery<
   >,
   Observer: typeof QueryObserver,
 ) {
+  // Duc - why do we need context here?
+  // Duc - how to implement this behavior in angular
+  // Duc - FROM the document: Required, but only if no default query function has been defined See Default Query Function for more information.
+  // https://tanstack.com/query/v4/docs/reference/useQuery?from=reactQueryV3&original=https://react-query-v3.tanstack.com/reference/useQuery
+  // maybe we can skip this for angular e.g. the default query function is required
   const queryClient = useQueryClient({ context: options.context })
+  // Duc - skip this in MVP
   const isRestoring = useIsRestoring()
+  // Duc - SKIP: since angular does not have ErrorBoundary
   const errorResetBoundary = useQueryErrorResetBoundary()
   const defaultedOptions = queryClient.defaultQueryOptions(options)
 
   // Make sure results are optimistically set in fetching state before subscribing or updating options
+  // Duc - skip this in MVP
   defaultedOptions._optimisticResults = isRestoring
     ? 'isRestoring'
     : 'optimistic'
 
+  // Duc - skip this in MVP
   // Include callbacks in batch renders
   if (defaultedOptions.onError) {
     defaultedOptions.onError = notifyManager.batchCalls(
@@ -46,12 +55,14 @@ export function useBaseQuery<
     )
   }
 
+  // Duc - skip this in MVP
   if (defaultedOptions.onSuccess) {
     defaultedOptions.onSuccess = notifyManager.batchCalls(
       defaultedOptions.onSuccess,
     )
   }
 
+  // Duc - skip this in MVP
   if (defaultedOptions.onSettled) {
     defaultedOptions.onSettled = notifyManager.batchCalls(
       defaultedOptions.onSettled,
@@ -66,10 +77,14 @@ export function useBaseQuery<
     }
   }
 
+  // Duc - SKIP: since angular does not have ErrorBoundary
   ensurePreventErrorBoundaryRetry(defaultedOptions, errorResetBoundary)
 
+  // Duc - SKIP: since angular does not have ErrorBoundary
   useClearResetErrorBoundary(errorResetBoundary)
 
+  // Duc - create an observer for this query one time
+  // and reuse it
   const [observer] = React.useState(
     () =>
       new Observer<TQueryFnData, TError, TData, TQueryData, TQueryKey>(
@@ -78,8 +93,11 @@ export function useBaseQuery<
       ),
   )
 
+  // Duc - skip this in MVP
   const result = observer.getOptimisticResult(defaultedOptions)
 
+  // Duc - why do we need useSyncExternalStore
+  // need to check React document to find out
   useSyncExternalStore(
     React.useCallback(
       (onStoreChange) =>
@@ -92,12 +110,15 @@ export function useBaseQuery<
     () => observer.getCurrentResult(),
   )
 
+  // Duc - update observer option if consumer options are changed
   React.useEffect(() => {
     // Do not notify on updates because of changes in the options because
     // these changes should already be reflected in the optimistic result.
     observer.setOptions(defaultedOptions, { listeners: false })
   }, [defaultedOptions, observer])
 
+  // Duc - is this react specific suspense logic?
+  // Duc - I guess we don't need this for Angular
   // Handle suspense
   if (
     defaultedOptions.suspense &&
@@ -118,6 +139,8 @@ export function useBaseQuery<
       })
   }
 
+  // Duc - is this react specific suspense logic?
+  // Duc - I guess we don't need this for Angular
   // Handle error boundary
   if (
     getHasError({


### PR DESCRIPTION
1. create a single ton queryClient and reuse it
    
    we can create an angular service
    
2. consumer notify query-core
    1. `queryArray`, `options` changes
        - query-core update query options
        
        `queryArray` and `options` are a behavior subject
        
        should we use the behavior subject to store options? is it ok to store both primitive data and callback in the behavior subject?
        
    2. onDestroy
        - query-core unsubscribe store’s cache
        
        notify the query-core observer to call observer.unsubscribe()
        
3. query-core notify the  consumer
    1. result is updated 
        1. the consumer uses the new data
            
            should we wrap the result inside a behavior subject?
            
        2. consumer/query-core trigger angular changeDetections
            
            if we use behavior subject should cover this already

instead of returning raw data, we return an observable and pipe that observable with rxjs's finalized operator to call observer.unsubscribe()