### PR TITLE
docs(useQueries): duplicate query keys disclaimer

### DIFF
--- a/docs/reference/useQueries.md
+++ b/docs/reference/useQueries.md
@@ -21,6 +21,8 @@ The `useQueries` hook accepts an options object with a **queries** key whose val
 - `context?: React.Context<QueryClient | undefined>`
   - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
+> Having the same query key more than once in the array of query objects may cause some data to be shared data between queries, e.g. when using `placeholderData` and `select`. To avoid this, consider de-duplicating the queries and map the results back to the desired structure.
+
 **Returns**
 
 The `useQueries` hook returns an array with all the query results.

--- a/docs/reference/useQueries.md
+++ b/docs/reference/useQueries.md
@@ -21,7 +21,7 @@ The `useQueries` hook accepts an options object with a **queries** key whose val
 - `context?: React.Context<QueryClient | undefined>`
   - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
-> Having the same query key more than once in the array of query objects may cause some data to be shared data between queries, e.g. when using `placeholderData` and `select`. To avoid this, consider de-duplicating the queries and map the results back to the desired structure.
+> Having the same query key more than once in the array of query objects may cause some data to be shared between queries, e.g. when using `placeholderData` and `select`. To avoid this, consider de-duplicating the queries and map the results back to the desired structure.
 
 **Returns**
 


### PR DESCRIPTION
This PR documents the issue described in #4187.

I considered adding it to `Parallell queries` as well, but since it's such a specific issue I decided not to.