### PR TITLE
fix(core): initialData should take precedence over keepPreviousData

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -600,15 +600,13 @@ function getDefaultState<
       ? (options.initialData as InitialDataFunction<TData>)()
       : options.initialData
 
-  const hasInitialData = typeof options.initialData !== 'undefined'
+  const hasData = typeof data !== 'undefined'
 
-  const initialDataUpdatedAt = hasInitialData
+  const initialDataUpdatedAt = hasData
     ? typeof options.initialDataUpdatedAt === 'function'
       ? (options.initialDataUpdatedAt as () => number | undefined)()
       : options.initialDataUpdatedAt
     : 0
-
-  const hasData = typeof data !== 'undefined'
 
   return {
     data,

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -457,7 +457,7 @@ export class QueryObserver<
     // Keep previous data if needed
     if (
       options.keepPreviousData &&
-      !state.dataUpdateCount &&
+      !state.dataUpdatedAt &&
       prevQueryResult?.isSuccess &&
       status !== 'error'
     ) {

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1993,13 +1993,15 @@ describe('createQuery', () => {
         states.push({ ...state })
       })
 
-      createEffect(() => {
-        setActTimeout(() => {
-          setCount(1)
-        }, 20)
-      })
-
-      return null
+      return (
+        <div>
+          <h1>
+            data: {state.data}, count: {count}, isFetching:{' '}
+            {String(state.isFetching)}
+          </h1>
+          <button onClick={() => setCount(1)}>inc</button>
+        </div>
+      )
     }
 
     render(() => (
@@ -2007,6 +2009,16 @@ describe('createQuery', () => {
         <Page />
       </QueryClientProvider>
     ))
+
+    await waitFor(() =>
+      screen.getByText('data: 0, count: 0, isFetching: false'),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'inc' }))
+
+    await waitFor(() =>
+      screen.getByText('data: 1, count: 1, isFetching: false'),
+    )
 
     await waitFor(() => expect(states.length).toBe(4))
 
@@ -2026,10 +2038,10 @@ describe('createQuery', () => {
     })
     // Set state
     expect(states[2]).toMatchObject({
-      data: 0,
+      data: 99,
       isFetching: true,
       isSuccess: true,
-      isPreviousData: true,
+      isPreviousData: false,
     })
     // New data
     expect(states[3]).toMatchObject({


### PR DESCRIPTION
closes #4415 

previousData is data that we want to show from a previous observer if we don't have any good data in the cache already. InitialData is always considered good data, just as if it were data that has been fetched. It might be potentially stale, but that's something that can be controlled via staleTime and initialDataUpdatedAt.

So that means we shouldn't show previousData if we also have initialData