### PR TITLE
fix: suspense link is not work

### DIFF
--- a/docs/guides/ssr.md
+++ b/docs/guides/ssr.md
@@ -236,7 +236,7 @@ async function handleRequest (req, res) {
 
 ### Client
 
-Make sure to [use suspense in your queries](./suspense.md).
+Make sure to [use suspense in your queries](../guides/suspense).
 
 ## Tips, Tricks and Caveats
 


### PR DESCRIPTION
Thank you for making such a good library. I'm always using `react-query` well.

While studying about ssr, I checked that the link is not working.

When I click this link
![image](https://user-images.githubusercontent.com/69495129/200447181-da277d87-12c1-4b88-98fe-059019e9305b.png)

It routes me https://tanstack.com/query/v4/docs/suspense.md

![image](https://user-images.githubusercontent.com/69495129/200447268-5f037dc1-b693-457c-84ed-4b3047353e8b.png)

this show me the undefined page so I corrected link
