### PR TITLE
fix(vue-query): proper function types in MaybeRefDeep

### DIFF
--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "vue": "3.2.39",
-    "@tanstack/vue-query": "^4.9.0"
+    "@tanstack/vue-query": "^4.13.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "3.1.0",

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -11,7 +11,9 @@ import type { QueryClient } from './queryClient'
 export type MaybeRef<T> = Ref<T> | T
 
 export type MaybeRefDeep<T> = MaybeRef<
-  T extends object
+  T extends Function
+    ? T
+    : T extends object
     ? {
         [Property in keyof T]: MaybeRefDeep<T[Property]>
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,7 +638,7 @@ importers:
 
   examples/vue/basic:
     specifiers:
-      '@tanstack/vue-query': ^4.9.0
+      '@tanstack/vue-query': ^4.13.2
       '@vitejs/plugin-vue': 3.1.0
       typescript: 4.8.4
       vite: 3.1.4


### PR DESCRIPTION
proper typing got lost in this commit: https://github.com/TanStack/query/pull/4339/files#diff-888f1e51a9068ca7a2a4551335ab573f35892ca6ecddc60438fc1b9405ad8bebL12

Closes: https://github.com/TanStack/query/issues/4366