### PR TITLE
test(query-core): v5: infiniteQueryBehavior: 100% code coverage

### DIFF
--- a/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
@@ -179,4 +179,99 @@ describe('InfiniteQueryBehavior', () => {
 
     unsubscribe()
   })
+
+  test('InfiniteQueryBehavior should apply pageParam', async () => {
+    const key = queryKey()
+    let abortSignal: AbortSignal | null = null
+
+    const queryFnSpy = jest.fn().mockImplementation(({ pageParam, signal }) => {
+      abortSignal = signal
+      return pageParam ?? 1
+    })
+
+    const observer = new InfiniteQueryObserver<number>(queryClient, {
+      queryKey: key,
+      queryFn: queryFnSpy,
+    })
+
+    let observerResult:
+      | InfiniteQueryObserverResult<unknown, unknown>
+      | undefined
+
+    const unsubscribe = observer.subscribe((result) => {
+      observerResult = result
+    })
+
+    // Wait for the first page to be fetched
+    await waitFor(() =>
+      expect(observerResult).toMatchObject({
+        isFetching: false,
+        data: { pages: [1], pageParams: [undefined] },
+      }),
+    )
+
+    queryFnSpy.mockClear()
+
+    // Fetch the next page using pageParam
+    await observer.fetchNextPage({ pageParam: 2 })
+
+    expect(queryFnSpy).toHaveBeenNthCalledWith(1, {
+      queryKey: key,
+      pageParam: 2,
+      meta: undefined,
+      signal: abortSignal,
+    })
+
+    expect(observerResult).toMatchObject({
+      isFetching: false,
+      data: { pages: [1, 2], pageParams: [undefined, 2] },
+    })
+
+    queryFnSpy.mockClear()
+
+    // Fetch the previous page using pageParam
+    await observer.fetchPreviousPage({ pageParam: 0 })
+
+    expect(queryFnSpy).toHaveBeenNthCalledWith(1, {
+      queryKey: key,
+      pageParam: 0,
+      meta: undefined,
+      signal: abortSignal,
+    })
+
+    expect(observerResult).toMatchObject({
+      isFetching: false,
+      data: { pages: [0, 1, 2], pageParams: [0, undefined, 2] },
+    })
+
+    queryFnSpy.mockClear()
+
+    // Refetch pages: old manual page params should be used
+    await observer.refetch()
+
+    expect(queryFnSpy).toHaveBeenCalledTimes(3)
+
+    expect(queryFnSpy).toHaveBeenNthCalledWith(1, {
+      queryKey: key,
+      pageParam: 0,
+      meta: undefined,
+      signal: abortSignal,
+    })
+
+    expect(queryFnSpy).toHaveBeenNthCalledWith(2, {
+      queryKey: key,
+      pageParam: undefined,
+      meta: undefined,
+      signal: abortSignal,
+    })
+
+    expect(queryFnSpy).toHaveBeenNthCalledWith(3, {
+      queryKey: key,
+      pageParam: 2,
+      meta: undefined,
+      signal: abortSignal,
+    })
+
+    unsubscribe()
+  })
 })


### PR DESCRIPTION
Tests added for `infiniteQueryBehavior` to reach 100% code coverage.
Done using v5 branch.