### PR TITLE
docs(svelte-query): Correctly type layout data when using prefetchQuery

### DIFF
--- a/docs/svelte/ssr.md
+++ b/docs/svelte/ssr.md
@@ -107,9 +107,9 @@ export const load: LayoutLoad = async () => {
 ```markdown
 <script lang="ts">
   import { QueryClientProvider } from '@tanstack/svelte-query'
-  import type { PageData } from './$types'
+  import type { LayoutData } from './$types'
 
-  export let data: PageData
+  export let data: LayoutData
 </script>
 
 <QueryClientProvider client={data.queryClient}>


### PR DESCRIPTION
A minor issue but the types for some `+layout.svelte` data prop was incorrect. This PR addresses that issue.