### PR TITLE
fix(query-persist-client-core): Move query-core to dependencies

### DIFF
--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -35,10 +35,7 @@
     "test:lib:dev": "pnpm run test:lib --watch",
     "build:types": "tsc --build"
   },
-  "devDependencies": {
-    "@tanstack/query-core": "workspace:*"
-  },
-  "peerDependencies": {
+  "dependencies": {
     "@tanstack/query-core": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,7 +897,7 @@ importers:
   packages/query-persist-client-core:
     specifiers:
       '@tanstack/query-core': workspace:*
-    devDependencies:
+    dependencies:
       '@tanstack/query-core': link:../query-core
 
   packages/query-sync-storage-persister:


### PR DESCRIPTION
Moves `query-core` to dependencies of `query-persist-client-core` so packages using `query-persist-client-core` don't have an unmet peer dependency warning

Closes #4885 