### PR TITLE
fix: update eslint-exhaustive-deps rule description

### DIFF
--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.rule.ts
@@ -13,7 +13,7 @@ export const rule = createRule({
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prefer object syntax for useQuery',
+      description: 'Exhaustive deps rule for useQuery',
       recommended: 'error',
     },
     messages: {


### PR DESCRIPTION
Just fix a description for @tanstack/query/exhaustive-deps. Looks like it was copypasted from prefer-query-object-syntax