### PR TITLE
fix(devTools styles): add direction style

### DIFF
--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -249,6 +249,7 @@ export function ReactQueryDevtools({
           styleNonce={styleNonce}
           {...otherPanelProps}
           style={{
+            direction:'ltr',
             position: 'fixed',
             bottom: '0',
             right: '0',

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -249,7 +249,7 @@ export function ReactQueryDevtools({
           styleNonce={styleNonce}
           {...otherPanelProps}
           style={{
-            direction:'ltr',
+            direction: 'ltr',
             position: 'fixed',
             bottom: '0',
             right: '0',


### PR DESCRIPTION
Add dir="ltr" to devtools panel beacause the devtools appear inverted when direction of a parent is rtl

Fixes #4282