### PR TITLE
fix(svelte-query): Fix createQueries result type

### DIFF
--- a/packages/svelte-query/src/__tests__/CreateMutation.svelte
+++ b/packages/svelte-query/src/__tests__/CreateMutation.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { createMutation, QueryClient, type CreateMutationOptions } from '../index'
+  import {
+    createMutation,
+    QueryClient,
+    type CreateMutationOptions,
+  } from '../index'
   import { setQueryClientContext } from '../context'
 
   export let options: CreateMutationOptions

--- a/packages/svelte-query/src/__tests__/CreateMutation.svelte
+++ b/packages/svelte-query/src/__tests__/CreateMutation.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
-  import { createMutation, QueryClient } from '../index'
+  import { createMutation, QueryClient, type CreateMutationOptions } from '../index'
   import { setQueryClientContext } from '../context'
 
-  export let mutationFn: () => Promise<string>
+  export let options: CreateMutationOptions
 
   const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
-  const mutation = createMutation({
-    mutationFn,
-  })
+  const mutation = createMutation(options)
 </script>
 
 <button on:click={() => $mutation.mutate()}>Click</button>

--- a/packages/svelte-query/src/__tests__/CreateQueries.svelte
+++ b/packages/svelte-query/src/__tests__/CreateQueries.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createQueries, QueryClient } from '../index'
   import { setQueryClientContext } from '../context'
-  import type { QueriesOptions } from "../createQueries"
+  import type { QueriesOptions } from '../createQueries'
 
   export let options: readonly [...QueriesOptions<any>]
 

--- a/packages/svelte-query/src/__tests__/CreateQueries.svelte
+++ b/packages/svelte-query/src/__tests__/CreateQueries.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { createQueries, QueryClient } from '../index'
+  import { setQueryClientContext } from '../context'
+  import type { QueriesOptions } from "../createQueries"
+
+  export let options: readonly [...QueriesOptions<any>]
+
+  const queryClient = new QueryClient()
+  setQueryClientContext(queryClient)
+
+  const queries = createQueries(options)
+</script>
+
+{#each $queries as query}
+  {#if query.isSuccess}
+    <p>{query.data}</p>
+  {/if}
+{/each}

--- a/packages/svelte-query/src/__tests__/CreateQuery.svelte
+++ b/packages/svelte-query/src/__tests__/CreateQuery.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
-  import { createQuery, QueryClient } from '../index'
+  import { createQuery, QueryClient, type CreateQueryOptions } from '../index'
   import { setQueryClientContext } from '../context'
 
-  export let queryKey: Array<string>
-  export let queryFn: () => Promise<string>
+  export let options: CreateQueryOptions
 
   const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
-  const query = createQuery({
-    queryKey,
-    queryFn,
-  })
+  const query = createQuery(options)
 </script>
 
 {#if $query.isLoading}

--- a/packages/svelte-query/src/__tests__/createMutation.test.ts
+++ b/packages/svelte-query/src/__tests__/createMutation.test.ts
@@ -9,13 +9,15 @@ describe('createMutation', () => {
 
     render(CreateMutation, {
       props: {
-        mutationFn,
+        options: {
+          mutationFn
+        },
       },
     })
 
     fireEvent.click(screen.getByRole('button'))
 
-    await sleep(200)
+    await sleep(20)
 
     expect(mutationFn).toHaveBeenCalledTimes(1)
   })

--- a/packages/svelte-query/src/__tests__/createMutation.test.ts
+++ b/packages/svelte-query/src/__tests__/createMutation.test.ts
@@ -10,7 +10,7 @@ describe('createMutation', () => {
     render(CreateMutation, {
       props: {
         options: {
-          mutationFn
+          mutationFn,
         },
       },
     })

--- a/packages/svelte-query/src/__tests__/createQueries.test.ts
+++ b/packages/svelte-query/src/__tests__/createQueries.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
+import CreateQueries from './CreateQueries.svelte'
+import { sleep } from './utils'
+
+describe('createQueries', () => {
+  it('Render and wait for success', async () => {
+    render(CreateQueries, {
+      props: {
+        options: [
+          {
+            queryKey: ['key-1'],
+            queryFn: async () => {
+              await sleep(10)
+              return 'Success 1'
+            },
+          },
+          {
+            queryKey: ['key-2'],
+            queryFn: async () => {
+              await sleep(10)
+              return 'Success 2'
+            },
+          }
+        ],
+      },
+    })
+
+    expect(screen.queryByText('Success 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Success 2')).not.toBeInTheDocument()
+
+    await sleep(20)
+
+    expect(screen.queryByText('Success 1')).toBeInTheDocument()
+    expect(screen.queryByText('Success 2')).toBeInTheDocument()
+  })
+})

--- a/packages/svelte-query/src/__tests__/createQueries.test.ts
+++ b/packages/svelte-query/src/__tests__/createQueries.test.ts
@@ -21,7 +21,7 @@ describe('createQueries', () => {
               await sleep(10)
               return 'Success 2'
             },
-          }
+          },
         ],
       },
     })

--- a/packages/svelte-query/src/__tests__/createQuery.test.ts
+++ b/packages/svelte-query/src/__tests__/createQuery.test.ts
@@ -7,10 +7,12 @@ describe('createQuery', () => {
   it('Render and wait for success', async () => {
     render(CreateQuery, {
       props: {
-        queryKey: ['test'],
-        queryFn: async () => {
-          await sleep(100)
-          return 'Success'
+        options: {
+          queryKey: ['test'],
+          queryFn: async () => {
+            await sleep(10)
+            return 'Success'
+          },
         },
       },
     })
@@ -19,7 +21,7 @@ describe('createQuery', () => {
     expect(screen.queryByText('Error')).not.toBeInTheDocument()
     expect(screen.queryByText('Success')).not.toBeInTheDocument()
 
-    await sleep(200)
+    await sleep(20)
 
     expect(screen.queryByText('Success')).toBeInTheDocument()
     expect(screen.queryByText('Loading')).not.toBeInTheDocument()

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -1,9 +1,9 @@
-import type { QueryKey, QueryFunction, QueryClient } from '@tanstack/query-core'
+import type { QueryKey, QueryFunction, QueryClient, QueryObserverResult } from '@tanstack/query-core'
 
 import { notifyManager, QueriesObserver } from '@tanstack/query-core'
 import { readable, type Readable } from 'svelte/store'
 
-import type { CreateQueryOptions, CreateQueryResult } from './types'
+import type { CreateQueryOptions } from './types'
 import { useQueryClient } from './useQueryClient'
 
 // This defines the `CreateQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
@@ -61,28 +61,28 @@ type GetOptions<T> =
 type GetResults<T> =
   // Part 1: responsible for mapping explicit type parameter to function result, if object
   T extends { queryFnData: any; error?: infer TError; data: infer TData }
-    ? CreateQueryResult<TData, TError>
+    ? QueryObserverResult<TData, TError>
     : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-    ? CreateQueryResult<TQueryFnData, TError>
+    ? QueryObserverResult<TQueryFnData, TError>
     : T extends { data: infer TData; error?: infer TError }
-    ? CreateQueryResult<TData, TError>
+    ? QueryObserverResult<TData, TError>
     : // Part 2: responsible for mapping explicit type parameter to function result, if tuple
     T extends [any, infer TError, infer TData]
-    ? CreateQueryResult<TData, TError>
+    ? QueryObserverResult<TData, TError>
     : T extends [infer TQueryFnData, infer TError]
-    ? CreateQueryResult<TQueryFnData, TError>
+    ? QueryObserverResult<TQueryFnData, TError>
     : T extends [infer TQueryFnData]
-    ? CreateQueryResult<TQueryFnData>
+    ? QueryObserverResult<TQueryFnData>
     : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
     T extends {
         queryFn?: QueryFunction<unknown, any>
         select: (data: any) => infer TData
       }
-    ? CreateQueryResult<TData>
+    ? QueryObserverResult<TData>
     : T extends { queryFn?: QueryFunction<infer TQueryFnData, any> }
-    ? CreateQueryResult<TQueryFnData>
+    ? QueryObserverResult<TQueryFnData>
     : // Fallback
-      CreateQueryResult
+      QueryObserverResult
 
 /**
  * QueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
@@ -121,7 +121,7 @@ export type QueriesResults<
   Result extends any[] = [],
   Depth extends ReadonlyArray<number> = [],
 > = Depth['length'] extends MAXIMUM_DEPTH
-  ? CreateQueryResult[]
+  ? QueryObserverResult[]
   : T extends []
   ? []
   : T extends [infer Head]
@@ -135,9 +135,9 @@ export type QueriesResults<
       any
     >[]
   ? // Dynamic-size (homogenous) CreateQueryOptions array: map directly to array of results
-    CreateQueryResult<unknown extends TData ? TQueryFnData : TData, TError>[]
+    QueryObserverResult<unknown extends TData ? TQueryFnData : TData, TError>[]
   : // Fallback
-    CreateQueryResult[]
+    QueryObserverResult[]
 
 export type CreateQueriesResult<T extends any[]> = Readable<QueriesResults<T>>
 

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -1,4 +1,9 @@
-import type { QueryKey, QueryFunction, QueryClient, QueryObserverResult } from '@tanstack/query-core'
+import type {
+  QueryKey,
+  QueryFunction,
+  QueryClient,
+  QueryObserverResult,
+} from '@tanstack/query-core'
 
 import { notifyManager, QueriesObserver } from '@tanstack/query-core'
 import { readable, type Readable } from 'svelte/store'


### PR DESCRIPTION
Fixes #4832. The results from createQueries were being incorrectly typed as each being svelte stores, as they were using the CreateQueryResult type. This changes each result to directly use QueryObserverResult. I've also added a very simple test.

Also @TkDodo I noticed that svelte-query alone takes an array of queries directly into createQueries (e.g. `createQueries([...])`) while the other packages all use an object with the queries key (e.g. `useQueries({ queries: [...] })`). Is this something I should change in v4, or wait until v5?