### PR TITLE
fix(core): make sure queries that never fetched can be garbage collected

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -173,6 +173,7 @@ export class Query<
     this.queryHash = config.queryHash
     this.initialState = config.state || getDefaultState(this.options)
     this.state = this.initialState
+    this.scheduleGc()
   }
 
   get meta(): QueryMeta | undefined {

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -883,4 +883,28 @@ describe('query', () => {
 
     expect(initialDataUpdatedAtSpy).toHaveBeenCalled()
   })
+
+  test('queries should be garbage collected even if they never fetched', async () => {
+    const key = queryKey()
+
+    queryClient.setQueryDefaults(key, { cacheTime: 10 })
+
+    const fn = jest.fn()
+
+    const unsubscribe = queryClient.getQueryCache().subscribe(fn)
+
+    queryClient.setQueryData(key, 'data')
+
+    await waitFor(() =>
+      expect(fn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'removed',
+        }),
+      ),
+    )
+
+    expect(queryClient.getQueryCache().findAll()).toHaveLength(0)
+
+    unsubscribe()
+  })
 })

--- a/packages/svelte-query/src/__tests__/createQuery.test.ts
+++ b/packages/svelte-query/src/__tests__/createQuery.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/svelte'
+import { render, waitFor } from '@testing-library/svelte'
 import CreateQuery from './CreateQuery.svelte'
 import { sleep } from './utils'
 
 describe('createQuery', () => {
   it('Render and wait for success', async () => {
-    render(CreateQuery, {
+    const rendered = render(CreateQuery, {
       props: {
         options: {
           queryKey: ['test'],
@@ -17,14 +17,12 @@ describe('createQuery', () => {
       },
     })
 
-    expect(screen.queryByText('Loading')).toBeInTheDocument()
-    expect(screen.queryByText('Error')).not.toBeInTheDocument()
-    expect(screen.queryByText('Success')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(rendered.getByText('Loading')).toBeInTheDocument()
+    })
 
-    await sleep(20)
-
-    expect(screen.queryByText('Success')).toBeInTheDocument()
-    expect(screen.queryByText('Loading')).not.toBeInTheDocument()
-    expect(screen.queryByText('Error')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(rendered.getByText('Success')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
This is important if data comes into the cache via a non-fetching method (like setQueryData or hydration) AND there is no active observer for them. Without this, they would never be gc'ed, but they should be after the default cacheTime

closes #4887