### PR TITLE
docs(guides refetchOnWindowFocus): more clear instructions for the use

### DIFF
--- a/docs/react/guides/window-focus-refetching.md
+++ b/docs/react/guides/window-focus-refetching.md
@@ -3,7 +3,7 @@ id: window-focus-refetching
 title: Window Focus Refetching
 ---
 
-If a user leaves your application and returns to stale data, **TanStack Query automatically requests fresh data for you in the background**. You can disable this globally or per-query using the `refetchOnWindowFocus` option:
+If a user leaves your application and returns and the query data is stale, **TanStack Query automatically requests fresh data for you in the background**. You can disable this globally or per-query using the `refetchOnWindowFocus` option:
 
 #### Disabling Globally
 
@@ -14,7 +14,7 @@ If a user leaves your application and returns to stale data, **TanStack Query au
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: false, // default: true
     },
   },
 })


### PR DESCRIPTION
I read the current documentation that there is no mention of the default value of refetchOnWindowFocus, and the current way of writing it makes me re-verify that only refetch when the data is stale, it took me 15 minutes to read the code to verify how it works, so I want to update the docs for more clear.