### PR TITLE
docs(useMutation): clarify `mutationFn` option default

### DIFF
--- a/docs/react/reference/useMutation.md
+++ b/docs/react/reference/useMutation.md
@@ -43,8 +43,7 @@ mutate(variables, {
 **Options**
 
 - `mutationFn: (variables: TVariables) => Promise<TData>`
-  - Optional
-  - Defaults to the global mutation configuration `mutationFn`, which is `undefined` by default.
+  - **Required, but only if no default mutation function has been defined**
   - A function that performs an asynchronous task and returns a promise.
   - `variables` is an object that `mutate` will pass to your `mutationFn`
 - `cacheTime: number | Infinity`

--- a/docs/react/reference/useMutation.md
+++ b/docs/react/reference/useMutation.md
@@ -43,7 +43,8 @@ mutate(variables, {
 **Options**
 
 - `mutationFn: (variables: TVariables) => Promise<TData>`
-  - **Required**
+  - Optional
+  - Defaults to the global mutation configuration `mutationFn`, which is `undefined` by default.
   - A function that performs an asynchronous task and returns a promise.
   - `variables` is an object that `mutate` will pass to your `mutationFn`
 - `cacheTime: number | Infinity`


### PR DESCRIPTION
This pull request clarifies the `useMutation` `mutationFn` option default as being the global mutation configuration `mutationFn`. 

### Notes

- This change came out of a conversation had in the TanStack Discord server between another member, Dominik, and me. 
- Please let me know if an issue would be useful for tracking. 