### PR TITLE
fix: Fix `getNextPageParam` types

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -34,12 +34,12 @@ export type QueryKeyHashFunction<TQueryKey extends QueryKey> = (
 ) => string
 
 export type GetPreviousPageParamFunction<TQueryFnData = unknown> = (
-  firstPage: TQueryFnData,
+  firstPage: TQueryFnData | undefined,
   allPages: TQueryFnData[],
 ) => unknown
 
 export type GetNextPageParamFunction<TQueryFnData = unknown> = (
-  lastPage: TQueryFnData,
+  lastPage: TQueryFnData | undefined,
   allPages: TQueryFnData[],
 ) => unknown
 


### PR DESCRIPTION
When using `useInfiniteQuery`, it can happen that `getNextPageParam` gets called with the first argument being `undefined`. The types however say that it cannot be undefined, so this is the fix to that.

Maybe I'm also using it wrong?

```tsx
interface Result {
  data: Transaction[]
  nextCursor: string | undefined
}
function getTransactions(address: string): Promise<Result> {
  ...
}

function App() {
  const { data, status, fetchNextPage, refetch } = useInfiniteQuery(
    'transactions',
    ({ pageParam }) => getTransactions(address),
    {
      getNextPageParam: (lastPage) => lastPage?.nextCursor, // <-- lastPage here can be undefined, but the type is 'Result<Transaction[]>' (no ' | undefined')
      initialData: { pages: [], pageParams: [] },
    }
  )

  ...
}
```