### PR TITLE
docs(QueryClient): fix setQueryData updater type

### DIFF
--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -219,7 +219,7 @@ queryClient.setQueryData(queryKey, updater)
 **Options**
 
 - `queryKey: QueryKey`: [Query Keys](../guides/query-keys)
-- `updater: TQueryFnData | (oldData: TQueryFnData | undefined) => TQueryFnData | undefined`
+- `updater: TQueryFnData | undefined | ((oldData: TQueryFnData | undefined) => TQueryFnData | undefined)`
   - If non-function is passed, the data will be updated to this value
   - If a function is passed, it will receive the old data value and be expected to return a new one.
 


### PR DESCRIPTION
Hi, I'm a react-query lover!!
I found that `queryClient.setQueryData` type is wrong in docs.

### before
`updater: TQueryFnData | (oldData: TQueryFnData | undefined) => TQueryFnData | undefined`

### after
`updater: TQueryFnData | undefined | ((oldData: TQueryFnData | undefined) => TQueryFnData | undefined)`

I think return type of `updater` should include undefined type.

Cause original updater type is this.
```ts
updater: Updater<TQueryFnData | undefined, TQueryFnData | undefined>
Updater<TInput, TOutput> = TOutput | DataUpdateFunction<TInput, TOutput>
```

`Updater` returns TOutput and incoming generic type of `updater` is `TQueryFnData | undefined`.

So, return type of `Updater` should aceept `TQueryFnData | undefined`.

And I think `oldData: TQueryFnData | undefined) => TQueryFnData | undefined` would be better to be parenthesized.