### PR TITLE
fix return type of MutateSyncFunction

### DIFF
--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -59,7 +59,7 @@ type MutateSyncFunction<
   TContext = unknown,
 > = (
   ...options: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
-) => void
+) => Promise<TData>
 
 export type UseMutationReturnType<
   TData,


### PR DESCRIPTION
According to [docs](https://tanstack.com/query/v4/docs/vue/reference/useMutation), `MutateSyncFunction` should return `Promise<TData>`.