### PR TITLE
feat(isDataEqual): Remove is data equal from useQuery

### DIFF
--- a/docs/react/guides/important-defaults.md
+++ b/docs/react/guides/important-defaults.md
@@ -30,7 +30,7 @@ If you see a refetch that you are not expecting, it is likely because you just f
 
 - Query results by default are **structurally shared to detect if data has actually changed** and if not, **the data reference remains unchanged** to better help with value stabilization with regards to useMemo and useCallback. If this concept sounds foreign, then don't worry about it! 99.9% of the time you will not need to disable this and it makes your app more performant at zero cost to you.
 
-  > Structural sharing only works with JSON-compatible values, any other value types will always be considered as changed. If you are seeing performance issues because of large responses for example, you can disable this feature with the `config.structuralSharing` flag. If you are dealing with non-JSON compatible values in your query responses and still want to detect if data has changed or not, you can define a data compare function with `config.isDataEqual` or provide your own custom function as `config.structuralSharing` to compute a value from the old and new responses, retaining references as required.
+  > Structural sharing only works with JSON-compatible values, any other value types will always be considered as changed. If you are seeing performance issues because of large responses for example, you can disable this feature with the `config.structuralSharing` flag. If you are dealing with non-JSON compatible values in your query responses and still want to detect if data has changed or not, you can provide your own custom function as `config.structuralSharing` to compute a value from the old and new responses, retaining references as required.
 
 ## Further Reading
 

--- a/docs/react/guides/migrating-to-react-query-5.md
+++ b/docs/react/guides/migrating-to-react-query-5.md
@@ -34,6 +34,8 @@ Previously, This function was used to indicate whether to use previous `data` (`
 You can achieve the same functionality by passing a function to `structuralSharing` instead:
 
 ```diff
-- isDataEqual: () => true
-+ structuralSharing: false
+ import { replaceEqualDeep } from '@tanstack/react-query'
+
+- isDataEqual: (oldData, newData) => customCheck(oldData, newData)
++ structuralSharing: (oldData, newData) => customCheck(oldData, newData) ? oldData : replaceEqualDeep(oldData, newData)
 ```

--- a/docs/react/guides/migrating-to-react-query-5.md
+++ b/docs/react/guides/migrating-to-react-query-5.md
@@ -26,3 +26,14 @@ if you still need to remove a query, you can use `queryClient.removeQueries({que
 ### The minimum required TypeScript version is now 4.7
 
 Mainly because an important fix was shipped around type inference. Please see this [TypeScript issue](https://github.com/microsoft/TypeScript/issues/43371) for more information.
+
+### The `isDataEqual` options has been removed from useQuery
+
+Previously, This function was used to indicate whether to use previous `data` (`true`) or new data (`false`) as a resolved data for the query.
+
+You can achieve the same functionality by passing a function to `structuralSharing` instead:
+
+```diff
+- isDataEqual: () => true
++ structuralSharing: false
+```

--- a/docs/react/reference/useQuery.md
+++ b/docs/react/reference/useQuery.md
@@ -168,12 +168,7 @@ const {
   - Optional
   - Defaults to `false`
   - If set, any previous `data` will be kept when fetching new data because the query key changed.
-- `isDataEqual: (oldData: TData | undefined, newData: TData) => boolean`
-  - **Deprecated**. You can achieve the same functionality by passing a function to `structuralSharing` instead:
-    - structuralSharing: (oldData, newData) => isDataEqual(oldData, newData) ? oldData : replaceEqualDeep(oldData, newData)
-  - Optional
-  - This function should return boolean indicating whether to use previous `data` (`true`) or new data (`false`) as a resolved data for the query.
-- `structuralSharing: boolean | ((oldData: TData | undefined, newData: TData) => TData)`
+    `structuralSharing: boolean | ((oldData: TData | undefined, newData: TData) => TData)`
   - Optional
   - Defaults to `true`
   - If set to `false`, structural sharing between query results will be disabled.

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -155,17 +155,6 @@ export class QueryObserver<
 
     this.options = this.client.defaultQueryOptions(options)
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      typeof options?.isDataEqual !== 'undefined'
-    ) {
-      this.client
-        .getLogger()
-        .error(
-          `The isDataEqual option has been deprecated and will be removed in the next major version. You can achieve the same functionality by passing a function as the structuralSharing option`,
-        )
-    }
-
     if (!shallowEqualObjects(prevOptions, this.options)) {
       this.client.getQueryCache().notify({
         type: 'observerOptionsUpdated',

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -326,18 +326,6 @@ describe('queryClient', () => {
       expect(queryCache.find(key)!.state.data).toEqual('new data + test data')
     })
 
-    test('should use prev data if an isDataEqual function is defined and returns "true"', () => {
-      const key = queryKey()
-
-      queryClient.setDefaultOptions({
-        queries: { isDataEqual: (_prev, data) => data === 'data' },
-      })
-      queryClient.setQueryData(key, 'prev data')
-      queryClient.setQueryData(key, 'data')
-
-      expect(queryCache.find(key)!.state.data).toEqual('prev data')
-    })
-
     test('should set the new data without comparison if structuralSharing is set to false', () => {
       const key = queryKey()
 

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -649,35 +649,6 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should prefer isDataEqual to structuralSharing', async () => {
-    const key = queryKey()
-
-    const data = { value: 'data' }
-    const newData = { value: 'data' }
-
-    const observer = new QueryObserver(queryClient, {
-      queryKey: key,
-      queryFn: () => data,
-    })
-
-    const unsubscribe = observer.subscribe(() => undefined)
-
-    await sleep(10)
-    expect(observer.getCurrentResult().data).toBe(data)
-
-    observer.setOptions({
-      queryKey: key,
-      queryFn: () => newData,
-      isDataEqual: () => true,
-      structuralSharing: false,
-    })
-
-    await observer.refetch()
-    expect(observer.getCurrentResult().data).toBe(data)
-
-    unsubscribe()
-  })
-
   test('select function error using placeholderdata should log an error', () => {
     const key = queryKey()
 

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -70,7 +70,6 @@ export interface QueryOptions<
   retryDelay?: RetryDelayValue<TError>
   networkMode?: NetworkMode
   cacheTime?: number
-  isDataEqual?: (oldData: TData | undefined, newData: TData) => boolean
   queryFn?: QueryFunction<TQueryFnData, TQueryKey>
   queryHash?: string
   queryKey?: TQueryKey

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -426,9 +426,7 @@ export function replaceData<
   TOptions extends QueryOptions<any, any, any, any>,
 >(prevData: TData | undefined, data: TData, options: TOptions): TData {
   // Use prev data if an isDataEqual function is defined and returns `true`
-  if (options.isDataEqual?.(prevData, data)) {
-    return prevData as TData
-  } else if (typeof options.structuralSharing === 'function') {
+  if (typeof options.structuralSharing === 'function') {
     return options.structuralSharing(prevData, data)
   } else if (options.structuralSharing !== false) {
     // Structurally share data between prev and new data if needed

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -425,7 +425,6 @@ export function replaceData<
   TData,
   TOptions extends QueryOptions<any, any, any, any>,
 >(prevData: TData | undefined, data: TData, options: TOptions): TData {
-  // Use prev data if an isDataEqual function is defined and returns `true`
   if (typeof options.structuralSharing === 'function') {
     return options.structuralSharing(prevData, data)
   } else if (options.structuralSharing !== false) {


### PR DESCRIPTION
This PR remove the options ```isDataEqual``` from useQuery