### PR TITLE
refactor(core): derive meta from options

### DIFF
--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -76,7 +76,7 @@ export function infiniteQueryBehavior<
           const queryFnContext: QueryFunctionContext = {
             queryKey: context.queryKey,
             pageParam: param,
-            meta: context.meta,
+            meta: context.options.meta,
           }
 
           addSignalProperty(queryFnContext)

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -91,7 +91,6 @@ export class Mutation<
   state: MutationState<TData, TError, TVariables, TContext>
   options: MutationOptions<TData, TError, TVariables, TContext>
   mutationId: number
-  meta: MutationMeta | undefined
 
   private observers: MutationObserver<TData, TError, TVariables, TContext>[]
   private mutationCache: MutationCache
@@ -110,10 +109,13 @@ export class Mutation<
     this.logger = config.logger || defaultLogger
     this.observers = []
     this.state = config.state || getDefaultState()
-    this.meta = config.meta
 
     this.updateCacheTime(this.options.cacheTime)
     this.scheduleGc()
+  }
+
+  get meta(): MutationMeta | undefined {
+    return this.options.meta
   }
 
   setState(state: MutationState<TData, TError, TVariables, TContext>): void {

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -101,7 +101,6 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
       defaultOptions: options.mutationKey
         ? client.getMutationDefaults(options.mutationKey)
         : undefined,
-      meta: options.meta,
     })
 
     this.add(mutation)

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -34,7 +34,6 @@ interface QueryConfig<
   options?: QueryOptions<TQueryFnData, TError, TData, TQueryKey>
   defaultOptions?: QueryOptions<TQueryFnData, TError, TData, TQueryKey>
   state?: QueryState<TData, TError>
-  meta: QueryMeta | undefined
 }
 
 export interface QueryState<TData = unknown, TError = unknown> {
@@ -64,7 +63,6 @@ export interface FetchContext<
   options: QueryOptions<TQueryFnData, TError, TData, any>
   queryKey: TQueryKey
   state: QueryState<TData, TError>
-  meta: QueryMeta | undefined
 }
 
 export interface QueryBehavior<
@@ -152,7 +150,6 @@ export class Query<
   initialState: QueryState<TData, TError>
   revertState?: QueryState<TData, TError>
   state: QueryState<TData, TError>
-  meta: QueryMeta | undefined
   isFetchingOptimistic?: boolean
 
   private cache: QueryCache
@@ -176,15 +173,16 @@ export class Query<
     this.queryHash = config.queryHash
     this.initialState = config.state || getDefaultState(this.options)
     this.state = this.initialState
-    this.meta = config.meta
+  }
+
+  get meta(): QueryMeta | undefined {
+    return this.options.meta
   }
 
   private setOptions(
     options?: QueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   ): void {
     this.options = { ...this.defaultOptions, ...options }
-
-    this.meta = options?.meta
 
     this.updateCacheTime(this.options.cacheTime)
   }
@@ -406,7 +404,6 @@ export class Query<
       queryKey: this.queryKey,
       state: this.state,
       fetchFn,
-      meta: this.meta,
     }
 
     addSignalProperty(context)

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -103,7 +103,6 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
         options: client.defaultQueryOptions(options),
         state,
         defaultOptions: client.getQueryDefaults(queryKey),
-        meta: options.meta,
       })
       this.add(query)
     }

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -596,6 +596,23 @@ describe('query', () => {
     expect(query.options.meta).toBeUndefined()
   })
 
+  test('can use default meta', async () => {
+    const meta = {
+      it: 'works',
+    }
+
+    const key = queryKey()
+    const queryFn = () => 'data'
+
+    queryClient.setQueryDefaults(key, { meta })
+
+    await queryClient.prefetchQuery(key, queryFn)
+
+    const query = queryCache.find(key)!
+
+    expect(query.meta).toBe(meta)
+  })
+
   test('provides meta object inside query function', async () => {
     const meta = {
       it: 'works',


### PR DESCRIPTION
this simplifies code because we don't need to pass meta around manually; we can keep the same public interface with a getter