### PR TITLE
fix(query-core): revert isServer check to check for window

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -68,7 +68,7 @@ export type QueryTypeFilter = 'all' | 'active' | 'inactive'
 
 // UTILS
 
-export const isServer = typeof document === 'undefined'
+export const isServer = typeof window === 'undefined' || 'Deno' in window
 
 export function noop(): undefined {
   return undefined


### PR DESCRIPTION
because document is not defined in react-native
additionally, we can check for `Deno` being available on the window to support the Deno runtime

fixes #4584 