### PR TITLE
docs: add react query suspense community contribution

### DIFF
--- a/docs/community/kappys-react-query-suspense.md
+++ b/docs/community/kappys-react-query-suspense.md
@@ -1,0 +1,86 @@
+---
+id: kappys-react-query-suspense
+title: React Query Suspense
+---
+
+Suspense your components until wherever call is completed just passing the query key.
+
+It's powerful because it isn't necessary pass isLoading props child by child or use the isLoading Hook. This does it by you
+
+## Installation
+You can install React Query Suspense via [NPM](https://www.npmjs.com/package/@kappys/react-query-suspense).
+
+```bash
+$ npm i @kappys/react-query-suspense
+# or
+$ pnpm add @kappys/react-query-suspense
+# or
+$ yarn add @kappys/react-query-suspense
+```
+
+## ⚡ Quick start
+
+Start wrapping the content that you want suspense until the call is ready to render.
+
+
+#### Simple way wrapping a component with `ReactQuerySuspense` waiting the example query key call.
+
+It's not necessary check isLoading or isSuccess, just pass by props the queryKey and forget all things.
+
+```ts
+import React from "react";
+import { ReactQuerySuspense, QueryKey } from '@kappys/react-query-suspense'
+
+export const SampleComponent: React.FC<React.PropsWithChildren<{
+  keys: QueryKey[];
+}>> = ({ children, keys }) => {
+
+  const key: QueryKey = ["example"];
+
+  return (
+    <ReactQuerySuspense Fallback={<>loading</>} queryKeys={keys}>
+      <div>{children}</div>
+    </ReactQuerySuspense>
+  );
+};
+```
+
+
+#### Example with `ReactQuerySuspense` in real world waiting multiples calls
+
+
+[![Edit react-query-suspense](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/react-query-suspense-qrjvtm?fontsize=14&hidenavigation=1&theme=dark&view=editor)
+
+
+## 📝 Features
+
+`Important: On Error fetch, this library will keep loading, in a future we will implement FallbackError`
+
+#### Suspense
+
+```ts
+<ReactQuerySuspense Fallback={<>loading</>} queryKeys={['query', 'key']}>
+  <div>Test</div>
+</ReactQuerySuspense>
+```
+
+#### Suspense with deferred fetch option
+- it will force to put the loading in the first rendering.
+```ts
+<ReactQuerySuspense Fallback={<>loading</>} queryKeys={['query', 'key']} deferredFetch>
+  <div>Test</div>
+</ReactQuerySuspense>
+```
+
+#### Suspense waiting multiples calls
+```ts
+const keys1 = ['query', 'key1'];
+const keys2 = ['query', 'key2'];
+
+<ReactQuerySuspense Fallback={<>loading</>} queryKeys={[[keys1], [keys2]]}>
+  <div>Test</div>
+</ReactQuerySuspense>
+```
+
+
+Check the complete documentation on [GitHub](https://github.com/kappys1/react-query-suspense).

--- a/docs/config.json
+++ b/docs/config.json
@@ -220,6 +220,10 @@
           "to": "community/liaoliao666-react-query-kit"
         },
         {
+          "label": "React Query Suspense",
+          "to": "community/kappys-react-query-suspense"
+        },
+        {
           "label": "Angular Query",
           "to": "community/angular-query"
         }


### PR DESCRIPTION
Hello Tanner and TkDodo, here's the PR adding the Query React Suspense package to the Community section on Docs.

I tried to add an easy examples about how it works. Maybe it will change if it's required add some new feature like FallbackError but now it's not urgent because is possible to do it with error boundary.

it didn't generate a codesandbox but I created:
[example](https://codesandbox.io/s/react-query-suspense-ijcolz)

Please let me know if you'd like for me to make any changes.