### PR TITLE
Export default hydration methods for easier extension in `dehydrateOptions`

### DIFF
--- a/docs/react/reference/hydration.md
+++ b/docs/react/reference/hydration.md
@@ -33,11 +33,13 @@ const dehydratedState = dehydrate(queryClient, {
     - This function is called for each mutation in the cache
     - Return `true` to include this mutation in dehydration, or `false` otherwise
     - The default version only includes paused mutations
+    - If you would like to extend the function while retaining the previous behavior, import and execute `defaultShouldDehydrateMutation` as part of the return statement
   - `shouldDehydrateQuery: (query: Query) => boolean`
     - Optional
     - This function is called for each query in the cache
     - Return `true` to include this query in dehydration, or `false` otherwise
     - The default version only includes successful queries, do `shouldDehydrateQuery: () => true` to include all queries
+    - If you would like to extend the function while retaining the previous behavior, import and execute `defaultShouldDehydrateQuery` as part of the return statement
 
 **Returns**
 

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -65,11 +65,11 @@ function dehydrateQuery(query: Query): DehydratedQuery {
   }
 }
 
-function defaultShouldDehydrateMutation(mutation: Mutation) {
+export function defaultShouldDehydrateMutation(mutation: Mutation) {
   return mutation.state.isPaused
 }
 
-function defaultShouldDehydrateQuery(query: Query) {
+export function defaultShouldDehydrateQuery(query: Query) {
   return query.state.status === 'success'
 }
 

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -23,7 +23,12 @@ export {
 } from './utils'
 export type { MutationFilters, QueryFilters, Updater } from './utils'
 export { isCancelledError } from './retryer'
-export { dehydrate, hydrate, defaultShouldDehydrateMutation, defaultShouldDehydrateQuery } from './hydration'
+export {
+  dehydrate,
+  hydrate,
+  defaultShouldDehydrateMutation,
+  defaultShouldDehydrateQuery,
+} from './hydration'
 
 // Types
 export * from './types'

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -23,7 +23,7 @@ export {
 } from './utils'
 export type { MutationFilters, QueryFilters, Updater } from './utils'
 export { isCancelledError } from './retryer'
-export { dehydrate, hydrate } from './hydration'
+export { dehydrate, hydrate, defaultShouldDehydrateMutation, defaultShouldDehydrateQuery } from './hydration'
 
 // Types
 export * from './types'


### PR DESCRIPTION
Export `defaultShouldDehydrateQuery` and `defaultShouldDehydrateMutation` to make it easier to retain the default behavior when extending these in the `dehydrateOptions`