### PR TITLE
docs(queries): rename `success` -> `isSuccess`

### DIFF
--- a/docs/react/guides/queries.md
+++ b/docs/react/guides/queries.md
@@ -47,7 +47,7 @@ The `result` object contains a few very important states you'll need to be aware
 Beyond those primary states, more information is available depending on the state of the query:
 
 - `error` - If the query is in an `isError` state, the error is available via the `error` property.
-- `data` - If the query is in a `success` state, the data is available via the `data` property.
+- `data` - If the query is in an `isSuccess` state, the data is available via the `data` property.
 
 For **most** queries, it's usually sufficient to check for the `isLoading` state, then the `isError` state, then finally, assume that the data is available and render the successful state:
 


### PR DESCRIPTION
Origin version: 
> error - If the query is in an isError state, the error is available via the error property.
> data - If the query is in a success state, the data is available via the data property.

Compared with the previous sentence,  `a success` should be changed to `an isSuccess`