### PR TITLE
fix(vue-query): fix bug where ref is destructured

### DIFF
--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -126,7 +126,7 @@ describe('useMutation', () => {
     )
   })
 
-  test('should allow for non-objects passed as arg1 & arg2 to trigger reactive updates', async () => {
+  test('should allow for options object passed as arg1 & arg2 to trigger reactive updates', async () => {
     const mutationKey = ref<string[]>(['foo'])
     const mutationFn = ref((params: string) => successMutator(params))
     const queryClient = useQueryClient()

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -131,10 +131,7 @@ describe('useMutation', () => {
     const mutationFn = ref((params: string) => successMutator(params))
     const queryClient = useQueryClient()
     const mutationCache = queryClient.getMutationCache()
-    const mutation = useMutation(
-      mutationKey,
-      mutationFn
-    )
+    const mutation = useMutation(mutationKey, mutationFn)
 
     mutationKey.value = ['bar']
     let proof = false

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -127,13 +127,13 @@ describe('useMutation', () => {
   })
 
   test('should allow for options object passed as arg1 & arg2 to trigger reactive updates', async () => {
-    const mutationKey = ref<string[]>(['foo'])
+    const mutationKey = ref<string[]>(['foo2'])
     const mutationFn = ref((params: string) => successMutator(params))
     const queryClient = useQueryClient()
     const mutationCache = queryClient.getMutationCache()
     const mutation = useMutation(mutationKey, mutationFn)
 
-    mutationKey.value = ['bar']
+    mutationKey.value = ['bar2']
     let proof = false
     mutationFn.value = (params: string) => {
       proof = true
@@ -144,8 +144,8 @@ describe('useMutation', () => {
     mutation.mutate('xyz')
     await flushPromises()
 
-    const mutations = mutationCache.find({ mutationKey: ['bar'] })
-    expect(mutations?.options.mutationKey).toEqual(['bar'])
+    const mutations = mutationCache.find({ mutationKey: ['bar2'] })
+    expect(mutations?.options.mutationKey).toEqual(['bar2'])
     expect(proof).toEqual(true)
   })
 

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -126,7 +126,7 @@ describe('useMutation', () => {
     )
   })
 
-  test('mutationFn and mutationKey are trigger reactive update when passed as arg1 or arg2', async () => {
+  test('should allow for non-objects passed as arg1 & arg2 to trigger reactive updates', async () => {
     const mutationKey = ref<string[]>(['foo'])
     const mutationFn = ref((params: string) => successMutator(params))
     const queryClient = useQueryClient()

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -126,7 +126,7 @@ describe('useMutation', () => {
     )
   })
 
-  test('should allow for options object passed as arg1 & arg2 to trigger reactive updates', async () => {
+  test('should allow for non-options object (mutationFn or mutationKey) passed as arg1 & arg2 to trigger reactive updates', async () => {
     const mutationKey = ref<string[]>(['foo2'])
     const mutationFn = ref((params: string) => successMutator(params))
     const queryClient = useQueryClient()

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -209,8 +209,8 @@ export function parseMutationArgs<
   const plainArg2 = isRef(arg2) ? arg2.value : arg2
   let options = plainArg1
   if (isMutationKey(plainArg1)) {
-    const plainArg3 = isRef(arg3) ? arg3.value : arg3
     if (typeof plainArg2 === 'function') {
+      const plainArg3 = isRef(arg3) ? arg3.value : arg3
       options = { ...plainArg3, mutationKey: plainArg1, mutationFn: plainArg2 }
     } else {
       options = { ...plainArg2, mutationKey: plainArg1 }

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -205,21 +205,20 @@ export function parseMutationArgs<
 ): WithQueryClientKey<
   MutationObserverOptions<TData, TError, TVariables, TContext>
 > {
-  let options = arg1
-  if (isMutationKey(arg1)) {
-    const plainFn = isRef(arg2) ? arg2.value : arg2
-    const plainOptions = isRef(arg3) ? arg3.value : arg3
-    if (typeof plainFn === 'function') {
-      options = { ...plainOptions, mutationKey: arg1, mutationFn: plainFn }
+  const plainArg1 = isRef(arg1) ? arg1.value : arg1
+  const plainArg2 = isRef(arg2) ? arg2.value : arg2
+  let options = plainArg1
+  if (isMutationKey(plainArg1)) {
+    const plainArg3 = isRef(arg3) ? arg3.value : arg3
+    if (typeof plainArg2 === 'function') {
+      options = { ...plainArg3, mutationKey: plainArg1, mutationFn: plainArg2 }
     } else {
-      options = { ...arg2, mutationKey: arg1 }
+      options = { ...plainArg2, mutationKey: plainArg1 }
     }
   }
 
-  const plainFn = isRef(arg1) ? arg1.value : arg1
-  const plainOptions = isRef(arg2) ? arg2.value : arg2
-  if (typeof plainFn === 'function') {
-    options = { ...plainOptions, mutationFn: plainFn }
+  if (typeof plainArg1 === 'function') {
+    options = { ...plainArg2, mutationFn: plainArg1 }
   }
 
   return cloneDeepUnref(options) as UseMutationOptions<

--- a/packages/vue-query/src/utils.ts
+++ b/packages/vue-query/src/utils.ts
@@ -15,8 +15,8 @@ export function isQueryKey(value: unknown): value is QueryKey {
   return Array.isArray(value)
 }
 
-export function isMutationKey(value: unknown): value is MaybeRef<MutationKey> {
-  return Array.isArray(isRef(value) ? value.value : value)
+export function isMutationKey(value: unknown): value is MutationKey {
+  return Array.isArray(value)
 }
 
 export function updateState(

--- a/packages/vue-query/src/utils.ts
+++ b/packages/vue-query/src/utils.ts
@@ -2,7 +2,6 @@
 import type { QueryKey, MutationKey } from '@tanstack/query-core'
 import { isRef, unref } from 'vue-demi'
 import type { UnwrapRef } from 'vue-demi'
-import type { MaybeRef } from './types'
 
 export const VUE_QUERY_CLIENT = 'VUE_QUERY_CLIENT'
 


### PR DESCRIPTION
non-plain object is no longer destructured. tests added to prevent similar bugs from occuring going forward. improve parseMutationArgs function