### PR TITLE
fix: adjusting nx json for the alpha branch

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,15 +16,15 @@
       "{workspaceRoot}/tsconfig.json",
       "{workspaceRoot}/tsconfig.base.json"
     ],
-    "globalNonBuildAffectingConfig": [
-      "{workspaceRoot}/.eslintrc",
-      "{workspaceRoot}/vitest.config.ts"
+    "globalNonBuildAffectingConfig": ["{workspaceRoot}/.eslintrc"],
+    "default": [
+      "{projectRoot}/**/*",
+      "globalBuildAffectingConfig",
+      "globalNonBuildAffectingConfig"
     ],
-    "default": ["{projectRoot}/**/*", "globalBuildAffectingConfig", "globalNonBuildAffectingConfig"],
     "public": [
       "default",
       "!{workspaceRoot}/.eslintrc",
-      "!{workspaceRoot}/vitest.config.ts",
       "!{workspaceRoot}/test-setup.ts",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
       "!{projectRoot}/.eslintrc"


### PR DESCRIPTION
@TkDodo - quick update on alpha: no need for a workspace root level `vitest.config.ts` file, as we don't have one!