### PR TITLE
refactor(reactBatchedUpdates): remove the side effect that sets batchNotifyFn in react

### DIFF
--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -21,9 +21,7 @@
     },
     "./package.json": "./package.json"
   },
-  "sideEffects": [
-    "./src/setBatchUpdatesFn.ts"
-  ],
+  "sideEffects": false,
   "scripts": {
     "clean": "rm -rf ./build",
     "test:codemods": "../../node_modules/.bin/jest --config codemods/jest.config.js",

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -1,8 +1,5 @@
 /* istanbul ignore file */
 
-// Side effects
-import './setBatchUpdatesFn'
-
 // Re-export core
 export * from '@tanstack/query-core'
 

--- a/packages/react-query/src/reactBatchedUpdates.native.ts
+++ b/packages/react-query/src/reactBatchedUpdates.native.ts
@@ -1,4 +1,0 @@
-// @ts-ignore
-// eslint-disable-next-line import/no-unresolved
-import { unstable_batchedUpdates } from 'react-native'
-export { unstable_batchedUpdates }

--- a/packages/react-query/src/reactBatchedUpdates.ts
+++ b/packages/react-query/src/reactBatchedUpdates.ts
@@ -1,2 +1,0 @@
-import * as ReactDOM from 'react-dom'
-export const unstable_batchedUpdates = ReactDOM.unstable_batchedUpdates

--- a/packages/react-query/src/setBatchUpdatesFn.ts
+++ b/packages/react-query/src/setBatchUpdatesFn.ts
@@ -1,4 +1,0 @@
-import { notifyManager } from '@tanstack/query-core'
-import { unstable_batchedUpdates } from './reactBatchedUpdates'
-
-notifyManager.setBatchNotifyFunction(unstable_batchedUpdates)

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -91,7 +91,6 @@ export default function rollup(options: RollupOptions): RollupOptions[] {
       outputFile: 'index',
       entryFile: [
         'src/index.ts',
-        'src/reactBatchedUpdates.native.ts',
         'src/useSyncExternalStore.native.ts',
       ],
       globals: {
@@ -368,8 +367,6 @@ function cjs({
       replace({
         // TODO: figure out a better way to produce extensionless cjs imports
         "require('./logger.js')": "require('./logger')",
-        "require('./reactBatchedUpdates.js')":
-          "require('./reactBatchedUpdates')",
         "require('./useSyncExternalStore.js')":
           "require('./useSyncExternalStore')",
         preventAssignment: true,


### PR DESCRIPTION
This PR attempts to fix #4685 of v5 milestones 

- set sideEffects to false in react-query/package.json
- remove the side effect import from index.ts
- delete reactBatchedUpdates.ts, reactBatchedUpdates.native.ts, setBatchUpdatesFn.ts files and references to them