### PR TITLE
fix: SSR Next.js typescript examples in Javascript

### DIFF
--- a/docs/guides/ssr.md
+++ b/docs/guides/ssr.md
@@ -58,10 +58,10 @@ To support caching queries on the server and set up hydration:
 - Wrap your app component with `<Hydrate>` and pass it the `dehydratedState` prop from `pageProps`
 
 ```tsx
-// _app.jsx
+// _app.tsx
 import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-export default function MyApp({ Component, pageProps }) {
+export default function MyApp({ Component, pageProps }: AppProps<any>) {
   const [queryClient] = React.useState(() => new QueryClient())
 
   return (
@@ -81,7 +81,7 @@ Now you are ready to prefetch some data in your pages with either [`getStaticPro
 - Use `dehydrate` to dehydrate the query cache and pass it to the page via the `dehydratedState` prop. This is the same prop that the cache will be picked up from in your `_app.js`
 
 ```tsx
-// pages/posts.jsx
+// pages/posts.tsx
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 
 export async function getStaticProps() {


### PR DESCRIPTION
I update the _app.tsx and pages/posts.tsx example.

In _app.tsx examples, we have the AppProps and we need to pass a generic type for pageProps. I don't know if this is the best approach or if there's another type to use here.

Before:
![image](https://user-images.githubusercontent.com/52859409/205147664-0ccc3de9-dce6-40bf-ba9b-d802f9b016a9.png)

After:
![image](https://user-images.githubusercontent.com/52859409/205147741-14526006-003b-49dc-9c13-6b82c0bbfed6.png)

And in the pages/posts.tsx I only updated the legend of the file name, I think there's nothing else to correct.
![image](https://user-images.githubusercontent.com/52859409/205147796-c9b2f36a-02da-4d6f-ab85-7f1d98e9d1e8.png)

If have a better type to use in AppProps, please show me so I can fix it. Thanks
