### PR TITLE
fix(svelte-query): Fix createMutation for functions that take no arguments

### DIFF
--- a/packages/svelte-query/src/__tests__/CreateMutation.svelte
+++ b/packages/svelte-query/src/__tests__/CreateMutation.svelte
@@ -2,12 +2,14 @@
   import { createMutation, QueryClient } from '../index'
   import { setQueryClientContext } from '../context'
 
-  export let queryFn: () => Promise<string>
+  export let mutationFn: () => Promise<string>
 
   const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
-  const mutation = createMutation(queryFn)
+  const mutation = createMutation({
+    mutationFn,
+  })
 </script>
 
 <button on:click={$mutation.mutate}>Click</button>

--- a/packages/svelte-query/src/__tests__/CreateMutation.svelte
+++ b/packages/svelte-query/src/__tests__/CreateMutation.svelte
@@ -12,4 +12,4 @@
   })
 </script>
 
-<button on:click={$mutation.mutate}>Click</button>
+<button on:click={() => $mutation.mutate()}>Click</button>

--- a/packages/svelte-query/src/__tests__/createMutation.test.ts
+++ b/packages/svelte-query/src/__tests__/createMutation.test.ts
@@ -5,11 +5,11 @@ import { sleep } from './utils'
 
 describe('createMutation', () => {
   it('Call mutate and check function runs', async () => {
-    const queryFn = vi.fn()
+    const mutationFn = vi.fn()
 
     render(CreateMutation, {
       props: {
-        queryFn,
+        mutationFn,
       },
     })
 
@@ -17,6 +17,6 @@ describe('createMutation', () => {
 
     await sleep(200)
 
-    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(mutationFn).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/svelte-query/src/createMutation.ts
+++ b/packages/svelte-query/src/createMutation.ts
@@ -7,7 +7,7 @@ import {
   parseMutationArgs,
 } from '@tanstack/query-core'
 import type {
-  UseMutateFunction,
+  CreateMutateFunction,
   CreateMutationOptions,
   CreateMutationResult,
 } from './types'
@@ -16,7 +16,7 @@ import { useQueryClient } from './useQueryClient'
 export function createMutation<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown,
 >(
   options: CreateMutationOptions<TData, TError, TVariables, TContext>,
@@ -25,7 +25,7 @@ export function createMutation<
 export function createMutation<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown,
 >(
   mutationFn: MutationFunction<TData, TVariables>,
@@ -38,7 +38,7 @@ export function createMutation<
 export function createMutation<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown,
 >(
   mutationKey: MutationKey,
@@ -51,7 +51,7 @@ export function createMutation<
 export function createMutation<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown,
 >(
   mutationKey: MutationKey,
@@ -65,7 +65,7 @@ export function createMutation<
 export function createMutation<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown,
 >(
   arg1:
@@ -83,7 +83,7 @@ export function createMutation<
     queryClient,
     options,
   )
-  let mutate: UseMutateFunction<TData, TError, TVariables, TContext>
+  let mutate: CreateMutateFunction<TData, TError, TVariables, TContext>
 
   readable(observer).subscribe(($observer) => {
     observer = $observer

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -87,7 +87,7 @@ export interface CreateMutationOptions<
       '_defaulted' | 'variables'
     > {}
 
-export type UseMutateFunction<
+export type CreateMutateFunction<
   TData = unknown,
   TError = unknown,
   TVariables = void,
@@ -96,22 +96,22 @@ export type UseMutateFunction<
   ...args: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
 ) => void
 
-export type UseMutateAsyncFunction<
+export type CreateMutateAsyncFunction<
   TData = unknown,
   TError = unknown,
   TVariables = void,
   TContext = unknown,
 > = MutateFunction<TData, TError, TVariables, TContext>
 
-export type UseBaseMutationResult<
+export type CreateBaseMutationResult<
   TData = unknown,
   TError = unknown,
   TVariables = unknown,
   TContext = unknown,
 > = Override<
   MutationObserverResult<TData, TError, TVariables, TContext>,
-  { mutate: UseMutateFunction<TData, TError, TVariables, TContext> }
-> & { mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TContext> }
+  { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+> & { mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext> }
 
 export interface CreateMutationResult<
   TData = unknown,
@@ -119,7 +119,7 @@ export interface CreateMutationResult<
   TVariables = unknown,
   TContext = unknown,
 > extends Readable<
-    UseBaseMutationResult<TData, TError, TVariables, TContext>
+    CreateBaseMutationResult<TData, TError, TVariables, TContext>
   > {}
 
 type Override<A, B> = { [K in keyof A]: K extends keyof B ? B[K] : A[K] }

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -111,7 +111,9 @@ export type CreateBaseMutationResult<
 > = Override<
   MutationObserverResult<TData, TError, TVariables, TContext>,
   { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
-> & { mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext> }
+> & {
+  mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
+}
 
 export interface CreateMutationResult<
   TData = unknown,


### PR DESCRIPTION
I was adding svelte-query into my own project and I was being told I needed 1-2 arguments for a mutation... since near-identical code was working in react-query I had a feeling this was a bug!