### PR TITLE
fix(eslint-plugin): get identifiers from unary, chain, and ts-non-null expressions

### DIFF
--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.test.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.test.ts
@@ -55,6 +55,14 @@ ruleTester.run('exhaustive-deps', rule, {
       `,
     },
     {
+      name: 'identify props?.id (chain expression)',
+      code: `
+        function MyComponent(props) {
+            useQuery({ queryKey: ["entity", props?.id], queryFn: () => api.entity.get(props?.id) });
+        }
+      `,
+    },
+    {
       name: 'should ignore keys from callback',
       code: `
         function MyComponent(props) {

--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.test.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.test.ts
@@ -63,6 +63,15 @@ ruleTester.run('exhaustive-deps', rule, {
       `,
     },
     {
+      only: true,
+      name: 'identify props!.id (ts non null expression)',
+      code: `
+        function MyComponent(props) {
+            useQuery({ queryKey: ["entity", props!.id], queryFn: () => api.entity.get(props!.id) });
+        }
+      `,
+    },
+    {
       name: 'should ignore keys from callback',
       code: `
         function MyComponent(props) {

--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.test.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.test.ts
@@ -47,6 +47,14 @@ ruleTester.run('exhaustive-deps', rule, {
       `,
     },
     {
+      name: 'identify !!props.id (unary expression)',
+      code: `
+        function MyComponent(props) {
+            useQuery({ queryKey: ["entity", !!props.id], queryFn: () => api.entity.get(props.id) });
+        }
+      `,
+    },
+    {
       name: 'should ignore keys from callback',
       code: `
         function MyComponent(props) {

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -67,6 +67,10 @@ export const ASTUtils = {
       identifiers.push(...ASTUtils.getNestedIdentifiers(node.object))
     }
 
+    if (node.type === AST_NODE_TYPES.UnaryExpression) {
+        identifiers.push(...ASTUtils.getNestedIdentifiers(node.argument))
+    }
+
     return identifiers
   },
   isAncestorIsCallee(identifier: TSESTree.Node) {

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -71,6 +71,10 @@ export const ASTUtils = {
         identifiers.push(...ASTUtils.getNestedIdentifiers(node.argument))
     }
 
+    if (node.type === AST_NODE_TYPES.ChainExpression) {
+        identifiers.push(...ASTUtils.getNestedIdentifiers(node.expression))
+    }
+
     return identifiers
   },
   isAncestorIsCallee(identifier: TSESTree.Node) {

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -68,15 +68,15 @@ export const ASTUtils = {
     }
 
     if (node.type === AST_NODE_TYPES.UnaryExpression) {
-        identifiers.push(...ASTUtils.getNestedIdentifiers(node.argument))
+      identifiers.push(...ASTUtils.getNestedIdentifiers(node.argument))
     }
 
     if (node.type === AST_NODE_TYPES.ChainExpression) {
-        identifiers.push(...ASTUtils.getNestedIdentifiers(node.expression))
+      identifiers.push(...ASTUtils.getNestedIdentifiers(node.expression))
     }
 
     if (node.type === AST_NODE_TYPES.TSNonNullExpression) {
-        identifiers.push(...ASTUtils.getNestedIdentifiers(node.expression))
+      identifiers.push(...ASTUtils.getNestedIdentifiers(node.expression))
     }
 
     return identifiers

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -75,6 +75,10 @@ export const ASTUtils = {
         identifiers.push(...ASTUtils.getNestedIdentifiers(node.expression))
     }
 
+    if (node.type === AST_NODE_TYPES.TSNonNullExpression) {
+        identifiers.push(...ASTUtils.getNestedIdentifiers(node.expression))
+    }
+
     return identifiers
   },
   isAncestorIsCallee(identifier: TSESTree.Node) {


### PR DESCRIPTION
fixes #4429 