### PR TITLE
add `eslint-plugin-no-typeof-window-undefined`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:import/typescript",
+    "plugin:no-typeof-window-undefined/recommended",
     "react-app",
     "prettier"
   ],

--- a/docs/guides/window-focus-refetching.md
+++ b/docs/guides/window-focus-refetching.md
@@ -39,7 +39,7 @@ In rare circumstances, you may want to manage your own window focus events that 
 ```tsx
 focusManager.setEventListener(handleFocus => {
   // Listen to visibilitychange and focus
-  if (typeof window !== 'undefined' && window.addEventListener) {
+  if (typeof document !== 'undefined' && window.addEventListener) {
     window.addEventListener('visibilitychange', handleFocus, false)
     window.addEventListener('focus', handleFocus, false)
   }

--- a/docs/reference/focusManager.md
+++ b/docs/reference/focusManager.md
@@ -22,7 +22,7 @@ import { focusManager } from '@tanstack/react-query'
 
 focusManager.setEventListener(handleFocus => {
   // Listen to visibilitychange and focus
-  if (typeof window !== 'undefined' && window.addEventListener) {
+  if (typeof document !== 'undefined' && window.addEventListener) {
     window.addEventListener('visibilitychange', handleFocus, false)
     window.addEventListener('focus', handleFocus, false)
   }

--- a/examples/react/prefetching/pages/[user]/[repo].js
+++ b/examples/react/prefetching/pages/[user]/[repo].js
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query'
 
 export default () => {
   const id =
-    typeof window !== 'undefined' ? window.location.pathname.slice(1) : ''
+    typeof document !== 'undefined' ? window.location.pathname.slice(1) : ''
 
   const { status, data, error, isFetching } = useQuery(['team', id], () =>
     fetch('/api/data?id=' + id),

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-flowtype": "5.x",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "6.x",
+    "eslint-plugin-no-typeof-window-undefined": "^0.0.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-promise": "^4.2.1",

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -282,7 +282,7 @@ export function ReactQueryDevtools({
 
       run()
 
-      if (typeof window !== 'undefined') {
+      if (typeof document !== 'undefined') {
         window.addEventListener('resize', run)
 
         return () => {

--- a/packages/react-query-devtools/src/useMediaQuery.ts
+++ b/packages/react-query-devtools/src/useMediaQuery.ts
@@ -3,14 +3,14 @@ import * as React from 'react'
 export default function useMediaQuery(query: string): boolean | undefined {
   // Keep track of the preference in state, start with the current match
   const [isMatch, setIsMatch] = React.useState(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof document !== 'undefined') {
       return window.matchMedia(query).matches
     }
   })
 
   // Watch for changes
   React.useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof document !== 'undefined') {
       // Create a matcher
       const matcher = window.matchMedia(query)
 

--- a/packages/react-query/src/QueryClientProvider.tsx
+++ b/packages/react-query/src/QueryClientProvider.tsx
@@ -28,7 +28,7 @@ function getQueryClientContext(
   if (context) {
     return context
   }
-  if (contextSharing && typeof window !== 'undefined') {
+  if (contextSharing && typeof document !== 'undefined') {
     if (!window.ReactQueryClientContext) {
       window.ReactQueryClientContext = defaultContext
     }

--- a/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
@@ -246,6 +246,11 @@ describe('QueryClientProvider', () => {
     })
 
     test('should not use window to get the context when contextSharing is true and window does not exist', () => {
+      const { document } = globalThis
+
+      // @ts-expect-error
+      delete globalThis.document
+
       const queryCache = new QueryCache()
       const queryClient = createQueryClient({ queryCache })
 
@@ -269,6 +274,7 @@ describe('QueryClientProvider', () => {
 
       expect(queryClientFromHook).toEqual(queryClient)
 
+      globalThis.document = document
       windowSpy.mockRestore()
     })
   })

--- a/packages/solid-query/src/QueryClientProvider.tsx
+++ b/packages/solid-query/src/QueryClientProvider.tsx
@@ -32,7 +32,7 @@ function getQueryClientContext(
   if (context) {
     return context
   }
-  if (contextSharing && typeof window !== 'undefined') {
+  if (contextSharing && typeof document !== 'undefined') {
     if (!window.SolidQueryClientContext) {
       window.SolidQueryClientContext = defaultContext
     }

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -38,7 +38,7 @@ export const VueQueryPlugin = {
     if ('queryClient' in options && options.queryClient) {
       client = options.queryClient
     } else {
-      if (options.contextSharing && typeof window !== 'undefined') {
+      if (options.contextSharing && typeof document !== 'undefined') {
         if (!window.__VUE_QUERY_CONTEXT__) {
           const clientConfig =
             'queryClientConfig' in options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,7 @@ importers:
       eslint-plugin-flowtype: 5.x
       eslint-plugin-import: ^2.22.1
       eslint-plugin-jsx-a11y: 6.x
+      eslint-plugin-no-typeof-window-undefined: ^0.0.2
       eslint-plugin-node: ^11.1.0
       eslint-plugin-prettier: ^3.1.3
       eslint-plugin-promise: ^4.2.1
@@ -113,6 +114,7 @@ importers:
       eslint-plugin-flowtype: 5.10.0_eslint@7.32.0
       eslint-plugin-import: 2.26.0_r6mdt2nwtavxychxvtdgpnclqq
       eslint-plugin-jsx-a11y: 6.6.0_eslint@7.32.0
+      eslint-plugin-no-typeof-window-undefined: 0.0.2_eslint@7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_rpj2lnfnqon5xeujjqgixljdgq
       eslint-plugin-promise: 4.3.1
@@ -8998,6 +9000,14 @@ packages:
       language-tags: 1.0.5
       minimatch: 3.1.2
       semver: 6.3.0
+    dev: true
+
+  /eslint-plugin-no-typeof-window-undefined/0.0.2_eslint@7.32.0:
+    resolution: {integrity: sha512-CVc5I2RcBkdir5UIahglMh8KYvyFKt9ZbsMFt7WUP+jKXGjS2uCPnbbOQGihTwAFA+tp5F3N6FIuOzIfWNLL1Q==}
+    peerDependencies:
+      eslint: ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      eslint: 7.32.0
     dev: true
 
   /eslint-plugin-node/11.1.0_eslint@7.32.0:


### PR DESCRIPTION
This PR adds [`eslint-plugin-no-typeof-window-undefined`](https://github.com/nirtamir2/eslint-plugin-no-typeof-window-undefined#readme) eslint plugin to prevent `typeof window === "undefined"` because Deno supports window (so this won't check well if the code is in browser / server-side) and replace it with `typeof document === "undefined"`

I run `pnpm test:eslint --fix` and it auto-fix some places the code uses `type window === "undefined"`, so make sure the conversion in those places works for you.

I'm following this tread https://twitter.com/TkDodo/status/1598227778435948545

## Notice
I run test and one of the tests (`should not use window to get the context when contextSharing is true and window does not exist`) failed, so I fix it by simulating `undefined` `document` (like another place in code does).
I found 2 more test cases with the same situation but they pass. (look for `// Mock a non web browser environment` in code) I'm not sure if it's better to use the same approach with deleting the document from `globalThis` and return it in the end of the test. Currently I did not touch them.