### PR TITLE
feat: replace custom context prop with custom queryClient instance

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -186,7 +186,7 @@
             },
             {
               "label": "Migrating to v5",
-              "to": "react/guides/migrating-v5"
+              "to": "react/guides/migrating-to-v5"
             }
           ]
         },

--- a/docs/react/guides/migrating-to-v5.md
+++ b/docs/react/guides/migrating-to-v5.md
@@ -1,5 +1,5 @@
 ---
-id: migrating-to-react-query-5
+id: migrating-to-tanstack-query-5
 title: Migrating to TanStack Query v5
 ---
 
@@ -117,12 +117,6 @@ if you still need to remove a query, you can use `queryClient.removeQueries({que
 
 Mainly because an important fix was shipped around type inference. Please see this [TypeScript issue](https://github.com/microsoft/TypeScript/issues/43371) for more information.
 
-### The `contextSharing` prop has been removed from QueryClientProvider
-
-You could previously use the `contextSharing` property to share the first (and at least one) instance of the query client context across the window. This ensured that if TanStack Query was used across different bundles or microfrontends then they will all use the same instance of the context, regardless of module scoping.
-
-However, isolation is often preferred for microfrontends. In v4 the option to pass a custom context to the `QueryClientProvider` was added, which allows exactly this. If you wish to use the same query client across multiple packages of an application, you can create a `QueryClient` in your application and then let the bundles share this through the `context` property of the `QueryClientProvider`.
-
 ### The `isDataEqual` options has been removed from useQuery
 
 Previously, This function was used to indicate whether to use previous `data` (`true`) or new data (`false`) as a resolved data for the query.
@@ -216,6 +210,36 @@ There are some caveats to this change however, which you must be aware of:
 
 The `visibilitychange` event is used exclusively now. This is possible because we only support browsers that support the `visibilitychange` event. This fixes a bunch of issues [as listed here](https://github.com/TanStack/query/pull/4805).
 
+### Removed custom `context` prop in favor of custom `queryClient` instance
+
+In v4, we introduced the possibility to pass a custom `context` to all react-query hooks. This allowed for proper isolation when using MicroFrontends.
+
+However, `context` is a react-only feature. All that `context` does is give us access to the `queryClient`. We could achieve the same isolation by allowing to pass in a custom `queryClient` directly.
+This in turn will enable other frameworks to have the same functionality in a framework-agnostic way.
+
+```diff
+import { queryClient } from './my-client'
+
+const { data } = useQuery(
+   {
+    queryKey: ['users', id],
+    queryFn: () => fetch(...),
+-   context: customContext
+  },
++  queryClient,
+)
+```
+
+[//]: # 'FrameworkBreakingChanges'
+
+## React Query Breaking Changes
+
+### The `contextSharing` prop has been removed from QueryClientProvider
+
+You could previously use the `contextSharing` property to share the first (and at least one) instance of the query client context across the window. This ensured that if TanStack Query was used across different bundles or microfrontends then they will all use the same instance of the context, regardless of module scoping.
+
+However, isolation is often preferred for microfrontends. In v4 the option to pass a custom context to the `QueryClientProvider` was added, which allows exactly this. If you wish to use the same query client across multiple packages of an application, you can create a `QueryClient` in your application and then let the bundles share this through the `context` property of the `QueryClientProvider`.
+
 ### No longer using `unstable_batchedUpdates` as the batching function in React and React Native
 
 Since the function `unstable_batchedUpdates` is noop in React 18, it will no longer be automatically set as the batching function in `react-query`.
@@ -246,6 +270,5 @@ The `Hydrate` component has been renamed to `HydrationBoundary`. The `Hydrate` c
 - </Hydrate>
 + </HydrationBoundary>
 ```
-```
 
-
+[//]: # 'FrameworkBreakingChanges'

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import { fireEvent, screen, waitFor, act } from '@testing-library/react'
-import { ErrorBoundary } from 'react-error-boundary'
 import '@testing-library/jest-dom'
-import type { QueryClient } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
 import { defaultPanelSize, sortFns } from '../utils'
 import {
@@ -11,13 +9,6 @@ import {
   sleep,
   createQueryClient,
 } from './utils'
-
-// TODO: This should be removed with the types for react-error-boundary get updated.
-declare module 'react-error-boundary' {
-  interface ErrorBoundaryPropsWithFallback {
-    children: any
-  }
-}
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -707,108 +698,6 @@ describe('ReactQueryDevtools', () => {
     expect(styleTag).toHaveAttribute('nonce', 'test-nonce')
 
     await screen.findByRole('button', { name: /react query devtools/i })
-  })
-
-  describe('with custom context', () => {
-    it('should render without error when the custom context aligns', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-      const { queryClient } = createQueryClient()
-
-      function Page() {
-        const { data = 'default' } = useQuery({
-          queryKey: ['check'],
-          queryFn: async () => 'test',
-          context,
-        })
-
-        return (
-          <div>
-            <h1>{data}</h1>
-          </div>
-        )
-      }
-
-      renderWithClient(queryClient, <Page />, {
-        initialIsOpen: false,
-        context,
-      })
-
-      await screen.findByRole('button', { name: /open react query devtools/i })
-    })
-
-    it('should render with error when the custom context is not passed to useQuery', async () => {
-      const consoleErrorMock = jest.spyOn(console, 'error')
-      consoleErrorMock.mockImplementation(() => undefined)
-
-      const context = React.createContext<QueryClient | undefined>(undefined)
-      const { queryClient } = createQueryClient()
-
-      function Page() {
-        const { data = 'default' } = useQuery({
-          queryKey: ['check'],
-          queryFn: async () => 'test',
-          throwErrors: true,
-        })
-
-        return (
-          <div>
-            <h1>{data}</h1>
-          </div>
-        )
-      }
-
-      const rendered = renderWithClient(
-        queryClient,
-        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>,
-        {
-          initialIsOpen: false,
-          context,
-        },
-      )
-
-      await waitFor(() => rendered.getByText('error boundary'))
-
-      consoleErrorMock.mockRestore()
-    })
-
-    it('should render with error when the custom context is not passed to ReactQueryDevtools', async () => {
-      const consoleErrorMock = jest.spyOn(console, 'error')
-      consoleErrorMock.mockImplementation(() => undefined)
-
-      const context = React.createContext<QueryClient | undefined>(undefined)
-      const { queryClient } = createQueryClient()
-
-      function Page() {
-        const { data = 'default' } = useQuery({
-          queryKey: ['check'],
-          queryFn: async () => 'test',
-          throwErrors: true,
-          context,
-        })
-
-        return (
-          <div>
-            <h1>{data}</h1>
-          </div>
-        )
-      }
-
-      const rendered = renderWithClient(
-        queryClient,
-        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>,
-        {
-          initialIsOpen: false,
-        },
-      )
-
-      await waitFor(() => rendered.getByText('error boundary'))
-
-      consoleErrorMock.mockRestore()
-    })
   })
 
   it('should render a menu to select panel position', async () => {

--- a/packages/react-query-devtools/src/__tests__/utils.tsx
+++ b/packages/react-query-devtools/src/__tests__/utils.tsx
@@ -15,7 +15,7 @@ export function renderWithClient(
   renderOptions?: RenderOptions,
 ): ReturnType<typeof render> {
   const { rerender, ...result } = render(
-    <QueryClientProvider client={client} context={devtoolsOptions.context}>
+    <QueryClientProvider client={client}>
       <ReactQueryDevtools {...devtoolsOptions} />
       {ui}
     </QueryClientProvider>,
@@ -25,7 +25,7 @@ export function renderWithClient(
     ...result,
     rerender: (rerenderUi: React.ReactElement) =>
       rerender(
-        <QueryClientProvider client={client} context={devtoolsOptions.context}>
+        <QueryClientProvider client={client}>
           <ReactQueryDevtools {...devtoolsOptions} />
           {rerenderUi}
         </QueryClientProvider>,

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -3,7 +3,6 @@ import type {
   QueryCache,
   QueryClient,
   QueryKey as QueryKeyType,
-  ContextOptions,
 } from '@tanstack/react-query'
 import {
   useQueryClient,
@@ -40,7 +39,7 @@ import { getQueryStatusLabel, getQueryStatusColor } from './utils'
 import Explorer from './Explorer'
 import Logo from './Logo'
 
-export interface DevtoolsOptions extends ContextOptions {
+export interface DevtoolsOptions {
   /**
    * Set this true if you want the dev tools to default to being open
    */
@@ -77,9 +76,13 @@ export interface DevtoolsOptions extends ContextOptions {
    * nonce for style element for CSP
    */
   styleNonce?: string
+  /**
+   * Custom instance of QueryClient
+   */
+  queryClient?: QueryClient
 }
 
-interface DevtoolsPanelOptions extends ContextOptions {
+interface DevtoolsPanelOptions {
   /**
    * The standard React style object used to style a component with inline styles
    */
@@ -121,6 +124,10 @@ interface DevtoolsPanelOptions extends ContextOptions {
    * Use this to add props to the close button. For example, you can add className, style (merge and override default style), onClick (extend default handler), etc.
    */
   closeButtonProps?: React.ComponentPropsWithoutRef<'button'>
+  /**
+   * Custom instance of QueryClient
+   */
+  queryClient?: QueryClient
 }
 
 export function ReactQueryDevtools({
@@ -130,7 +137,7 @@ export function ReactQueryDevtools({
   toggleButtonProps = {},
   position = 'bottom-left',
   containerElement: Container = 'aside',
-  context,
+  queryClient,
   styleNonce,
   panelPosition: initialPanelPosition = 'bottom',
 }: DevtoolsOptions): React.ReactElement | null {
@@ -330,7 +337,7 @@ export function ReactQueryDevtools({
       <ThemeProvider theme={theme}>
         <ReactQueryDevtoolsPanel
           ref={panelRef as any}
-          context={context}
+          queryClient={queryClient}
           styleNonce={styleNonce}
           position={panelPosition}
           onPositionChange={setPanelPosition}
@@ -425,7 +432,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
     isOpen = true,
     styleNonce,
     setIsOpen,
-    context,
+    queryClient,
     onDragStart,
     onPositionChange,
     showCloseButton,
@@ -436,8 +443,8 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
 
   const { onClick: onCloseClick, ...otherCloseButtonProps } = closeButtonProps
 
-  const queryClient = useQueryClient({ context })
-  const queryCache = queryClient.getQueryCache()
+  const client = useQueryClient(queryClient)
+  const queryCache = client.getQueryCache()
 
   const [sort, setSort] = useLocalStorage(
     'reactQueryDevtoolsSortFn',
@@ -747,7 +754,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
           <ActiveQuery
             activeQueryHash={activeQueryHash}
             queryCache={queryCache}
-            queryClient={queryClient}
+            queryClient={client}
           />
         ) : null}
 

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -1,22 +1,23 @@
 import * as React from 'react'
 
-import type { HydrateOptions } from '@tanstack/query-core'
+import type { HydrateOptions, QueryClient } from '@tanstack/query-core'
 import { hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
-import type { ContextOptions } from './types'
 
 export interface HydrationBoundaryProps {
   state?: unknown
-  options?: HydrateOptions & ContextOptions
+  options?: HydrateOptions
   children?: React.ReactNode
+  queryClient?: QueryClient
 }
 
 export const HydrationBoundary = ({
   children,
   options = {},
   state,
+  queryClient,
 }: HydrationBoundaryProps) => {
-  const queryClient = useQueryClient({ context: options.context })
+  const client = useQueryClient(queryClient)
 
   const optionsRef = React.useRef(options)
   optionsRef.current = options
@@ -27,9 +28,9 @@ export const HydrationBoundary = ({
   // hydrate can and should be run *during* render here for SSR to work properly
   React.useMemo(() => {
     if (state) {
-      hydrate(queryClient, state, optionsRef.current)
+      hydrate(client, state, optionsRef.current)
     }
-  }, [queryClient, state])
+  }, [client, state])
 
   return children as React.ReactElement
 }

--- a/packages/react-query/src/QueryClientProvider.tsx
+++ b/packages/react-query/src/QueryClientProvider.tsx
@@ -1,41 +1,33 @@
 import * as React from 'react'
 
 import type { QueryClient } from '@tanstack/query-core'
-import type { ContextOptions } from './types'
 
-export const defaultContext = React.createContext<QueryClient | undefined>(
+export const QueryClientContext = React.createContext<QueryClient | undefined>(
   undefined,
 )
 
-function getQueryClientContext(
-  context: React.Context<QueryClient | undefined> | undefined,
-) {
-  if (context) {
-    return context
+export const useQueryClient = (queryClient?: QueryClient) => {
+  const client = React.useContext(QueryClientContext)
+
+  if (queryClient) {
+    return queryClient
   }
 
-  return defaultContext
-}
-
-export const useQueryClient = ({ context }: ContextOptions = {}) => {
-  const queryClient = React.useContext(getQueryClientContext(context))
-
-  if (!queryClient) {
+  if (!client) {
     throw new Error('No QueryClient set, use QueryClientProvider to set one')
   }
 
-  return queryClient
+  return client
 }
 
 export type QueryClientProviderProps = {
   client: QueryClient
   children?: React.ReactNode
-} & ContextOptions
+}
 
 export const QueryClientProvider = ({
   client,
   children,
-  context,
 }: QueryClientProviderProps): JSX.Element => {
   React.useEffect(() => {
     client.mount()
@@ -43,8 +35,6 @@ export const QueryClientProvider = ({
       client.unmount()
     }
   }, [client])
-
-  const QueryClientContext = getQueryClientContext(context)
 
   return (
     <QueryClientContext.Provider value={client}>

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -62,8 +62,6 @@ describe('React hydration', () => {
   })
 
   test('should hydrate queries to the cache on custom context', async () => {
-    const context = React.createContext<QueryClient | undefined>(undefined)
-
     const queryCacheOuter = new QueryCache()
     const queryCacheInner = new QueryCache()
 
@@ -76,7 +74,6 @@ describe('React hydration', () => {
       const { data } = useQuery({
         queryKey: ['string'],
         queryFn: () => dataQuery(['string']),
-        context,
       })
       return (
         <div>
@@ -86,9 +83,9 @@ describe('React hydration', () => {
     }
 
     const rendered = render(
-      <QueryClientProvider client={queryClientOuter} context={context}>
+      <QueryClientProvider client={queryClientOuter}>
         <QueryClientProvider client={queryClientInner}>
-          <HydrationBoundary state={dehydratedState} options={{ context }}>
+          <HydrationBoundary state={dehydratedState}>
             <Page />
           </HydrationBoundary>
         </QueryClientProvider>

--- a/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
@@ -2,13 +2,7 @@ import * as React from 'react'
 import { render, waitFor } from '@testing-library/react'
 
 import { sleep, queryKey, createQueryClient } from './utils'
-import {
-  QueryClient,
-  QueryClientProvider,
-  QueryCache,
-  useQuery,
-  useQueryClient,
-} from '..'
+import { QueryClientProvider, QueryCache, useQuery, useQueryClient } from '..'
 
 describe('QueryClientProvider', () => {
   test('sets a specific cache for all queries to use', async () => {
@@ -144,69 +138,6 @@ describe('QueryClientProvider', () => {
 
     expect(queryCache.find({ queryKey: key })).toBeDefined()
     expect(queryCache.find({ queryKey: key })?.options.cacheTime).toBe(Infinity)
-  })
-
-  describe('with custom context', () => {
-    it('uses the correct context', async () => {
-      const key = queryKey()
-
-      const contextOuter = React.createContext<QueryClient | undefined>(
-        undefined,
-      )
-      const contextInner = React.createContext<QueryClient | undefined>(
-        undefined,
-      )
-
-      const queryCacheOuter = new QueryCache()
-      const queryClientOuter = new QueryClient({ queryCache: queryCacheOuter })
-
-      const queryCacheInner = new QueryCache()
-      const queryClientInner = new QueryClient({ queryCache: queryCacheInner })
-
-      const queryCacheInnerInner = new QueryCache()
-      const queryClientInnerInner = new QueryClient({
-        queryCache: queryCacheInnerInner,
-      })
-
-      function Page() {
-        const { data: testOuter } = useQuery({
-          queryKey: key,
-          queryFn: async () => 'testOuter',
-          context: contextOuter,
-        })
-        const { data: testInner } = useQuery({
-          queryKey: key,
-          queryFn: async () => 'testInner',
-          context: contextInner,
-        })
-        const { data: testInnerInner } = useQuery({
-          queryKey: key,
-          queryFn: async () => 'testInnerInner',
-        })
-
-        return (
-          <div>
-            <h1>
-              {testOuter} {testInner} {testInnerInner}
-            </h1>
-          </div>
-        )
-      }
-
-      const rendered = render(
-        <QueryClientProvider client={queryClientOuter} context={contextOuter}>
-          <QueryClientProvider client={queryClientInner} context={contextInner}>
-            <QueryClientProvider client={queryClientInnerInner}>
-              <Page />
-            </QueryClientProvider>
-          </QueryClientProvider>
-        </QueryClientProvider>,
-      )
-
-      await waitFor(() =>
-        rendered.getByText('testOuter testInner testInnerInner'),
-      )
-    })
   })
 
   describe('useQueryClient', () => {

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 
 import {
@@ -1760,5 +1760,28 @@ describe('useInfiniteQuery', () => {
     await waitFor(() => rendered.getByText('hidden'))
 
     expect(cancelFn).toHaveBeenCalled()
+  })
+
+  it('should use provided custom queryClient', async () => {
+    const key = queryKey()
+    const queryFn = async () => {
+      return Promise.resolve('custom client')
+    }
+
+    function Page() {
+      const { data } = useInfiniteQuery(
+        {
+          queryKey: key,
+          queryFn,
+        },
+        queryClient,
+      )
+
+      return <div>data: {data?.pages[0]}</div>
+    }
+
+    const rendered = render(<Page></Page>)
+
+    await waitFor(() => rendered.getByText('data: custom client'))
   })
 })

--- a/packages/react-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/react-query/src/__tests__/useIsFetching.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
 
 import {
   createQueryClient,
@@ -9,7 +8,6 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
-import type { QueryClient } from '..'
 import { QueryCache, useIsFetching, useQuery } from '..'
 
 describe('useIsFetching', () => {
@@ -172,90 +170,6 @@ describe('useIsFetching', () => {
     await findByText('isFetching: 0')
     // at no point should we have isFetching: 2
     expect(isFetchings).toEqual(expect.not.arrayContaining([2]))
-  })
-
-  describe('with custom context', () => {
-    it('should update as queries start and stop fetching', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      const queryCache = new QueryCache()
-      const queryClient = createQueryClient({ queryCache })
-      const key = queryKey()
-
-      function Page() {
-        const [ready, setReady] = React.useState(false)
-
-        const isFetching = useIsFetching(undefined, { context: context })
-
-        useQuery({
-          queryKey: key,
-          queryFn: async () => {
-            await sleep(50)
-            return 'test'
-          },
-          enabled: ready,
-          context,
-        })
-
-        return (
-          <div>
-            <div>isFetching: {isFetching}</div>
-            <button onClick={() => setReady(true)}>setReady</button>
-          </div>
-        )
-      }
-
-      const { findByText, getByRole } = renderWithClient(
-        queryClient,
-        <Page />,
-        {
-          context,
-        },
-      )
-
-      await findByText('isFetching: 0')
-      fireEvent.click(getByRole('button', { name: /setReady/i }))
-      await findByText('isFetching: 1')
-      await findByText('isFetching: 0')
-    })
-
-    it('should throw if the context is not passed to useIsFetching', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      const queryCache = new QueryCache()
-      const queryClient = createQueryClient({ queryCache })
-      const key = queryKey()
-
-      function Page() {
-        const isFetching = useIsFetching()
-
-        useQuery({
-          queryKey: key,
-          queryFn: async () => 'test',
-          enabled: true,
-          context,
-          throwErrors: true,
-        })
-
-        return (
-          <div>
-            <div>isFetching: {isFetching}</div>
-          </div>
-        )
-      }
-
-      const rendered = renderWithClient(
-        queryClient,
-        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>,
-        {
-          context,
-        },
-      )
-
-      await waitFor(() => rendered.getByText('error boundary'))
-    })
   })
 
   it('should show the correct fetching state when mounted after a query', async () => {

--- a/packages/react-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/react-query/src/__tests__/useIsFetching.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 
 import {
@@ -198,5 +198,35 @@ describe('useIsFetching', () => {
 
     await rendered.findByText('isFetching: 1')
     await rendered.findByText('isFetching: 0')
+  })
+
+  it('should use provided custom queryClient', async () => {
+    const queryClient = createQueryClient()
+    const key = queryKey()
+
+    function Page() {
+      useQuery(
+        {
+          queryKey: key,
+          queryFn: async () => {
+            await sleep(10)
+            return 'test'
+          },
+        },
+        queryClient,
+      )
+
+      const isFetching = useIsFetching({}, queryClient)
+
+      return (
+        <div>
+          <div>isFetching: {isFetching}</div>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page></Page>)
+
+    await waitFor(() => rendered.getByText('isFetching: 1'))
   })
 })

--- a/packages/react-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/react-query/src/__tests__/useIsMutating.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { useIsMutating } from '../useIsMutating'
 import { useMutation } from '../useMutation'
@@ -192,5 +192,37 @@ describe('useIsMutating', () => {
 
     await sleep(20)
     MutationCacheSpy.mockRestore()
+  })
+
+  it('should use provided custom queryClient', async () => {
+    const queryClient = createQueryClient()
+
+    function Page() {
+      const isMutating = useIsMutating({}, queryClient)
+      const { mutate } = useMutation(
+        {
+          mutationKey: ['mutation1'],
+          mutationFn: async () => {
+            await sleep(10)
+            return 'data'
+          },
+        },
+        queryClient,
+      )
+
+      React.useEffect(() => {
+        mutate()
+      }, [mutate])
+
+      return (
+        <div>
+          <div>mutating: {isMutating}</div>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page></Page>)
+
+    await waitFor(() => rendered.getByText('mutating: 1'))
   })
 })

--- a/packages/react-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/react-query/src/__tests__/useIsMutating.test.tsx
@@ -8,8 +8,6 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
-import { ErrorBoundary } from 'react-error-boundary'
-import { QueryClient } from '@tanstack/query-core'
 import * as MutationCacheModule from '../../../query-core/src/mutationCache'
 
 describe('useIsMutating', () => {
@@ -194,89 +192,5 @@ describe('useIsMutating', () => {
 
     await sleep(20)
     MutationCacheSpy.mockRestore()
-  })
-
-  describe('with custom context', () => {
-    it('should return the number of fetching mutations', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      const isMutatings: number[] = []
-      const queryClient = new QueryClient()
-
-      function IsMutating() {
-        const isMutating = useIsMutating(undefined, { context })
-        isMutatings.push(isMutating)
-        return null
-      }
-
-      function Page() {
-        const { mutate: mutate1 } = useMutation({
-          mutationKey: ['mutation1'],
-          mutationFn: async () => {
-            await sleep(150)
-            return 'data'
-          },
-          context,
-        })
-        const { mutate: mutate2 } = useMutation({
-          mutationKey: ['mutation2'],
-          mutationFn: async () => {
-            await sleep(50)
-            return 'data'
-          },
-          context,
-        })
-
-        React.useEffect(() => {
-          mutate1()
-          setActTimeout(() => {
-            mutate2()
-          }, 50)
-        }, [mutate1, mutate2])
-
-        return <IsMutating />
-      }
-
-      renderWithClient(queryClient, <Page />, { context })
-      await waitFor(() => expect(isMutatings).toEqual([0, 1, 1, 2, 2, 1, 0]))
-    })
-
-    it('should throw if the context is not passed to useIsMutating', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      const isMutatings: number[] = []
-      const queryClient = new QueryClient()
-
-      function IsMutating() {
-        const isMutating = useIsMutating(undefined)
-        isMutatings.push(isMutating)
-        return null
-      }
-
-      function Page() {
-        const { mutate } = useMutation({
-          mutationKey: ['mutation'],
-          mutationFn: async () => 'data',
-          throwErrors: true,
-          context,
-        })
-
-        React.useEffect(() => {
-          mutate()
-        }, [mutate])
-
-        return <IsMutating />
-      }
-
-      const rendered = renderWithClient(
-        queryClient,
-        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>,
-        { context },
-      )
-
-      await waitFor(() => rendered.getByText('error boundary'))
-    })
   })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
-import type { QueryClient } from '..'
 import { MutationCache, QueryCache, useMutation } from '..'
 import type { UseMutationResult } from '../types'
 import {
@@ -904,73 +903,6 @@ describe('useMutation', () => {
     expect(onSettled).toHaveBeenCalledTimes(1)
     expect(onSuccessMutate).toHaveBeenCalledTimes(0)
     expect(onSettledMutate).toHaveBeenCalledTimes(0)
-  })
-
-  describe('with custom context', () => {
-    it('should be able to reset `data`', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      function Page() {
-        const {
-          mutate,
-          data = 'empty',
-          reset,
-        } = useMutation({
-          mutationFn: () => Promise.resolve('mutation'),
-          context,
-        })
-
-        return (
-          <div>
-            <h1>{data}</h1>
-            <button onClick={() => reset()}>reset</button>
-            <button onClick={() => mutate()}>mutate</button>
-          </div>
-        )
-      }
-
-      const { getByRole } = renderWithClient(queryClient, <Page />, { context })
-
-      expect(getByRole('heading').textContent).toBe('empty')
-
-      fireEvent.click(getByRole('button', { name: /mutate/i }))
-
-      await waitFor(() => {
-        expect(getByRole('heading').textContent).toBe('mutation')
-      })
-
-      fireEvent.click(getByRole('button', { name: /reset/i }))
-
-      await waitFor(() => {
-        expect(getByRole('heading').textContent).toBe('empty')
-      })
-    })
-
-    it('should throw if the context is not passed to useMutation', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      function Page() {
-        const { data = '' } = useMutation({
-          mutationFn: () => Promise.resolve('mutation'),
-        })
-
-        return (
-          <div>
-            <h1 data-testid="title">{data}</h1>
-          </div>
-        )
-      }
-
-      const rendered = renderWithClient(
-        queryClient,
-        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>,
-        { context },
-      )
-
-      await waitFor(() => rendered.getByText('error boundary'))
-    })
   })
 
   it('should call mutate callbacks only for the last observer', async () => {

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -1069,5 +1069,37 @@ describe('useMutation', () => {
     await rendered.findByText('error: mutateFnError, status: error')
 
     expect(onError).toHaveBeenCalledWith(mutateFnError, 'todo', undefined)
+  })
+
+  it('should use provided custom queryClient', async () => {
+    function Page() {
+      const mutation = useMutation(
+        {
+          mutationFn: async (text: string) => {
+            return Promise.resolve(text)
+          },
+        },
+        queryClient,
+      )
+
+      return (
+        <div>
+          <button onClick={() => mutation.mutate('custom client')}>
+            mutate
+          </button>
+          <div>
+            data: {mutation.data ?? 'null'}, status: {mutation.status}
+          </div>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page></Page>)
+
+    await rendered.findByText('data: null, status: idle')
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+
+    await rendered.findByText('data: custom client, status: success')
   })
 })

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -13,7 +13,6 @@ import {
   sleep,
 } from './utils'
 import type {
-  QueryClient,
   QueryFunction,
   QueryKey,
   QueryObserverResult,
@@ -774,88 +773,6 @@ describe('useQueries', () => {
 
     await sleep(20)
     QueriesObserverSpy.mockRestore()
-  })
-
-  describe('with custom context', () => {
-    it('should return the correct states', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      const key1 = queryKey()
-      const key2 = queryKey()
-      const results: UseQueryResult[][] = []
-
-      function Page() {
-        const result = useQueries({
-          context,
-          queries: [
-            {
-              queryKey: key1,
-              queryFn: async () => {
-                await sleep(5)
-                return 1
-              },
-            },
-            {
-              queryKey: key2,
-              queryFn: async () => {
-                await sleep(10)
-                return 2
-              },
-            },
-          ],
-        })
-        results.push(result)
-        return null
-      }
-
-      renderWithClient(queryClient, <Page />, { context })
-
-      await sleep(30)
-
-      expect(results[0]).toMatchObject([
-        { data: undefined },
-        { data: undefined },
-      ])
-      expect(results[results.length - 1]).toMatchObject([
-        { data: 1 },
-        { data: 2 },
-      ])
-    })
-
-    it('should throw if the context is necessary and is not passed to useQueries', async () => {
-      const context = React.createContext<QueryClient | undefined>(undefined)
-
-      const key1 = queryKey()
-      const key2 = queryKey()
-      const results: UseQueryResult[][] = []
-
-      function Page() {
-        const result = useQueries({
-          queries: [
-            {
-              queryKey: key1,
-              queryFn: async () => 1,
-            },
-            {
-              queryKey: key2,
-              queryFn: async () => 2,
-            },
-          ],
-        })
-        results.push(result)
-        return null
-      }
-
-      const rendered = renderWithClient(
-        queryClient,
-        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>,
-        { context },
-      )
-
-      await waitFor(() => rendered.getByText('error boundary'))
-    })
   })
 
   it("should throw error if in one of queries' queryFn throws and throwErrors is in use", async () => {

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
@@ -897,5 +897,30 @@ describe('useQueries', () => {
 
     await waitFor(() => rendered.getByText('error boundary'))
     await waitFor(() => rendered.getByText('single query error'))
+  })
+
+  it('should use provided custom queryClient', async () => {
+    const key = queryKey()
+    const queryFn = async () => {
+      return Promise.resolve('custom client')
+    }
+
+    function Page() {
+      const queries = useQueries({
+        queries: [
+          {
+            queryKey: key,
+            queryFn,
+          },
+        ],
+        queryClient,
+      })
+
+      return <div>data: {queries[0].data}</div>
+    }
+
+    const rendered = render(<Page></Page>)
+
+    await waitFor(() => rendered.getByText('data: custom client'))
   })
 })

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import * as React from 'react'
 import {
@@ -6027,5 +6027,28 @@ describe('useQuery', () => {
     await waitFor(() => rendered.getByText('data: 2'))
     fireEvent.click(fetchBtn)
     await waitFor(() => rendered.getByText('data: 3'))
+  })
+
+  it('should use provided custom queryClient', async () => {
+    const key = queryKey()
+    const queryFn = async () => {
+      return Promise.resolve('custom client')
+    }
+
+    function Page() {
+      const { data } = useQuery(
+        {
+          queryKey: key,
+          queryFn,
+        },
+        queryClient,
+      )
+
+      return <div>data: {data}</div>
+    }
+
+    const rendered = render(<Page></Page>)
+
+    await waitFor(() => rendered.getByText('data: custom client'))
   })
 })

--- a/packages/react-query/src/__tests__/utils.tsx
+++ b/packages/react-query/src/__tests__/utils.tsx
@@ -1,26 +1,21 @@
 import * as React from 'react'
 import { act, render } from '@testing-library/react'
-import type { ContextOptions, QueryClientConfig, MutationOptions } from '..'
+import type { QueryClientConfig, MutationOptions } from '..'
 import { QueryClient, QueryClientProvider } from '..'
 import * as utils from '@tanstack/query-core'
 
 export function renderWithClient(
   client: QueryClient,
   ui: React.ReactElement,
-  options: ContextOptions = {},
 ): ReturnType<typeof render> {
   const { rerender, ...result } = render(
-    <QueryClientProvider client={client} context={options.context}>
-      {ui}
-    </QueryClientProvider>,
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
   )
   return {
     ...result,
     rerender: (rerenderUi: React.ReactElement) =>
       rerender(
-        <QueryClientProvider client={client} context={options.context}>
-          {rerenderUi}
-        </QueryClientProvider>,
+        <QueryClientProvider client={client}>{rerenderUi}</QueryClientProvider>,
       ),
   } as any
 }

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -9,7 +9,7 @@ export { useQueries } from './useQueries'
 export type { QueriesResults, QueriesOptions } from './useQueries'
 export { useQuery } from './useQuery'
 export {
-  defaultContext,
+  QueryClientContext,
   QueryClientProvider,
   useQueryClient,
 } from './QueryClientProvider'

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -1,6 +1,5 @@
 /* istanbul ignore file */
 
-import type * as React from 'react'
 import type {
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
@@ -13,14 +12,6 @@ import type {
   DefinedQueryObserverResult,
   WithRequired,
 } from '@tanstack/query-core'
-import type { QueryClient } from '@tanstack/query-core'
-
-export interface ContextOptions {
-  /**
-   * Use this to pass your React Query context. Otherwise, `defaultContext` will be used.
-   */
-  context?: React.Context<QueryClient | undefined>
-}
 
 export interface UseBaseQueryOptions<
   TQueryFnData = unknown,
@@ -28,11 +19,10 @@ export interface UseBaseQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends ContextOptions,
-    WithRequired<
-      QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
-      'queryKey'
-    > {}
+> extends WithRequired<
+    QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+    'queryKey'
+  > {}
 
 export interface UseQueryOptions<
   TQueryFnData = unknown,
@@ -50,17 +40,16 @@ export interface UseInfiniteQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends ContextOptions,
-    WithRequired<
-      InfiniteQueryObserverOptions<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData,
-        TQueryKey
-      >,
-      'queryKey'
-    > {}
+> extends WithRequired<
+    InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >,
+    'queryKey'
+  > {}
 
 export type UseBaseQueryResult<
   TData = unknown,
@@ -92,11 +81,10 @@ export interface UseMutationOptions<
   TError = Error,
   TVariables = void,
   TContext = unknown,
-> extends ContextOptions,
-    Omit<
-      MutationObserverOptions<TData, TError, TVariables, TContext>,
-      '_defaulted' | 'variables'
-    > {}
+> extends Omit<
+    MutationObserverOptions<TData, TError, TVariables, TContext>,
+    '_defaulted' | 'variables'
+  > {}
 
 export type UseMutateFunction<
   TData = unknown,

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import type { QueryKey, QueryObserver } from '@tanstack/query-core'
+import type { QueryClient, QueryKey, QueryObserver } from '@tanstack/query-core'
 import { notifyManager } from '@tanstack/query-core'
 import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import { useQueryClient } from './QueryClientProvider'
@@ -28,11 +28,12 @@ export function useBaseQuery<
     TQueryKey
   >,
   Observer: typeof QueryObserver,
+  queryClient?: QueryClient,
 ) {
-  const queryClient = useQueryClient({ context: options.context })
+  const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
   const errorResetBoundary = useQueryErrorResetBoundary()
-  const defaultedOptions = queryClient.defaultQueryOptions(options)
+  const defaultedOptions = client.defaultQueryOptions(options)
 
   // Make sure results are optimistically set in fetching state before subscribing or updating options
   defaultedOptions._optimisticResults = isRestoring
@@ -66,7 +67,7 @@ export function useBaseQuery<
   const [observer] = React.useState(
     () =>
       new Observer<TQueryFnData, TError, TData, TQueryData, TQueryKey>(
-        queryClient,
+        client,
         defaultedOptions,
       ),
   )

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryObserver, QueryKey } from '@tanstack/query-core'
+import type { QueryObserver, QueryKey, QueryClient } from '@tanstack/query-core'
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import type { UseInfiniteQueryOptions, UseInfiniteQueryResult } from './types'
 import { useBaseQuery } from './useBaseQuery'
@@ -17,9 +17,11 @@ export function useInfiniteQuery<
     TQueryFnData,
     TQueryKey
   >,
+  queryClient?: QueryClient,
 ): UseInfiniteQueryResult<TData, TError> {
   return useBaseQuery(
     options,
     InfiniteQueryObserver as typeof QueryObserver,
+    queryClient,
   ) as UseInfiniteQueryResult<TData, TError>
 }

--- a/packages/react-query/src/useIsFetching.ts
+++ b/packages/react-query/src/useIsFetching.ts
@@ -1,18 +1,15 @@
 import * as React from 'react'
-import type { QueryFilters } from '@tanstack/query-core'
+import type { QueryClient, QueryFilters } from '@tanstack/query-core'
 import { notifyManager } from '@tanstack/query-core'
 
-import type { ContextOptions } from './types'
 import { useQueryClient } from './QueryClientProvider'
-
-interface Options extends ContextOptions {}
 
 export function useIsFetching(
   filters?: QueryFilters,
-  options: Options = {},
+  queryClient?: QueryClient,
 ): number {
-  const queryClient = useQueryClient({ context: options.context })
-  const queryCache = queryClient.getQueryCache()
+  const client = useQueryClient(queryClient)
+  const queryCache = client.getQueryCache()
 
   return React.useSyncExternalStore(
     React.useCallback(
@@ -20,7 +17,7 @@ export function useIsFetching(
         queryCache.subscribe(notifyManager.batchCalls(onStoreChange)),
       [queryCache],
     ),
-    () => queryClient.isFetching(filters),
-    () => queryClient.isFetching(filters),
+    () => client.isFetching(filters),
+    () => client.isFetching(filters),
   )
 }

--- a/packages/react-query/src/useIsMutating.ts
+++ b/packages/react-query/src/useIsMutating.ts
@@ -1,18 +1,15 @@
 import * as React from 'react'
 
-import type { MutationFilters } from '@tanstack/query-core'
+import type { MutationFilters, QueryClient } from '@tanstack/query-core'
 import { notifyManager } from '@tanstack/query-core'
-import type { ContextOptions } from './types'
 import { useQueryClient } from './QueryClientProvider'
-
-interface Options extends ContextOptions {}
 
 export function useIsMutating(
   filters?: MutationFilters,
-  options: Options = {},
+  queryClient?: QueryClient,
 ): number {
-  const queryClient = useQueryClient({ context: options.context })
-  const mutationCache = queryClient.getMutationCache()
+  const client = useQueryClient(queryClient)
+  const mutationCache = client.getMutationCache()
 
   return React.useSyncExternalStore(
     React.useCallback(
@@ -20,7 +17,7 @@ export function useIsMutating(
         mutationCache.subscribe(notifyManager.batchCalls(onStoreChange)),
       [mutationCache],
     ),
-    () => queryClient.isMutating(filters),
-    () => queryClient.isMutating(filters),
+    () => client.isMutating(filters),
+    () => client.isMutating(filters),
   )
 }

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import type { QueryClient } from '@tanstack/query-core'
 import { notifyManager, MutationObserver } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
@@ -17,13 +18,14 @@ export function useMutation<
   TContext = unknown,
 >(
   options: UseMutationOptions<TData, TError, TVariables, TContext>,
+  queryClient?: QueryClient,
 ): UseMutationResult<TData, TError, TVariables, TContext> {
-  const queryClient = useQueryClient({ context: options.context })
+  const client = useQueryClient(queryClient)
 
   const [observer] = React.useState(
     () =>
       new MutationObserver<TData, TError, TVariables, TContext>(
-        queryClient,
+        client,
         options,
       ),
   )

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryKey } from '@tanstack/query-core'
+import type { QueryClient, QueryKey } from '@tanstack/query-core'
 import { QueryObserver } from '@tanstack/query-core'
 import type {
   DefinedUseQueryResult,
@@ -33,6 +33,7 @@ export function useQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError>
 
 export function useQuery<
@@ -42,6 +43,7 @@ export function useQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError>
 
 export function useQuery<
@@ -49,6 +51,9 @@ export function useQuery<
   TError = Error,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
->(options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>) {
-  return useBaseQuery(options, QueryObserver)
+>(
+  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
+) {
+  return useBaseQuery(options, QueryObserver, queryClient)
 }

--- a/packages/solid-query/src/QueryClientProvider.tsx
+++ b/packages/solid-query/src/QueryClientProvider.tsx
@@ -1,34 +1,29 @@
 import type { QueryClient } from '@tanstack/query-core'
-import type { Context, JSX } from 'solid-js'
+import type { JSX } from 'solid-js'
 import { createContext, useContext, onMount, onCleanup } from 'solid-js'
-import type { ContextOptions } from './types'
 
-export const defaultContext = createContext<QueryClient | undefined>(undefined)
+export const QueryClientContext = createContext<QueryClient | undefined>(
+  undefined,
+)
 
-function getQueryClientContext(
-  context: Context<QueryClient | undefined> | undefined,
-) {
-  if (context) {
-    return context
+export const useQueryClient = (queryClient?: QueryClient) => {
+  const client = useContext(QueryClientContext)
+
+  if (queryClient) {
+    return queryClient
   }
 
-  return defaultContext
-}
-
-export const useQueryClient = ({ context }: ContextOptions = {}) => {
-  const queryClient = useContext(getQueryClientContext(context))
-
-  if (!queryClient) {
+  if (!client) {
     throw new Error('No QueryClient set, use QueryClientProvider to set one')
   }
 
-  return queryClient
+  return client
 }
 
 export type QueryClientProviderProps = {
   client: QueryClient
   children?: JSX.Element
-} & ContextOptions
+}
 
 export const QueryClientProvider = (
   props: QueryClientProviderProps,
@@ -37,8 +32,6 @@ export const QueryClientProvider = (
     props.client.mount()
   })
   onCleanup(() => props.client.unmount())
-
-  const QueryClientContext = getQueryClientContext(props.context)
 
   return (
     <QueryClientContext.Provider value={props.client}>

--- a/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen, waitFor } from 'solid-testing-library'
 import { queryKey } from './utils'
 
-import { QueryCache, QueryClient } from '@tanstack/query-core'
-import { createContext } from 'solid-js'
+import { QueryCache } from '@tanstack/query-core'
 import { createQuery, QueryClientProvider, useQueryClient } from '..'
 import { createQueryClient, sleep } from './utils'
 
@@ -142,65 +141,6 @@ describe('QueryClientProvider', () => {
 
     expect(queryCache.find({ queryKey: key })).toBeDefined()
     expect(queryCache.find({ queryKey: key })?.options.cacheTime).toBe(Infinity)
-  })
-
-  describe('with custom context', () => {
-    it('uses the correct context', async () => {
-      const key = queryKey()
-
-      const contextOuter = createContext<QueryClient | undefined>(undefined)
-      const contextInner = createContext<QueryClient | undefined>(undefined)
-
-      const queryCacheOuter = new QueryCache()
-      const queryClientOuter = new QueryClient({ queryCache: queryCacheOuter })
-
-      const queryCacheInner = new QueryCache()
-      const queryClientInner = new QueryClient({ queryCache: queryCacheInner })
-
-      const queryCacheInnerInner = new QueryCache()
-      const queryClientInnerInner = new QueryClient({
-        queryCache: queryCacheInnerInner,
-      })
-
-      function Page() {
-        const queryOuter = createQuery(() => ({
-          queryKey: key,
-          queryFn: async () => 'testOuter',
-          context: contextOuter,
-        }))
-        const queryInner = createQuery(() => ({
-          queryKey: key,
-          queryFn: async () => 'testInner',
-          context: contextInner,
-        }))
-        const queryInnerInner = createQuery(() => ({
-          queryKey: key,
-          queryFn: async () => 'testInnerInner',
-        }))
-
-        return (
-          <div>
-            <h1>
-              {queryOuter.data} {queryInner.data} {queryInnerInner.data}
-            </h1>
-          </div>
-        )
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClientOuter} context={contextOuter}>
-          <QueryClientProvider client={queryClientInner} context={contextInner}>
-            <QueryClientProvider client={queryClientInnerInner}>
-              <Page />
-            </QueryClientProvider>
-          </QueryClientProvider>
-        </QueryClientProvider>
-      ))
-
-      await waitFor(() =>
-        screen.getByText('testOuter testInner testInnerInner'),
-      )
-    })
   })
 
   describe('useQueryClient', () => {

--- a/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
@@ -1877,4 +1877,27 @@ describe('useInfiniteQuery', () => {
 
     expect(cancelFn).toHaveBeenCalled()
   })
+
+  it('should use provided custom queryClient', async () => {
+    const key = queryKey()
+    const queryFn = () => {
+      return Promise.resolve('custom client')
+    }
+
+    function Page() {
+      const state = createInfiniteQuery(
+        () => ({ queryKey: key, queryFn }),
+        () => queryClient,
+      )
+      return (
+        <div>
+          <h1>Status: {state.data?.pages[0]}</h1>
+        </div>
+      )
+    }
+
+    render(() => <Page />)
+
+    await waitFor(() => screen.getByText('Status: custom client'))
+  })
 })

--- a/packages/solid-query/src/__tests__/createMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/createMutation.test.tsx
@@ -1184,4 +1184,36 @@ describe('useMutation', () => {
 
     expect(onError).toHaveBeenCalledWith(mutateFnError, 'todo', undefined)
   })
+
+  it('should use provided custom queryClient', async () => {
+    function Page() {
+      const mutation = createMutation(
+        () => ({
+          mutationFn: async (text: string) => {
+            return Promise.resolve(text)
+          },
+        }),
+        () => queryClient,
+      )
+
+      return (
+        <div>
+          <button onClick={() => mutation.mutate('custom client')}>
+            mutate
+          </button>
+          <div>
+            data: {mutation.data ?? 'null'}, status: {mutation.status}
+          </div>
+        </div>
+      )
+    }
+
+    render(() => <Page></Page>)
+
+    await screen.findByText('data: null, status: idle')
+
+    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+
+    await screen.findByText('data: custom client, status: success')
+  })
 })

--- a/packages/solid-query/src/__tests__/createMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/createMutation.test.tsx
@@ -1,13 +1,11 @@
 import '@testing-library/jest-dom'
 import {
-  createContext,
   createEffect,
   createRenderEffect,
   createSignal,
   ErrorBoundary,
 } from 'solid-js'
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
-import type { QueryClient } from '..'
 import {
   createMutation,
   MutationCache,
@@ -1003,74 +1001,6 @@ describe('useMutation', () => {
     expect(onSettled).toHaveBeenCalledTimes(1)
     expect(onSuccessMutate).toHaveBeenCalledTimes(0)
     expect(onSettledMutate).toHaveBeenCalledTimes(0)
-  })
-
-  describe('with custom context', () => {
-    it('should be able to reset `data`', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      function Page() {
-        const mutation = createMutation(() => ({
-          mutationFn: () => Promise.resolve('mutation'),
-          context,
-        }))
-
-        return (
-          <div>
-            <h1>{mutation.data ?? 'empty'}</h1>
-            <button onClick={() => mutation.reset()}>reset</button>
-            <button onClick={() => mutation.mutate()}>mutate</button>
-          </div>
-        )
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <Page />
-        </QueryClientProvider>
-      ))
-
-      expect(screen.getByRole('heading').textContent).toBe('empty')
-
-      fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-
-      await waitFor(() => {
-        expect(screen.getByRole('heading').textContent).toBe('mutation')
-      })
-
-      fireEvent.click(screen.getByRole('button', { name: /reset/i }))
-
-      await waitFor(() => {
-        expect(screen.getByRole('heading').textContent).toBe('empty')
-      })
-    })
-
-    it('should throw if the context is not passed to useMutation', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      function Page() {
-        const { data = '' } = createMutation(() => ({
-          mutationFn: () => Promise.resolve('mutation'),
-        }))
-
-        return (
-          <div>
-            <h1 data-testid="title">{data}</h1>
-          </div>
-        )
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <ErrorBoundary fallback={() => <div>error boundary</div>}>
-            <Page />
-          </ErrorBoundary>
-          ,
-        </QueryClientProvider>
-      ))
-
-      await waitFor(() => screen.getByText('error boundary'))
-    })
   })
 
   it('should call mutate callbacks only for the last observer', async () => {

--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -789,4 +789,27 @@ describe('useQueries', () => {
     await sleep(20)
     QueriesObserverSpy.mockRestore()
   })
+
+  it('should use provided custom queryClient', async () => {
+    const key = queryKey()
+    const queryFn = () => {
+      return Promise.resolve('custom client')
+    }
+
+    function Page() {
+      const state = createQueries(() => ({
+        queries: [{ queryKey: key, queryFn }],
+        queryClient,
+      }))
+      return (
+        <div>
+          <h1>Status: {state[0]?.data}</h1>
+        </div>
+      )
+    }
+
+    render(() => <Page />)
+
+    await waitFor(() => screen.getByText('Status: custom client'))
+  })
 })

--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -3,15 +3,9 @@ import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 import * as QueriesObserverModule from '../../../query-core/src/queriesObserver'
 
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
-import {
-  createContext,
-  createRenderEffect,
-  createSignal,
-  ErrorBoundary,
-} from 'solid-js'
+import { createRenderEffect, createSignal } from 'solid-js'
 import type {
   CreateQueryResult,
-  QueryClient,
   QueryFunction,
   QueryObserverResult,
   SolidQueryOptions,
@@ -794,93 +788,5 @@ describe('useQueries', () => {
 
     await sleep(20)
     QueriesObserverSpy.mockRestore()
-  })
-
-  describe('with custom context', () => {
-    it('should return the correct states', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      const key1 = queryKey()
-      const key2 = queryKey()
-      const results: CreateQueryResult[][] = []
-
-      function Page() {
-        const result = createQueries(() => ({
-          context,
-          queries: [
-            {
-              queryKey: key1,
-              queryFn: async () => {
-                await sleep(5)
-                return 1
-              },
-            },
-            {
-              queryKey: key2,
-              queryFn: async () => {
-                await sleep(10)
-                return 2
-              },
-            },
-          ],
-        }))
-        createRenderEffect(() => {
-          results.push([...result])
-        })
-        return null
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <Page />
-        </QueryClientProvider>
-      ))
-
-      await sleep(30)
-
-      expect(results[0]).toMatchObject([
-        { data: undefined },
-        { data: undefined },
-      ])
-      expect(results[results.length - 1]).toMatchObject([
-        { data: 1 },
-        { data: 2 },
-      ])
-    })
-
-    it('should throw if the context is necessary and is not passed to useQueries', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      const key1 = queryKey()
-      const key2 = queryKey()
-      const results: CreateQueryResult[][] = []
-
-      function Page() {
-        const result = createQueries(() => ({
-          queries: [
-            {
-              queryKey: key1,
-              queryFn: async () => 1,
-            },
-            {
-              queryKey: key2,
-              queryFn: async () => 2,
-            },
-          ],
-        }))
-        results.push(result)
-        return null
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <ErrorBoundary fallback={() => <div>error boundary</div>}>
-            <Page />
-          </ErrorBoundary>
-        </QueryClientProvider>
-      ))
-
-      await waitFor(() => screen.getByText('error boundary'))
-    })
   })
 })

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -6127,4 +6127,27 @@ describe('createQuery', () => {
     fireEvent.click(fetchBtn)
     await waitFor(() => screen.getByText('data: 3'))
   })
+
+  it('should use provided custom queryClient', async () => {
+    const key = queryKey()
+    const queryFn = () => {
+      return Promise.resolve('custom client')
+    }
+
+    function Page() {
+      const state = createQuery(
+        () => ({ queryKey: key, queryFn }),
+        () => queryClient,
+      )
+      return (
+        <div>
+          <h1>Status: {state.data}</h1>
+        </div>
+      )
+    }
+
+    render(() => <Page />)
+
+    await waitFor(() => screen.getByText('Status: custom client'))
+  })
 })

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -1,14 +1,6 @@
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 
-import {
-  createContext,
-  createEffect,
-  createRenderEffect,
-  createSignal,
-  ErrorBoundary,
-  Show,
-} from 'solid-js'
-import type { QueryClient } from '..'
+import { createEffect, createRenderEffect, createSignal, Show } from 'solid-js'
 import { createQuery, QueryCache, QueryClientProvider, useIsFetching } from '..'
 import { createQueryClient, queryKey, setActTimeout, sleep } from './utils'
 
@@ -195,90 +187,6 @@ describe('useIsFetching', () => {
     await screen.findByText('isFetching: 0')
     // at no point should we have isFetching: 2
     expect(isFetchings).toEqual(expect.not.arrayContaining([2]))
-  })
-
-  describe('with custom context', () => {
-    it('should update as queries start and stop fetching', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      const queryCache = new QueryCache()
-      const queryClient = createQueryClient({ queryCache })
-      const key = queryKey()
-
-      function Page() {
-        const [ready, setReady] = createSignal(false)
-
-        const isFetching = useIsFetching(() => ({
-          options: {
-            context,
-          },
-        }))
-
-        createQuery(() => ({
-          queryKey: key,
-          queryFn: async () => {
-            await sleep(50)
-            return 'test'
-          },
-          enabled: ready(),
-          context,
-        }))
-
-        return (
-          <div>
-            <div>isFetching: {isFetching}</div>
-            <button onClick={() => setReady(true)}>setReady</button>
-          </div>
-        )
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <Page />
-        </QueryClientProvider>
-      ))
-
-      await screen.findByText('isFetching: 0')
-      fireEvent.click(screen.getByRole('button', { name: /setReady/i }))
-      await screen.findByText('isFetching: 1')
-      await screen.findByText('isFetching: 0')
-    })
-
-    it('should throw if the context is not passed to useIsFetching', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      const queryCache = new QueryCache()
-      const queryClient = createQueryClient({ queryCache })
-      const key = queryKey()
-
-      function Page() {
-        const isFetching = useIsFetching()
-
-        createQuery(() => ({
-          queryKey: key,
-          queryFn: async () => 'test',
-          enabled: true,
-          context,
-          throwErrors: true,
-        }))
-
-        return (
-          <div>
-            <div>isFetching: {isFetching}</div>
-          </div>
-        )
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <ErrorBoundary fallback={() => <div>error boundary</div>}>
-            <Page />
-          </ErrorBoundary>
-        </QueryClientProvider>
-      ))
-
-      await waitFor(() => screen.getByText('error boundary'))
-    })
   })
 
   it('should show the correct fetching state when mounted after a query', async () => {

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -220,4 +220,34 @@ describe('useIsFetching', () => {
     await screen.findByText('isFetching: 1')
     await screen.findByText('isFetching: 0')
   })
+
+  it('should use provided custom queryClient', async () => {
+    const queryClient = createQueryClient()
+    const key = queryKey()
+
+    function Page() {
+      createQuery(
+        () => ({
+          queryKey: key,
+          queryFn: async () => {
+            await sleep(10)
+            return 'test'
+          },
+        }),
+        () => queryClient,
+      )
+
+      const isFetching = useIsFetching(() => ({ queryClient }))
+
+      return (
+        <div>
+          <div>isFetching: {isFetching}</div>
+        </div>
+      )
+    }
+
+    render(() => <Page></Page>)
+
+    await screen.findByText('isFetching: 1')
+  })
 })

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -221,4 +221,36 @@ describe('useIsMutating', () => {
     await sleep(20)
     MutationCacheSpy.mockRestore()
   })
+
+  it('should use provided custom queryClient', async () => {
+    const queryClient = createQueryClient()
+
+    function Page() {
+      const isMutating = useIsMutating(() => ({ queryClient }))
+      const { mutate } = createMutation(
+        () => ({
+          mutationKey: ['mutation1'],
+          mutationFn: async () => {
+            await sleep(10)
+            return 'data'
+          },
+        }),
+        () => queryClient,
+      )
+
+      createEffect(() => {
+        mutate()
+      })
+
+      return (
+        <div>
+          <div>mutating: {isMutating}</div>
+        </div>
+      )
+    }
+
+    render(() => <Page></Page>)
+
+    await waitFor(() => screen.findByText('mutating: 1'))
+  })
 })

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -1,20 +1,8 @@
 import { fireEvent, screen, waitFor } from 'solid-testing-library'
-import {
-  createMutation,
-  QueryClient,
-  QueryClientProvider,
-  useIsMutating,
-} from '..'
+import { createMutation, QueryClientProvider, useIsMutating } from '..'
 import { createQueryClient, sleep } from './utils'
 
-import {
-  createContext,
-  createEffect,
-  createRenderEffect,
-  createSignal,
-  ErrorBoundary,
-  Show,
-} from 'solid-js'
+import { createEffect, createRenderEffect, createSignal, Show } from 'solid-js'
 import { render } from 'solid-testing-library'
 import * as MutationCacheModule from '../../../query-core/src/mutationCache'
 import { setActTimeout } from './utils'
@@ -232,101 +220,5 @@ describe('useIsMutating', () => {
 
     await sleep(20)
     MutationCacheSpy.mockRestore()
-  })
-
-  describe('with custom context', () => {
-    it('should return the number of fetching mutations', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      const isMutatings: number[] = []
-      const queryClient = new QueryClient()
-
-      function IsMutating() {
-        const isMutating = useIsMutating(() => ({
-          options: {
-            context,
-          },
-        }))
-
-        createRenderEffect(() => {
-          isMutatings.push(isMutating())
-        })
-
-        return null
-      }
-
-      function Page() {
-        const { mutate: mutate1 } = createMutation(() => ({
-          mutationKey: ['mutation1'],
-          mutationFn: async () => {
-            await sleep(150)
-            return 'data'
-          },
-          context,
-        }))
-        const { mutate: mutate2 } = createMutation(() => ({
-          mutationKey: ['mutation2'],
-          mutationFn: async () => {
-            await sleep(50)
-            return 'data'
-          },
-          context,
-        }))
-
-        createEffect(() => {
-          mutate1()
-          setActTimeout(() => {
-            mutate2()
-          }, 50)
-        })
-
-        return <IsMutating />
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <Page />
-        </QueryClientProvider>
-      ))
-      await waitFor(() => expect(isMutatings).toEqual([0, 1, 2, 1, 0]))
-    })
-
-    it('should throw if the context is not passed to useIsMutating', async () => {
-      const context = createContext<QueryClient | undefined>(undefined)
-
-      const isMutatings: number[] = []
-      const queryClient = new QueryClient()
-
-      function IsMutating() {
-        const isMutating = useIsMutating(undefined)
-        isMutatings.push(isMutating())
-        return null
-      }
-
-      function Page() {
-        const { mutate } = createMutation(() => ({
-          mutationKey: ['mutation'],
-          mutationFn: async () => 'data',
-          throwErrors: true,
-          context,
-        }))
-
-        createEffect(() => {
-          mutate()
-        })
-
-        return <IsMutating />
-      }
-
-      render(() => (
-        <QueryClientProvider client={queryClient} context={context}>
-          <ErrorBoundary fallback={() => <div>error boundary</div>}>
-            <Page />
-          </ErrorBoundary>
-        </QueryClientProvider>
-      ))
-
-      await waitFor(() => screen.getByText('error boundary'))
-    })
   })
 })

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -1,4 +1,5 @@
 import type {
+  QueryClient,
   QueryKey,
   QueryObserver,
   QueryObserverResult,
@@ -31,15 +32,14 @@ export function createBaseQuery<
     CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   Observer: typeof QueryObserver,
+  queryClient?: () => QueryClient,
 ) {
-  const queryClient = createMemo(() =>
-    useQueryClient({ context: options().context }),
-  )
+  const client = createMemo(() => useQueryClient(queryClient?.()))
   const emptyData = Symbol('empty')
 
-  const defaultedOptions = queryClient().defaultQueryOptions(options())
+  const defaultedOptions = client().defaultQueryOptions(options())
   defaultedOptions._optimisticResults = 'optimistic'
-  const observer = new Observer(queryClient(), defaultedOptions)
+  const observer = new Observer(client(), defaultedOptions)
 
   const [state, setState] = createStore<QueryObserverResult<TData, TError>>(
     observer.getOptimisticResult(defaultedOptions),
@@ -85,7 +85,7 @@ export function createBaseQuery<
   })
 
   createComputed(() => {
-    observer.setOptions(queryClient().defaultQueryOptions(options()))
+    observer.setOptions(client().defaultQueryOptions(options()))
   })
 
   createComputed(

--- a/packages/solid-query/src/createInfiniteQuery.ts
+++ b/packages/solid-query/src/createInfiniteQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryObserver, QueryKey } from '@tanstack/query-core'
+import type { QueryObserver, QueryKey, QueryClient } from '@tanstack/query-core'
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import type {
   CreateInfiniteQueryOptions,
@@ -14,9 +14,11 @@ export function createInfiniteQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: () => QueryClient,
 ): CreateInfiniteQueryResult<TData, TError> {
   return createBaseQuery(
     createMemo(() => options()),
     InfiniteQueryObserver as typeof QueryObserver,
+    queryClient,
   ) as CreateInfiniteQueryResult<TData, TError>
 }

--- a/packages/solid-query/src/createMutation.ts
+++ b/packages/solid-query/src/createMutation.ts
@@ -1,3 +1,4 @@
+import type { QueryClient } from '@tanstack/query-core'
 import { MutationObserver } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
@@ -17,11 +18,12 @@ export function createMutation<
   TContext = unknown,
 >(
   options: CreateMutationOptions<TData, TError, TVariables, TContext>,
+  queryClient?: () => QueryClient,
 ): CreateMutationResult<TData, TError, TVariables, TContext> {
-  const queryClient = useQueryClient({ context: options().context })
+  const client = useQueryClient(queryClient?.())
 
   const observer = new MutationObserver<TData, TError, TVariables, TContext>(
-    queryClient,
+    client,
     options(),
   )
 

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -1,5 +1,6 @@
 import type {
   QueriesPlaceholderDataFunction,
+  QueryClient,
   QueryFunction,
   QueryKey,
 } from '@tanstack/query-core'
@@ -10,7 +11,7 @@ import { useQueryClient } from './QueryClientProvider'
 import type { CreateQueryResult, SolidQueryOptions } from './types'
 
 // This defines the `UseQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
-// - `context` is omitted as it is passed as a root-level option to `useQueries` instead.
+// `placeholderData` function does not have a parameter
 type CreateQueryOptionsForCreateQueries<
   TQueryFnData = unknown,
   TError = Error,
@@ -18,7 +19,7 @@ type CreateQueryOptionsForCreateQueries<
   TQueryKey extends QueryKey = QueryKey,
 > = Omit<
   SolidQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  'context' | 'placeholderData'
+  'placeholderData'
 > & {
   placeholderData?: TQueryFnData | QueriesPlaceholderDataFunction<TQueryFnData>
 }
@@ -148,10 +149,10 @@ export type QueriesResults<
 export function createQueries<T extends any[]>(
   queriesOptions: () => {
     queries: readonly [...QueriesOptions<T>]
-    context?: SolidQueryOptions['context']
+    queryClient?: QueryClient
   },
 ): QueriesResults<T> {
-  const queryClient = useQueryClient({ context: queriesOptions().context })
+  const queryClient = useQueryClient(queriesOptions().queryClient)
 
   const defaultedQueries = queriesOptions().queries.map((options) => {
     const defaultedOptions = queryClient.defaultQueryOptions(options)

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryKey } from '@tanstack/query-core'
+import type { QueryClient, QueryKey } from '@tanstack/query-core'
 import { QueryObserver } from '@tanstack/query-core'
 import { createMemo } from 'solid-js'
 import { createBaseQuery } from './createBaseQuery'
@@ -39,6 +39,7 @@ export function createQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: () => QueryClient,
 ): CreateQueryResult<TData, TError>
 
 export function createQuery<
@@ -48,15 +49,20 @@ export function createQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: () => QueryClient,
 ): DefinedCreateQueryResult<TData, TError>
 export function createQuery<
   TQueryFnData,
   TError = Error,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
->(options: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>) {
+>(
+  options: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: () => QueryClient,
+) {
   return createBaseQuery(
     createMemo(() => options()),
     QueryObserver,
+    queryClient,
   )
 }

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -10,7 +10,7 @@ export * from '@tanstack/query-core'
 export * from './types'
 export { createQuery } from './createQuery'
 export {
-  defaultContext,
+  QueryClientContext,
   QueryClientProvider,
   useQueryClient,
 } from './QueryClientProvider'

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -1,8 +1,6 @@
 /* istanbul ignore file */
 
-import type { Context } from 'solid-js'
 import type {
-  QueryClient,
   QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
@@ -15,13 +13,6 @@ import type {
   WithRequired,
 } from '@tanstack/query-core'
 
-export interface ContextOptions {
-  /**
-   * Use this to pass your Solid Query context. Otherwise, `defaultContext` will be used.
-   */
-  context?: Context<QueryClient | undefined>
-}
-
 export type FunctionedParams<T> = () => T
 
 export interface CreateBaseQueryOptions<
@@ -30,11 +21,10 @@ export interface CreateBaseQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends ContextOptions,
-    WithRequired<
-      QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
-      'queryKey'
-    > {}
+> extends WithRequired<
+    QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+    'queryKey'
+  > {}
 
 export interface SolidQueryOptions<
   TQueryFnData = unknown,
@@ -88,17 +78,16 @@ export interface SolidInfiniteQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends ContextOptions,
-    Omit<
-      InfiniteQueryObserverOptions<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData,
-        TQueryKey
-      >,
-      'queryKey'
-    > {
+> extends Omit<
+    InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >,
+    'queryKey'
+  > {
   queryKey: TQueryKey
 }
 
@@ -128,11 +117,10 @@ export interface SolidMutationOptions<
   TError = Error,
   TVariables = void,
   TContext = unknown,
-> extends ContextOptions,
-    Omit<
-      MutationObserverOptions<TData, TError, TVariables, TContext>,
-      '_defaulted' | 'variables'
-    > {}
+> extends Omit<
+    MutationObserverOptions<TData, TError, TVariables, TContext>,
+    '_defaulted' | 'variables'
+  > {}
 
 export type CreateMutationOptions<
   TData = unknown,

--- a/packages/solid-query/src/useIsFetching.ts
+++ b/packages/solid-query/src/useIsFetching.ts
@@ -1,18 +1,15 @@
-import type { QueryFilters } from '@tanstack/query-core'
+import type { QueryClient, QueryFilters } from '@tanstack/query-core'
 import type { Accessor } from 'solid-js'
 import { createMemo, createSignal, onCleanup } from 'solid-js'
 import { useQueryClient } from './QueryClientProvider'
-import type { ContextOptions } from './types'
 
 type Options = () => {
   filters?: QueryFilters
-  options?: ContextOptions
+  queryClient?: QueryClient
 }
 
 export function useIsFetching(options: Options = () => ({})): Accessor<number> {
-  const queryClient = createMemo(() =>
-    useQueryClient({ context: options().options?.context }),
-  )
+  const queryClient = createMemo(() => useQueryClient(options().queryClient))
   const queryCache = createMemo(() => queryClient().getQueryCache())
 
   const [fetches, setFetches] = createSignal(

--- a/packages/solid-query/src/useIsMutating.ts
+++ b/packages/solid-query/src/useIsMutating.ts
@@ -1,17 +1,16 @@
-import type { MutationFilters } from '@tanstack/query-core'
-import type { ContextOptions } from './types'
+import type { MutationFilters, QueryClient } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type { Accessor } from 'solid-js'
 import { createSignal, onCleanup, createMemo } from 'solid-js'
 
 type Options = () => {
   filters?: MutationFilters
-  options?: ContextOptions
+  queryClient?: QueryClient
 }
 
 export function useIsMutating(options: Options = () => ({})): Accessor<number> {
   const queryClient = createMemo(() =>
-    useQueryClient({ context: options().options?.context }),
+    useQueryClient(options().queryClient),
   )
   const mutationCache = createMemo(() => queryClient().getMutationCache())
 

--- a/packages/solid-query/src/useIsMutating.ts
+++ b/packages/solid-query/src/useIsMutating.ts
@@ -9,9 +9,7 @@ type Options = () => {
 }
 
 export function useIsMutating(options: Options = () => ({})): Accessor<number> {
-  const queryClient = createMemo(() =>
-    useQueryClient(options().queryClient),
-  )
+  const queryClient = createMemo(() => useQueryClient(options().queryClient))
   const mutationCache = createMemo(() => queryClient().getMutationCache())
 
   const [mutations, setMutations] = createSignal(

--- a/packages/vue-query/src/__tests__/useIsMutating.test.ts
+++ b/packages/vue-query/src/__tests__/useIsMutating.test.ts
@@ -3,7 +3,6 @@ import { onScopeDispose, reactive, ref } from 'vue-demi'
 import { flushPromises, successMutator } from './test-utils'
 import { useMutation } from '../useMutation'
 import { unrefFilterArgs, useIsMutating } from '../useIsMutating'
-import { useQueryClient } from '../useQueryClient'
 
 jest.mock('../useQueryClient')
 
@@ -59,13 +58,6 @@ describe('useIsMutating', () => {
     expect(isMutating.value).toStrictEqual(0)
 
     onScopeDisposeMock.mockReset()
-  })
-
-  test('should call `useQueryClient` with a proper `queryClientKey`', async () => {
-    const queryClientKey = 'foo'
-    useIsMutating({ queryClientKey })
-
-    expect(useQueryClient).toHaveBeenCalledWith(queryClientKey)
   })
 
   test('should properly update filters', async () => {

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -211,24 +211,4 @@ describe('useQueries', () => {
 
     expect(useQueryClient).toHaveBeenCalledTimes(0)
   })
-
-  test('should use queryClient provided via query options', async () => {
-    const queryClient = new QueryClient()
-    const queries = [
-      {
-        queryKey: ['key41'],
-        queryFn: simpleFetcher,
-        queryClient,
-      },
-      {
-        queryKey: ['key42'],
-        queryFn: simpleFetcher,
-      },
-    ]
-
-    useQueries({ queries })
-    await flushPromises()
-
-    expect(useQueryClient).toHaveBeenCalledTimes(0)
-  })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -23,11 +23,15 @@ describe('useQuery', () => {
   test('should properly execute query', () => {
     useQuery({ queryKey: ['key0'], queryFn: simpleFetcher, staleTime: 1000 })
 
-    expect(useBaseQuery).toBeCalledWith(QueryObserver, {
-      queryKey: ['key0'],
-      queryFn: simpleFetcher,
-      staleTime: 1000,
-    })
+    expect(useBaseQuery).toBeCalledWith(
+      QueryObserver,
+      {
+        queryKey: ['key0'],
+        queryFn: simpleFetcher,
+        staleTime: 1000,
+      },
+      undefined,
+    )
   })
 
   test('should return loading status initially', () => {

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -275,11 +275,13 @@ describe('VueQueryPlugin', () => {
 
       const fnSpy = jest.fn()
 
-      const query = useQuery({
-        queryKey: ['persist'],
-        queryFn: fnSpy,
-        queryClient: customClient,
-      })
+      const query = useQuery(
+        {
+          queryKey: ['persist'],
+          queryFn: fnSpy,
+        },
+        customClient,
+      )
 
       expect(customClient.isRestoring.value).toBeTruthy()
       expect(query.isFetching.value).toBeFalsy()
@@ -325,9 +327,9 @@ describe('VueQueryPlugin', () => {
           {
             queryKey: ['persist'],
             queryFn: fnSpy,
-            queryClient: customClient,
           },
         ],
+        queryClient: customClient,
       })
 
       expect(customClient.isRestoring.value).toBeTruthy()

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -6,7 +6,6 @@ import type {
   InfiniteQueryObserverOptions,
 } from '@tanstack/query-core'
 import type { Ref, UnwrapRef } from 'vue-demi'
-import type { QueryClient } from './queryClient'
 
 export type MaybeRef<T> = Ref<T> | T
 
@@ -19,11 +18,6 @@ export type MaybeRefDeep<T> = MaybeRef<
       }
     : T
 >
-
-export type WithQueryClientKey<T> = T & {
-  queryClientKey?: string
-  queryClient?: QueryClient
-}
 
 // A Vue version of QueriesObserverOptions from "@tanstack/query-core"
 // Accept refs as options

--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -9,11 +9,8 @@ import type {
 import { useBaseQuery } from './useBaseQuery'
 import type { UseQueryReturnType } from './useBaseQuery'
 
-import type {
-  WithQueryClientKey,
-  VueInfiniteQueryObserverOptions,
-  DistributiveOmit,
-} from './types'
+import type { VueInfiniteQueryObserverOptions, DistributiveOmit } from './types'
+import type { QueryClient } from './queryClient'
 
 export type UseInfiniteQueryOptions<
   TQueryFnData = unknown,
@@ -21,14 +18,12 @@ export type UseInfiniteQueryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = WithRequired<
-  WithQueryClientKey<
-    VueInfiniteQueryObserverOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryFnData,
-      TQueryKey
-    >
+  VueInfiniteQueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey
   >,
   'queryKey'
 >
@@ -57,10 +52,12 @@ export function useInfiniteQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
 ): UseInfiniteQueryReturnType<TData, TError> {
   const result = useBaseQuery(
     InfiniteQueryObserver as typeof QueryObserver,
     options,
+    queryClient,
   ) as InfiniteQueryReturnType<TData, TError>
   return {
     ...result,

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -3,25 +3,28 @@ import type { Ref } from 'vue-demi'
 import type { QueryFilters as QF } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref } from './utils'
-import type { MaybeRefDeep, WithQueryClientKey } from './types'
+import type { MaybeRefDeep } from './types'
+import type { QueryClient } from './queryClient'
 
-export type QueryFilters = MaybeRefDeep<WithQueryClientKey<QF>>
+export type QueryFilters = MaybeRefDeep<QF>
 
-export function useIsFetching(fetchingFilters: QueryFilters = {}): Ref<number> {
+export function useIsFetching(
+  fetchingFilters: QueryFilters = {},
+  queryClient?: QueryClient,
+): Ref<number> {
   const filters = computed(() => unrefFilterArgs(fetchingFilters))
-  const queryClient =
-    filters.value.queryClient ?? useQueryClient(filters.value.queryClientKey)
+  const client = queryClient || useQueryClient()
 
-  const isFetching = ref(queryClient.isFetching(filters))
+  const isFetching = ref(client.isFetching(filters))
 
-  const unsubscribe = queryClient.getQueryCache().subscribe(() => {
-    isFetching.value = queryClient.isFetching(filters)
+  const unsubscribe = client.getQueryCache().subscribe(() => {
+    isFetching.value = client.isFetching(filters)
   })
 
   watch(
     filters,
     () => {
-      isFetching.value = queryClient.isFetching(filters)
+      isFetching.value = client.isFetching(filters)
     },
     { deep: true },
   )
@@ -35,5 +38,5 @@ export function useIsFetching(fetchingFilters: QueryFilters = {}): Ref<number> {
 
 export function unrefFilterArgs(arg: QueryFilters) {
   const options = unref(arg)
-  return cloneDeepUnref(options) as WithQueryClientKey<QF>
+  return cloneDeepUnref(options) as QF
 }

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -4,27 +4,28 @@ import type { MutationFilters as MF } from '@tanstack/query-core'
 
 import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref } from './utils'
-import type { MaybeRefDeep, WithQueryClientKey } from './types'
+import type { MaybeRefDeep } from './types'
+import type { QueryClient } from './queryClient'
 
-export type MutationFilters = MaybeRefDeep<WithQueryClientKey<MF>>
+export type MutationFilters = MaybeRefDeep<MF>
 
 export function useIsMutating(
   mutationFilters: MutationFilters = {},
+  queryClient?: QueryClient,
 ): Ref<number> {
   const filters = computed(() => unrefFilterArgs(mutationFilters))
-  const queryClient =
-    filters.value.queryClient ?? useQueryClient(filters.value.queryClientKey)
+  const client = queryClient || useQueryClient()
 
-  const isMutating = ref(queryClient.isMutating(filters))
+  const isMutating = ref(client.isMutating(filters))
 
-  const unsubscribe = queryClient.getMutationCache().subscribe(() => {
-    isMutating.value = queryClient.isMutating(filters)
+  const unsubscribe = client.getMutationCache().subscribe(() => {
+    isMutating.value = client.isMutating(filters)
   })
 
   watch(
     filters,
     () => {
-      isMutating.value = queryClient.isMutating(filters)
+      isMutating.value = client.isMutating(filters)
     },
     { deep: true },
   )
@@ -38,5 +39,5 @@ export function useIsMutating(
 
 export function unrefFilterArgs(arg: MutationFilters) {
   const options = unref(arg)
-  return cloneDeepUnref(options) as WithQueryClientKey<MF>
+  return cloneDeepUnref(options) as MF
 }

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -8,11 +8,8 @@ import type {
 } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
 import type { UseQueryReturnType as UQRT } from './useBaseQuery'
-import type {
-  WithQueryClientKey,
-  VueQueryObserverOptions,
-  DistributiveOmit,
-} from './types'
+import type { VueQueryObserverOptions, DistributiveOmit } from './types'
+import type { QueryClient } from './queryClient'
 
 export type UseQueryReturnType<TData, TError> = DistributiveOmit<
   UQRT<TData, TError>,
@@ -35,15 +32,7 @@ export type UseQueryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = WithRequired<
-  WithQueryClientKey<
-    VueQueryObserverOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryFnData,
-      TQueryKey
-    >
-  >,
+  VueQueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
   'queryKey'
 >
 
@@ -72,6 +61,7 @@ export function useQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
 ): UseQueryReturnType<TData, TError>
 
 export function useQuery<
@@ -81,6 +71,7 @@ export function useQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
 ): UseQueryDefinedReturnType<TData, TError>
 
 export function useQuery<
@@ -90,10 +81,11 @@ export function useQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
 ):
   | UseQueryReturnType<TData, TError>
   | UseQueryDefinedReturnType<TData, TError> {
-  const result = useBaseQuery(QueryObserver, options)
+  const result = useBaseQuery(QueryObserver, options, queryClient)
 
   return {
     ...result,


### PR DESCRIPTION
BREAKING CHANGE: custom context has been removed from hooks in favor of passing custom queryClient instance

Closes: #4682

TODO:
- [x] Migration guide entry
- [x] Add replaceable content section in migration guide for framework specific section