### PR TITLE
docs: fix typo (quey -> query)

### DIFF
--- a/docs/react/guides/caching.md
+++ b/docs/react/guides/caching.md
@@ -27,7 +27,7 @@ Let's assume we are using the default `cacheTime` of **5 minutes** and the defau
   - When the request completes successfully, the cache's data under the `['todos']` key is updated with the new data, and both instances are updated with the new data.
 - Both instances of the `useQuery({ queryKey: ['todos'], queryFn: fetchTodos })` query are unmounted and no longer in use.
   - Since there are no more active instances of this query, a cache timeout is set using `cacheTime` to delete and garbage collect the query (defaults to **5 minutes**).
-- Before the cache timeout has completed, another instance of `useQuery({ queryKey: ['todos'], queyFn: fetchTodos })` mounts. The query immediately returns the available cached data while the `fetchTodos` function is being run in the background. When it completes successfully, it will populate the cache with fresh data.
+- Before the cache timeout has completed, another instance of `useQuery({ queryKey: ['todos'], queryFn: fetchTodos })` mounts. The query immediately returns the available cached data while the `fetchTodos` function is being run in the background. When it completes successfully, it will populate the cache with fresh data.
 - The final instance of `useQuery({ queryKey: ['todos'], queryFn: fetchTodos })` unmounts.
-- No more instances of `useQuery({ queyKey: ['todos'], queryFn: fetchTodos })` appear within **5 minutes**.
+- No more instances of `useQuery({ queryKey: ['todos'], queryFn: fetchTodos })` appear within **5 minutes**.
   - The cached data under the `['todos']` key is deleted and garbage collected.

--- a/docs/react/guides/placeholder-query-data.md
+++ b/docs/react/guides/placeholder-query-data.md
@@ -44,7 +44,7 @@ If the process for accessing a query's placeholder data is intensive or just not
 function Todos() {
   const placeholderData = useMemo(() => generateFakeTodos(), [])
   const result = useQuery({
-    queyKey: ['todos'],
+    queryKey: ['todos'],
     queryFn: () => fetch('/todos'),
     placeholderData,
   })

--- a/packages/vue-query/README.md
+++ b/packages/vue-query/README.md
@@ -79,5 +79,5 @@ Visit https://tanstack.com/query/v4/docs/adapters/vue-query
    const id = ref(1);
    const enabled = ref(false);
 
-   const query = useQuery({ queyKey: ["todos", id], queryFn: () => getTodos(id), enabled });
+   const query = useQuery({ queryKey: ["todos", id], queryFn: () => getTodos(id), enabled });
    ```


### PR DESCRIPTION
Corrected typo "quey" to "query".