### PR TITLE
docs(Query Invalidation): Adds a missing square bracket

### DIFF
--- a/docs/guides/query-invalidation.md
+++ b/docs/guides/query-invalidation.md
@@ -48,7 +48,7 @@ You can even invalidate queries with specific variables by passing a more specif
 
 ```tsx
 queryClient.invalidateQueries({
-  queryKey: ['todos', { type: 'done' },
+  queryKey: ['todos', { type: 'done' }],
 })
 
 // The query below will be invalidated


### PR DESCRIPTION
Adds a missing closing ] bracket in the second code example of [Query Matching with invalidateQueries](https://tanstack.com/query/v4/docs/guides/query-invalidation#query-matching-with-invalidatequeries)