### PR TITLE
docs(useQueryClient): add `context` option

### DIFF
--- a/docs/reference/useQueryClient.md
+++ b/docs/reference/useQueryClient.md
@@ -8,5 +8,10 @@ The `useQueryClient` hook returns the current `QueryClient` instance.
 ```tsx
 import { useQueryClient } from '@tanstack/react-query'
 
-const queryClient = useQueryClient()
+const queryClient = useQueryClient({ context })
 ```
+
+**Options**
+
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.


### PR DESCRIPTION
Sources:

> https://github.com/TanStack/query/blob/1d57f01c94360e71e502e6dcce6ef36af3330e6b/packages/react-query/src/QueryClientProvider.tsx#L42

> https://github.com/TanStack/query/blob/1d57f01c94360e71e502e6dcce6ef36af3330e6b/packages/react-query/src/types.ts#L17-L22

I used the description wording used in other docs pages, though, not the exact wording in the source code comment above. For example:

> https://github.com/TanStack/query/blob/1d57f01c94360e71e502e6dcce6ef36af3330e6b/docs/reference/useQuery.md?plain=1#L194-L195