### PR TITLE
test(queryCache): add failing test for partially undefined key (#3741)

### DIFF
--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -206,8 +206,13 @@ describe('queryCache', () => {
 
     test('should return all the queries when key contains object with an undefined property', async () => {
       const baseKey = queryKey()
-      await queryClient.prefetchQuery([...baseKey, { a: 1 }], () => 'data1')
-      expect(queryCache.findAll([...baseKey, { a: undefined }])).toHaveLength(1)
+      const createKey = (filter?: string) => [{ ...baseKey, filter }]
+      await queryClient.prefetchQuery(
+        createKey('filter1'),
+        () => 'filtered-data',
+      )
+      await queryClient.prefetchQuery(createKey(), () => 'all-data')
+      expect(queryCache.findAll(createKey())).toHaveLength(2)
     })
   })
 

--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -203,6 +203,12 @@ describe('queryCache', () => {
       await queryClient.prefetchQuery(key2, () => 'data2')
       expect(queryCache.findAll().length).toBe(2)
     })
+
+    test('should return all the queries when key contains object with an undefined property', async () => {
+      const baseKey = queryKey()
+      await queryClient.prefetchQuery([...baseKey, { a: 1 }], () => 'data1')
+      expect(queryCache.findAll([...baseKey, { a: undefined }])).toHaveLength(1)
+    })
   })
 
   describe('QueryCacheConfig.onError', () => {


### PR DESCRIPTION
The current behavior when using functions such as invalidateQueries or setQueriesData is unexpected when objects with undefined properties are involved.

A key containing an object with an undefined property is hashed without the undefined property, yet the property is considered in the partialDeepEqual function.

This creates some confusing scenarios, as demonstrated in the discussion on TkDodo's blog
<https://github.com/TkDodo/blog-comments/discussions/71#discussioncomment-4348406> and in the referenced issue

This commit includes a failing test to demonstrate the expected behavior