### PR TITLE
Use useMemo for the useMutation result

### DIFF
--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -118,7 +118,10 @@ export function useMutation<
     throw result.error
   }
 
-  return { ...result, mutate, mutateAsync: result.mutate }
+  return React.useMemo(
+    () => ({ ...result, mutate, mutateAsync: result.mutate }),
+    [mutate, result],
+  )
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
Otherwise, an infinite loop is very likely.
One may not use the result destructuring and provide the value to the `useEffect` dependencies.

```javascript
const mutation = useMutation(...)

useEffect(() => { ... }, mutation)
```