### PR TITLE
docs: update link for v2 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [TanStack T
 ## Visit [tanstack.com/query](https://tanstack.com/query) for docs, guides, API and more!
 
 Still on **React Query v2**? No problem! Check out the v2 docs here: https://github.com/TanStack/query/tree/2.x/docs/src/pages/docs. <br />
-Still on **React Query v3**? No problem! Check out the v3 docs here: https://react-query-v3.tanstack.com/.
+Still on **React Query v3**? No problem! Check out the v3 docs here: https://tanstack.com/query/v3/docs/.
 
 ## Quick Features
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [TanStack T
 
 ## Visit [tanstack.com/query](https://tanstack.com/query) for docs, guides, API and more!
 
-Still on **React Query v2**? No problem! Check out the v2 docs here: https://react-query-v2.tanstack.com/. <br />
+Still on **React Query v2**? No problem! Check out the v2 docs here: https://github.com/TanStack/query/tree/2.x/docs/src/pages/docs. <br />
 Still on **React Query v3**? No problem! Check out the v3 docs here: https://react-query-v3.tanstack.com/.
 
 ## Quick Features


### PR DESCRIPTION
The v2 site is down. Updating the link for v2 docs to point to the source code as highlighted in this comment:

https://github.com/TanStack/query/issues/4919#issuecomment-1412660461

Alternatively, also in favour of removing the mention of v2 from README altogether since it is to be considered unmaintained.