### PR TITLE
fix(query-async-storage-persister): support wider range of types

### DIFF
--- a/packages/query-async-storage-persister/src/index.ts
+++ b/packages/query-async-storage-persister/src/index.ts
@@ -7,7 +7,7 @@ import { asyncThrottle } from './asyncThrottle'
 
 interface AsyncStorage {
   getItem: (key: string) => Promise<string | null>
-  setItem: (key: string, value: string) => Promise<void>
+  setItem: (key: string, value: string) => Promise<unknown>
   removeItem: (key: string) => Promise<void>
 }
 

--- a/packages/react-query/src/__tests__/suspense.test.tsx
+++ b/packages/react-query/src/__tests__/suspense.test.tsx
@@ -1096,6 +1096,7 @@ describe('useQueries with suspense', () => {
               await sleep(20)
               return '2'
             },
+            staleTime: 1000,
             suspense: false,
           },
         ],


### PR DESCRIPTION
interfaces like localforage return a Promise<T> from setItem; we don't really care, as long as it's a Promise