### PR TITLE
feat: fine grained storage persister

### DIFF
--- a/examples/vue/persister/package.json
+++ b/examples/vue/persister/package.json
@@ -8,10 +8,12 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "vue": "3.2.41",
-    "@tanstack/vue-query": "^4.14.1",
+    "@tanstack/query-core": "^4.14.1",
     "@tanstack/query-persist-client-core": "^4.14.1",
-    "@tanstack/query-sync-storage-persister": "^4.14.1"
+    "@tanstack/query-sync-storage-persister": "^4.14.1",
+    "@tanstack/vue-query": "^4.14.1",
+    "idb-keyval": "^6.2.0",
+    "vue": "3.2.41"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "3.2.0",

--- a/examples/vue/persister/src/Post.vue
+++ b/examples/vue/persister/src/Post.vue
@@ -1,8 +1,10 @@
 <script lang="ts">
+import { get, set, del } from 'idb-keyval'
 import { defineComponent } from 'vue'
-import { useQuery } from '@tanstack/vue-query'
+import { useQuery, useQueryClient } from '@tanstack/vue-query'
 
 import { Post } from './types'
+import { createPersister } from './persister'
 
 const fetcher = async (id: number): Promise<Post> =>
   await fetch(`https://jsonplaceholder.typicode.com/posts/${id}`).then(
@@ -19,9 +21,18 @@ export default defineComponent({
   },
   emits: ['setPostId'],
   setup(props) {
+    const queryClient = useQueryClient()
+
     const { isLoading, isError, isFetching, data, error } = useQuery({
       queryKey: ['post', props.postId],
-      queryFn: () => fetcher(props.postId),
+      queryFn: createPersister(() => fetcher(props.postId), {
+        storage: {
+          getItem: (key: string) => get(key),
+          setItem: (key: string, value: string) => set(key, value),
+          removeItem: (key: string) => del(key),
+        },
+        queryClient,
+      }),
     })
 
     return { isLoading, isError, isFetching, data, error }

--- a/examples/vue/persister/src/Posts.vue
+++ b/examples/vue/persister/src/Posts.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { useQuery } from '@tanstack/vue-query'
+import { useQuery, useQueryClient } from '@tanstack/vue-query'
 
 import { Post } from './types'
+import { createPersister } from './persister'
 
 const fetcher = async (): Promise<Post[]> =>
   await fetch('https://jsonplaceholder.typicode.com/posts').then((response) =>
@@ -19,9 +20,14 @@ export default defineComponent({
   },
   emits: ['setPostId'],
   setup() {
+    const queryClient = useQueryClient()
+
     const { isLoading, isError, isFetching, data, error, refetch } = useQuery({
       queryKey: ['posts'],
-      queryFn: fetcher,
+      queryFn: createPersister(fetcher, {
+        storage: localStorage,
+        queryClient,
+      }),
     })
 
     return { isLoading, isError, isFetching, data, error, refetch }

--- a/examples/vue/persister/src/main.ts
+++ b/examples/vue/persister/src/main.ts
@@ -9,17 +9,17 @@ const vueQueryOptions: VueQueryPluginOptions = {
   queryClientConfig: {
     defaultOptions: {
       queries: {
-        gcTime: 1000 * 60 * 60 * 24,
-        staleTime: 1000 * 60 * 60 * 24,
+        cacheTime: 1000 * 60 * 60 * 24,
+        staleTime: 1000 * 10,
       },
     },
   },
-  clientPersister: (queryClient) => {
-    return persistQueryClient({
-      queryClient,
-      persister: createSyncStoragePersister({ storage: localStorage }),
-    })
-  },
+  // clientPersister: (queryClient) => {
+  //   return persistQueryClient({
+  //     queryClient,
+  //     persister: createSyncStoragePersister({ storage: localStorage }),
+  //   })
+  // },
 }
 
 createApp(App).use(VueQueryPlugin, vueQueryOptions).mount('#app')

--- a/examples/vue/persister/src/persister.ts
+++ b/examples/vue/persister/src/persister.ts
@@ -1,0 +1,128 @@
+import type {
+  QueryClient,
+  QueryFunctionContext,
+  QueryKey,
+  QueryState,
+} from '@tanstack/query-core'
+import { hashQueryKey } from '@tanstack/query-core'
+
+export type Promisable<T> = T | PromiseLike<T>
+
+export interface PersistedQuery {
+  buster: string
+  timestamp: number
+  queryHash: string
+  queryKey: QueryKey
+  state: QueryState
+}
+
+export type PersistRetryer = (props: {
+  persistedQuery: PersistedQuery
+  error: Error
+  errorCount: number
+}) => Promisable<PersistedQuery | undefined>
+
+export interface AsyncStorage {
+  getItem: (key: string) => Promise<string | undefined | null>
+  setItem: (key: string, value: string) => Promise<void>
+  removeItem: (key: string) => Promise<void>
+}
+
+export interface StoragePersisterOptions<QC extends QueryClient> {
+  // TODO: if we decide to move this to an API layer, we could make this work without passing queryClient
+  /**
+   * Query Client instance
+   */
+  queryClient: QC
+  /** The storage client used for setting and retrieving items from cache.
+   * For SSR pass in `undefined`.
+   */
+  storage: AsyncStorage | Storage | undefined | null
+  /**
+   * How to serialize the data to storage.
+   * @default `JSON.stringify`
+   */
+  serialize?: (client: PersistedQuery) => string
+  /**
+   * How to deserialize the data from storage.
+   * @default `JSON.parse`
+   */
+  deserialize?: (cachedString: string) => PersistedQuery
+  /**
+   * A unique string that can be used to forcefully invalidate existing caches,
+   * if they do not share the same buster string
+   */
+  buster?: string
+  /**
+   * The max-allowed age of the cache in milliseconds.
+   * If a persisted cache is found that is older than this
+   * time, it will be discarded
+   */
+  maxAge?: number
+}
+
+export function createPersister<T, QC extends QueryClient>(
+  queryFn: () => Promise<T>,
+  {
+    queryClient,
+    storage,
+    buster = '',
+    maxAge = 1000 * 60 * 60 * 24,
+    serialize = JSON.stringify,
+    deserialize = JSON.parse,
+  }: StoragePersisterOptions<QC>,
+) {
+  return async (context: QueryFunctionContext) => {
+    const queryHash = hashQueryKey(context.queryKey)
+    const queryState = queryClient.getQueryState(context.queryKey)
+
+    if (!queryState?.data && storage != null) {
+      const storedData = await storage.getItem(queryHash)
+      if (storedData) {
+        const persistedQuery = deserialize(storedData) as PersistedQuery
+
+        if (persistedQuery.timestamp) {
+          const expired = Date.now() - persistedQuery.timestamp > maxAge
+          const busted = persistedQuery.buster !== buster
+          if (expired || busted) {
+            await storage.removeItem(queryHash)
+          } else {
+            queryClient.getQueryCache().build(
+              queryClient,
+              {
+                queryKey: context.queryKey,
+                queryHash: queryHash,
+              },
+              persistedQuery.state,
+            )
+            return Promise.resolve(persistedQuery.state.data as T)
+          }
+        } else {
+          await storage.removeItem(queryHash)
+        }
+      }
+    }
+
+    const queryFnResult = await queryFn()
+
+    if (storage != null) {
+      // TODO: if we decide to move this to an API layer, we could make this work without additional timeout
+      setTimeout(() => {
+        const newState = queryClient.getQueryState(context.queryKey)
+
+        storage.setItem(
+          queryHash,
+          serialize({
+            state: newState!,
+            queryKey: context.queryKey,
+            queryHash: queryHash,
+            timestamp: Date.now(),
+            buster: buster,
+          }),
+        )
+      }, 0)
+    }
+
+    return Promise.resolve(queryFnResult)
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,17 +842,21 @@ importers:
 
   examples/vue/persister:
     specifiers:
+      '@tanstack/query-core': ^4.14.1
       '@tanstack/query-persist-client-core': ^4.14.1
       '@tanstack/query-sync-storage-persister': ^4.14.1
       '@tanstack/vue-query': ^4.14.1
       '@vitejs/plugin-vue': 3.2.0
+      idb-keyval: ^6.2.0
       typescript: 4.8.4
       vite: 3.2.2
       vue: 3.2.41
     dependencies:
+      '@tanstack/query-core': 4.24.4
       '@tanstack/query-persist-client-core': 4.24.4
       '@tanstack/query-sync-storage-persister': 4.24.4
       '@tanstack/vue-query': 4.24.4_vue@3.2.41
+      idb-keyval: 6.2.0
       vue: 3.2.41
     devDependencies:
       '@vitejs/plugin-vue': 3.2.0_vite@3.2.2+vue@3.2.41
@@ -11308,6 +11312,12 @@ packages:
     dependencies:
       safer-buffer: 2.1.2
 
+  /idb-keyval/6.2.0:
+    resolution: {integrity: sha512-uw+MIyQn2jl3+hroD7hF8J7PUviBU7BPKWw4f/ISf32D4LoGu98yHjrzWWJDASu9QNrX10tCJqk9YY0ClWm8Ng==}
+    dependencies:
+      safari-14-idb-fix: 3.0.0
+    dev: false
+
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -15412,6 +15422,9 @@ packages:
     dependencies:
       mri: 1.2.0
     dev: true
+
+  /safari-14-idb-fix/3.0.0:
+    resolution: {integrity: sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog==}
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}


### PR DESCRIPTION
Ref: https://github.com/TanStack/query/issues/4693

This is a POC of a `persister` that works for both `sync` and `async` storage

Things that are missing from the currently implemented client persister:
- `throttling`
  - do we need it when persisting one query at a time?
- `retry`
  - TODO
  - needed for `out of space` issues that were reported previously
- `single key storage`
  - do we really need it? you can search in local storage, but may trigger some people OCD
- `persisting paused mutations`
  - offline mode?

How to run?
- `cd examples/vue/persister`
- `pnpm i`
- `pnpm run dev`
- list is persisted to `localStorage` and pages to `idb`

Seems to be working pretty well...