### PR TITLE
fix(eslint-plugin): false positive for factory functions

### DIFF
--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
@@ -48,6 +48,35 @@ ruleTester.run(name, rule, {
         const usePosts = () => useQuery(postsQuery);
       `,
     },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        const getQuery = () => ({ queryKey: ['foo'], queryFn: () => Promise.resolve(5) })
+        useQuery(getQuery())
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        const getQuery = () => {
+          return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };
+        }
+        useQuery(getQuery())
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        const getQuery = () => {
+          try {
+            return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };  
+          } finally {
+            return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };
+          }
+        }
+        useQuery(getQuery())
+      `,
+    },
   ],
 
   invalid: [
@@ -124,6 +153,104 @@ ruleTester.run(name, rule, {
         import { useQuery } from "@tanstack/react-query";
         useQuery({ queryKey, queryFn, enabled });
       `,
+    },
+    {
+      code: normalizeIndent`
+      import { useQuery } from "@tanstack/react-query";
+      const getQuery = () => "foo";
+      useQuery(getQuery());
+      `,
+      errors: [
+        {
+          messageId: 'returnTypeAreNotObjectSyntax',
+          data: { returnType: '"foo"' },
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+      import { useQuery } from "@tanstack/react-query";
+      const getQuery = (x) => {
+        return x
+          ? { queryKey: "foo", queryFn: () => Promise.resolve(1) }
+          : null;
+      };
+      useQuery(getQuery(x));
+      `,
+      errors: [
+        {
+          messageId: 'returnTypeAreNotObjectSyntax',
+          data: {
+            returnType: `x\n    ? { queryKey: "foo", queryFn: () => Promise.resolve(1) }\n    : null`,
+          },
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+      import { useQuery } from "@tanstack/react-query";
+      const getQuery = (x) => {
+        try {
+          return { queryKey: "foo", queryFn: () => Promise.resolve(1) };
+        } catch (e) {
+          if (x > 1) {
+            return { queryKey: "bar", queryFn: () => Promise.resolve(2) };
+          } else {
+            return null;
+          }
+        }
+      };
+      useQuery(getQuery(x));
+      `,
+      errors: [
+        {
+          messageId: 'returnTypeAreNotObjectSyntax',
+          data: { returnType: 'null' },
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+      import { useQuery } from "@tanstack/react-query";
+      const getQuery = (x) => {
+        switch (x) {
+          case 1:
+            return { queryKey: "foo", queryFn: () => Promise.resolve(1) };
+          default:
+            return null;
+        }
+      };
+      useQuery(getQuery(x));
+      `,
+      errors: [
+        {
+          messageId: 'returnTypeAreNotObjectSyntax',
+          data: { returnType: 'null' },
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+      import { useQuery } from "@tanstack/react-query";
+      const getQuery = (x, y) => {
+        if (x) {
+          return { queryKey: "foo", queryFn: () => Promise.resolve(1) };
+        } else {
+          if (y) {
+            return { queryKey: "bar", queryFn: () => Promise.resolve(2) };
+          } else {
+            return () => Promise.resolve(3);
+          }
+        }
+      };
+      useQuery(getQuery(x));
+      `,
+      errors: [
+        {
+          messageId: 'returnTypeAreNotObjectSyntax',
+          data: { returnType: '() => Promise.resolve(3)' },
+        },
+      ],
     },
     {
       code: normalizeIndent`

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
@@ -68,6 +68,19 @@ ruleTester.run(name, rule, {
       code: normalizeIndent`
         import { useQuery } from "@tanstack/react-query";
         const getQuery = () => {
+          const queryKey = () => ['foo'];
+          const queryFn = () => {
+            return Promise.resolve(5);
+          }
+          return { queryKey, queryFn };
+        }
+        useQuery(getQuery())
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        const getQuery = () => {
           try {
             return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };  
           } finally {

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
@@ -1,129 +1,234 @@
-import type { TSESLint } from '@typescript-eslint/utils'
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils'
 import { createRule } from '../../utils/create-rule'
 import { ASTUtils } from '../../utils/ast-utils'
 
 const QUERY_CALLS = ['useQuery', 'createQuery']
 
+const messages = {
+  preferObjectSyntax: `Objects syntax for query is preferred`,
+  returnTypeAreNotObjectSyntax: `Return type of query should be object syntax. Got {{returnType}} instead`,
+}
+
+type MessageKey = keyof typeof messages
+
 export const name = 'prefer-query-object-syntax'
 
-export const rule = createRule({
-  name,
-  meta: {
-    type: 'problem',
-    docs: {
-      description: 'Prefer object syntax for useQuery',
-      recommended: 'error',
+export const rule: TSESLint.RuleModule<MessageKey, readonly unknown[]> =
+  createRule({
+    name,
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'Prefer object syntax for useQuery',
+        recommended: 'error',
+      },
+      messages: messages,
+      fixable: 'code',
+      schema: [],
     },
-    messages: {
-      preferObjectSyntax: `Objects syntax for useQuery is preferred`,
-    },
-    fixable: 'code',
-    schema: [],
-  },
-  defaultOptions: [],
+    defaultOptions: [],
 
-  create(context, _, helpers) {
-    const sourceCode = context.getSourceCode()
-    return {
-      CallExpression(node) {
-        const isUseQuery =
-          node.callee.type === 'Identifier' &&
-          QUERY_CALLS.includes(node.callee.name) &&
-          helpers.isReactQueryImport(node.callee)
-        if (!isUseQuery) {
-          return
-        }
+    create(context, _, helpers) {
+      return {
+        CallExpression(node) {
+          const isTanstackQueryCall =
+            ASTUtils.isIdentifierWithOneOfNames(node.callee, QUERY_CALLS) &&
+            helpers.isTanstackQueryImport(node.callee)
 
-        let firstArgument = node.arguments[0]
-        if (!firstArgument) {
-          return
-        }
+          if (!isTanstackQueryCall) {
+            return
+          }
 
-        const reference = context
-          .getScope()
-          .references.find((ref) => ref.identifier === firstArgument)
+          const firstArgument = node.arguments[0]
 
-        if (
-          reference?.resolved?.defs[0]?.node.type === 'VariableDeclarator' &&
-          reference.resolved.defs[0].node.init?.type === 'ObjectExpression'
-        ) {
-          firstArgument = reference.resolved.defs[0].node.init
-        }
+          if (!firstArgument) {
+            return
+          }
 
-        const hasFirstObjectArgument = firstArgument.type === 'ObjectExpression'
-        if (hasFirstObjectArgument) {
-          return
-        }
+          if (firstArgument.type === AST_NODE_TYPES.CallExpression) {
+            const referencedCallExpression =
+              ASTUtils.getReferencedExpressionByIdentifier({
+                context,
+                node: firstArgument.callee,
+              })
 
-        const secondArgument = node.arguments[1]
-        const thirdArgument = node.arguments[2]
-
-        const optionsObject =
-          secondArgument?.type === 'ObjectExpression'
-            ? secondArgument
-            : thirdArgument?.type === 'ObjectExpression'
-            ? thirdArgument
-            : undefined
-
-        if (
-          secondArgument &&
-          !thirdArgument &&
-          secondArgument !== optionsObject &&
-          secondArgument.type === 'Identifier'
-        ) {
-          // Unable to determine if the secondArgument identifier is the options object or query fn.
-          // User has to fix the code manually.
-          context.report({ node, messageId: 'preferObjectSyntax' })
-          return
-        }
-
-        context.report({
-          node,
-          messageId: 'preferObjectSyntax',
-          fix(fixer) {
-            const ruleFixes: TSESLint.RuleFix[] = []
-            const optionsObjectProperties: string[] = []
-
-            // queryKey
-            const queryKey = sourceCode.getText(firstArgument)
-            const queryKeyProperty =
-              queryKey === 'queryKey' ? 'queryKey' : `queryKey: ${queryKey}`
-            optionsObjectProperties.push(queryKeyProperty)
-
-            // queryFn
-            if (secondArgument && secondArgument !== optionsObject) {
-              const queryFn = sourceCode.getText(secondArgument)
-              const queryFnProperty =
-                queryFn === 'queryFn' ? 'queryFn' : `queryFn: ${queryFn}`
-              optionsObjectProperties.push(queryFnProperty)
+            if (
+              referencedCallExpression === null ||
+              !ASTUtils.isNodeOfOneOf(referencedCallExpression, [
+                AST_NODE_TYPES.ArrowFunctionExpression,
+                AST_NODE_TYPES.FunctionExpression,
+              ])
+            ) {
+              return
             }
 
-            // options
-            if (optionsObject) {
-              const existingObjectProperties = optionsObject.properties.map(
-                (objectLiteral) => {
-                  return sourceCode.getText(objectLiteral)
+            if (
+              !ASTUtils.isNodeOfOneOf(referencedCallExpression.body, [
+                AST_NODE_TYPES.BlockStatement,
+                AST_NODE_TYPES.ObjectExpression,
+              ])
+            ) {
+              return context.report({
+                node,
+                messageId: 'returnTypeAreNotObjectSyntax',
+                data: {
+                  returnType: context
+                    .getSourceCode()
+                    .getText(referencedCallExpression.body),
                 },
-              )
-              optionsObjectProperties.push(...existingObjectProperties)
+              })
             }
 
-            const argumentsRange = ASTUtils.getRangeOfArguments(node)
-            if (argumentsRange) {
-              ruleFixes.push(fixer.removeRange(argumentsRange))
-            }
-
-            ruleFixes.push(
-              fixer.insertTextAfterRange(
-                [node.range[0], node.range[1] - 1],
-                `{ ${optionsObjectProperties.join(', ')} }`,
-              ),
+            const returnStmts = ASTUtils.getNestedReturnStatements(
+              referencedCallExpression,
             )
 
-            return ruleFixes
-          },
-        })
+            for (const stmt of returnStmts) {
+              if (stmt.argument === null) {
+                return context.report({
+                  node,
+                  messageId: 'returnTypeAreNotObjectSyntax',
+                  data: {
+                    returnType: 'void',
+                  },
+                })
+              }
+
+              runCheckOnNode({
+                context: context,
+                callNode: node,
+                expression: stmt.argument,
+                messageId: 'returnTypeAreNotObjectSyntax',
+              })
+            }
+
+            return
+          }
+
+          if (firstArgument.type === AST_NODE_TYPES.Identifier) {
+            const referencedNode = ASTUtils.getReferencedExpressionByIdentifier(
+              {
+                context,
+                node: firstArgument,
+              },
+            )
+
+            if (referencedNode?.type === AST_NODE_TYPES.ObjectExpression) {
+              return runCheckOnNode({
+                context: context,
+                callNode: node,
+                expression: referencedNode,
+                messageId: 'preferObjectSyntax',
+              })
+            }
+          }
+
+          runCheckOnNode({
+            context: context,
+            callNode: node,
+            expression: firstArgument,
+            messageId: 'preferObjectSyntax',
+          })
+        },
+      }
+    },
+  })
+
+function runCheckOnNode(params: {
+  context: Readonly<TSESLint.RuleContext<MessageKey, readonly unknown[]>>
+  callNode: TSESTree.CallExpression
+  expression: TSESTree.Node
+  messageId: MessageKey
+}) {
+  const { context, expression, messageId, callNode } = params
+  const sourceCode = context.getSourceCode()
+
+  if (expression.type === AST_NODE_TYPES.ObjectExpression) {
+    return
+  }
+
+  const secondArgument = callNode.arguments[1]
+  const thirdArgument = callNode.arguments[2]
+
+  const optionsObject =
+    secondArgument?.type === AST_NODE_TYPES.ObjectExpression
+      ? secondArgument
+      : thirdArgument?.type === AST_NODE_TYPES.ObjectExpression
+      ? thirdArgument
+      : undefined
+
+  if (
+    secondArgument &&
+    !thirdArgument &&
+    secondArgument !== optionsObject &&
+    secondArgument.type === AST_NODE_TYPES.Identifier
+  ) {
+    // Unable to determine if the secondArgument identifier is the options object or query fn.
+    // User has to fix the code manually.
+    context.report({ node: callNode, messageId: messageId })
+    return
+  }
+
+  if (messageId === 'returnTypeAreNotObjectSyntax') {
+    context.report({
+      node: callNode,
+      messageId: 'returnTypeAreNotObjectSyntax',
+      data: {
+        returnType: sourceCode.getText(expression),
       },
-    }
-  },
-})
+    })
+    return
+  }
+
+  context.report({
+    node: callNode,
+    messageId: 'preferObjectSyntax',
+    fix(fixer) {
+      const ruleFixes: TSESLint.RuleFix[] = []
+      const optionsObjectProperties: string[] = []
+
+      // queryKey
+      const firstArgument = callNode.arguments[0]
+      const queryKey = sourceCode.getText(firstArgument)
+      const queryKeyProperty =
+        queryKey === 'queryKey' ? 'queryKey' : `queryKey: ${queryKey}`
+
+      optionsObjectProperties.push(queryKeyProperty)
+
+      // queryFn
+      if (secondArgument && secondArgument !== optionsObject) {
+        const queryFn = sourceCode.getText(secondArgument)
+        const queryFnProperty =
+          queryFn === 'queryFn' ? 'queryFn' : `queryFn: ${queryFn}`
+
+        optionsObjectProperties.push(queryFnProperty)
+      }
+
+      // options
+      if (optionsObject) {
+        const existingObjectProperties = optionsObject.properties.map(
+          (objectLiteral) => {
+            return sourceCode.getText(objectLiteral)
+          },
+        )
+
+        optionsObjectProperties.push(...existingObjectProperties)
+      }
+
+      const argumentsRange = ASTUtils.getRangeOfArguments(callNode)
+
+      if (argumentsRange) {
+        ruleFixes.push(fixer.removeRange(argumentsRange))
+      }
+
+      ruleFixes.push(
+        fixer.insertTextAfterRange(
+          [callNode.range[0], callNode.range[1] - 1],
+          `{ ${optionsObjectProperties.join(', ')} }`,
+        ),
+      )
+
+      return ruleFixes
+    },
+  })
+}

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -1,8 +1,15 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+import type { RuleContext } from '@typescript-eslint/utils/dist/ts-eslint'
 import { uniqueBy } from './unique-by'
 
 export const ASTUtils = {
+  isNodeOfOneOf<T extends AST_NODE_TYPES>(
+    node: TSESTree.Node,
+    types: readonly T[],
+  ): node is TSESTree.Node & { type: T } {
+    return types.includes(node.type as T)
+  },
   isIdentifier(node: TSESTree.Node): node is TSESTree.Identifier {
     return node.type === AST_NODE_TYPES.Identifier
   },
@@ -11,6 +18,12 @@ export const ASTUtils = {
     name: string,
   ): node is TSESTree.Identifier {
     return ASTUtils.isIdentifier(node) && node.name === name
+  },
+  isIdentifierWithOneOfNames(
+    node: TSESTree.Node,
+    name: string[],
+  ): node is TSESTree.Identifier {
+    return ASTUtils.isIdentifier(node) && name.includes(node.name)
   },
   isProperty(node: TSESTree.Node): node is TSESTree.Property {
     return node.type === AST_NODE_TYPES.Property
@@ -155,5 +168,104 @@ export const ASTUtils = {
         AST_NODE_TYPES.Identifier,
       ]),
     )
+  },
+  getReferencedExpressionByIdentifier(params: {
+    node: TSESTree.Node
+    context: Readonly<RuleContext<string, readonly unknown[]>>
+  }) {
+    const { node, context } = params
+
+    const resolvedNode = context
+      .getScope()
+      .references.find((ref) => ref.identifier === node)?.resolved
+      ?.defs[0]?.node
+
+    if (resolvedNode?.type !== AST_NODE_TYPES.VariableDeclarator) {
+      return null
+    }
+
+    return resolvedNode.init
+  },
+  getNestedReturnStatements(node: TSESTree.Node): TSESTree.ReturnStatement[] {
+    const returnStatements: TSESTree.ReturnStatement[] = []
+
+    if (node.type === AST_NODE_TYPES.ReturnStatement) {
+      returnStatements.push(node)
+    }
+
+    if ('body' in node && node.body !== undefined && node.body !== null) {
+      Array.isArray(node.body)
+        ? node.body.forEach((x) => {
+            returnStatements.push(...ASTUtils.getNestedReturnStatements(x))
+          })
+        : returnStatements.push(
+            ...ASTUtils.getNestedReturnStatements(node.body),
+          )
+    }
+
+    if (
+      'consequent' in node &&
+      node.consequent !== undefined &&
+      node.consequent !== null
+    ) {
+      Array.isArray(node.consequent)
+        ? node.consequent.forEach((x) => {
+            returnStatements.push(...ASTUtils.getNestedReturnStatements(x))
+          })
+        : returnStatements.push(
+            ...ASTUtils.getNestedReturnStatements(node.consequent),
+          )
+    }
+
+    if (
+      'alternate' in node &&
+      node.alternate !== undefined &&
+      node.alternate !== null
+    ) {
+      Array.isArray(node.alternate)
+        ? node.alternate.forEach((x) => {
+            returnStatements.push(...ASTUtils.getNestedReturnStatements(x))
+          })
+        : returnStatements.push(
+            ...ASTUtils.getNestedReturnStatements(node.alternate),
+          )
+    }
+
+    if ('cases' in node && node.cases !== undefined && node.cases !== null) {
+      node.cases.forEach((x) => {
+        returnStatements.push(...ASTUtils.getNestedReturnStatements(x))
+      })
+    }
+
+    if ('block' in node) {
+      returnStatements.push(...ASTUtils.getNestedReturnStatements(node.block))
+    }
+
+    if ('handler' in node && node.handler !== null) {
+      returnStatements.push(...ASTUtils.getNestedReturnStatements(node.handler))
+    }
+
+    if ('finalizer' in node && node.finalizer !== null) {
+      returnStatements.push(
+        ...ASTUtils.getNestedReturnStatements(node.finalizer),
+      )
+    }
+
+    if (
+      'expression' in node &&
+      node.expression !== null &&
+      node.expression !== true &&
+      node.expression !== false
+    ) {
+      returnStatements.push(
+        ...ASTUtils.getNestedReturnStatements(node.expression),
+      )
+    }
+
+    if ('test' in node && node.test !== null) {
+      returnStatements.push(...ASTUtils.getNestedReturnStatements(node.test))
+    }
+
+    return returnStatements
   },
 }

--- a/packages/eslint-plugin-query/src/utils/create-rule.ts
+++ b/packages/eslint-plugin-query/src/utils/create-rule.ts
@@ -1,6 +1,6 @@
 import { ESLintUtils } from '@typescript-eslint/utils'
 import type { EnhancedCreate } from './detect-react-query-imports'
-import { detectReactQueryImports } from './detect-react-query-imports'
+import { detectTanstackQueryImports } from './detect-react-query-imports'
 
 const getDocsUrl = (ruleName: string): string =>
   `https://tanstack.com/query/v4/docs/eslint/${ruleName}`
@@ -15,6 +15,6 @@ type EslintRule = Omit<
 export function createRule({ create, ...rest }: EslintRule) {
   return ESLintUtils.RuleCreator(getDocsUrl)({
     ...rest,
-    create: detectReactQueryImports(create),
+    create: detectTanstackQueryImports(create),
   })
 }

--- a/packages/eslint-plugin-query/src/utils/detect-react-query-imports.ts
+++ b/packages/eslint-plugin-query/src/utils/detect-react-query-imports.ts
@@ -7,7 +7,7 @@ type Create = Parameters<
 type Context = Parameters<Create>[0]
 type Options = Parameters<Create>[1]
 type Helpers = {
-  isReactQueryImport: (node: TSESTree.Identifier) => boolean
+  isTanstackQueryImport: (node: TSESTree.Identifier) => boolean
 }
 
 export type EnhancedCreate = (
@@ -16,13 +16,13 @@ export type EnhancedCreate = (
   helpers: Helpers,
 ) => ReturnType<Create>
 
-export function detectReactQueryImports(create: EnhancedCreate): Create {
+export function detectTanstackQueryImports(create: EnhancedCreate): Create {
   return (context, optionsWithDefault) => {
-    const reactQueryImportSpecifiers: TSESTree.ImportClause[] = []
+    const tanstackQueryImportSpecifiers: TSESTree.ImportClause[] = []
 
     const helpers: Helpers = {
-      isReactQueryImport(node) {
-        return !!reactQueryImportSpecifiers.find((specifier) => {
+      isTanstackQueryImport(node) {
+        return !!tanstackQueryImportSpecifiers.find((specifier) => {
           if (specifier.type === 'ImportSpecifier') {
             return node.name === specifier.local.name
           }
@@ -38,7 +38,7 @@ export function detectReactQueryImports(create: EnhancedCreate): Create {
           node.source.value.startsWith('@tanstack/') &&
           node.source.value.endsWith('-query')
         ) {
-          reactQueryImportSpecifiers.push(...node.specifiers)
+          tanstackQueryImportSpecifiers.push(...node.specifiers)
         }
       },
     }


### PR DESCRIPTION
fixes https://github.com/TanStack/query/issues/4476

Honestly, I'm unsure how I feel about this fix. Since we need to support `@babel/eslint-parser`, we need to find a different way to get a function's "return type".

I'm not sure how I feel about my approach - The linter will check all possible return nodes, and if at least one node is not an `ObjectExpression`, the linter will report that node.

I'm open to suggestions.