### PR TITLE
docs(svelte-query): Add recommended defaults to prefetchQuery setup

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -696,12 +696,12 @@
               "to": "svelte/installation"
             },
             {
-              "label": "Reactivity",
-              "to": "svelte/reactivity"
-            },
-            {
               "label": "SSR & SvelteKit",
               "to": "svelte/ssr"
+            },
+            {
+              "label": "Reactivity",
+              "to": "svelte/reactivity"
             }
           ]
         },

--- a/docs/svelte/overview.md
+++ b/docs/svelte/overview.md
@@ -11,7 +11,7 @@ Include the QueryClientProvider near the root of your project:
 
 ```markdown
 <script lang="ts">
-  import { QueryClientProvider, QueryClient } from '@tanstack/svelte-query'
+  import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query'
   import Example from './lib/Example.svelte'
 
   const queryClient = new QueryClient()

--- a/docs/svelte/ssr.md
+++ b/docs/svelte/ssr.md
@@ -9,10 +9,12 @@ SvelteKit defaults to rendering routes with SSR. Because of this, you need to di
 
 The recommended way to achieve this is to use the `browser` module from SvelteKit in your `QueryClient` object. This will not disable `queryClient.prefetchQuery()`, which is used in one of the solutions below.
 
+**src/routes/+layout.svelte**
+
 ```markdown
 <script lang="ts">
   import { browser } from '$app/environment'
-  import { QueryClient } from '@tanstack/svelte-query'
+  import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query'
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -83,11 +85,19 @@ Svelte Query supports prefetching queries on the server. Using this setup below,
 **src/routes/+layout.ts**
 
 ```ts
+import { browser } from '$app/environment'
 import { QueryClient } from '@tanstack/svelte-query'
 import type { LayoutLoad } from './$types'
 
 export const load: LayoutLoad = async () => {
-  const queryClient = new QueryClient()
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        enabled: browser,
+      },
+    },
+  })
+
   return { queryClient }
 }
 ```


### PR DESCRIPTION
I forgot to add the `enabled: browser` logic down to a lower section :/ Last change to this page for a while, I promise!

I've also bumped the page up the sidebar since it is important for anyone using SvelteKit.