### PR TITLE
fix(core): make sure mutations get updated options

### DIFF
--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -89,10 +89,11 @@ export class Mutation<
   TContext = unknown,
 > extends Removable {
   state: MutationState<TData, TError, TVariables, TContext>
-  options: MutationOptions<TData, TError, TVariables, TContext>
+  options!: MutationOptions<TData, TError, TVariables, TContext>
   mutationId: number
 
   private observers: MutationObserver<TData, TError, TVariables, TContext>[]
+  private defaultOptions?: MutationOptions<TData, TError, TVariables, TContext>
   private mutationCache: MutationCache
   private logger: Logger
   private retryer?: Retryer<TData>
@@ -100,18 +101,23 @@ export class Mutation<
   constructor(config: MutationConfig<TData, TError, TVariables, TContext>) {
     super()
 
-    this.options = {
-      ...config.defaultOptions,
-      ...config.options,
-    }
+    this.defaultOptions = config.defaultOptions
     this.mutationId = config.mutationId
     this.mutationCache = config.mutationCache
     this.logger = config.logger || defaultLogger
     this.observers = []
     this.state = config.state || getDefaultState()
 
-    this.updateCacheTime(this.options.cacheTime)
+    this.setOptions(config.options)
     this.scheduleGc()
+  }
+
+  setOptions(
+    options?: MutationOptions<TData, TError, TVariables, TContext>,
+  ): void {
+    this.options = { ...this.defaultOptions, ...options }
+
+    this.updateCacheTime(this.options.cacheTime)
   }
 
   get meta(): MutationMeta | undefined {

--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -74,6 +74,7 @@ export class MutationObserver<
         observer: this,
       })
     }
+    this.currentMutation?.setOptions(this.options)
   }
 
   protected onUnsubscribe(): void {


### PR DESCRIPTION
this fixes an issue around stale closures where callbacks are not updated, thus are called with wrong values in the closure

fixes #5056 