### PR TITLE
fix(vue-query): simplify vue hooks, fix types

### DIFF
--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -846,14 +846,12 @@ describe('useInfiniteQuery', () => {
       Promise<number>,
       [QueryFunctionContext<typeof key, number>]
     >(async ({ pageParam = start, signal }) => {
-      if (signal) {
-        const onAbort = jest.fn()
-        const abortListener = jest.fn()
-        onAborts.push(onAbort)
-        abortListeners.push(abortListener)
-        signal.onabort = onAbort
-        signal.addEventListener('abort', abortListener)
-      }
+      const onAbort = jest.fn()
+      const abortListener = jest.fn()
+      onAborts.push(onAbort)
+      abortListeners.push(abortListener)
+      signal.onabort = onAbort
+      signal.addEventListener('abort', abortListener)
       await sleep(50)
       return Number(pageParam)
     })
@@ -891,7 +889,7 @@ describe('useInfiniteQuery', () => {
     expect(firstCtx.pageParam).toBeUndefined()
     expect(firstCtx.queryKey).toEqual(key)
     expect(firstCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(firstCtx.signal?.aborted).toBe(false)
+    expect(firstCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
 
@@ -900,7 +898,7 @@ describe('useInfiniteQuery', () => {
     expect(secondCtx.pageParam).toBe(11)
     expect(secondCtx.queryKey).toEqual(key)
     expect(secondCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(secondCtx.signal?.aborted).toBe(true)
+    expect(secondCtx.signal.aborted).toBe(true)
     expect(onAborts[callIndex]).toHaveBeenCalledTimes(1)
     expect(abortListeners[callIndex]).toHaveBeenCalledTimes(1)
 
@@ -909,7 +907,7 @@ describe('useInfiniteQuery', () => {
     expect(thirdCtx.pageParam).toBe(11)
     expect(thirdCtx.queryKey).toEqual(key)
     expect(thirdCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(thirdCtx.signal?.aborted).toBe(false)
+    expect(thirdCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
   })
@@ -923,14 +921,13 @@ describe('useInfiniteQuery', () => {
       Promise<number>,
       [QueryFunctionContext<typeof key, number>]
     >(async ({ pageParam = start, signal }) => {
-      if (signal) {
-        const onAbort = jest.fn()
-        const abortListener = jest.fn()
-        onAborts.push(onAbort)
-        abortListeners.push(abortListener)
-        signal.onabort = onAbort
-        signal.addEventListener('abort', abortListener)
-      }
+      const onAbort = jest.fn()
+      const abortListener = jest.fn()
+      onAborts.push(onAbort)
+      abortListeners.push(abortListener)
+      signal.onabort = onAbort
+      signal.addEventListener('abort', abortListener)
+
       await sleep(50)
       return Number(pageParam)
     })
@@ -968,7 +965,7 @@ describe('useInfiniteQuery', () => {
     expect(firstCtx.pageParam).toBeUndefined()
     expect(firstCtx.queryKey).toEqual(key)
     expect(firstCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(firstCtx.signal?.aborted).toBe(false)
+    expect(firstCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
 
@@ -977,7 +974,7 @@ describe('useInfiniteQuery', () => {
     expect(secondCtx.pageParam).toBe(11)
     expect(secondCtx.queryKey).toEqual(key)
     expect(secondCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(secondCtx.signal?.aborted).toBe(false)
+    expect(secondCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
   })

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -5720,11 +5720,10 @@ describe('useQuery', () => {
       function Component() {
         const state = useQuery({
           queryKey: key,
-          queryFn: async ({ signal }) => {
+          queryFn: async ({ signal: _signal }) => {
             count++
             await sleep(10)
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            return `${signal ? 'signal' : 'data'}${count}`
+            return `signal${count}`
           },
         })
 

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -4664,6 +4664,7 @@ describe('useQuery', () => {
       ctx,
     ) => {
       const [, limit] = ctx.queryKey
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const value = limit % 2 && ctx.signal ? 'abort' : `data ${limit}`
       await sleep(25)
       return value
@@ -5722,6 +5723,7 @@ describe('useQuery', () => {
           queryFn: async ({ signal }) => {
             count++
             await sleep(10)
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             return `${signal ? 'signal' : 'data'}${count}`
           },
         })

--- a/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
@@ -910,14 +910,13 @@ describe('useInfiniteQuery', () => {
       Promise<number>,
       [QueryFunctionContext<typeof key, number>]
     >(async ({ pageParam = start, signal }) => {
-      if (signal) {
-        const onAbort = jest.fn()
-        const abortListener = jest.fn()
-        onAborts.push(onAbort)
-        abortListeners.push(abortListener)
-        signal.onabort = onAbort
-        signal.addEventListener('abort', abortListener)
-      }
+      const onAbort = jest.fn()
+      const abortListener = jest.fn()
+      onAborts.push(onAbort)
+      abortListeners.push(abortListener)
+      signal.onabort = onAbort
+      signal.addEventListener('abort', abortListener)
+
       await sleep(50)
       return Number(pageParam)
     })
@@ -960,7 +959,7 @@ describe('useInfiniteQuery', () => {
     expect(firstCtx.pageParam).toBeUndefined()
     expect(firstCtx.queryKey).toEqual(key)
     expect(firstCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(firstCtx.signal?.aborted).toBe(false)
+    expect(firstCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
 
@@ -969,7 +968,7 @@ describe('useInfiniteQuery', () => {
     expect(secondCtx.pageParam).toBe(11)
     expect(secondCtx.queryKey).toEqual(key)
     expect(secondCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(secondCtx.signal?.aborted).toBe(true)
+    expect(secondCtx.signal.aborted).toBe(true)
     expect(onAborts[callIndex]).toHaveBeenCalledTimes(1)
     expect(abortListeners[callIndex]).toHaveBeenCalledTimes(1)
 
@@ -978,7 +977,7 @@ describe('useInfiniteQuery', () => {
     expect(thirdCtx.pageParam).toBe(11)
     expect(thirdCtx.queryKey).toEqual(key)
     expect(thirdCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(thirdCtx.signal?.aborted).toBe(false)
+    expect(thirdCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
   })
@@ -992,14 +991,13 @@ describe('useInfiniteQuery', () => {
       Promise<number>,
       [QueryFunctionContext<typeof key, number>]
     >(async ({ pageParam = start, signal }) => {
-      if (signal) {
-        const onAbort = jest.fn()
-        const abortListener = jest.fn()
-        onAborts.push(onAbort)
-        abortListeners.push(abortListener)
-        signal.onabort = onAbort
-        signal.addEventListener('abort', abortListener)
-      }
+      const onAbort = jest.fn()
+      const abortListener = jest.fn()
+      onAborts.push(onAbort)
+      abortListeners.push(abortListener)
+      signal.onabort = onAbort
+      signal.addEventListener('abort', abortListener)
+
       await sleep(50)
       return Number(pageParam)
     })
@@ -1042,7 +1040,7 @@ describe('useInfiniteQuery', () => {
     expect(firstCtx.pageParam).toBeUndefined()
     expect(firstCtx.queryKey).toEqual(key)
     expect(firstCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(firstCtx.signal?.aborted).toBe(false)
+    expect(firstCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
 
@@ -1051,7 +1049,7 @@ describe('useInfiniteQuery', () => {
     expect(secondCtx.pageParam).toBe(11)
     expect(secondCtx.queryKey).toEqual(key)
     expect(secondCtx.signal).toBeInstanceOf(AbortSignal)
-    expect(secondCtx.signal?.aborted).toBe(false)
+    expect(secondCtx.signal.aborted).toBe(false)
     expect(onAborts[callIndex]).not.toHaveBeenCalled()
     expect(abortListeners[callIndex]).not.toHaveBeenCalled()
   })

--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -803,7 +803,7 @@ describe('useQueries', () => {
       }))
       return (
         <div>
-          <h1>Status: {state[0]?.data}</h1>
+          <h1>Status: {state[0].data}</h1>
         </div>
       )
     }

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -5790,11 +5790,10 @@ describe('createQuery', () => {
       function Component() {
         const state = createQuery(() => ({
           queryKey: key,
-          queryFn: async ({ signal }) => {
+          queryFn: async ({ signal: _signal }) => {
             count++
             await sleep(10)
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            return `${signal ? 'signal' : 'data'}${count}`
+            return `signal${count}`
           },
         }))
 

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -4650,6 +4650,7 @@ describe('createQuery', () => {
       readonly [typeof key, number]
     > = async (ctx) => {
       const [, limit] = ctx.queryKey
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const value = limit % 2 && ctx.signal ? 'abort' : `data ${limit}`
       await sleep(25)
       return value
@@ -5792,6 +5793,7 @@ describe('createQuery', () => {
           queryFn: async ({ signal }) => {
             count++
             await sleep(10)
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             return `${signal ? 'signal' : 'data'}${count}`
           },
         }))

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.types.test.tsx
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.types.test.tsx
@@ -1,7 +1,8 @@
-import { InfiniteData } from '@tanstack/query-core'
+import type { InfiniteData } from '@tanstack/query-core'
 import { reactive } from 'vue'
 import { useInfiniteQuery } from '../useInfiniteQuery'
-import { doNotExecute, Equal, Expect, simpleFetcher } from './test-utils'
+import type { Equal, Expect } from './test-utils'
+import { doNotExecute, simpleFetcher } from './test-utils'
 
 describe('Discriminated union return type', () => {
   it('data should be possibly undefined by default', () => {

--- a/packages/vue-query/src/__tests__/useIsFetching.test.ts
+++ b/packages/vue-query/src/__tests__/useIsFetching.test.ts
@@ -1,8 +1,8 @@
-import { onScopeDispose, reactive, ref } from 'vue-demi'
+import { onScopeDispose, reactive } from 'vue-demi'
 
 import { flushPromises, simpleFetcher } from './test-utils'
 import { useQuery } from '../useQuery'
-import { unrefFilterArgs, useIsFetching } from '../useIsFetching'
+import { useIsFetching } from '../useIsFetching'
 
 jest.mock('../useQueryClient')
 
@@ -73,26 +73,5 @@ describe('useIsFetching', () => {
     expect(isFetching.value).toStrictEqual(1)
 
     await flushPromises(100)
-  })
-
-  describe('parseFilterArgs', () => {
-    test('should merge query key with filters', () => {
-      const filters = { queryKey: ['key'], stale: true }
-
-      const result = unrefFilterArgs(filters)
-      const expected = { ...filters, queryKey: ['key'] }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs arguments', () => {
-      const key = ref(['key'])
-      const filters = ref({ queryKey: key, stale: ref(true) })
-
-      const result = unrefFilterArgs(filters)
-      const expected = { queryKey: ['key'], stale: true }
-
-      expect(result).toEqual(expected)
-    })
   })
 })

--- a/packages/vue-query/src/__tests__/useIsMutating.test.ts
+++ b/packages/vue-query/src/__tests__/useIsMutating.test.ts
@@ -1,8 +1,8 @@
-import { onScopeDispose, reactive, ref } from 'vue-demi'
+import { onScopeDispose, reactive } from 'vue-demi'
 
 import { flushPromises, successMutator } from './test-utils'
 import { useMutation } from '../useMutation'
-import { unrefFilterArgs, useIsMutating } from '../useIsMutating'
+import { useIsMutating } from '../useIsMutating'
 
 jest.mock('../useQueryClient')
 
@@ -77,26 +77,5 @@ describe('useIsMutating', () => {
     await flushPromises()
 
     expect(isMutating.value).toStrictEqual(1)
-  })
-
-  describe('parseMutationFilterArgs', () => {
-    test('should merge mutation key with filters', () => {
-      const filters = { mutationKey: ['key'], fetching: true }
-
-      const result = unrefFilterArgs(filters)
-      const expected = { ...filters, mutationKey: ['key'] }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs arguments', () => {
-      const key = ref(['key'])
-      const filters = ref({ mutationKey: key, fetching: ref(true) })
-
-      const result = unrefFilterArgs(filters)
-      const expected = { mutationKey: ['key'], fetching: true }
-
-      expect(result).toEqual(expected)
-    })
   })
 })

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -1,6 +1,6 @@
 import { reactive, ref } from 'vue-demi'
 import { errorMutator, flushPromises, successMutator } from './test-utils'
-import { unrefMutationArgs, useMutation } from '../useMutation'
+import { useMutation } from '../useMutation'
 import { useQueryClient } from '../useQueryClient'
 
 jest.mock('../useQueryClient')
@@ -329,62 +329,6 @@ describe('useMutation', () => {
         data: { value: undefined },
         error: { value: Error('Some error') },
       })
-    })
-  })
-
-  describe('parseMutationArgs', () => {
-    test('should return the same instance of options', () => {
-      const options = { retry: false }
-      const result = unrefMutationArgs(options)
-
-      expect(result).toEqual(options)
-    })
-
-    test('should merge query key with options', () => {
-      const options = { mutationKey: ['key'], retry: false }
-      const result = unrefMutationArgs(options)
-      const expected = { ...options, mutationKey: ['key'] }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should merge query fn with options', () => {
-      const options = { mutationFn: successMutator, retry: false }
-      const result = unrefMutationArgs(options)
-      const expected = { ...options, mutationFn: successMutator }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should merge query key and fn with options', () => {
-      const options = {
-        mutationKey: ['key'],
-        mutationFn: successMutator,
-        retry: false,
-      }
-      const result = unrefMutationArgs(options)
-      const expected = {
-        ...options,
-        mutationKey: ['key'],
-        mutationFn: successMutator,
-      }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs arguments', () => {
-      const key = ref(['key'])
-      const mutationFn = ref(successMutator)
-      const options = ref({ mutationKey: key, mutationFn, retry: ref(12) })
-
-      const result = unrefMutationArgs(options)
-      const expected = {
-        mutationKey: ['key'],
-        mutationFn: successMutator,
-        retry: 12,
-      }
-
-      expect(result).toEqual(expected)
     })
   })
 })

--- a/packages/vue-query/src/__tests__/useMutation.types.test.tsx
+++ b/packages/vue-query/src/__tests__/useMutation.types.test.tsx
@@ -1,6 +1,7 @@
 import { reactive } from 'vue'
 import { useMutation } from '../useMutation'
-import { doNotExecute, Equal, Expect, successMutator } from './test-utils'
+import { doNotExecute, successMutator } from './test-utils'
+import type { Equal, Expect } from './test-utils'
 
 describe('Discriminated union return type', () => {
   it('data should be possibly undefined by default', () => {

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -14,7 +14,7 @@ import {
   getSimpleFetcherWithReturnData,
 } from './test-utils'
 import { useQuery } from '../useQuery'
-import { unrefQueryArgs, useBaseQuery } from '../useBaseQuery'
+import { useBaseQuery } from '../useBaseQuery'
 
 jest.mock('../useQueryClient')
 jest.mock('../useBaseQuery')
@@ -252,23 +252,6 @@ describe('useQuery', () => {
     await flushPromises()
 
     expect(status.value).toStrictEqual('loading')
-  })
-
-  describe('parseQueryArgs', () => {
-    test('should unwrap refs in options', () => {
-      const key = ref(['key'])
-      const fn = ref(simpleFetcher)
-      const options = ref({ queryKey: key, queryFn: fn, enabled: ref(true) })
-
-      const result = unrefQueryArgs(options)
-      const expected = {
-        queryKey: ['key'],
-        queryFn: simpleFetcher,
-        enabled: true,
-      }
-
-      expect(result).toEqual(expected)
-    })
   })
 
   describe('suspense', () => {

--- a/packages/vue-query/src/__tests__/useQuery.types.test.tsx
+++ b/packages/vue-query/src/__tests__/useQuery.types.test.tsx
@@ -1,6 +1,7 @@
 import { reactive } from 'vue'
 import { useQuery } from '../useQuery'
-import { doNotExecute, Equal, Expect, simpleFetcher } from './test-utils'
+import { doNotExecute, simpleFetcher } from './test-utils'
+import type { Equal, Expect } from './test-utils'
 
 describe('Discriminated union return type', () => {
   it('data should be possibly undefined by default', () => {

--- a/packages/vue-query/src/mutationCache.ts
+++ b/packages/vue-query/src/mutationCache.ts
@@ -7,10 +7,10 @@ export class MutationCache extends MC {
   find<TData = unknown, TError = Error, TVariables = any, TContext = unknown>(
     filters: MaybeRefDeep<MutationFilters>,
   ): Mutation<TData, TError, TVariables, TContext> | undefined {
-    return super.find(cloneDeepUnref(filters) as MutationFilters)
+    return super.find(cloneDeepUnref(filters))
   }
 
   findAll(filters: MaybeRefDeep<MutationFilters>): Mutation[] {
-    return super.findAll(cloneDeepUnref(filters) as MutationFilters)
+    return super.findAll(cloneDeepUnref(filters))
   }
 }

--- a/packages/vue-query/src/queryCache.ts
+++ b/packages/vue-query/src/queryCache.ts
@@ -7,15 +7,10 @@ export class QueryCache extends QC {
   find<TQueryFnData = unknown, TError = Error, TData = TQueryFnData>(
     filters: MaybeRefDeep<WithRequired<QueryFilters, 'queryKey'>>,
   ): Query<TQueryFnData, TError, TData> | undefined {
-    const filtersUnreffed = cloneDeepUnref(filters) as WithRequired<
-      QueryFilters,
-      'queryKey'
-    >
-    return super.find(filtersUnreffed)
+    return super.find(cloneDeepUnref(filters))
   }
 
-  findAll(filters?: MaybeRefDeep<QueryFilters>): Query[] {
-    const filtersUnreffed = cloneDeepUnref(filters) as QueryFilters
-    return super.findAll(filtersUnreffed)
+  findAll(filters: MaybeRefDeep<QueryFilters> = {}): Query[] {
+    return super.findAll(cloneDeepUnref(filters))
   }
 }

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -30,10 +30,10 @@ import { MutationCache } from './mutationCache'
 
 export class QueryClient extends QC {
   constructor(config: MaybeRefDeep<QueryClientConfig> = {}) {
-    const unreffedConfig = cloneDeepUnref(config) as QueryClientConfig
+    const unreffedConfig = cloneDeepUnref(config)
     const vueQueryConfig: QueryClientConfig = {
-      logger: cloneDeepUnref(unreffedConfig.logger),
-      defaultOptions: cloneDeepUnref(unreffedConfig.defaultOptions),
+      logger: unreffedConfig.logger,
+      defaultOptions: unreffedConfig.defaultOptions,
       queryCache: unreffedConfig.queryCache || new QueryCache(),
       mutationCache: unreffedConfig.mutationCache || new MutationCache(),
     }
@@ -42,103 +42,92 @@ export class QueryClient extends QC {
 
   isRestoring = ref(false)
 
-  isFetching(filters?: MaybeRefDeep<QueryFilters>): number {
-    const filtersUnreffed = cloneDeepUnref(filters) as QueryFilters
-    return super.isFetching(filtersUnreffed)
+  isFetching(filters: MaybeRefDeep<QueryFilters> = {}): number {
+    return super.isFetching(cloneDeepUnref(filters))
   }
 
-  isMutating(filters?: MaybeRefDeep<MutationFilters>): number {
-    return super.isMutating(cloneDeepUnref(filters) as MutationFilters)
+  isMutating(filters: MaybeRefDeep<MutationFilters> = {}): number {
+    return super.isMutating(cloneDeepUnref(filters))
   }
 
   getQueryData<TData = unknown>(
     queryKey: MaybeRefDeep<QueryKey>,
   ): TData | undefined {
-    return super.getQueryData(cloneDeepUnref(queryKey) as QueryKey)
+    return super.getQueryData(cloneDeepUnref(queryKey))
   }
 
   getQueriesData<TData = unknown>(
     filters: MaybeRefDeep<QueryFilters>,
   ): [QueryKey, TData | undefined][] {
-    const unreffed = cloneDeepUnref(filters) as QueryFilters
-    return super.getQueriesData(unreffed)
+    return super.getQueriesData(cloneDeepUnref(filters))
   }
 
   setQueryData<TData>(
     queryKey: MaybeRefDeep<QueryKey>,
     updater: Updater<TData | undefined, TData | undefined>,
-    options?: MaybeRefDeep<SetDataOptions>,
+    options: MaybeRefDeep<SetDataOptions> = {},
   ): TData | undefined {
     return super.setQueryData(
-      cloneDeepUnref(queryKey) as QueryKey,
+      cloneDeepUnref(queryKey),
       updater,
-      cloneDeepUnref(options) as SetDataOptions,
+      cloneDeepUnref(options),
     )
   }
 
   setQueriesData<TData>(
     filters: MaybeRefDeep<QueryFilters>,
     updater: Updater<TData | undefined, TData | undefined>,
-    options?: MaybeRefDeep<SetDataOptions>,
+    options: MaybeRefDeep<SetDataOptions> = {},
   ): [QueryKey, TData | undefined][] {
-    const filtersUnreffed = cloneDeepUnref(filters) as QueryFilters
-    const optionsUnreffed = cloneDeepUnref(options) as SetDataOptions
-
-    return super.setQueriesData(filtersUnreffed, updater, optionsUnreffed)
+    return super.setQueriesData(
+      cloneDeepUnref(filters),
+      updater,
+      cloneDeepUnref(options),
+    )
   }
 
   getQueryState<TData = unknown, TError = Error>(
     queryKey: MaybeRefDeep<QueryKey>,
   ): QueryState<TData, TError> | undefined {
-    return super.getQueryState(cloneDeepUnref(queryKey) as QueryKey)
+    return super.getQueryState(cloneDeepUnref(queryKey))
   }
 
-  removeQueries(filters?: MaybeRefDeep<QueryFilters>): void {
-    const filtersUnreffed = cloneDeepUnref(filters) as QueryFilters
-    return super.removeQueries(filtersUnreffed)
+  removeQueries(filters: MaybeRefDeep<QueryFilters> = {}): void {
+    return super.removeQueries(cloneDeepUnref(filters))
   }
 
   resetQueries<TPageData = unknown>(
-    filters?: MaybeRefDeep<ResetQueryFilters<TPageData>>,
-    options?: MaybeRefDeep<ResetOptions>,
+    filters: MaybeRefDeep<ResetQueryFilters<TPageData>> = {},
+    options: MaybeRefDeep<ResetOptions> = {},
   ): Promise<void> {
-    const filtersUnreffed = cloneDeepUnref(filters) as ResetQueryFilters
-    const optionsUnreffed = cloneDeepUnref(options) as ResetOptions
-
-    return super.resetQueries(filtersUnreffed, optionsUnreffed)
+    return super.resetQueries(cloneDeepUnref(filters), cloneDeepUnref(options))
   }
 
   cancelQueries(
-    filters?: MaybeRefDeep<QueryFilters>,
-    options?: MaybeRefDeep<CancelOptions>,
+    filters: MaybeRefDeep<QueryFilters> = {},
+    options: MaybeRefDeep<CancelOptions> = {},
   ): Promise<void> {
-    const filtersUnreffed = cloneDeepUnref(filters) as QueryFilters
-    const optionsUnreffed = cloneDeepUnref(options) as CancelOptions
-    return super.cancelQueries(filtersUnreffed, optionsUnreffed)
+    return super.cancelQueries(cloneDeepUnref(filters), cloneDeepUnref(options))
   }
 
   invalidateQueries<TPageData = unknown>(
-    filters?: MaybeRefDeep<InvalidateQueryFilters<TPageData>>,
-    options?: MaybeRefDeep<InvalidateOptions>,
+    filters: MaybeRefDeep<InvalidateQueryFilters<TPageData>> = {},
+    options: MaybeRefDeep<InvalidateOptions> = {},
   ): Promise<void> {
-    const filtersUnreffed = cloneDeepUnref(
-      filters,
-    ) as InvalidateQueryFilters<TPageData>
-    const optionsUnreffed = cloneDeepUnref(options) as InvalidateOptions
-
-    return super.invalidateQueries(filtersUnreffed, optionsUnreffed)
+    return super.invalidateQueries(
+      cloneDeepUnref(filters),
+      cloneDeepUnref(options),
+    )
   }
 
   refetchQueries<TPageData = unknown>(
-    filters?: MaybeRefDeep<RefetchQueryFilters<TPageData>>,
-    options?: MaybeRefDeep<RefetchOptions>,
+    filters: MaybeRefDeep<RefetchQueryFilters<TPageData>> = {},
+    options: MaybeRefDeep<RefetchOptions> = {},
   ): Promise<void> {
-    const filtersUnreffed = cloneDeepUnref(
-      filters,
-    ) as RefetchQueryFilters<TPageData>
-    const optionsUnreffed = cloneDeepUnref(options) as RefetchOptions
-
-    return super.refetchQueries(filtersUnreffed, optionsUnreffed)
+    return super.refetchQueries(
+      cloneDeepUnref(filters),
+      cloneDeepUnref(options),
+    )
   }
 
   fetchQuery<
@@ -151,7 +140,7 @@ export class QueryClient extends QC {
   ): Promise<TData>
   fetchQuery<
     TQueryFnData,
-    TError,
+    TError = Error,
     TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
   >(
@@ -159,14 +148,7 @@ export class QueryClient extends QC {
       FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>
     >,
   ): Promise<TData> {
-    const optionsUnreffed = cloneDeepUnref(options) as FetchQueryOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryKey
-    >
-
-    return super.fetchQuery(optionsUnreffed)
+    return super.fetchQuery(cloneDeepUnref(options))
   }
 
   prefetchQuery<
@@ -187,13 +169,7 @@ export class QueryClient extends QC {
       FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>
     >,
   ): Promise<void> {
-    const optionsUnreffed = cloneDeepUnref(options) as FetchQueryOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryKey
-    >
-    return super.prefetchQuery(optionsUnreffed)
+    return super.prefetchQuery(cloneDeepUnref(options))
   }
 
   fetchInfiniteQuery<
@@ -214,11 +190,7 @@ export class QueryClient extends QC {
       FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
     >,
   ): Promise<InfiniteData<TData>> {
-    const optionsUnreffed = cloneDeepUnref(
-      options,
-    ) as FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-
-    return super.fetchInfiniteQuery(optionsUnreffed)
+    return super.fetchInfiniteQuery(cloneDeepUnref(options))
   }
 
   prefetchInfiniteQuery<
@@ -239,14 +211,11 @@ export class QueryClient extends QC {
       FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
     >,
   ): Promise<void> {
-    const optionsUnreffed = cloneDeepUnref(
-      options,
-    ) as FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-    return super.prefetchInfiniteQuery(optionsUnreffed)
+    return super.prefetchInfiniteQuery(cloneDeepUnref(options))
   }
 
   setDefaultOptions(options: MaybeRefDeep<DefaultOptions>): void {
-    super.setDefaultOptions(cloneDeepUnref(options) as DefaultOptions)
+    super.setDefaultOptions(cloneDeepUnref(options))
   }
 
   setQueryDefaults(
@@ -255,12 +224,7 @@ export class QueryClient extends QC {
       Omit<QueryObserverOptions<unknown, any, any, any>, 'queryKey'>
     >,
   ): void {
-    const queryKeyUnreffed = cloneDeepUnref(queryKey) as QueryKey
-    const optionsUnreffed = cloneDeepUnref(options) as Omit<
-      QueryObserverOptions<unknown, any, any, any>,
-      'queryKey'
-    >
-    super.setQueryDefaults(queryKeyUnreffed, optionsUnreffed)
+    super.setQueryDefaults(cloneDeepUnref(queryKey), cloneDeepUnref(options))
   }
 
   getQueryDefaults(
@@ -275,7 +239,7 @@ export class QueryClient extends QC {
   ): void {
     super.setMutationDefaults(
       cloneDeepUnref(mutationKey),
-      cloneDeepUnref(options) as any,
+      cloneDeepUnref(options),
     )
   }
 

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -1,11 +1,6 @@
 /* istanbul ignore file */
 
-import type {
-  QueryKey,
-  QueryObserverOptions,
-  InfiniteQueryObserverOptions,
-} from '@tanstack/query-core'
-import type { Ref, UnwrapRef } from 'vue-demi'
+import type { Ref } from 'vue-demi'
 
 export type MaybeRef<T> = Ref<T> | T
 
@@ -18,74 +13,6 @@ export type MaybeRefDeep<T> = MaybeRef<
       }
     : T
 >
-
-// A Vue version of QueriesObserverOptions from "@tanstack/query-core"
-// Accept refs as options
-export type VueQueryObserverOptions<
-  TQueryFnData = unknown,
-  TError = Error,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = {
-  [Property in keyof QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  >]: Property extends 'queryFn'
-    ? QueryObserverOptions<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData,
-        UnwrapRef<TQueryKey>
-      >[Property]
-    : MaybeRef<
-        QueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          TQueryKey
-        >[Property]
-      >
-}
-
-// A Vue version of InfiniteQueryObserverOptions from "@tanstack/query-core"
-// Accept refs as options
-export type VueInfiniteQueryObserverOptions<
-  TQueryFnData = unknown,
-  TError = Error,
-  TData = unknown,
-  TQueryData = unknown,
-  TQueryKey extends QueryKey = QueryKey,
-> = {
-  [Property in keyof InfiniteQueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  >]: Property extends 'queryFn'
-    ? InfiniteQueryObserverOptions<
-        TQueryFnData,
-        TError,
-        TData,
-        TQueryData,
-        UnwrapRef<TQueryKey>
-      >[Property]
-    : MaybeRef<
-        InfiniteQueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          TQueryKey
-        >[Property]
-      >
-}
 
 export type DistributiveOmit<T, K extends keyof any> = T extends any
   ? Omit<T, K>

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -6,23 +6,21 @@ import {
   watch,
   ref,
   computed,
-  unref,
 } from 'vue-demi'
 import type { ToRefs } from 'vue-demi'
 import type {
   QueryObserver,
   QueryKey,
-  QueryObserverOptions,
   QueryObserverResult,
+  DefaultedQueryObserverOptions,
 } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient'
 import { updateState, cloneDeepUnref } from './utils'
-import type { MaybeRef } from './types'
+import type { QueryClient } from './queryClient'
 import type { UseQueryOptions } from './useQuery'
 import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
-import type { QueryClient } from './queryClient'
 
-export type UseQueryReturnType<
+export type UseBaseQueryReturnType<
   TData,
   TError,
   Result = QueryObserverResult<TData, TError>,
@@ -46,20 +44,22 @@ export function useBaseQuery<
   TQueryKey extends QueryKey,
 >(
   Observer: typeof QueryObserver,
-  genericOptions: UseQueryOptionsGeneric<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryKey
-  >,
+  options: UseQueryOptionsGeneric<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError> {
-  const options = computed(() => unrefQueryArgs(genericOptions))
-
+): UseBaseQueryReturnType<TData, TError> {
   const client = queryClient || useQueryClient()
 
   const defaultedOptions = computed(() => {
-    const defaulted = client.defaultQueryOptions(options.value)
+    const defaulted = client.defaultQueryOptions(
+      cloneDeepUnref(options as any),
+    ) as DefaultedQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey
+    >
+
     defaulted._optimisticResults = client.isRestoring.value
       ? 'isRestoring'
       : 'optimistic'
@@ -133,25 +133,4 @@ export function useBaseQuery<
     >),
     suspense,
   }
-}
-
-export function unrefQueryArgs<
-  TQueryFnData = unknown,
-  TError = Error,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  arg1: MaybeRef<
-    UseQueryOptionsGeneric<TQueryFnData, TError, TData, TQueryKey>
-  >,
-): QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> {
-  const options = unref(arg1)
-  return cloneDeepUnref(options) as QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  >
 }

--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -4,31 +4,52 @@ import type {
   WithRequired,
   QueryKey,
   InfiniteQueryObserverResult,
+  InfiniteQueryObserverOptions,
 } from '@tanstack/query-core'
 
 import { useBaseQuery } from './useBaseQuery'
-import type { UseQueryReturnType } from './useBaseQuery'
+import type { UseBaseQueryReturnType } from './useBaseQuery'
 
-import type { VueInfiniteQueryObserverOptions, DistributiveOmit } from './types'
+import type { DistributiveOmit, MaybeRefDeep } from './types'
 import type { QueryClient } from './queryClient'
+import type { UnwrapRef } from 'vue-demi'
 
 export type UseInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = Error,
-  TData = TQueryFnData,
+  TData = unknown,
+  TQueryData = unknown,
   TQueryKey extends QueryKey = QueryKey,
-> = WithRequired<
-  VueInfiniteQueryObserverOptions<
+> = {
+  [Property in keyof InfiniteQueryObserverOptions<
     TQueryFnData,
     TError,
     TData,
-    TQueryFnData,
+    TQueryData,
     TQueryKey
-  >,
-  'queryKey'
->
+  >]: Property extends 'queryFn'
+    ? InfiniteQueryObserverOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryData,
+        UnwrapRef<TQueryKey>
+      >[Property]
+    : MaybeRefDeep<
+        WithRequired<
+          InfiniteQueryObserverOptions<
+            TQueryFnData,
+            TError,
+            TData,
+            TQueryData,
+            TQueryKey
+          >,
+          'queryKey'
+        >[Property]
+      >
+}
 
-type InfiniteQueryReturnType<TData, TError> = UseQueryReturnType<
+type InfiniteQueryReturnType<TData, TError> = UseBaseQueryReturnType<
   TData,
   TError,
   InfiniteQueryObserverResult<TData, TError>

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -1,4 +1,4 @@
-import { computed, unref, onScopeDispose, ref, watch } from 'vue-demi'
+import { computed, onScopeDispose, ref, watch } from 'vue-demi'
 import type { Ref } from 'vue-demi'
 import type { QueryFilters as QF } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient'
@@ -9,10 +9,10 @@ import type { QueryClient } from './queryClient'
 export type QueryFilters = MaybeRefDeep<QF>
 
 export function useIsFetching(
-  fetchingFilters: QueryFilters = {},
+  fetchingFilters: MaybeRefDeep<QF> = {},
   queryClient?: QueryClient,
 ): Ref<number> {
-  const filters = computed(() => unrefFilterArgs(fetchingFilters))
+  const filters = computed(() => cloneDeepUnref(fetchingFilters))
   const client = queryClient || useQueryClient()
 
   const isFetching = ref(client.isFetching(filters))
@@ -34,9 +34,4 @@ export function useIsFetching(
   })
 
   return isFetching
-}
-
-export function unrefFilterArgs(arg: QueryFilters) {
-  const options = unref(arg)
-  return cloneDeepUnref(options) as QF
 }

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -1,4 +1,4 @@
-import { computed, unref, onScopeDispose, ref, watch } from 'vue-demi'
+import { computed, onScopeDispose, ref, watch } from 'vue-demi'
 import type { Ref } from 'vue-demi'
 import type { MutationFilters as MF } from '@tanstack/query-core'
 
@@ -10,10 +10,10 @@ import type { QueryClient } from './queryClient'
 export type MutationFilters = MaybeRefDeep<MF>
 
 export function useIsMutating(
-  mutationFilters: MutationFilters = {},
+  mutationFilters: MaybeRefDeep<MF> = {},
   queryClient?: QueryClient,
 ): Ref<number> {
-  const filters = computed(() => unrefFilterArgs(mutationFilters))
+  const filters = computed(() => cloneDeepUnref(mutationFilters))
   const client = queryClient || useQueryClient()
 
   const isMutating = ref(client.isMutating(filters))
@@ -35,9 +35,4 @@ export function useIsMutating(
   })
 
   return isMutating
-}
-
-export function unrefFilterArgs(arg: MutationFilters) {
-  const options = unref(arg)
-  return cloneDeepUnref(options) as MF
 }

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -1,18 +1,54 @@
-import type { ToRefs } from 'vue-demi'
+import type { ToRefs, UnwrapRef } from 'vue-demi'
 import { QueryObserver } from '@tanstack/query-core'
 import type {
   QueryKey,
   QueryObserverResult,
   DefinedQueryObserverResult,
   WithRequired,
+  QueryObserverOptions,
 } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type { UseQueryReturnType as UQRT } from './useBaseQuery'
-import type { VueQueryObserverOptions, DistributiveOmit } from './types'
+import type { UseBaseQueryReturnType } from './useBaseQuery'
+import type { DistributiveOmit, MaybeRefDeep } from './types'
 import type { QueryClient } from './queryClient'
 
+export type UseQueryOptions<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = {
+  [Property in keyof QueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryData,
+    TQueryKey
+  >]: Property extends 'queryFn'
+    ? QueryObserverOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryData,
+        UnwrapRef<TQueryKey>
+      >[Property]
+    : MaybeRefDeep<
+        WithRequired<
+          QueryObserverOptions<
+            TQueryFnData,
+            TError,
+            TData,
+            TQueryData,
+            TQueryKey
+          >,
+          'queryKey'
+        >[Property]
+      >
+}
+
 export type UseQueryReturnType<TData, TError> = DistributiveOmit<
-  UQRT<TData, TError>,
+  UseBaseQueryReturnType<TData, TError>,
   'refetch'
 > & {
   refetch: QueryObserverResult<TData, TError>['refetch']
@@ -26,41 +62,21 @@ export type UseQueryDefinedReturnType<TData, TError> = DistributiveOmit<
   refetch: QueryObserverResult<TData, TError>['refetch']
 }
 
-export type UseQueryOptions<
-  TQueryFnData = unknown,
-  TError = Error,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = WithRequired<
-  VueQueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
-  'queryKey'
->
-
-type UndefinedInitialDataOptions<
-  TQueryFnData = unknown,
-  TError = Error,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  initialData?: undefined
-}
-
-type DefinedInitialDataOptions<
-  TQueryFnData = unknown,
-  TError = Error,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  initialData: TQueryFnData | (() => TQueryFnData)
-}
-
 export function useQuery<
   TQueryFnData = unknown,
   TError = Error,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UseQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey
+  > & {
+    initialData?: undefined
+  },
   queryClient?: QueryClient,
 ): UseQueryReturnType<TData, TError>
 
@@ -70,7 +86,15 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UseQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey
+  > & {
+    initialData: TQueryFnData | (() => TQueryFnData)
+  },
   queryClient?: QueryClient,
 ): UseQueryDefinedReturnType<TData, TError>
 

--- a/packages/vue-query/src/utils.ts
+++ b/packages/vue-query/src/utils.ts
@@ -33,7 +33,7 @@ export function cloneDeep<T>(
   }
 
   if (Array.isArray(value)) {
-    return value.map((val) => cloneDeep(val, customizer)) as T
+    return value.map((val) => cloneDeep(val, customizer)) as unknown as T
   }
 
   if (typeof value === 'object' && isPlainObject(value)) {
@@ -53,7 +53,7 @@ export function cloneDeepUnref<T>(obj: MaybeRefDeep<T>): T {
       return cloneDeepUnref(unref(val))
     }
 
-    return undefined;
+    return undefined
   })
 }
 

--- a/packages/vue-query/src/utils.ts
+++ b/packages/vue-query/src/utils.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { isRef, unref } from 'vue-demi'
-import type { UnwrapRef } from 'vue-demi'
+import type { MaybeRefDeep } from './types'
 
 export const VUE_QUERY_CLIENT = 'VUE_QUERY_CLIENT'
 
@@ -19,18 +18,22 @@ export function updateState(
 }
 
 export function cloneDeep<T>(
-  value: T,
-  customizer?: (val: unknown) => unknown | void,
+  value: MaybeRefDeep<T>,
+  customizer?: (val: MaybeRefDeep<T>) => T | undefined,
 ): T {
   if (customizer) {
     const result = customizer(value)
-    if (result !== undefined || isRef(value)) {
-      return result as typeof value
+    // If it's a ref of undefined, return undefined
+    if (result === undefined && isRef(value)) {
+      return result as T
+    }
+    if (result !== undefined) {
+      return result
     }
   }
 
   if (Array.isArray(value)) {
-    return value.map((val) => cloneDeep(val, customizer)) as typeof value
+    return value.map((val) => cloneDeep(val, customizer)) as T
   }
 
   if (typeof value === 'object' && isPlainObject(value)) {
@@ -41,15 +44,17 @@ export function cloneDeep<T>(
     return Object.fromEntries(entries)
   }
 
-  return value
+  return value as T
 }
 
-export function cloneDeepUnref<T>(obj: T): UnwrapRef<T> {
+export function cloneDeepUnref<T>(obj: MaybeRefDeep<T>): T {
   return cloneDeep(obj, (val) => {
     if (isRef(val)) {
       return cloneDeepUnref(unref(val))
     }
-  }) as UnwrapRef<typeof obj>
+
+    return undefined;
+  })
 }
 
 function isPlainObject(value: unknown): value is Object {


### PR DESCRIPTION
@TkDodo I beleive this PR was auto-closed, since it was targeting another PR , not v5 directly...
I beleive github previously just switched the branch in such PR, but in this case it got closed.

https://github.com/TanStack/query/pull/4838