### PR TITLE
Change the name of second parameter of onError handler to `variables`

### DIFF
--- a/docs/react/guides/optimistic-updates.md
+++ b/docs/react/guides/optimistic-updates.md
@@ -68,7 +68,7 @@ useMutation({
     return { previousTodo, newTodo }
   },
   // If the mutation fails, use the context we returned above
-  onError: (err, newTodo, context) => {
+  onError: (err, variables, context) => {
     queryClient.setQueryData(
       ['todos', context.newTodo.id],
       context.previousTodo,


### PR DESCRIPTION
The second parameter of onError handler is named `newTodo`. 
Unfortunately, it's not `newTodo` but `variables` from `mutate`.
This naming can confuse readers.