### PR TITLE
fix(solid-query): Split client/server sub function

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -43,23 +43,15 @@ export function createBaseQuery<
 
   const defaultedOptions = client().defaultQueryOptions(options())
   defaultedOptions._optimisticResults = 'optimistic'
+  if (isServer) {
+    defaultedOptions.retry = false
+    defaultedOptions.throwErrors = true
+  }
   const observer = new Observer(client(), defaultedOptions)
 
   const [state, setState] = createStore<QueryObserverResult<TData, TError>>(
     observer.getOptimisticResult(defaultedOptions),
   )
-
-  const createSubscriber = (
-    cb: (result: QueryObserverResult<TData, TError>) => void,
-  ) => {
-    return observer.subscribe((result) => {
-      notifyManager.batchCalls(() => {
-        const unwrappedResult = { ...unwrap(result) }
-        setState(unwrappedResult)
-        cb(unwrappedResult)
-      })()
-    })
-  }
 
   const createServerSubscriber = (
     resolve: (
@@ -68,26 +60,60 @@ export function createBaseQuery<
         | PromiseLike<QueryObserverResult<TData, TError> | undefined>
         | undefined,
     ) => void,
-  ) => createSubscriber(resolve)
+    reject: (reason?: any) => void,
+  ) => {
+    return observer.subscribe((result) => {
+      notifyManager.batchCalls(() => {
+        const unwrappedResult = { ...unwrap(result) }
+        if (unwrappedResult.isError) {
+          if (process.env['NODE_ENV'] === 'development') {
+            console.error(unwrappedResult.error)
+          }
+          reject(unwrappedResult.error)
+        }
+        if (unwrappedResult.isSuccess) {
+          resolve(unwrappedResult)
+        }
+      })()
+    })
+  }
 
-  const createClientSubscriber = (refetch: () => void) =>
-    createSubscriber(refetch)
+  const createClientSubscriber = () => {
+    return observer.subscribe((result) => {
+      notifyManager.batchCalls(() => {
+        const unwrappedResult = { ...unwrap(result) }
+        // If the query has data we dont suspend but instead mutate the resource
+        // This could happen when placeholderData/initialData is defined
+        if (
+          queryResource()?.data &&
+          unwrappedResult.data &&
+          !queryResource.loading
+        ) {
+          setState(unwrappedResult)
+          mutate(state)
+        } else {
+          setState(unwrappedResult)
+          refetch()
+        }
+      })()
+    })
+  }
 
   /**
    * Unsubscribe is set lazily, so that we can subscribe after hydration when needed.
    */
   let unsubscribe: (() => void) | null = null
 
-  const [queryResource, { refetch }] = createResource<
+  const [queryResource, { refetch, mutate }] = createResource<
     QueryObserverResult<TData, TError> | undefined
   >(
     () => {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         if (isServer) {
-          unsubscribe = createServerSubscriber(resolve)
+          unsubscribe = createServerSubscriber(resolve, reject)
         } else {
           if (!unsubscribe) {
-            unsubscribe = createClientSubscriber(() => refetch())
+            unsubscribe = createClientSubscriber()
           }
         }
         if (!state.isLoading) {
@@ -128,11 +154,15 @@ export function createBaseQuery<
            * Do not refetch query on mount if query was fetched on server,
            * even if `staleTime` is not set.
            */
+          let newOptions = { ...defaultedOptions }
           if (defaultedOptions.staleTime || !defaultedOptions.initialData) {
-            defaultedOptions.refetchOnMount = false
+            newOptions.refetchOnMount = false
           }
-          setState(observer.getOptimisticResult(defaultedOptions))
-          unsubscribe = createClientSubscriber(() => refetch())
+          // Setting the options as an immutable object to prevent
+          // wonky behavior with observer subscriptions
+          observer.setOptions(newOptions)
+          setState(observer.getOptimisticResult(newOptions))
+          unsubscribe = createClientSubscriber()
         }
       },
     },


### PR DESCRIPTION
The current implementation tried to use a common subscriber function for observers mounted on the server or the client. There are a few issues with this approach:

1. There is no reactivity on the server. So setting state with `setState` is a noop. Also, when a query fails on the server, we should not retry it and throw the error to the closest errorBoundary regardless of whether `throwErrors` is set. The error also needs to be thrown by the resource since resources are the only reactive piece in SSR land that will trigger a Suspense boundary.

2. On the client, the observer subscriber used to put the resource in a refetch state even when data was defined for a query using placeholderData/keepPreviousData/InitialData. This would trigger suspense and redraw the DOM nodes on every update. This is not ideal behavior. If placeholderData is defined then we want to skip suspending the resource and just mutate it instead.

This change splits the subscribers into two different functions that work best for the environment they run in. 