### PR TITLE
Rename `Hydrate` -> `HydrationBoundary`

### DIFF
--- a/docs/react/guides/migrating-to-v5.md
+++ b/docs/react/guides/migrating-to-v5.md
@@ -231,7 +231,7 @@ import { batch } from 'solid-js'
 notifyManager.setBatchNotifyFunction(batch)
 ```
 
-### `Hydrate` has been renamed to `HydrationBoundary` the `useHydrate` hook has been removed
+### `Hydrate` has been renamed to `HydrationBoundary` and the `useHydrate` hook has been removed
 
 The `Hydrate` component has been renamed to `HydrationBoundary`. The `Hydrate` component was also a wrapper over `useHydrate` hook, which has been removed.
 

--- a/docs/react/guides/migrating-to-v5.md
+++ b/docs/react/guides/migrating-to-v5.md
@@ -222,3 +222,22 @@ import { batch } from 'solid-js'
 
 notifyManager.setBatchNotifyFunction(batch)
 ```
+
+### `Hydrate` has been renamed to `HydrationBoundary` the `useHydrate` hook has been removed
+
+The `Hydrate` component has been renamed to `HydrationBoundary`. The `Hydrate` component was also a wrapper over `useHydrate` hook, which has been removed.
+
+```diff
+- import { Hydrate } from '@tanstack/react-query'
++ import { HydrationBoundary } from '@tanstack/react-query'
+
+
+- <Hydrate state={dehydratedState}>
++ <HydrationBoundary state={dehydratedState}>
+  <App />
+- </Hydrate>
++ </HydrationBoundary>
+```
+```
+
+

--- a/docs/react/guides/ssr.md
+++ b/docs/react/guides/ssr.md
@@ -55,20 +55,20 @@ To support caching queries on the server and set up hydration:
 
 - Create a new `QueryClient` instance **inside of your app, and on an instance ref (or in React state). This ensures that data is not shared between different users and requests, while still only creating the QueryClient once per component lifecycle.**
 - Wrap your app component with `<QueryClientProvider>` and pass it the client instance
-- Wrap your app component with `<Hydrate>` and pass it the `dehydratedState` prop from `pageProps`
+- Wrap your app component with `<HydrationBoundary>` and pass it the `dehydratedState` prop from `pageProps`
 
 ```tsx
 // _app.jsx
-import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { HydrationBoundary, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 export default function MyApp({ Component, pageProps }) {
   const [queryClient] = React.useState(() => new QueryClient())
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Hydrate state={pageProps.dehydratedState}>
+      <HydrationBoundary state={pageProps.dehydratedState}>
         <Component {...pageProps} />
-      </Hydrate>
+      </HydrationBoundary>
     </QueryClientProvider>
   )
 }
@@ -157,7 +157,7 @@ To support caching queries on the server and set up hydration:
 
 - Create a new `QueryClient` instance **inside of your app, and on an instance ref (or in React state). This ensures that data is not shared between different users and requests, while still only creating the QueryClient once per component lifecycle.**
 - Wrap your app component with `<QueryClientProvider>` and pass it the client instance
-- Wrap your app component with `<Hydrate>` and pass it the `dehydratedState` prop from `useDehydratedState()`
+- Wrap your app component with `<HydrationBoundary>` and pass it the `dehydratedState` prop from `useDehydratedState()`
 
 ```bash
 npm i use-dehydrated-state
@@ -169,7 +169,7 @@ yarn add use-dehydrated-state
 
 ```tsx
 // root.tsx
-import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { HydrationBoundary, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { useDehydratedState } from 'use-dehydrated-state'
 
@@ -180,9 +180,9 @@ export default function MyApp() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Hydrate state={dehydratedState}>
+      <HydrationBoundary state={dehydratedState}>
         <Outlet />
-      </Hydrate>
+      </HydrationBoundary>
     </QueryClientProvider>
   )
 }
@@ -239,7 +239,7 @@ This guide is at-best, a high level overview of how SSR with React Query should 
 > SECURITY NOTE: Serializing data with `JSON.stringify` can put you at risk for XSS-vulnerabilities, [this blog post explains why and how to solve it](https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0)
 
 ```tsx
-import { dehydrate, Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { dehydrate, HydrationBoundary, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 async function handleRequest (req, res) {
   const queryClient = new QueryClient()
@@ -248,9 +248,9 @@ async function handleRequest (req, res) {
 
   const html = ReactDOM.renderToString(
     <QueryClientProvider client={queryClient}>
-      <Hydrate state={dehydratedState}>
+      <HydrationBoundary state={dehydratedState}>
         <App />
-      </Hydrate>
+      </HydrationBoundary>
     </QueryClientProvider>
   )
 
@@ -276,7 +276,7 @@ async function handleRequest (req, res) {
 - Render your app with the client provider and also **using the dehydrated state. This is extremely important! You must render both server and client using the same dehydrated state to ensure hydration on the client produces the exact same markup as the server.**
 
 ```tsx
-import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { HydrationBoundary, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const dehydratedState = window.__REACT_QUERY_STATE__
 
@@ -284,9 +284,9 @@ const queryClient = new QueryClient()
 
 ReactDOM.hydrate(
   <QueryClientProvider client={queryClient}>
-    <Hydrate state={dehydratedState}>
+    <HydrationBoundary state={dehydratedState}>
       <App />
-    </Hydrate>
+    </HydrationBoundary>
   </QueryClientProvider>,
   document.getElementById('root')
 )

--- a/docs/react/reference/hydration.md
+++ b/docs/react/reference/hydration.md
@@ -5,7 +5,7 @@ title: hydration
 
 ## `dehydrate`
 
-`dehydrate` creates a frozen representation of a `cache` that can later be hydrated with `Hydrate`, `useHydrate`, or `hydrate`. This is useful for passing prefetched queries from server to client or persisting queries to localStorage or other persistent locations. It only includes currently successful queries by default.
+`dehydrate` creates a frozen representation of a `cache` that can later be hydrated with `HydrationBoundary` or `hydrate`. This is useful for passing prefetched queries from server to client or persisting queries to localStorage or other persistent locations. It only includes currently successful queries by default.
 
 ```tsx
 import { dehydrate } from '@tanstack/react-query'
@@ -91,42 +91,17 @@ hydrate(queryClient, dehydratedState, options)
 
 If the queries included in dehydration already exist in the queryCache, `hydrate` does not overwrite them and they will be **silently** discarded.
 
-[//]: # 'useHydrate'
 
-## `useHydrate`
+[//]: # 'HydrationBoundary'
+## `HydrationBoundary`
 
-`useHydrate` adds a previously dehydrated state into the `queryClient` that would be returned by `useQueryClient()`. If the client already contains data, the new queries will be intelligently merged based on update timestamp.
-
-```tsx
-import { useHydrate } from '@tanstack/react-query'
-
-useHydrate(dehydratedState, options)
-```
-
-**Options**
-
-- `dehydratedState: DehydratedState`
-  - **Required**
-  - The state to hydrate
-- `options: HydrateOptions`
-  - Optional
-  - `defaultOptions: QueryOptions`
-    - The default query options to use for the hydrated queries.
-  - `context?: React.Context<QueryClient | undefined>`
-    - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
-
-[//]: # 'useHydrate'
-[//]: # 'Hydrate'
-
-## `Hydrate`
-
-`Hydrate` wraps `useHydrate` into component. Can be useful when you need hydrate in class component or need hydrate on same level where `QueryClientProvider` rendered.
+`HydrationBoundary` adds a previously dehydrated state into the `queryClient` that would be returned by `useQueryClient()`. If the client already contains data, the new queries will be intelligently merged based on update timestamp.
 
 ```tsx
-import { Hydrate } from '@tanstack/react-query'
+import { HydrationBoundary } from '@tanstack/react-query'
 
 function App() {
-  return <Hydrate state={dehydratedState}>...</Hydrate>
+  return <HydrationBoundary state={dehydratedState}>...</HydrationBoundary>
 }
 ```
 
@@ -141,4 +116,4 @@ function App() {
   - `context?: React.Context<QueryClient | undefined>`
     - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
-[//]: # 'Hydrate'
+[//]: # 'HydrationBoundary'

--- a/examples/react/nextjs/pages/_app.js
+++ b/examples/react/nextjs/pages/_app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {
-  Hydrate,
+  HydrationBoundary,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
@@ -11,9 +11,9 @@ export default function MyApp({ Component, pageProps }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Hydrate state={pageProps.dehydratedState}>
+      <HydrationBoundary state={pageProps.dehydratedState}>
         <Component {...pageProps} />
-      </Hydrate>
+      </HydrationBoundary>
       <ReactQueryDevtools />
     </QueryClientProvider>
   )

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -7,11 +7,15 @@ import type { ContextOptions } from './types'
 
 export interface HydrationBoundaryProps {
   state?: unknown
-  options?: HydrateOptions & ContextOptions,
+  options?: HydrateOptions & ContextOptions
   children?: React.ReactNode
 }
 
-export const HydrationBoundary = ({ children, options = {}, state }: HydrationBoundaryProps) => {
+export const HydrationBoundary = ({
+  children,
+  options = {},
+  state,
+}: HydrationBoundaryProps) => {
   const queryClient = useQueryClient({ context: options.context })
 
   const optionsRef = React.useRef(options)

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -5,10 +5,13 @@ import { hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type { ContextOptions } from './types'
 
-export function useHydrate(
-  state: unknown,
-  options: HydrateOptions & ContextOptions = {},
-) {
+export interface HydrationBoundaryProps {
+  state?: unknown
+  options?: HydrateOptions & ContextOptions,
+  children?: React.ReactNode
+}
+
+export const HydrationBoundary = ({ children, options = {}, state }: HydrationBoundaryProps) => {
   const queryClient = useQueryClient({ context: options.context })
 
   const optionsRef = React.useRef(options)
@@ -23,15 +26,6 @@ export function useHydrate(
       hydrate(queryClient, state, optionsRef.current)
     }
   }, [queryClient, state])
-}
 
-export interface HydrateProps {
-  state?: unknown
-  options?: HydrateOptions
-  children?: React.ReactNode
-}
-
-export const Hydrate = ({ children, options, state }: HydrateProps) => {
-  useHydrate(state, options)
   return children as React.ReactElement
 }

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -15,8 +15,8 @@ export {
 } from './QueryClientProvider'
 export type { QueryClientProviderProps } from './QueryClientProvider'
 export type { QueryErrorResetBoundaryProps } from './QueryErrorResetBoundary'
-export { useHydrate, Hydrate } from './Hydrate'
-export type { HydrateProps } from './Hydrate'
+export { HydrationBoundary } from './HydrationBoundary'
+export type { HydrationBoundaryProps } from './HydrationBoundary'
 export {
   QueryErrorResetBoundary,
   useQueryErrorResetBoundary,


### PR DESCRIPTION
- Rename `Hydrate` -> `HydartionBoundary`
- Remove `useHydrate` hook
- Update migration guide

Fixes #4692 