### PR TITLE
docs(useQuery): remove reference to `setQueryData` from onSuccess doc

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -203,7 +203,7 @@ export interface QueryObserverOptions<
    */
   notifyOnChangeProps?: Array<keyof InfiniteQueryObserverResult> | 'all'
   /**
-   * This callback will fire any time the query successfully fetches new data or the cache is updated via `setQueryData`.
+   * This callback will fire any time the query successfully fetches new data.
    */
   onSuccess?: (data: TData) => void
   /**


### PR DESCRIPTION
The docs no longer state that `onSuccess` is called after `setQueryData` (which isn't true as of #2969).  