### PR TITLE
docs(svelte-query): Fix variable reference issue on sveltekit doc

### DIFF
--- a/docs/svelte/ssr.md
+++ b/docs/svelte/ssr.md
@@ -62,7 +62,7 @@ export const load: PageLoad = async () => {
   const query = createQuery({
     queryKey: ['posts'],
     queryFn: getPosts,
-    initialData: posts
+    initialData: data.posts
   })
 </script>
 ```


### PR DESCRIPTION
Just adding my two cents here. Here's a small documentation fix around the sveltekit data load function.

`posts` wasn't defined nor extracted from `data`. So I just added `data.posts` to make it make sense.

btw I love TanStack Query! 🙌🏼 Congrats to the team!