### PR TITLE
refactor(vue-query): Calls `isRef` replaced by `unref` where possible

### DIFF
--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -6,7 +6,7 @@ import {
   watch,
   ref,
   computed,
-  isRef,
+  unref,
 } from 'vue-demi'
 import type { ToRefs, UnwrapRef } from 'vue-demi'
 import type {
@@ -155,9 +155,9 @@ export function parseQueryArgs<
 ): WithQueryClientKey<
   QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
 > {
-  const plainArg1 = isRef(arg1) ? arg1.value : arg1
-  const plainArg2 = isRef(arg2) ? arg2.value : arg2
-  const plainArg3 = isRef(arg3) ? arg3.value : arg3
+  const plainArg1 = unref(arg1)
+  const plainArg2 = unref(arg2)
+  const plainArg3 = unref(arg3)
 
   let options = plainArg1
 

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -1,4 +1,4 @@
-import { computed, isRef, onScopeDispose, ref, watch } from 'vue-demi'
+import { computed, unref, onScopeDispose, ref, watch } from 'vue-demi'
 import type { Ref } from 'vue-demi'
 import type { QueryKey, QueryFilters as QF } from '@tanstack/query-core'
 
@@ -46,8 +46,8 @@ export function parseFilterArgs(
   arg1?: MaybeRef<QueryKey> | QueryFilters,
   arg2: QueryFilters = {},
 ) {
-  const plainArg1 = isRef(arg1) ? arg1.value : arg1
-  const plainArg2 = isRef(arg2) ? arg2.value : arg2
+  const plainArg1 = unref(arg1)
+  const plainArg2 = unref(arg2)
 
   let options = plainArg1
 

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -1,4 +1,4 @@
-import { computed, isRef, onScopeDispose, ref, watch } from 'vue-demi'
+import { computed, unref, onScopeDispose, ref, watch } from 'vue-demi'
 import type { Ref } from 'vue-demi'
 import type { MutationKey, MutationFilters as MF } from '@tanstack/query-core'
 
@@ -46,8 +46,8 @@ export function parseFilterArgs(
   arg1?: MaybeRef<MutationKey> | MutationFilters,
   arg2: MutationFilters = {},
 ) {
-  const plainArg1 = isRef(arg1) ? arg1.value : arg1
-  const plainArg2 = isRef(arg2) ? arg2.value : arg2
+  const plainArg1 = unref(arg1)
+  const plainArg2 = unref(arg2)
 
   let options = plainArg1
 

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -5,7 +5,7 @@ import {
   toRefs,
   watch,
   computed,
-  isRef,
+  unref,
 } from 'vue-demi'
 import type { ToRefs } from 'vue-demi'
 import type {
@@ -210,12 +210,12 @@ export function parseMutationArgs<
 ): WithQueryClientKey<
   MutationObserverOptions<TData, TError, TVariables, TContext>
 > {
-  const plainArg1 = isRef(arg1) ? arg1.value : arg1
-  const plainArg2 = isRef(arg2) ? arg2.value : arg2
+  const plainArg1 = unref(arg1)
+  const plainArg2 = unref(arg2)
   let options = plainArg1
   if (isMutationKey(plainArg1)) {
     if (typeof plainArg2 === 'function') {
-      const plainArg3 = isRef(arg3) ? arg3.value : arg3
+      const plainArg3 = unref(arg3)
       options = { ...plainArg3, mutationKey: plainArg1, mutationFn: plainArg2 }
     } else {
       options = { ...plainArg2, mutationKey: plainArg1 }


### PR DESCRIPTION
Just replace all `isRef(val) ? val.value : val` to `unref(val)` where possible.
> `unref` is a sugar function for `val = isRef(val) ? val.value : val`.