### PR TITLE
fix(query-core): await global mutation cache callbacks

### DIFF
--- a/docs/reference/MutationCache.md
+++ b/docs/reference/MutationCache.md
@@ -28,15 +28,18 @@ Its available methods are:
 
 **Options**
 
-- `onError?: (error: unknown, variables: unknown, context: unknown, mutation: Mutation) => void`
+- `onError?: (error: unknown, variables: unknown, context: unknown, mutation: Mutation) => Promise<unknown> | unknown`
   - Optional
   - This function will be called if some mutation encounters an error.
-- `onSuccess?: (data: unknown, variables: unknown, context: unknown, mutation: Mutation) => void`
+  - If you return a Promise from it, it will be awaited
+- `onSuccess?: (data: unknown, variables: unknown, context: unknown, mutation: Mutation) => Promise<unknown> | unknown`
   - Optional
   - This function will be called if some mutation is successful.
-- `onMutate?: (variables: unknown, mutation: Mutation) => void`
+  - If you return a Promise from it, it will be awaited
+- `onMutate?: (variables: unknown, mutation: Mutation) => Promise<unknown> | unknown`
   - Optional
   - This function will be called before some mutation executes.
+  - If you return a Promise from it, it will be awaited
 
 ## Global callbacks
 

--- a/docs/reference/useMutation.md
+++ b/docs/reference/useMutation.md
@@ -58,15 +58,15 @@ mutate(variables, {
   - This function will fire before the mutation function is fired and is passed the same variables the mutation function would receive
   - Useful to perform optimistic updates to a resource in hopes that the mutation succeeds
   - The value returned from this function will be passed to both the `onError` and `onSettled` functions in the event of a mutation failure and can be useful for rolling back optimistic updates.
-- `onSuccess: (data: TData, variables: TVariables, context?: TContext) => Promise<unknown> | void`
+- `onSuccess: (data: TData, variables: TVariables, context?: TContext) => Promise<unknown> | unknown`
   - Optional
   - This function will fire when the mutation is successful and will be passed the mutation's result.
   - If a promise is returned, it will be awaited and resolved before proceeding
-- `onError: (err: TError, variables: TVariables, context?: TContext) => Promise<unknown> | void`
+- `onError: (err: TError, variables: TVariables, context?: TContext) => Promise<unknown> | unknown`
   - Optional
   - This function will fire if the mutation encounters an error and will be passed the error.
   - If a promise is returned, it will be awaited and resolved before proceeding
-- `onSettled: (data: TData, error: TError, variables: TVariables, context?: TContext) => Promise<unknown> | void`
+- `onSettled: (data: TData, error: TError, variables: TVariables, context?: TContext) => Promise<unknown> | unknown`
   - Optional
   - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
   - If a promise is returned, it will be awaited and resolved before proceeding

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -193,7 +193,7 @@ export class Mutation<
       if (!restored) {
         this.dispatch({ type: 'loading', variables: this.options.variables! })
         // Notify cache callback
-        this.mutationCache.config.onMutate?.(
+        await this.mutationCache.config.onMutate?.(
           this.state.variables,
           this as Mutation<unknown, unknown, unknown, unknown>,
         )
@@ -209,7 +209,7 @@ export class Mutation<
       const data = await executeMutation()
 
       // Notify cache callback
-      this.mutationCache.config.onSuccess?.(
+      await this.mutationCache.config.onSuccess?.(
         data,
         this.state.variables,
         this.state.context,
@@ -234,7 +234,7 @@ export class Mutation<
     } catch (error) {
       try {
         // Notify cache callback
-        this.mutationCache.config.onError?.(
+        await this.mutationCache.config.onError?.(
           error,
           this.state.variables,
           this.state.context,

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -16,17 +16,17 @@ interface MutationCacheConfig {
     variables: unknown,
     context: unknown,
     mutation: Mutation<unknown, unknown, unknown>,
-  ) => void
+  ) => Promise<unknown> | unknown
   onSuccess?: (
     data: unknown,
     variables: unknown,
     context: unknown,
     mutation: Mutation<unknown, unknown, unknown>,
-  ) => void
+  ) => Promise<unknown> | unknown
   onMutate?: (
     variables: unknown,
     mutation: Mutation<unknown, unknown, unknown, unknown>,
-  ) => void
+  ) => Promise<unknown> | unknown
 }
 
 interface NotifyEventMutationAdded {


### PR DESCRIPTION
global mutation cache callbacks are always invoked, just like the callbacks on useMutation; however, they were not awaited, so you couldn't really do invalidations in them