### PR TITLE
docs(react): Fix SSR custom framework guide -  `dehydratedState ` should be deconstructed

### DIFF
--- a/docs/react/guides/ssr.md
+++ b/docs/react/guides/ssr.md
@@ -303,7 +303,7 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query'
 
-const dehydratedState = window.__REACT_QUERY_STATE__
+const { dehydratedState } = window.__REACT_QUERY_STATE__
 
 const queryClient = new QueryClient()
 


### PR DESCRIPTION
I'm using Razzle as a SSR framework, I've found this issue while integrating react-query.