### PR TITLE
docs(query-cancellation): remove more references to old cancel fn

### DIFF
--- a/docs/guides/query-cancellation.md
+++ b/docs/guides/query-cancellation.md
@@ -11,7 +11,7 @@ The `AbortController` API is available in [most runtime environments](https://de
 
 By default, queries that unmount or become unused before their promises are resolved are _not_ cancelled. This means that after the promise has resolved, the resulting data will be available in the cache. This is helpful if you've started receiving a query, but then unmount the component before it finishes. If you mount the component again and the query has not been garbage collected yet, data will be available.
 
-However, if you consume the `AbortSignal` or attach a `cancel` function to your Promise, the Promise will be cancelled (e.g. aborting the fetch) and therefore, also the Query must be cancelled. Cancelling the query will result in its state being _reverted_ to its previous state.
+However, if you consume the `AbortSignal`, the Promise will be cancelled (e.g. aborting the fetch) and therefore, also the Query must be cancelled. Cancelling the query will result in its state being _reverted_ to its previous state.
 
 ## Using `fetch`
 
@@ -137,7 +137,7 @@ const query = useQuery({
 
 ## Manual Cancellation
 
-You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries({ queryKey })`, which will cancel the query and revert it back to its previous state. If `promise.cancel` is available, or you have consumed the `signal` passed to the query function, React Query will additionally also cancel the Promise.
+You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries({ queryKey })`, which will cancel the query and revert it back to its previous state. If you have consumed the `signal` passed to the query function, React Query will additionally also cancel the Promise.
 
 ```tsx
 const query = useQuery({


### PR DESCRIPTION
Apparently these were missed in https://github.com/TanStack/query/commit/a1050eb0d7c7c44731fc7e6839e77f69f83bab67.

It is confusing because the [Migration to v4 guide](https://tanstack.com/query/v4/docs/guides/migrating-to-react-query-4#the-cancel-method-on-promises-is-no-longer-supported) states that the `cancel` property in promises is no longer supported, but the current docs for Query Cancellation seem to imply that it is.

I assume that it is not supported anymore based on the commit linked above, the migration guide and my own testing.
If that is indeed the case, let's clean this up.

Also, please make sure that this new phrasing reflects actual behavior. That is, promises get cancelled when the signal is consumed and no `cancel` prop is needed.