### PR TITLE
feat(core): re-export matchQuery from utils

### DIFF
--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -16,6 +16,7 @@ export {
   replaceEqualDeep,
   isError,
   isServer,
+  matchQuery,
   parseQueryArgs,
   parseFilterArgs,
   parseMutationFilterArgs,


### PR DESCRIPTION
Hi everyone, based on our [previous discussion](https://github.com/TanStack/query/discussions/5064), I would like to open a PR that allows clients to import `matchQuery` from the `core` package. I attach the content of the original thread as a reference below.

Because this change exposes `matchQuery` as part of the public API, I assume it should be covered with tests independently - as far as I understand, it is currently only covered implicitly by the tests in `queryCache.test.ts`. I'll start to work on these as soon as I get a go. I also wonder about documentation: are inline docs sufficient or would you like to have the function documented somewhere else?

Thank you very much in advance for looking into this PR.

### Problem:
Since the entrypoints of the core package are limited using `exports` in `package.json`, this function can't be imported anymore by clients.

### Rationale:
We currently employ a coarse-grained cache invalidation strategy, where we usually invalidate most cache keys. In certain situations, we need to exclude a small set of keys and their sub-keys from invalidation.

To implement our strategy, we make use of the `queryClient.invalidateQueries` API and provide a custom predicate to filter out certain cache keys. To do so, the function `matchQuery` has been proven to be very useful.

### Solution:
The function `matchQuery` could be re-exported in `index.ts` of the `core` package.