### PR TITLE
fix(solid-query): ssr fixes

### DIFF
--- a/examples/solid/basic-graphql-request/package.json
+++ b/examples/solid/basic-graphql-request/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-query": "^4.3.9",
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
-    "solid-js": "^1.6.2"
+    "solid-js": "^1.6.13"
   },
   "devDependencies": {
     "typescript": "4.7.4",

--- a/examples/solid/basic-typescript/package.json
+++ b/examples/solid/basic-typescript/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@tanstack/solid-query": "^4.3.9",
-    "solid-js": "^1.6.2"
+    "solid-js": "^1.6.13"
   },
   "devDependencies": {
     "typescript": "4.7.4",

--- a/examples/solid/default-query-function/package.json
+++ b/examples/solid/default-query-function/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@tanstack/solid-query": "^4.3.9",
-    "solid-js": "^1.6.2"
+    "solid-js": "^1.6.13"
   },
   "devDependencies": {
     "typescript": "4.7.4",

--- a/examples/solid/simple/package.json
+++ b/examples/solid/simple/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@tanstack/solid-query": "^4.3.9",
-    "solid-js": "^1.6.2"
+    "solid-js": "^1.6.13"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^4.13.0",

--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -11,15 +11,15 @@
     "esbuild": "^0.14.54",
     "postcss": "^8.4.18",
     "solid-start-node": "^0.2.0",
-    "typescript": "^4.8.4",
-    "vite": "^3.1.8"
+    "typescript": "^4.9.4",
+    "vite": "^4.1.4"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^4.3.9",
+    "@tanstack/solid-query": "^5.0.0-alpha.3",
     "@solidjs/meta": "^0.28.2",
-    "@solidjs/router": "^0.6.0",
-    "solid-js": "^1.6.9",
-    "solid-start": "^0.2.15",
+    "@solidjs/router": "^0.7.0",
+    "solid-js": "^1.6.13",
+    "solid-start": "^0.2.23",
     "undici": "^5.11.0"
   },
   "engines": {

--- a/examples/solid/solid-start-streaming/src/root.css
+++ b/examples/solid/solid-start-streaming/src/root.css
@@ -85,3 +85,13 @@ p {
   font-weight: bold;
   flex-grow: 1;
 }
+
+.example--table {
+  padding: 0.5rem;
+}
+
+.example--table th,
+.example--table td {
+  padding: 4px 12px;
+  white-space: nowrap;
+}

--- a/examples/solid/solid-start-streaming/src/root.tsx
+++ b/examples/solid/solid-start-streaming/src/root.tsx
@@ -43,6 +43,7 @@ export default function Root() {
               <A href="/deferred">Deferred</A>
               <A href="/mixed">Mixed</A>
               <A href="/with-error">With Error</A>
+              <A href="/hydration">Hydration</A>
 
               <Routes>
                 <FileRoutes />

--- a/examples/solid/solid-start-streaming/src/root.tsx
+++ b/examples/solid/solid-start-streaming/src/root.tsx
@@ -20,7 +20,7 @@ export default function Root() {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
-        retry: 0,
+        retry: false,
       },
     },
   })

--- a/examples/solid/solid-start-streaming/src/routes/hydration.tsx
+++ b/examples/solid/solid-start-streaming/src/routes/hydration.tsx
@@ -1,0 +1,95 @@
+import type { CreateQueryResult } from '@tanstack/solid-query'
+import { createQuery } from '@tanstack/solid-query'
+import { createSignal, Suspense } from 'solid-js'
+import { fetchUser } from '~/utils/api'
+import { NoHydration } from 'solid-js/web'
+import { Title } from 'solid-start'
+
+export default function Hydration() {
+  const query = createQuery(() => ({
+    queryKey: ['user'],
+    queryFn: () => fetchUser({ sleep: 500 }),
+    deferStream: true,
+  }))
+
+  const [initialQueryState] = createSignal(JSON.parse(JSON.stringify(query)))
+
+  return (
+    <main>
+      <Title>Solid Query - Hydration</Title>
+
+      <h1>Solid Query - Hydration Example</h1>
+
+      <div class="description">
+        <p>
+          Lists the query state as seen on the server, initial render on the
+          client (right after hydration), and current client value. Ideally, if
+          SSR is setup correctly, these values are exactly the same in all three
+          contexts.
+        </p>
+      </div>
+
+      <button onClick={() => query.refetch()}>Refetch</button>
+
+      <table class="example example--table">
+        <thead>
+          <tr>
+            <th>Context</th>
+            <th>data.name</th>
+            <th>isFetching</th>
+            <th>isFetched</th>
+            <th>isPending</th>
+            <th>isRefetching</th>
+            <th>isLoading</th>
+            <th>isStale</th>
+            <th>isSuccess</th>
+            <th>fetchStatus</th>
+            <th>dataUpdatedAt</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <Suspense>
+            <NoHydration>
+              <QueryStateRow context="server" query={query} />
+            </NoHydration>
+
+            <QueryStateRow
+              context="client (initial render)"
+              query={initialQueryState()!}
+            />
+
+            <QueryStateRow context="client" query={query} />
+          </Suspense>
+        </tbody>
+      </table>
+    </main>
+  )
+}
+
+type QueryState = CreateQueryResult<
+  {
+    id: string
+    name: string
+    queryTime: number
+  },
+  Error
+>
+
+const QueryStateRow = (props: { context: string; query: QueryState }) => {
+  return (
+    <tr>
+      <td>{props.context}</td>
+      <td>{props.query.data?.name}</td>
+      <td>{String(props.query.isFetching)}</td>
+      <td>{String(props.query.isFetched)}</td>
+      <td>{String(props.query.isPending)}</td>
+      <td>{String(props.query.isRefetching)}</td>
+      <td>{String(props.query.isLoading)}</td>
+      <td>{String(props.query.isStale)}</td>
+      <td>{String(props.query.isSuccess)}</td>
+      <td>{String(props.query.fetchStatus)}</td>
+      <td>{String(props.query.dataUpdatedAt)}</td>
+    </tr>
+  )
+}

--- a/examples/solid/solid-start-streaming/src/routes/hydration.tsx
+++ b/examples/solid/solid-start-streaming/src/routes/hydration.tsx
@@ -43,6 +43,8 @@ export default function Hydration() {
             <th>isLoading</th>
             <th>isStale</th>
             <th>isSuccess</th>
+            <th>isError</th>
+            <th>error</th>
             <th>fetchStatus</th>
             <th>dataUpdatedAt</th>
           </tr>
@@ -88,6 +90,8 @@ const QueryStateRow = (props: { context: string; query: QueryState }) => {
       <td>{String(props.query.isLoading)}</td>
       <td>{String(props.query.isStale)}</td>
       <td>{String(props.query.isSuccess)}</td>
+      <td>{String(props.query.isError)}</td>
+      <td>{String(props.query.error)}</td>
       <td>{String(props.query.fetchStatus)}</td>
       <td>{String(props.query.dataUpdatedAt)}</td>
     </tr>

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "rollup-plugin-visualizer": "^5.9.0",
     "rollup-preset-solid": "^1.4.0",
     "semver": "^7.3.8",
-    "solid-js": "^1.5.7",
+    "solid-js": "^1.6.13",
     "solid-testing-library": "^0.3.0",
     "stream-to-array": "^2.3.0",
     "ts-node": "^10.9.1",

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -54,7 +54,7 @@
     "@tanstack/query-core": "workspace:*"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.2"
+    "solid-js": "^1.6.13"
   },
   "peerDependenciesMeta": {}
 }

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -172,7 +172,7 @@ export function createBaseQuery<
   )
 
   onCleanup(() => {
-    if (unsubscribe) {
+    if (!isServer && unsubscribe) {
       unsubscribe()
       unsubscribe = null
     }

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -209,10 +209,8 @@ export function createBaseQuery<
       target: QueryObserverResult<TData, TError>,
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
-      if (prop === 'data') {
-        return queryResource()?.data
-      }
-      return Reflect.get(target, prop)
+      const val = queryResource()?.[prop]
+      return val !== void 0 ? val : Reflect.get(target, prop)
     },
   }
 

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -63,7 +63,20 @@ export function createBaseQuery<
   ) => {
     return observer.subscribe((result) => {
       notifyManager.batchCalls(() => {
-        const unwrappedResult = { ...unwrap(result) }
+        const query = observer.getCurrentQuery()
+        const unwrappedResult = {
+          ...unwrap(result),
+
+          // hydrate() expects a QueryState object, which is similar but not
+          // quite the same as a QueryObserverResult object. Thus, for now, we're
+          // copying over the missing properties from state in order to support hydration
+          dataUpdateCount: query.state.dataUpdateCount,
+          fetchFailureCount: query.state.fetchFailureCount,
+          fetchFailureReason: query.state.fetchFailureReason,
+          fetchMeta: query.state.fetchMeta,
+          isInvalidated: query.state.isInvalidated,
+        }
+
         if (unwrappedResult.isError) {
           if (process.env['NODE_ENV'] === 'development') {
             console.error(unwrappedResult.error)

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -177,9 +177,17 @@ export function createBaseQuery<
     }
   })
 
-  createComputed(() => {
-    observer.setOptions(client().defaultQueryOptions(options()))
-  })
+  createComputed(
+    on(
+      () => client().defaultQueryOptions(options()),
+      () => observer.setOptions(client().defaultQueryOptions(options())),
+      {
+        // Defer because we don't need to trigger on first render
+        // This only cares about changes to options after the observer is created
+        defer: true,
+      },
+    ),
+  )
 
   createComputed(
     on(

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -210,7 +210,7 @@ export function createBaseQuery<
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
       const val = queryResource()?.[prop]
-      return val !== void 0 ? val : Reflect.get(target, prop)
+      return val !== undefined ? val : Reflect.get(target, prop)
     },
   }
 

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -172,7 +172,7 @@ export function createBaseQuery<
   )
 
   onCleanup(() => {
-    if (!isServer && unsubscribe) {
+    if (unsubscribe) {
       unsubscribe()
       unsubscribe = null
     }

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -18,7 +18,6 @@ import {
   createResource,
   on,
   onCleanup,
-  onMount,
 } from 'solid-js'
 import { createStore, unwrap } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
@@ -176,10 +175,6 @@ export function createBaseQuery<
       unsubscribe()
       unsubscribe = null
     }
-  })
-
-  onMount(() => {
-    observer.setOptions(defaultedOptions, { listeners: false })
   })
 
   createComputed(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
       rollup-plugin-visualizer: ^5.9.0
       rollup-preset-solid: ^1.4.0
       semver: ^7.3.8
-      solid-js: ^1.5.7
+      solid-js: ^1.6.13
       solid-testing-library: ^0.3.0
       stream-to-array: ^2.3.0
       ts-node: ^10.9.1
@@ -99,7 +99,7 @@ importers:
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       '@types/semver': 7.3.13
-      '@types/testing-library__jest-dom': 5.14.5
+      '@types/testing-library__jest-dom': 5.14.5_d573maxasnl5kxwdyzebcnmhpm
       '@typescript-eslint/eslint-plugin': 5.53.0_3pv6zwhjhlqsinbw2jej3zaxq4
       '@typescript-eslint/parser': 5.53.0_r4nhl7oghl6mgx4ukbxrwoekle
       '@vitest/coverage-istanbul': 0.27.1
@@ -141,8 +141,8 @@ importers:
       rollup-plugin-visualizer: 5.9.0_rollup@3.15.0
       rollup-preset-solid: 1.4.0
       semver: 7.3.8
-      solid-js: 1.5.7
-      solid-testing-library: 0.3.0_solid-js@1.5.7
+      solid-js: 1.6.16
+      solid-testing-library: 0.3.0_solid-js@1.6.16
       stream-to-array: 2.3.0
       ts-node: 10.9.1_j777nnsruz44drbtesvg2fqc7y
       typescript: 4.7.4
@@ -639,95 +639,95 @@ importers:
       '@tanstack/solid-query': ^4.3.9
       graphql: ^16.6.0
       graphql-request: ^5.0.0
-      solid-js: ^1.6.2
+      solid-js: ^1.6.13
       typescript: 4.7.4
       vite: ^3.0.9
       vite-plugin-solid: ^2.3.9
     dependencies:
-      '@tanstack/solid-query': 4.26.1_solid-js@1.6.11
+      '@tanstack/solid-query': 4.26.1_solid-js@1.6.16
       graphql: 16.6.0
       graphql-request: 5.0.0_graphql@16.6.0
-      solid-js: 1.6.11
+      solid-js: 1.6.16
     devDependencies:
       typescript: 4.7.4
       vite: 3.1.3
-      vite-plugin-solid: 2.3.9_solid-js@1.6.11+vite@3.1.3
+      vite-plugin-solid: 2.3.9_solid-js@1.6.16+vite@3.1.3
 
   examples/solid/basic-typescript:
     specifiers:
       '@tanstack/solid-query': ^4.3.9
-      solid-js: ^1.6.2
+      solid-js: ^1.6.13
       typescript: 4.7.4
       vite: ^3.0.9
       vite-plugin-solid: ^2.3.9
     dependencies:
-      '@tanstack/solid-query': 4.26.1_solid-js@1.6.11
-      solid-js: 1.6.11
+      '@tanstack/solid-query': 4.26.1_solid-js@1.6.16
+      solid-js: 1.6.16
     devDependencies:
       typescript: 4.7.4
       vite: 3.1.3
-      vite-plugin-solid: 2.3.9_solid-js@1.6.11+vite@3.1.3
+      vite-plugin-solid: 2.3.9_solid-js@1.6.16+vite@3.1.3
 
   examples/solid/default-query-function:
     specifiers:
       '@tanstack/solid-query': ^4.3.9
-      solid-js: ^1.6.2
+      solid-js: ^1.6.13
       typescript: 4.7.4
       vite: ^3.0.9
       vite-plugin-solid: ^2.3.9
     dependencies:
-      '@tanstack/solid-query': 4.26.1_solid-js@1.6.11
-      solid-js: 1.6.11
+      '@tanstack/solid-query': 4.26.1_solid-js@1.6.16
+      solid-js: 1.6.16
     devDependencies:
       typescript: 4.7.4
       vite: 3.1.3
-      vite-plugin-solid: 2.3.9_solid-js@1.6.11+vite@3.1.3
+      vite-plugin-solid: 2.3.9_solid-js@1.6.16+vite@3.1.3
 
   examples/solid/simple:
     specifiers:
       '@tanstack/eslint-plugin-query': ^4.13.0
       '@tanstack/solid-query': ^4.3.9
-      solid-js: ^1.6.2
+      solid-js: ^1.6.13
       typescript: 4.7.4
       vite: ^3.0.9
       vite-plugin-solid: ^2.3.9
     dependencies:
-      '@tanstack/solid-query': 4.26.1_solid-js@1.6.11
-      solid-js: 1.6.11
+      '@tanstack/solid-query': 4.26.1_solid-js@1.6.16
+      solid-js: 1.6.16
     devDependencies:
       '@tanstack/eslint-plugin-query': 4.26.2
       typescript: 4.7.4
       vite: 3.1.3
-      vite-plugin-solid: 2.3.9_solid-js@1.6.11+vite@3.1.3
+      vite-plugin-solid: 2.3.9_solid-js@1.6.16+vite@3.1.3
 
   examples/solid/solid-start-streaming:
     specifiers:
       '@solidjs/meta': ^0.28.2
-      '@solidjs/router': ^0.6.0
-      '@tanstack/solid-query': ^4.3.9
+      '@solidjs/router': ^0.7.0
+      '@tanstack/solid-query': ^5.0.0-alpha.3
       '@types/node': ^18.11.9
       esbuild: ^0.14.54
       postcss: ^8.4.18
-      solid-js: ^1.6.9
-      solid-start: ^0.2.15
+      solid-js: ^1.6.13
+      solid-start: ^0.2.23
       solid-start-node: ^0.2.0
-      typescript: ^4.8.4
+      typescript: ^4.9.4
       undici: ^5.11.0
-      vite: ^3.1.8
+      vite: ^4.1.4
     dependencies:
-      '@solidjs/meta': 0.28.2_solid-js@1.6.11
-      '@solidjs/router': 0.6.0_solid-js@1.6.11
-      '@tanstack/solid-query': 4.26.1_solid-js@1.6.11
-      solid-js: 1.6.11
-      solid-start: 0.2.21_hj77zfsbczccdokc5ewmqqrrvy
+      '@solidjs/meta': 0.28.2_solid-js@1.6.16
+      '@solidjs/router': 0.7.1_solid-js@1.6.16
+      '@tanstack/solid-query': link:../../../packages/solid-query
+      solid-js: 1.6.16
+      solid-start: 0.2.24_euxzheln45tfyr565dhf2xv3la
       undici: 5.14.0
     devDependencies:
       '@types/node': 18.13.0
       esbuild: 0.14.54
       postcss: 8.4.21
-      solid-start-node: 0.2.21_pnrae6sj5z7x4ihr4h4m5jbpx4
-      typescript: 4.8.4
-      vite: 3.2.2
+      solid-start-node: 0.2.21_2vqkbilyolq35n53mildrhalmu
+      typescript: 4.9.5
+      vite: 4.2.1_@types+node@18.13.0
 
   examples/svelte/auto-refetching:
     specifiers:
@@ -1379,18 +1379,27 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
+  /@babel/generator/7.21.3:
+    resolution: {integrity: sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.21.3
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
+      jsesc: 2.5.2
+
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.6:
     resolution: {integrity: sha512-KT10c1oWEpmrIRYnthbzHgoOf6B+Xd6a5yhdbNtdhtG7aO1or5HViuf1TQR36xY/QprXA5nvxO6nAjhJ4y38jw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-compilation-targets/7.19.1_@babel+core@7.19.1:
     resolution: {integrity: sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==}
@@ -1622,32 +1631,32 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-function-name/7.19.0:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-member-expression-to-functions/7.18.6:
     resolution: {integrity: sha512-CeHxqwwipekotzPDUuJOfIMtcIHBuc7WAzLmTYWctVigqS5RktNMQ5bEwQSuGewzYnCtTWa3BARXeiLxDTv+Ng==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-member-expression-to-functions/7.20.7:
     resolution: {integrity: sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -1664,7 +1673,7 @@ packages:
       '@babel/helper-simple-access': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.18.10
+      '@babel/template': 7.20.7
       '@babel/traverse': 7.19.1
       '@babel/types': 7.20.7
     transitivePeerDependencies:
@@ -1689,12 +1698,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
-
-  /@babel/helper-plugin-utils/7.19.0:
-    resolution: {integrity: sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==}
-    engines: {node: '>=6.9.0'}
-    dev: false
+      '@babel/types': 7.21.3
 
   /@babel/helper-plugin-utils/7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
@@ -1710,7 +1714,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1725,7 +1729,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1739,7 +1743,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1753,7 +1757,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1761,31 +1765,31 @@ packages:
     resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-simple-access/7.20.2:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-skip-transparent-expression-wrappers/7.18.6:
     resolution: {integrity: sha512-4KoLhwGS9vGethZpAhYnMejWkX64wsnHPDwvOsKWU6Fg4+AlK2Jz3TyjQLMEPvz+1zemi/WBdkYxCD0bAfIkiw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -1806,7 +1810,7 @@ packages:
       '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1814,7 +1818,7 @@ packages:
     resolution: {integrity: sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
+      '@babel/template': 7.20.7
       '@babel/traverse': 7.19.1
       '@babel/types': 7.20.7
     transitivePeerDependencies:
@@ -3685,7 +3689,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.1
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-transform-object-assign/7.18.6_@babel+core@7.20.12:
@@ -3695,7 +3699,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.19.1:
@@ -4697,6 +4701,14 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
+  /@babel/types/7.21.3:
+    resolution: {integrity: sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+
   /@callstack/eslint-config/10.2.0_wnilx7boviscikmvsfkd6ljepe:
     resolution: {integrity: sha512-vefzK3GT0HvLnr+1YxyvykF82bRfc6Oo7Tgof7pG9Xeh+PKHXuLjyUC4rjz3sMlBOsDoQdQulSayV5wIxZlxnA==}
     engines: {node: '>=10.13.0'}
@@ -4785,6 +4797,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm/0.16.15:
@@ -4796,6 +4809,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm/0.17.14:
+    resolution: {integrity: sha512-0CnlwnjDU8cks0yJLXfkaU/uoLyRf9VZJs4p1PskBr2AlAHeEsFEwJEo0of/Z3g+ilw5mpyDwThlxzNEIxOE4g==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-arm64/0.16.15:
     resolution: {integrity: sha512-OdbkUv7468dSsgoFtHIwTaYAuI5lDEv/v+dlfGBUbVa2xSDIIuSOHXawynw5N9+5lygo/JdXa5/sgGjiEU18gQ==}
     engines: {node: '>=12'}
@@ -4803,6 +4824,14 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-arm64/0.17.14:
+    resolution: {integrity: sha512-eLOpPO1RvtsP71afiFTvS7tVFShJBCT0txiv/xjFBo5a7R7Gjw7X0IgIaFoLKhqXYAXhahoXm7qAmRXhY4guJg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/android-x64/0.16.15:
@@ -4814,6 +4843,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-x64/0.17.14:
+    resolution: {integrity: sha512-nrfQYWBfLGfSGLvRVlt6xi63B5IbfHm3tZCdu/82zuFPQ7zez4XjmRtF/wIRYbJQ/DsZrxJdEvYFE67avYXyng==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/darwin-arm64/0.16.15:
     resolution: {integrity: sha512-AksarYV85Hxgwh5/zb6qGl4sYWxIXPQGBAZ+jUro1ZpINy3EWumK+/4DPOKUBPnsrOIvnNXy7Rq4mTeCsMQDNA==}
     engines: {node: '>=12'}
@@ -4821,6 +4858,14 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64/0.17.14:
+    resolution: {integrity: sha512-eoSjEuDsU1ROwgBH/c+fZzuSyJUVXQTOIN9xuLs9dE/9HbV/A5IqdXHU1p2OfIMwBwOYJ9SFVGGldxeRCUJFyw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@esbuild/darwin-x64/0.16.15:
@@ -4832,6 +4877,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-x64/0.17.14:
+    resolution: {integrity: sha512-zN0U8RWfrDttdFNkHqFYZtOH8hdi22z0pFm0aIJPsNC4QQZv7je8DWCX5iA4Zx6tRhS0CCc0XC2m7wKsbWEo5g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/freebsd-arm64/0.16.15:
     resolution: {integrity: sha512-LBWaep6RvJm5KnsKkocdVEzuwnGMjz54fcRVZ9d3R7FSEWOtPBxMhuxeA1n98JVbCLMkTPFmKN6xSnfhnM9WXQ==}
     engines: {node: '>=12'}
@@ -4839,6 +4892,14 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.17.14:
+    resolution: {integrity: sha512-z0VcD4ibeZWVQCW1O7szaLxGsx54gcCnajEJMdYoYjLiq4g1jrP2lMq6pk71dbS5+7op/L2Aod+erw+EUr28/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/freebsd-x64/0.16.15:
@@ -4850,6 +4911,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-x64/0.17.14:
+    resolution: {integrity: sha512-hd9mPcxfTgJlolrPlcXkQk9BMwNBvNBsVaUe5eNUqXut6weDQH8whcNaKNF2RO8NbpT6GY8rHOK2A9y++s+ehw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-arm/0.16.15:
     resolution: {integrity: sha512-+1sGlqtMJTOnJUXwLUGnDhPaGRKqxT0UONtYacS+EjdDOrSgpQ/1gUXlnze45Z/BogwYaswQM19Gu1YD1T19/w==}
     engines: {node: '>=12'}
@@ -4857,6 +4926,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-arm/0.17.14:
+    resolution: {integrity: sha512-BNTl+wSJ1omsH8s3TkQmIIIQHwvwJrU9u1ggb9XU2KTVM4TmthRIVyxSp2qxROJHhZuW/r8fht46/QE8hU8Qvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-arm64/0.16.15:
@@ -4868,6 +4945,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64/0.17.14:
+    resolution: {integrity: sha512-FhAMNYOq3Iblcj9i+K0l1Fp/MHt+zBeRu/Qkf0LtrcFu3T45jcwB6A1iMsemQ42vR3GBhjNZJZTaCe3VFPbn9g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-ia32/0.16.15:
     resolution: {integrity: sha512-puXVFvY4m8EB6/fzu3LdgjiNnEZ3gZMSR7NmKoQe51l3hyQalvTjab3Dt7aX4qGf+8Pj7dsCOBNzNzkSlr/4Aw==}
     engines: {node: '>=12'}
@@ -4875,6 +4960,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-ia32/0.17.14:
+    resolution: {integrity: sha512-91OK/lQ5y2v7AsmnFT+0EyxdPTNhov3y2CWMdizyMfxSxRqHazXdzgBKtlmkU2KYIc+9ZK3Vwp2KyXogEATYxQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-loong64/0.14.54:
@@ -4891,6 +4984,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64/0.16.15:
@@ -4902,6 +4996,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-loong64/0.17.14:
+    resolution: {integrity: sha512-vp15H+5NR6hubNgMluqqKza85HcGJgq7t6rMH7O3Y6ApiOWPkvW2AJfNojUQimfTp6OUrACUXfR4hmpcENXoMQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-mips64el/0.16.15:
     resolution: {integrity: sha512-3SEA4L82OnoSATW+Ve8rPgLaKjC8WMt8fnx7De9kvi/NcVbkj8W+J7qnu/tK2P9pUPQP7Au/0sjPEqZtFeyKQQ==}
     engines: {node: '>=12'}
@@ -4909,6 +5011,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el/0.17.14:
+    resolution: {integrity: sha512-90TOdFV7N+fgi6c2+GO9ochEkmm9kBAKnuD5e08GQMgMINOdOFHuYLPQ91RYVrnWwQ5683sJKuLi9l4SsbJ7Hg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-ppc64/0.16.15:
@@ -4920,6 +5030,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ppc64/0.17.14:
+    resolution: {integrity: sha512-NnBGeoqKkTugpBOBZZoktQQ1Yqb7aHKmHxsw43NddPB2YWLAlpb7THZIzsRsTr0Xw3nqiPxbA1H31ZMOG+VVPQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-riscv64/0.16.15:
     resolution: {integrity: sha512-U+coqH+89vbPVoU30no1Fllrn6gvEeO5tfEArBhjYZ+dQ3Gv7ciQXYf5nrT1QdlIFwEjH4Is1U1iiaGWW+tGpQ==}
     engines: {node: '>=12'}
@@ -4927,6 +5045,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64/0.17.14:
+    resolution: {integrity: sha512-0qdlKScLXA8MGVy21JUKvMzCYWovctuP8KKqhtE5A6IVPq4onxXhSuhwDd2g5sRCzNDlDjitc5sX31BzDoL5Fw==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-s390x/0.16.15:
@@ -4938,6 +5064,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x/0.17.14:
+    resolution: {integrity: sha512-Hdm2Jo1yaaOro4v3+6/zJk6ygCqIZuSDJHdHaf8nVH/tfOuoEX5Riv03Ka15LmQBYJObUTNS1UdyoMk0WUn9Ww==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-x64/0.16.15:
     resolution: {integrity: sha512-t7/fOXBUKfigvhJLGKZ9TPHHgqNgpIpYaAbcXQk1X+fPeUG7x0tpAbXJ2wST9F/gJ02+CLETPMnhG7Tra2wqsQ==}
     engines: {node: '>=12'}
@@ -4945,6 +5079,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-x64/0.17.14:
+    resolution: {integrity: sha512-8KHF17OstlK4DuzeF/KmSgzrTWQrkWj5boluiiq7kvJCiQVzUrmSkaBvcLB2UgHpKENO2i6BthPkmUhNDaJsVw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/netbsd-x64/0.16.15:
@@ -4956,6 +5098,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64/0.17.14:
+    resolution: {integrity: sha512-nVwpqvb3yyXztxIT2+VsxJhB5GCgzPdk1n0HHSnchRAcxqKO6ghXwHhJnr0j/B+5FSyEqSxF4q03rbA2fKXtUQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/openbsd-x64/0.16.15:
     resolution: {integrity: sha512-3SkckazfIbdSjsGpuIYT3d6n2Hx0tck3MS1yVsbahhWiLvdy4QozTpvlbjqO3GmvtvhxY4qdyhFOO2wiZKeTAQ==}
     engines: {node: '>=12'}
@@ -4963,6 +5113,14 @@ packages:
     os: [openbsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64/0.17.14:
+    resolution: {integrity: sha512-1RZ7uQQ9zcy/GSAJL1xPdN7NDdOOtNEGiJalg/MOzeakZeTrgH/DoCkbq7TaPDiPhWqnDF+4bnydxRqQD7il6g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/sunos-x64/0.16.15:
@@ -4974,6 +5132,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64/0.17.14:
+    resolution: {integrity: sha512-nqMjDsFwv7vp7msrwWRysnM38Sd44PKmW8EzV01YzDBTcTWUpczQg6mGao9VLicXSgW/iookNK6AxeogNVNDZA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-arm64/0.16.15:
     resolution: {integrity: sha512-YPaSgm/mm7kNcATB53OxVGVfn6rDNbImTn330ZlF3hKej1e9ktCaljGjn2vH08z2dlHEf3kdt57tNjE6zs8SzA==}
     engines: {node: '>=12'}
@@ -4981,6 +5147,14 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/win32-arm64/0.17.14:
+    resolution: {integrity: sha512-xrD0mccTKRBBIotrITV7WVQAwNJ5+1va6L0H9zN92v2yEdjfAN7864cUaZwJS7JPEs53bDTzKFbfqVlG2HhyKQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@esbuild/win32-ia32/0.16.15:
@@ -4992,6 +5166,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32/0.17.14:
+    resolution: {integrity: sha512-nXpkz9bbJrLLyUTYtRotSS3t5b+FOuljg8LgLdINWFs3FfqZMtbnBCZFUmBzQPyxqU87F8Av+3Nco/M3hEcu1w==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-x64/0.16.15:
     resolution: {integrity: sha512-27h5GCcbfomVAqAnMJWvR1LqEY0dFqIq4vTe5nY3becnZNu0SX8F0+gTk3JPvgWQHzaGc6VkPzlOiMkdSUunUA==}
     engines: {node: '>=12'}
@@ -4999,6 +5181,14 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/win32-x64/0.17.14:
+    resolution: {integrity: sha512-gPQmsi2DKTaEgG14hc3CHXHp62k8g6qr0Pas+I4lUxRMugGSATh/Bi8Dgusoz9IQ0IfdrvLpco6kujEIBoaogA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@eslint/eslintrc/0.4.3:
@@ -5781,7 +5971,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.14
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/resolve-uri/3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -5795,7 +5985,7 @@ packages:
     resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.14
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
@@ -5805,6 +5995,7 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -5924,7 +6115,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@types/set-cookie-parser': 2.4.2
-      set-cookie-parser: 2.5.0
+      set-cookie-parser: 2.5.1
     dev: false
 
   /@mswjs/interceptors/0.15.3:
@@ -6618,6 +6809,20 @@ packages:
       picomatch: 2.3.1
       rollup: 3.15.0
 
+  /@rollup/pluginutils/5.0.2_rollup@3.20.2:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.20.2
+
   /@rushstack/eslint-patch/1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: true
@@ -6637,19 +6842,19 @@ packages:
     resolution: {integrity: sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ==}
     dev: true
 
-  /@solidjs/meta/0.28.2_solid-js@1.6.11:
+  /@solidjs/meta/0.28.2_solid-js@1.6.16:
     resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
-      solid-js: 1.6.11
+      solid-js: 1.6.16
 
-  /@solidjs/router/0.6.0_solid-js@1.6.11:
-    resolution: {integrity: sha512-7ug2fzXXhvvDBL4CQyMvMM9o3dgBE6PoRh38T8UTmMnYz4rcCfROqSZc9yq+YEC96qWt5OvJgZ1Uj/4EAQXlfA==}
+  /@solidjs/router/0.7.1_solid-js@1.6.16:
+    resolution: {integrity: sha512-wLE1GjZB/h9HmHMe+S4QBeS7FsjwlpkuNAJ0vOC5WFoyRECKS7sTrzPhGGJB9rxC4OMsXPwXDOXYQ599MMe0Dg==}
     peerDependencies:
       solid-js: ^1.5.3
     dependencies:
-      solid-js: 1.6.11
+      solid-js: 1.6.16
 
   /@sveltejs/adapter-auto/1.0.0_@sveltejs+kit@1.0.7:
     resolution: {integrity: sha512-yKyPvlLVua1bJ/42FrR3X041mFGdB4GzTZOAEoHUcNBRE5Mhx94+eqHpC3hNvAOiLEDcKfVO0ObyKSu7qldU+w==}
@@ -6852,13 +7057,13 @@ packages:
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  /@tanstack/solid-query/4.26.1_solid-js@1.6.11:
+  /@tanstack/solid-query/4.26.1_solid-js@1.6.16:
     resolution: {integrity: sha512-MU313rBrU8iJfBx0/fUXzzZiyQeRYJy1TNI2YKYzVUAU9bfioMcvAXMgB8R9h4SCOz9tN4xCC7JGnuB8k39KaA==}
     peerDependencies:
       solid-js: ^1.5.7
     dependencies:
       '@tanstack/query-core': 4.26.1
-      solid-js: 1.6.11
+      solid-js: 1.6.16
     dev: false
 
   /@tanstack/svelte-query/4.26.1_svelte@3.55.0:
@@ -6936,7 +7141,7 @@ packages:
     dependencies:
       '@adobe/css-tools': 4.1.0
       '@babel/runtime': 7.21.0
-      '@types/testing-library__jest-dom': 5.14.5
+      '@types/testing-library__jest-dom': 5.14.5_d573maxasnl5kxwdyzebcnmhpm
       aria-query: 5.1.3
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -7027,6 +7232,31 @@ packages:
   /@types/aria-query/4.2.2:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
     dev: true
+
+  /@types/babel__core/7.20.0:
+    resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
+    dependencies:
+      '@babel/parser': 7.20.15
+      '@babel/types': 7.20.7
+      '@types/babel__generator': 7.6.4
+      '@types/babel__template': 7.4.1
+      '@types/babel__traverse': 7.18.3
+
+  /@types/babel__generator/7.6.4:
+    resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
+    dependencies:
+      '@babel/types': 7.20.7
+
+  /@types/babel__template/7.4.1:
+    resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
+    dependencies:
+      '@babel/parser': 7.20.15
+      '@babel/types': 7.20.7
+
+  /@types/babel__traverse/7.18.3:
+    resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
+    dependencies:
+      '@babel/types': 7.20.7
 
   /@types/chai-subset/1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
@@ -7225,11 +7455,12 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
-  /@types/testing-library__jest-dom/5.14.5:
+  /@types/testing-library__jest-dom/5.14.5_d573maxasnl5kxwdyzebcnmhpm:
     resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
     dependencies:
       '@types/jest': 29.4.0
     dev: true
+    patched: true
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -8464,7 +8695,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -8472,7 +8703,7 @@ packages:
   /axios/0.24.0:
     resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: true
@@ -8487,7 +8718,7 @@ packages:
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -8495,7 +8726,7 @@ packages:
   /axios/1.3.3:
     resolution: {integrity: sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -10093,6 +10324,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-arm64/0.14.54:
@@ -10109,6 +10341,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-64/0.14.54:
@@ -10125,6 +10358,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-arm64/0.14.54:
@@ -10141,6 +10375,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-64/0.14.54:
@@ -10157,6 +10392,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-arm64/0.14.54:
@@ -10173,6 +10409,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-32/0.14.54:
@@ -10189,6 +10426,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-64/0.14.54:
@@ -10205,6 +10443,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm/0.14.54:
@@ -10221,6 +10460,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm64/0.14.54:
@@ -10237,6 +10477,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-mips64le/0.14.54:
@@ -10253,6 +10494,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-ppc64le/0.14.54:
@@ -10269,6 +10511,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-riscv64/0.14.54:
@@ -10285,6 +10528,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-s390x/0.14.54:
@@ -10301,6 +10545,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.14.54:
@@ -10317,6 +10562,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-openbsd-64/0.14.54:
@@ -10333,9 +10579,10 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
-  /esbuild-plugin-solid/0.4.2_bve56rijdtklnf27lceyb3zzei:
+  /esbuild-plugin-solid/0.4.2_ajcandgzujanbl7g4gahkpcrcq:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -10345,7 +10592,7 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       babel-preset-solid: 1.6.10_@babel+core@7.20.12
       esbuild: 0.14.54
-      solid-js: 1.6.11
+      solid-js: 1.6.16
     transitivePeerDependencies:
       - supports-color
 
@@ -10363,6 +10610,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-32/0.14.54:
@@ -10379,6 +10627,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-64/0.14.54:
@@ -10395,6 +10644,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-arm64/0.14.54:
@@ -10411,6 +10661,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild/0.14.54:
@@ -10469,6 +10720,7 @@ packages:
       esbuild-windows-32: 0.15.9
       esbuild-windows-64: 0.15.9
       esbuild-windows-arm64: 0.15.9
+    dev: true
 
   /esbuild/0.16.15:
     resolution: {integrity: sha512-v+3ozjy9wyj8cOElzx3//Lsb4TCxPfZxRmdsfm0YaEkvZu7y6rKH7Zi1UpDx4JI7dSQui+U1Qxhfij9KBbHfrA==}
@@ -10499,6 +10751,35 @@ packages:
       '@esbuild/win32-ia32': 0.16.15
       '@esbuild/win32-x64': 0.16.15
     dev: true
+
+  /esbuild/0.17.14:
+    resolution: {integrity: sha512-vOO5XhmVj/1XQR9NQ1UPq6qvMYL7QFJU57J5fKBKBKxp17uDt5PgxFDb4A2nEiXhr1qQs4x0F5+66hVVw4ruNw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.14
+      '@esbuild/android-arm64': 0.17.14
+      '@esbuild/android-x64': 0.17.14
+      '@esbuild/darwin-arm64': 0.17.14
+      '@esbuild/darwin-x64': 0.17.14
+      '@esbuild/freebsd-arm64': 0.17.14
+      '@esbuild/freebsd-x64': 0.17.14
+      '@esbuild/linux-arm': 0.17.14
+      '@esbuild/linux-arm64': 0.17.14
+      '@esbuild/linux-ia32': 0.17.14
+      '@esbuild/linux-loong64': 0.17.14
+      '@esbuild/linux-mips64el': 0.17.14
+      '@esbuild/linux-ppc64': 0.17.14
+      '@esbuild/linux-riscv64': 0.17.14
+      '@esbuild/linux-s390x': 0.17.14
+      '@esbuild/linux-x64': 0.17.14
+      '@esbuild/netbsd-x64': 0.17.14
+      '@esbuild/openbsd-x64': 0.17.14
+      '@esbuild/sunos-x64': 0.17.14
+      '@esbuild/win32-arm64': 0.17.14
+      '@esbuild/win32-ia32': 0.17.14
+      '@esbuild/win32-x64': 0.17.14
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -11854,6 +12135,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
 
   /follow-redirects/1.15.1_debug@4.3.4:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
@@ -12649,12 +12931,6 @@ packages:
 
   /is-core-module/2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
-    dependencies:
-      has: 1.0.3
-    dev: true
-
-  /is-core-module/2.9.0:
-    resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
     dependencies:
       has: 1.0.3
 
@@ -14152,7 +14428,7 @@ packages:
     resolution: {integrity: sha512-0w5CmCM+ybSqXIjqU4RiK40t4bvANL6lafabQ2GP2XD3vSwkLY+StWzCtsb4mPuyi9R/SgoLBel+ZOXHXAH0eQ==}
     dependencies:
       '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
       invariant: 2.2.4
       metro-symbolicate: 0.59.0
       ob1: 0.59.0
@@ -14210,7 +14486,7 @@ packages:
     resolution: {integrity: sha512-iTIRBD/wBI98plfxj8jAoNUUXfXLNlyvcjPtshhpGvdwu9pzQilGfnDnOaaK+vbITcOk9w5oQectXyJwAqTr1A==}
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/generator': 7.20.14
+      '@babel/generator': 7.21.3
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.13
       nullthrows: 1.1.1
@@ -14222,9 +14498,9 @@ packages:
     resolution: {integrity: sha512-wegRtK8GyLF6IPZRBJp+zsORgA4iX0h1DRpknyAMDCtSbJ4VU2xV/AojteOgAsDvY3ucAGsvfuZLNDJHUdUNHQ==}
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/generator': 7.20.14
+      '@babel/generator': 7.21.3
       '@babel/parser': 7.20.15
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
       babel-preset-fbjs: 3.4.0_@babel+core@7.20.12
       metro: 0.64.0
       metro-babel-transformer: 0.64.0
@@ -14247,11 +14523,11 @@ packages:
     dependencies:
       '@babel/code-frame': 7.18.6
       '@babel/core': 7.20.12
-      '@babel/generator': 7.20.14
+      '@babel/generator': 7.21.3
       '@babel/parser': 7.20.15
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.3
       absolute-path: 0.0.0
       accepts: 1.3.8
       async: 2.6.4
@@ -16128,7 +16404,7 @@ packages:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.9.0
+      is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -16243,6 +16519,23 @@ packages:
       rollup: 3.15.0
       source-map: 0.7.4
       yargs: 17.5.1
+    dev: true
+
+  /rollup-plugin-visualizer/5.9.0_rollup@3.20.2:
+    resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.0
+      picomatch: 2.3.1
+      rollup: 3.20.2
+      source-map: 0.7.4
+      yargs: 17.5.1
 
   /rollup-preset-solid/1.4.0:
     resolution: {integrity: sha512-rjUH0dMkyHxkin1uBcdZX110DL/P0hppMWF0RAwJdl7ly9IH/N+jHxmnyf7OzkyI2pGUBO9Lr1NN8Me9TFKN6Q==}
@@ -16264,13 +16557,13 @@ packages:
       - supports-color
     dev: true
 
-  /rollup-route-manifest/1.0.0_rollup@3.15.0:
+  /rollup-route-manifest/1.0.0_rollup@3.20.2:
     resolution: {integrity: sha512-3CmcMmCLAzJDUXiO3z6386/Pt8/k9xTZv8gIHyXI8hYGoAInnYdOsFXiGGzQRMy6TXR1jUZme2qbdwjH2nFMjg==}
     engines: {node: '>=8'}
     peerDependencies:
       rollup: '>=2.0.0'
     dependencies:
-      rollup: 3.15.0
+      rollup: 3.20.2
       route-sort: 1.0.0
 
   /rollup/2.78.1:
@@ -16287,9 +16580,17 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rollup/3.15.0:
     resolution: {integrity: sha512-F9hrCAhnp5/zx/7HYmftvsNBkMfLfk/dXUh73hPSM2E3CRgap65orDNJbLetoiUFwSAk6iHPLvBrZ5iHYvzqsg==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /rollup/3.20.2:
+    resolution: {integrity: sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -16494,10 +16795,6 @@ packages:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: false
 
-  /set-cookie-parser/2.5.0:
-    resolution: {integrity: sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w==}
-    dev: false
-
   /set-cookie-parser/2.5.1:
     resolution: {integrity: sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==}
 
@@ -16692,14 +16989,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /solid-js/1.5.7:
-    resolution: {integrity: sha512-L1UuyMuZZARAwzXo5NZDhE6yxc14aqNbVOUoGzvlcxRZo1Cm4ExhPV0diEfwDyiKG/igqNNLkNurHkXiI5sVEg==}
-    dependencies:
-      csstype: 3.1.0
-    dev: true
-
-  /solid-js/1.6.11:
-    resolution: {integrity: sha512-JquQQHPArGq+i2PLURxJ99Pcz2/1docpbycSio/cKSA0SeI3z5zRjy0TNcH4NRYvbOLrcini+iovXwnexKabyw==}
+  /solid-js/1.6.16:
+    resolution: {integrity: sha512-Ng4CahvLlpGA3BXIMiiMdwhI8WpObZ8gXqm97GCKR4+MpnODs6Pdpco+tmVCY/4ZDFaEKDxz7WRLAAdoXdlY7w==}
     dependencies:
       csstype: 3.1.0
 
@@ -16713,7 +17004,7 @@ packages:
       '@babel/types': 7.20.7
     dev: true
 
-  /solid-refresh/0.4.1_solid-js@1.6.11:
+  /solid-refresh/0.4.1_solid-js@1.6.16:
     resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
     peerDependencies:
       solid-js: ^1.3
@@ -16721,9 +17012,20 @@ packages:
       '@babel/generator': 7.20.14
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.20.7
-      solid-js: 1.6.11
+      solid-js: 1.6.16
+    dev: true
 
-  /solid-start-node/0.2.21_pnrae6sj5z7x4ihr4h4m5jbpx4:
+  /solid-refresh/0.5.2_solid-js@1.6.16:
+    resolution: {integrity: sha512-I69HmFj0LsGRJ3n8CEMVjyQFgVtuM2bSjznu2hCnsY+i5oOxh8ioWj00nnHBv0UYD3WpE/Sq4Q3TNw2IKmKN7A==}
+    peerDependencies:
+      solid-js: ^1.3
+    dependencies:
+      '@babel/generator': 7.21.3
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/types': 7.21.3
+      solid-js: 1.6.16
+
+  /solid-start-node/0.2.21_2vqkbilyolq35n53mildrhalmu:
     resolution: {integrity: sha512-DmmJT6K+uF0yLPkn1GQvIHmZRUdYlQwBijruvCiEWuy3d1sLedRnP22K/+u9eKqm8ruFOTQHrc/1wuGVcj3JXg==}
     peerDependencies:
       solid-start: '*'
@@ -16737,19 +17039,19 @@ packages:
       polka: 1.0.0-next.22
       rollup: 3.15.0
       sirv: 2.0.2
-      solid-start: 0.2.21_hj77zfsbczccdokc5ewmqqrrvy
+      solid-start: 0.2.24_euxzheln45tfyr565dhf2xv3la
       terser: 5.16.3
       undici: 5.14.0
-      vite: 3.2.2
+      vite: 4.2.1_@types+node@18.13.0
     transitivePeerDependencies:
       - supports-color
 
-  /solid-start/0.2.21_hj77zfsbczccdokc5ewmqqrrvy:
-    resolution: {integrity: sha512-igh1vI6d8sBm9BeGGcJOE7ewEOSlhzmL3f4iVX0bg5oz+9xtqAf1EA0MvNkTLTvq5YKsVKYy80oJmm/xg0F8jw==}
+  /solid-start/0.2.24_euxzheln45tfyr565dhf2xv3la:
+    resolution: {integrity: sha512-7nbl4mRiWwts7KN4ep1vT4eRcjacB6StdP/JalaCWtovpX0EctcEwXpJQeHKkGCL+J0n3M+aph0qkzUyJ5tD6Q==}
     hasBin: true
     peerDependencies:
       '@solidjs/meta': ^0.28.0
-      '@solidjs/router': ^0.7.0
+      '@solidjs/router': ^0.8.2
       solid-js: ^1.6.2
       solid-start-aws: '*'
       solid-start-cloudflare-pages: '*'
@@ -16759,7 +17061,7 @@ packages:
       solid-start-node: '*'
       solid-start-static: '*'
       solid-start-vercel: '*'
-      vite: ^3.1.8
+      vite: ^4.1.4
     peerDependenciesMeta:
       solid-start-aws:
         optional: true
@@ -16784,8 +17086,8 @@ packages:
       '@babel/preset-env': 7.20.2_@babel+core@7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       '@babel/template': 7.20.7
-      '@solidjs/meta': 0.28.2_solid-js@1.6.11
-      '@solidjs/router': 0.6.0_solid-js@1.6.11
+      '@solidjs/meta': 0.28.2_solid-js@1.6.16
+      '@solidjs/router': 0.7.1_solid-js@1.6.16
       '@types/cookie': 0.5.1
       chokidar: 3.5.3
       compression: 1.7.4
@@ -16795,36 +17097,36 @@ packages:
       dotenv: 16.0.3
       es-module-lexer: 1.1.1
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2_bve56rijdtklnf27lceyb3zzei
+      esbuild-plugin-solid: 0.4.2_ajcandgzujanbl7g4gahkpcrcq
       fast-glob: 3.2.12
       get-port: 6.1.2
       parse-multipart-data: 1.5.0
       picocolors: 1.0.0
-      rollup: 3.15.0
-      rollup-plugin-visualizer: 5.9.0_rollup@3.15.0
-      rollup-route-manifest: 1.0.0_rollup@3.15.0
+      rollup: 3.20.2
+      rollup-plugin-visualizer: 5.9.0_rollup@3.20.2
+      rollup-route-manifest: 1.0.0_rollup@3.20.2
       sade: 1.8.1
       set-cookie-parser: 2.5.1
       sirv: 2.0.2
-      solid-js: 1.6.11
-      solid-start-node: 0.2.21_pnrae6sj5z7x4ihr4h4m5jbpx4
+      solid-js: 1.6.16
+      solid-start-node: 0.2.21_2vqkbilyolq35n53mildrhalmu
       terser: 5.16.3
       undici: 5.19.1
-      vite: 3.2.2
-      vite-plugin-inspect: 0.7.15_rollup@3.15.0+vite@3.2.2
-      vite-plugin-solid: 2.5.0_solid-js@1.6.11+vite@3.2.2
+      vite: 4.2.1_@types+node@18.13.0
+      vite-plugin-inspect: 0.7.15_rollup@3.20.2+vite@4.2.1
+      vite-plugin-solid: 2.6.1_solid-js@1.6.16+vite@4.2.1
       wait-on: 6.0.1_debug@4.3.4
     transitivePeerDependencies:
       - supports-color
 
-  /solid-testing-library/0.3.0_solid-js@1.5.7:
+  /solid-testing-library/0.3.0_solid-js@1.6.16:
     resolution: {integrity: sha512-6NWVbySNVzyReBm2N6p3eF8bzxRZXHZTAmPix4vFWYol16QWVjNQsEUxvr+ZOutb0yuMZmNuGx3b6WIJYmjwMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
       '@testing-library/dom': 7.31.2
-      solid-js: 1.5.7
+      solid-js: 1.6.16
     dev: true
 
   /sorcery/0.10.0:
@@ -18120,7 +18422,7 @@ packages:
     dev: true
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
   /uuid/3.4.0:
@@ -18171,7 +18473,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.0.4_@types+node@18.13.0
+      vite: 4.2.1_@types+node@18.13.0
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18182,25 +18484,25 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-inspect/0.7.15_rollup@3.15.0+vite@3.2.2:
+  /vite-plugin-inspect/0.7.15_rollup@3.20.2+vite@4.2.1:
     resolution: {integrity: sha512-oxeZCljacA/slhGFbDNlBqdhDU9fgdHL84i7Nz7DnaAIE7DhTiW2djanw3d/BKuZtduKUY82vRUQ4iaG917t2A==}
     engines: {node: '>=14'}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
     dependencies:
       '@antfu/utils': 0.7.2
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.20.2
       debug: 4.3.4
       fs-extra: 11.1.0
       kolorist: 1.7.0
       sirv: 2.0.2
       ufo: 1.0.1
-      vite: 3.2.2
+      vite: 4.2.1_@types+node@18.13.0
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  /vite-plugin-solid/2.3.9_solid-js@1.6.11+vite@3.1.3:
+  /vite-plugin-solid/2.3.9_solid-js@1.6.16+vite@3.1.3:
     resolution: {integrity: sha512-+lprsYgt9DVNp0kbDj2d2HWAPI13L8ff5xslk9SjiPBcsY/YUZ/1Wj0J/Oj5aiVAhwfPm8IcM3bzyHJUPlmc8w==}
     peerDependencies:
       solid-js: ^1.3.17
@@ -18210,8 +18512,8 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       babel-preset-solid: 1.6.10_@babel+core@7.20.12
       merge-anything: 5.0.4
-      solid-js: 1.6.11
-      solid-refresh: 0.4.1_solid-js@1.6.11
+      solid-js: 1.6.16
+      solid-refresh: 0.4.1_solid-js@1.6.16
       vite: 3.1.3
     transitivePeerDependencies:
       - supports-color
@@ -18233,20 +18535,21 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid/2.5.0_solid-js@1.6.11+vite@3.2.2:
-    resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
+  /vite-plugin-solid/2.6.1_solid-js@1.6.16+vite@4.2.1:
+    resolution: {integrity: sha512-/khM/ha3B5/pTWQWVJd/0n6ODPIrOcajwhbrD8Gnv37XmJJssu+KA8ssN73raMIicf2eiQKiTAV39w7dSl4Irg==}
     peerDependencies:
       solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
+      '@types/babel__core': 7.20.0
       babel-preset-solid: 1.6.10_@babel+core@7.20.12
       merge-anything: 5.1.4
-      solid-js: 1.6.11
-      solid-refresh: 0.4.1_solid-js@1.6.11
-      vite: 3.2.2
-      vitefu: 0.2.4_vite@3.2.2
+      solid-js: 1.6.16
+      solid-refresh: 0.5.2_solid-js@1.6.16
+      vite: 4.2.1_@types+node@18.13.0
+      vitefu: 0.2.4_vite@4.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -18359,6 +18662,7 @@ packages:
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vite/4.0.4:
     resolution: {integrity: sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==}
@@ -18427,6 +18731,39 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vite/4.2.1_@types+node@18.13.0:
+    resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.13.0
+      esbuild: 0.17.14
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.20.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
   /vitefu/0.2.4:
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
@@ -18435,16 +18772,6 @@ packages:
       vite:
         optional: true
     dev: true
-
-  /vitefu/0.2.4_vite@3.2.2:
-    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      vite: 3.2.2
 
   /vitefu/0.2.4_vite@4.0.4:
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
@@ -18456,6 +18783,16 @@ packages:
     dependencies:
       vite: 4.0.4
     dev: true
+
+  /vitefu/0.2.4_vite@4.2.1:
+    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 4.2.1_@types+node@18.13.0
 
   /vitest/0.27.1:
     resolution: {integrity: sha512-1sIpQ1DVFTEn7c1ici1XHcVfdU4nKiBmPtPAtGKJJJLuJjojTv/OHGgcf69P57alM4ty8V4NMv+7Yoi5Cxqx9g==}

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -35,12 +35,12 @@ const babelPlugin = (type: 'legacy' | 'modern') =>
       type === 'modern'
         ? ''
         : {
-            chrome: 73,
-            firefox: 78,
-            edge: 79,
-            safari: 12,
-            ios: 12,
-            opera: 53,
+            chrome: '73',
+            firefox: '78',
+            edge: '79',
+            safari: '12',
+            ios: '12',
+            opera: '53',
           },
     babelHelpers: 'bundled',
     exclude: /node_modules/,


### PR DESCRIPTION
~### 1. Don't use `onCleanup` on the server~

~It's still not safe to rely on `onCleanup` on the server, so I've re-added the `!isServer` check for the time being. I was able to isolate + reproduce the `onCleanup` behavior, and opened an issue in the solidjs repo - we'll see what Ryan + team thinks -> https://github.com/solidjs/solid/issues/1599.~

Nevermind! Ryan fixed the https://github.com/solidjs/solid/issues/1599 in solid v1.6.13 - I verified it solves the problem here in solid-query, and bumped the minimum solid-js version to 1.6.13.

**Before**

Any page with more than one query on it cannot be rendered in SSR (streaming or regular async render). Try firing up the example and loading `http://127.0.0.1:3000/deferred` - it will load indefinitely.

<img width="737" alt="Screenshot 2023-03-07 at 3 49 57 PM" src="https://user-images.githubusercontent.com/847542/223561155-2c2b3137-6ae5-40db-99e9-2f59968b5ac2.png">

**After**

Routes with more than one query on them can be rendered in SSR.

### 2. Update to prefer the query resource value, if present

In particular, this makes it possible to rely on props like `isFetching`, etc, while rendering on the server. It also ensures that the query state on the client starts with the correct values (e.g. if the query was already fetched on the server, `isFetched` should start off as `true` on the client).

I'm still unsure how to add tests for SSR related behavior, so for now my best "testing" method has been to create examples and manually verify. I added a `http://127.0.0.1:3000/hydration` route to the `solid-start-streaming` example. 

**Before**

Note the mis-match on values like `isFetching` - the server and initial render still think it is true, when in fact it is done fetching and should be false. Also.. `isRefetching` set to `true` across the board - weird.

<img width="1356" alt="Screenshot 2023-03-07 at 3 38 56 PM" src="https://user-images.githubusercontent.com/847542/223558945-1b0fd10a-b5e5-4de9-9ed6-949f262949fe.png">

**After**

Note how after these changes, the values on the server, and on initial render, are more along the lines of what one would expect.

<img width="1327" alt="Screenshot 2023-03-07 at 3 39 46 PM" src="https://user-images.githubusercontent.com/847542/223559090-51620a0f-8454-4a08-a60f-2a0faebe7fb2.png">

I'm not sure if there is a better way to solve this issue, or if something else is going on that is better fixed in query-core. There is still one weird bit of behavior - on first refetch note how `isFetched` briefly is set to false. Overall though this change feels like a solid step forward.. just not QUITE there yet across the board.

![2023-03-07 15 45 10](https://user-images.githubusercontent.com/847542/223560176-558a2cbd-72e7-44e0-bb56-afa1987cf5b6.gif)

---

In case @ardeora or anybody else wants to mess around with the behavior, here's he best way I've found to get the example going for local dev:

1. Set `@tanstack/solid-query` to `workspace:*` in the example package.json (https://github.com/TanStack/query/blob/alpha/examples/solid/solid-start-streaming/package.json#L18)
2. Set `main` in the solid-query `package.json` to `"main": "src/index.js",`. Remove the `exports`, `module`, and `types` properties.
3. `pnpm i`
4. `cd examples/solid/solid-start-streaming && pnpm dev`
5. Make changes to the solid-query package as needed, the example will hot-reload