### PR TITLE
fix(react-query-devtools): do not stretch query status label

### DIFF
--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -836,7 +836,7 @@ const ActiveQuery = ({
           style={{
             marginBottom: '.5em',
             display: 'flex',
-            alignItems: 'stretch',
+            alignItems: 'flex-start',
             justifyContent: 'space-between',
           }}
         >


### PR DESCRIPTION
Do not stretch query status label (fresh, fetching, paused, stale, inactive) shown on Query Details view.

before:
<img width="1146" alt="before" src="https://user-images.githubusercontent.com/32389974/222450307-84bfda11-a687-40e5-a27a-77a825b797d2.png">

after:
<img width="1148" alt="after" src="https://user-images.githubusercontent.com/32389974/222450362-4f744e7d-2f5f-4619-942b-526ec1b9c743.png">
