### PR TITLE
fix(useQuery.md): add missing isInitialLoading as possible return

### DIFF
--- a/docs/react/reference/useQuery.md
+++ b/docs/react/reference/useQuery.md
@@ -22,6 +22,7 @@ const {
   isPreviousData,
   isRefetchError,
   isRefetching,
+  isInitialLoading,
   isStale,
   isSuccess,
   refetch,


### PR DESCRIPTION
It seems like return value `isInitialLoading` is missing in top part of the docs (although its correctly listed in second part of the page with all the rest descriptions).

![image](https://user-images.githubusercontent.com/8258455/216284077-5a53ea7c-f868-42d7-bd20-46a9437bbd30.png)
