### PR TITLE
fix(solid-query): fix disappearing data key during fetching state

### DIFF
--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1803,7 +1803,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        states.push({...state})
+        states.push({ ...state })
       })
 
       createEffect(() => {
@@ -5090,7 +5090,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        states.push({...state})
+        states.push({ ...state })
       })
 
       return (
@@ -5164,7 +5164,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        states.push({...state})
+        states.push({ ...state })
       })
 
       const { refetch } = state

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1386,7 +1386,7 @@ describe('createQuery', () => {
 
   it('should create a new query when refetching a removed query', async () => {
     const key = queryKey()
-    const states: Partial<CreateQueryResult<number>>[] = []
+    const states: CreateQueryResult<number>[] = []
     let count = 0
 
     function Page() {
@@ -1400,7 +1400,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        states.push({ data: state.data, dataUpdatedAt: state.dataUpdatedAt })
+        states.push({ ...state })
       })
 
       return (
@@ -1510,7 +1510,7 @@ describe('createQuery', () => {
 
   it('should use query function from hook when the existing query does not have a query function', async () => {
     const key = queryKey()
-    const results: Partial<CreateQueryResult<string>>[] = []
+    const results: CreateQueryResult<string>[] = []
 
     queryClient.setQueryData(key(), 'set')
 
@@ -1528,7 +1528,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        results.push({ data: result.data, isFetching: result.isFetching })
+        results.push({ ...result })
       })
 
       return (
@@ -1725,7 +1725,7 @@ describe('createQuery', () => {
 
   it('should not fetch when switching to a disabled query', async () => {
     const key = queryKey()
-    const states: Partial<CreateQueryResult<number>>[] = []
+    const states: CreateQueryResult<number>[] = []
 
     function Page() {
       const [count, setCount] = createSignal(0)
@@ -1744,12 +1744,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        const { data, isSuccess, isFetching } = state
-        states.push({
-          data,
-          isFetching,
-          isSuccess,
-        })
+        states.push({ ...state })
       })
 
       createEffect(() => {
@@ -1793,7 +1788,7 @@ describe('createQuery', () => {
 
   it('should keep the previous data when keepPreviousData is set', async () => {
     const key = queryKey()
-    const states: Partial<CreateQueryResult<number>>[] = []
+    const states: CreateQueryResult<number>[] = []
 
     function Page() {
       const [count, setCount] = createSignal(0)
@@ -1808,13 +1803,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        const { data, isFetching, isSuccess, isPreviousData } = state
-        states.push({
-          data,
-          isFetching,
-          isSuccess,
-          isPreviousData,
-        })
+        states.push({...state})
       })
 
       createEffect(() => {
@@ -2137,7 +2126,7 @@ describe('createQuery', () => {
 
   it('should keep the previous data on disabled query when keepPreviousData is set and switching query key multiple times', async () => {
     const key = queryKey()
-    const states: Partial<CreateQueryResult<number>>[] = []
+    const states: CreateQueryResult<number>[] = []
 
     queryClient.setQueryData([key(), 10], 10)
 
@@ -2156,8 +2145,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        const { data, isFetching, isSuccess, isPreviousData } = state
-        states.push({ data, isFetching, isSuccess, isPreviousData })
+        states.push({ ...state })
       })
 
       createEffect(() => {
@@ -2780,7 +2768,7 @@ describe('createQuery', () => {
     const key = queryKey()
     const variables = { number: 5, boolean: false, object: {}, array: [] }
     type CustomQueryKey = readonly [ReturnType<typeof key>, typeof variables]
-    const states: Partial<CreateQueryResult<CustomQueryKey>>[] = []
+    const states: CreateQueryResult<CustomQueryKey>[] = []
 
     // TODO(lukemurray): extract the query function to a variable queryFn
 
@@ -5087,7 +5075,7 @@ describe('createQuery', () => {
 
   it('should update query state and refetch when reset with resetQueries', async () => {
     const key = queryKey()
-    const states: Optional<Partial<CreateQueryResult<number>>>[] = []
+    const states: CreateQueryResult<number>[] = []
     let count = 0
 
     function Page() {
@@ -5102,15 +5090,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        const { data, isLoading, isFetching, isSuccess, isStale } = state
-
-        states.push({
-          data,
-          isLoading,
-          isFetching,
-          isSuccess,
-          isStale,
-        })
+        states.push({...state})
       })
 
       return (
@@ -5169,7 +5149,7 @@ describe('createQuery', () => {
 
   it('should update query state and not refetch when resetting a disabled query with resetQueries', async () => {
     const key = queryKey()
-    const states: Partial<CreateQueryResult<number>>[] = []
+    const states: CreateQueryResult<number>[] = []
     let count = 0
 
     function Page() {
@@ -5184,14 +5164,7 @@ describe('createQuery', () => {
       )
 
       createRenderEffect(() => {
-        const { data, isLoading, isFetching, isSuccess, isStale } = state
-        states.push({
-          data,
-          isLoading,
-          isFetching,
-          isSuccess,
-          isStale,
-        })
+        states.push({...state})
       })
 
       const { refetch } = state

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -805,52 +805,6 @@ describe("useQuery's in Suspense mode", () => {
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
 
-  it('should not render suspense fallback when not enabled', async () => {
-    const key = queryKey()
-
-    function Page() {
-      const [enabled, setEnabled] = createSignal(false)
-      const result = createQuery(
-        key,
-        () => {
-          sleep(10)
-          return 'data'
-        },
-        {
-          suspense: true,
-          get enabled() {
-            return enabled()
-          },
-        },
-      )
-
-      return (
-        <div>
-          <button onClick={() => setEnabled(true)}>fire</button>
-          <h1>{result.data ?? 'default'}</h1>
-        </div>
-      )
-    }
-
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback="Loading...">
-          <Page />
-        </Suspense>
-      </QueryClientProvider>
-    ))
-
-    expect(screen.queryByText('Loading...')).toBeNull()
-    expect(screen.getByRole('heading').textContent).toBe('default')
-    await sleep(5)
-    fireEvent.click(screen.getByRole('button', { name: /fire/i }))
-    await waitFor(() => screen.getByText('Loading...'))
-
-    await waitFor(() => {
-      expect(screen.getByRole('heading').textContent).toBe('data')
-    })
-  })
-
   it('should error catched in error boundary without infinite loop', async () => {
     const key = queryKey()
 

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -64,7 +64,7 @@ export function createBaseQuery<
   const unsubscribe = observer.subscribe((result) => {
     taskQueue.push(() => {
       batch(() => {
-        let unwrappedResult = { ...unwrap(result) }
+        const unwrappedResult = { ...unwrap(result) }
         if (unwrappedResult.data === undefined) {
           // This is a hack to prevent Solid
           // from deleting the data property when it is `undefined`

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -31,7 +31,7 @@ export function createBaseQuery<
   Observer: typeof QueryObserver,
 ): QueryObserverResult<TData, TError> {
   const queryClient = useQueryClient({ context: options.context })
-
+  const emptyData = Symbol('empty')
   const defaultedOptions = queryClient.defaultQueryOptions(options)
   defaultedOptions._optimisticResults = 'optimistic'
   const observer = new Observer(queryClient, defaultedOptions)
@@ -45,6 +45,9 @@ export function createBaseQuery<
     () => {
       return new Promise((resolve) => {
         if (!(state.isFetching && state.isLoading)) {
+          if (unwrap(state.data) === emptyData) {
+            resolve(undefined)
+          }
           resolve(unwrap(state.data))
         }
       })
@@ -61,7 +64,15 @@ export function createBaseQuery<
   const unsubscribe = observer.subscribe((result) => {
     taskQueue.push(() => {
       batch(() => {
-        setState(unwrap(result))
+        let unwrappedResult = { ...unwrap(result) }
+        if (unwrappedResult.data === undefined) {
+          // This is a hack to prevent Solid 
+          // from deleting the data property when it is `undefined`
+          // ref: https://www.solidjs.com/docs/latest/api#updating-stores
+          // @ts-ignore
+          unwrappedResult.data = emptyData
+        }
+        setState(unwrap(unwrappedResult))
         mutate(() => unwrap(result.data))
         refetch()
       })
@@ -110,8 +121,8 @@ export function createBaseQuery<
       target: QueryObserverResult<TData, TError>,
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
-      if (prop === 'data' && target.isLoading && target.isFetching) {
-        return dataResource()
+      if (prop === 'data') {
+        return dataResource();
       }
       return Reflect.get(target, prop)
     },

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -66,7 +66,7 @@ export function createBaseQuery<
       batch(() => {
         let unwrappedResult = { ...unwrap(result) }
         if (unwrappedResult.data === undefined) {
-          // This is a hack to prevent Solid 
+          // This is a hack to prevent Solid
           // from deleting the data property when it is `undefined`
           // ref: https://www.solidjs.com/docs/latest/api#updating-stores
           // @ts-ignore
@@ -122,7 +122,7 @@ export function createBaseQuery<
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
       if (prop === 'data') {
-        return dataResource();
+        return dataResource()
       }
       return Reflect.get(target, prop)
     },


### PR DESCRIPTION
#4288 uncovered a bug in createBaseQuery.tsx, this PR aims to solve this. 

### The issue
`createBaseQuery` uses a SolidJS store to persist the queryObserver result and exposes it when `createQuery` is called. Scenarios when a query is reset or when a new query key is mounted on the same observer, The queryObserver result initially updates into this state -> `{ data: undefined, isLoading: true; }`.  Updating the store with `setStore` when `data` is `undefined` removes the `data` property from the store. ref: [Updating Stores in SolidJS](https://www.solidjs.com/docs/latest/api#updating-stores)

This is why this fix uses an empty `Symbol` in place of undefined data to prevent SolidJS from deleting the data key and keeps the state consistent between updates.