### PR TITLE
fix: queryClient consistent as a second parameter

### DIFF
--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -914,15 +914,17 @@ describe('useQueries', () => {
     }
 
     function Page() {
-      const queries = useQueries({
-        queries: [
-          {
-            queryKey: key,
-            queryFn,
-          },
-        ],
+      const queries = useQueries(
+        {
+          queries: [
+            {
+              queryKey: key,
+              queryFn,
+            },
+          ],
+        },
         queryClient,
-      })
+      )
 
       return <div>data: {queries[0].data}</div>
     }

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -155,13 +155,14 @@ export type QueriesResults<
   : // Fallback
     UseQueryResult[]
 
-export function useQueries<T extends any[]>({
-  queries,
-  queryClient,
-}: {
-  queries: readonly [...QueriesOptions<T>]
-  queryClient?: QueryClient
-}): QueriesResults<T> {
+export function useQueries<T extends any[]>(
+  {
+    queries,
+  }: {
+    queries: readonly [...QueriesOptions<T>]
+  },
+  queryClient?: QueryClient,
+): QueriesResults<T> {
   const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
 

--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -797,10 +797,12 @@ describe('useQueries', () => {
     }
 
     function Page() {
-      const state = createQueries(() => ({
-        queries: [{ queryKey: key, queryFn }],
-        queryClient,
-      }))
+      const state = createQueries(
+        () => ({
+          queries: [{ queryKey: key, queryFn }],
+        }),
+        () => queryClient,
+      )
       return (
         <div>
           <h1>Status: {state[0].data}</h1>

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -152,9 +152,7 @@ describe('useIsFetching', () => {
     function Page() {
       const [started, setStarted] = createSignal(false)
       const isFetching = useIsFetching(() => ({
-        filters: {
-          queryKey: key1,
-        },
+        queryKey: key1,
       }))
 
       createRenderEffect(() => {
@@ -237,7 +235,7 @@ describe('useIsFetching', () => {
         () => queryClient,
       )
 
-      const isFetching = useIsFetching(() => ({ queryClient }))
+      const isFetching = useIsFetching(undefined, () => queryClient)
 
       return (
         <div>

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -68,9 +68,7 @@ describe('useIsMutating', () => {
     const queryClient = createQueryClient()
 
     function IsMutating() {
-      const isMutating = useIsMutating(() => ({
-        filters: { mutationKey: ['mutation1'] },
-      }))
+      const isMutating = useIsMutating(() => ({ mutationKey: ['mutation1'] }))
       createRenderEffect(() => {
         isMutatings.push(isMutating())
       })
@@ -116,10 +114,8 @@ describe('useIsMutating', () => {
 
     function IsMutating() {
       const isMutating = useIsMutating(() => ({
-        filters: {
-          predicate: (mutation) =>
-            mutation.options.mutationKey?.[0] === 'mutation1',
-        },
+        predicate: (mutation) =>
+          mutation.options.mutationKey?.[0] === 'mutation1',
       }))
       createRenderEffect(() => {
         isMutatings.push(isMutating())
@@ -226,7 +222,7 @@ describe('useIsMutating', () => {
     const queryClient = createQueryClient()
 
     function Page() {
-      const isMutating = useIsMutating(() => ({ queryClient }))
+      const isMutating = useIsMutating(undefined, () => queryClient)
       const { mutate } = createMutation(
         () => ({
           mutationKey: ['mutation1'],

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -37,7 +37,7 @@ export function createBaseQuery<
     CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   Observer: typeof QueryObserver,
-  queryClient?: () => QueryClient,
+  queryClient?: Accessor<QueryClient>,
 ) {
   const client = createMemo(() => useQueryClient(queryClient?.()))
 

--- a/packages/solid-query/src/createInfiniteQuery.ts
+++ b/packages/solid-query/src/createInfiniteQuery.ts
@@ -12,6 +12,7 @@ import type {
 } from './types'
 import { createBaseQuery } from './createBaseQuery'
 import { createMemo } from 'solid-js'
+import type { Accessor} from 'solid-js';
 
 export function createInfiniteQuery<
   TQueryFnData,
@@ -27,7 +28,7 @@ export function createInfiniteQuery<
     TQueryKey,
     TPageParam
   >,
-  queryClient?: () => QueryClient,
+  queryClient?: Accessor<QueryClient>,
 ): CreateInfiniteQueryResult<TData, TError> {
   return createBaseQuery(
     createMemo(() => options()),

--- a/packages/solid-query/src/createInfiniteQuery.ts
+++ b/packages/solid-query/src/createInfiniteQuery.ts
@@ -12,7 +12,7 @@ import type {
 } from './types'
 import { createBaseQuery } from './createBaseQuery'
 import { createMemo } from 'solid-js'
-import type { Accessor} from 'solid-js';
+import type { Accessor } from 'solid-js'
 
 export function createInfiniteQuery<
   TQueryFnData,

--- a/packages/solid-query/src/createMutation.ts
+++ b/packages/solid-query/src/createMutation.ts
@@ -6,7 +6,7 @@ import type {
   CreateMutationOptions,
   CreateMutationResult,
 } from './types'
-import type { Accessor } from 'solid-js';
+import type { Accessor } from 'solid-js'
 import { createComputed, onCleanup, on } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { shouldThrowError } from './utils'

--- a/packages/solid-query/src/createMutation.ts
+++ b/packages/solid-query/src/createMutation.ts
@@ -6,6 +6,7 @@ import type {
   CreateMutationOptions,
   CreateMutationResult,
 } from './types'
+import type { Accessor } from 'solid-js';
 import { createComputed, onCleanup, on } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { shouldThrowError } from './utils'
@@ -18,7 +19,7 @@ export function createMutation<
   TContext = unknown,
 >(
   options: CreateMutationOptions<TData, TError, TVariables, TContext>,
-  queryClient?: () => QueryClient,
+  queryClient?: Accessor<QueryClient>,
 ): CreateMutationResult<TData, TError, TVariables, TContext> {
   const client = useQueryClient(queryClient?.())
 

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -150,18 +150,18 @@ export type QueriesResults<
 export function createQueries<T extends any[]>(
   queriesOptions: () => {
     queries: readonly [...QueriesOptions<T>]
-    queryClient?: QueryClient
   },
+  queryClient?: () => QueryClient,
 ): QueriesResults<T> {
-  const queryClient = useQueryClient(queriesOptions().queryClient)
+  const client = useQueryClient(queryClient?.())
 
   const defaultedQueries = queriesOptions().queries.map((options) => {
-    const defaultedOptions = queryClient.defaultQueryOptions(options)
+    const defaultedOptions = client.defaultQueryOptions(options)
     defaultedOptions._optimisticResults = 'optimistic'
     return defaultedOptions
   })
 
-  const observer = new QueriesObserver(queryClient, defaultedQueries)
+  const observer = new QueriesObserver(client, defaultedQueries)
 
   const [state, setState] = createStore(
     observer.getOptimisticResult(defaultedQueries),
@@ -181,7 +181,7 @@ export function createQueries<T extends any[]>(
 
   createComputed(() => {
     const updatedQueries = queriesOptions().queries.map((options) => {
-      const defaultedOptions = queryClient.defaultQueryOptions(options)
+      const defaultedOptions = client.defaultQueryOptions(options)
       defaultedOptions._optimisticResults = 'optimistic'
       return defaultedOptions
     })

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -6,6 +6,7 @@ import type {
   DefaultError,
 } from '@tanstack/query-core'
 import { notifyManager, QueriesObserver } from '@tanstack/query-core'
+import type { Accessor } from 'solid-js'
 import { createComputed, onCleanup, onMount } from 'solid-js'
 import { createStore, unwrap } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
@@ -148,10 +149,10 @@ export type QueriesResults<
     CreateQueryResult[]
 
 export function createQueries<T extends any[]>(
-  queriesOptions: () => {
+  queriesOptions: Accessor<{
     queries: readonly [...QueriesOptions<T>]
-  },
-  queryClient?: () => QueryClient,
+  }>,
+  queryClient?: Accessor<QueryClient>,
 ): QueriesResults<T> {
   const client = useQueryClient(queryClient?.())
 

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -1,5 +1,6 @@
 import type { QueryClient, QueryKey, DefaultError } from '@tanstack/query-core'
 import { QueryObserver } from '@tanstack/query-core'
+import type { Accessor } from 'solid-js'
 import { createMemo } from 'solid-js'
 import { createBaseQuery } from './createBaseQuery'
 import type {
@@ -58,7 +59,7 @@ export function createQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  queryClient?: () => QueryClient,
+  queryClient?: Accessor<QueryClient>,
 ) {
   return createBaseQuery(
     createMemo(() => options()),

--- a/packages/solid-query/src/useIsFetching.ts
+++ b/packages/solid-query/src/useIsFetching.ts
@@ -3,21 +3,17 @@ import type { Accessor } from 'solid-js'
 import { createMemo, createSignal, onCleanup } from 'solid-js'
 import { useQueryClient } from './QueryClientProvider'
 
-type Options = () => {
-  filters?: QueryFilters
-  queryClient?: QueryClient
-}
+export function useIsFetching(
+  filters?: Accessor<QueryFilters>,
+  queryClient?: Accessor<QueryClient>,
+): Accessor<number> {
+  const client = createMemo(() => useQueryClient(queryClient?.()))
+  const queryCache = createMemo(() => client().getQueryCache())
 
-export function useIsFetching(options: Options = () => ({})): Accessor<number> {
-  const queryClient = createMemo(() => useQueryClient(options().queryClient))
-  const queryCache = createMemo(() => queryClient().getQueryCache())
-
-  const [fetches, setFetches] = createSignal(
-    queryClient().isFetching(options().filters),
-  )
+  const [fetches, setFetches] = createSignal(client().isFetching(filters?.()))
 
   const unsubscribe = queryCache().subscribe(() => {
-    setFetches(queryClient().isFetching(options().filters))
+    setFetches(client().isFetching(filters?.()))
   })
 
   onCleanup(unsubscribe)

--- a/packages/solid-query/src/useIsMutating.ts
+++ b/packages/solid-query/src/useIsMutating.ts
@@ -3,21 +3,19 @@ import { useQueryClient } from './QueryClientProvider'
 import type { Accessor } from 'solid-js'
 import { createSignal, onCleanup, createMemo } from 'solid-js'
 
-type Options = () => {
-  filters?: MutationFilters
-  queryClient?: QueryClient
-}
-
-export function useIsMutating(options: Options = () => ({})): Accessor<number> {
-  const queryClient = createMemo(() => useQueryClient(options().queryClient))
-  const mutationCache = createMemo(() => queryClient().getMutationCache())
+export function useIsMutating(
+  filters?: Accessor<MutationFilters>,
+  queryClient?: Accessor<QueryClient>,
+): Accessor<number> {
+  const client = createMemo(() => useQueryClient(queryClient?.()))
+  const mutationCache = createMemo(() => client().getMutationCache())
 
   const [mutations, setMutations] = createSignal(
-    queryClient().isMutating(options().filters),
+    client().isMutating(filters?.()),
   )
 
   const unsubscribe = mutationCache().subscribe((_result) => {
-    setMutations(queryClient().isMutating(options().filters))
+    setMutations(client().isMutating(filters?.()))
   })
 
   onCleanup(unsubscribe)

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -152,13 +152,14 @@ export type QueriesResults<
 
 export type CreateQueriesResult<T extends any[]> = Readable<QueriesResults<T>>
 
-export function createQueries<T extends any[]>({
-  queries,
-  queryClient,
-}: {
-  queries: WritableOrVal<[...QueriesOptions<T>]>
-  queryClient?: QueryClient
-}): CreateQueriesResult<T> {
+export function createQueries<T extends any[]>(
+  {
+    queries,
+  }: {
+    queries: WritableOrVal<[...QueriesOptions<T>]>
+  },
+  queryClient?: QueryClient,
+): CreateQueriesResult<T> {
   const client = useQueryClient(queryClient)
   // const isRestoring = useIsRestoring()
 

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -206,7 +206,7 @@ describe('useQueries', () => {
       },
     ]
 
-    useQueries({ queries, queryClient })
+    useQueries({ queries }, queryClient)
     await flushPromises()
 
     expect(useQueryClient).toHaveBeenCalledTimes(0)

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -322,15 +322,17 @@ describe('VueQueryPlugin', () => {
 
       const fnSpy = jest.fn()
 
-      const queries = useQueries({
-        queries: [
-          {
-            queryKey: ['persist'],
-            queryFn: fnSpy,
-          },
-        ],
-        queryClient: customClient,
-      })
+      const queries = useQueries(
+        {
+          queries: [
+            {
+              queryKey: ['persist'],
+              queryFn: fnSpy,
+            },
+          ],
+        },
+        customClient,
+      )
 
       expect(customClient.isRestoring.value).toBeTruthy()
       expect(queries.value[0].isFetching).toBeFalsy()

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -145,13 +145,14 @@ export type UseQueriesResults<
 
 type UseQueriesOptionsArg<T extends any[]> = readonly [...UseQueriesOptions<T>]
 
-export function useQueries<T extends any[]>({
-  queries,
-  queryClient,
-}: {
-  queries: MaybeRefDeep<UseQueriesOptionsArg<T>>
-  queryClient?: QueryClient
-}): Readonly<Ref<UseQueriesResults<T>>> {
+export function useQueries<T extends any[]>(
+  {
+    queries,
+  }: {
+    queries: MaybeRefDeep<UseQueriesOptionsArg<T>>
+  },
+  queryClient?: QueryClient,
+): Readonly<Ref<UseQueriesResults<T>>> {
   const client = queryClient || useQueryClient()
 
   const defaultedQueries = computed(() =>


### PR DESCRIPTION
- `useQueries` accept `queryClient` as second parameter just like other hooks
- solid `useIsFetching` and `useIsMutating` accept `queryClient` as second parameter