### PR TITLE
docs(examples/react): fix prefetch pagination logic when trying to quickly get to the last page

### DIFF
--- a/examples/react/pagination/pages/index.js
+++ b/examples/react/pagination/pages/index.js
@@ -40,7 +40,7 @@ function Example() {
         fetchProjects(page + 1),
       )
     }
-  }, [data, page, queryClient])
+  }, [data, isPreviousData, page, queryClient])
 
   return (
     <div>

--- a/examples/react/pagination/pages/index.js
+++ b/examples/react/pagination/pages/index.js
@@ -35,7 +35,7 @@ function Example() {
 
   // Prefetch the next page!
   React.useEffect(() => {
-    if (data?.hasMore) {
+    if (!isPreviousData && data?.hasMore) {
       queryClient.prefetchQuery(['projects', page + 1], () =>
         fetchProjects(page + 1),
       )


### PR DESCRIPTION
In the useQuery call we set "keepPreviousData", so we must make sure that for fetching the next page we don't base our logic on the data from potentially two pages away.
If user would click very fast to get to the last page we would potentially load the eleventh page and that could result in an error depending on the backend implementation.