### PR TITLE
docs(vue import): fix import path for Vue plugin

### DIFF
--- a/docs/vue/installation.md
+++ b/docs/vue/installation.md
@@ -26,7 +26,7 @@ Vue Query is compatible with Vue 2.x and 3.x
 Before using Vue Query, you need to initialize it using `VueQueryPlugin`
 
 ```ts
-import { VueQueryPlugin } from "vue-query";
+import { VueQueryPlugin } from "@tanstack/vue-query";
 
 app.use(VueQueryPlugin);
 ```

--- a/docs/vue/installation.md
+++ b/docs/vue/installation.md
@@ -42,7 +42,7 @@ If you are not a fan of `<script setup>` syntax, you can easily translate all th
 ```vue
 <script>
 import { defineComponent } from "vue";
-import { useQuery } from "vue-query";
+import { useQuery } from "@tanstack/vue-query";
 
 export default defineComponent({
   name: "Todos",


### PR DESCRIPTION
The docs were showing `vue-query` instead of `@tanstack/vue-query` for installing in Vue