### PR TITLE
docs:eslint:plugin-name-typo-fix

### DIFF
--- a/docs/react/eslint/eslint-plugin-query.md
+++ b/docs/react/eslint/eslint-plugin-query.md
@@ -23,7 +23,7 @@ Add `@tanstack/eslint-plugin-query` to the plugins section of your `.eslintrc` c
 
 ```json
 {
-  "plugins": ["@tanstack/query"]
+  "plugins": ["@tanstack/eslint-plugin-query"]
 }
 ```
 


### PR DESCRIPTION
[Usage guide](https://tanstack.com/query/v4/docs/react/eslint/eslint-plugin-query)

Guide about modifying .eslintrc is updated to include valid eslint plugin name.