### PR TITLE
Set `fetchStatus` to `idle` when dehydrating

### DIFF
--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -59,7 +59,7 @@ function dehydrateMutation(mutation: Mutation): DehydratedMutation {
 // in the html-payload, but not consume it on the initial render.
 function dehydrateQuery(query: Query): DehydratedQuery {
   return {
-    state: query.state,
+    state: { ...query.state, fetchStatus: 'idle' },
     queryKey: query.queryKey,
     queryHash: query.queryHash,
   }

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -1,7 +1,6 @@
 import type { QueryClient } from './queryClient'
 import type { Query, QueryState } from './query'
 import type {
-  FetchStatus,
   MutationKey,
   MutationOptions,
   QueryKey,
@@ -147,12 +146,12 @@ export function hydrate(
     // query being stuck in fetching state upon hydration
     const dehydratedQueryState = {
       ...dehydratedQuery.state,
-      fetchStatus: 'idle' as FetchStatus,
+      fetchStatus: 'idle' as const,
     }
 
     // Do not hydrate if an existing query exists with newer data
     if (query) {
-      if (query.state.dataUpdatedAt < dehydratedQuery.state.dataUpdatedAt) {
+      if (query.state.dataUpdatedAt < dehydratedQueryState.dataUpdatedAt) {
         query.setState(dehydratedQueryState)
       }
       return

--- a/packages/query-core/src/tests/hydration.test.tsx
+++ b/packages/query-core/src/tests/hydration.test.tsx
@@ -5,6 +5,7 @@ import {
   sleep,
 } from './utils'
 import { QueryCache } from '../queryCache'
+import type { DehydratedState } from '../hydration'
 import { dehydrate, hydrate } from '../hydration'
 
 async function fetchData<TData>(value: TData, ms?: number): Promise<TData> {
@@ -425,5 +426,19 @@ describe('dehydration and rehydration', () => {
     expect(() => hydrate(queryClient, {})).not.toThrow()
 
     queryClient.clear()
+  })
+
+  test('should set the fetchStatus to idle in all cases when dehydrating', async () => {
+    const queryCache = new QueryCache()
+    const queryClient = createQueryClient({ queryCache })
+    await queryClient.prefetchQuery(['string'], () => fetchData('string', 10))
+
+    queryClient.refetchQueries(['string'])
+
+    const dehydrated = dehydrate(queryClient)
+    const stringified = JSON.stringify(dehydrated)
+
+    const parsed = JSON.parse(stringified) as DehydratedState
+    expect(parsed.queries[0]?.state.fetchStatus).toBe('idle')
   })
 })

--- a/packages/query-core/src/tests/hydration.test.tsx
+++ b/packages/query-core/src/tests/hydration.test.tsx
@@ -5,7 +5,6 @@ import {
   sleep,
 } from './utils'
 import { QueryCache } from '../queryCache'
-import type { DehydratedState } from '../hydration'
 import { dehydrate, hydrate } from '../hydration'
 
 async function fetchData<TData>(value: TData, ms?: number): Promise<TData> {
@@ -454,16 +453,14 @@ describe('dehydration and rehydration', () => {
 
     const dehydrated = dehydrate(queryClient)
     resolvePromise('string')
+    expect(
+      dehydrated.queries.find((q) => q.queryHash === '["string"]')?.state
+        .fetchStatus,
+    ).toBe('fetching')
     const stringified = JSON.stringify(dehydrated)
 
     // ---
-    const parsed = JSON.parse(stringified) as DehydratedState
-    expect(
-      parsed.queries.find((q) => q.queryHash === '["string"]')?.state
-        .fetchStatus,
-    ).toBe('fetching')
-
-    // ---
+    const parsed = JSON.parse(stringified)
     const hydrationCache = new QueryCache()
     const hydrationClient = createQueryClient({ queryCache: hydrationCache })
     hydrate(hydrationClient, parsed)

--- a/packages/query-core/src/tests/hydration.test.tsx
+++ b/packages/query-core/src/tests/hydration.test.tsx
@@ -456,7 +456,17 @@ describe('dehydration and rehydration', () => {
     resolvePromise('string')
     const stringified = JSON.stringify(dehydrated)
 
+    // ---
     const parsed = JSON.parse(stringified) as DehydratedState
-    expect(parsed.queries[0]?.state.fetchStatus).toBe('idle')
+    expect(
+      parsed.queries.find((q) => q.queryHash === '["string"]')?.state
+        .fetchStatus,
+    ).toBe('fetching')
+
+    // ---
+    const hydrationCache = new QueryCache()
+    const hydrationClient = createQueryClient({ queryCache: hydrationCache })
+    hydrate(hydrationClient, parsed)
+    expect(hydrationCache.find(['string'])?.state.fetchStatus).toBe('idle')
   })
 })

--- a/packages/query-core/src/tests/hydration.test.tsx
+++ b/packages/query-core/src/tests/hydration.test.tsx
@@ -432,7 +432,6 @@ describe('dehydration and rehydration', () => {
     const queryCache = new QueryCache()
     const queryClient = createQueryClient({ queryCache })
 
-
     let isInitialFetch = true
     let resolvePromise: (value: unknown) => void = () => undefined
 


### PR DESCRIPTION
Fixes a bug which caused the `fetchStatus` to be `fetching` forever with persisters when a successful query was refetching in background and the app was quit before the fetch succeeds