### PR TITLE
chore: downgrade chalk to v4 because v5 is ESM only

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-plugin-transform-async-to-promises": "^0.8.18",
     "babel-preset-solid": "^1.5.4",
     "bundlewatch": "^0.3.2",
-    "chalk": "^5.2.0",
+    "chalk": "^4.1.2",
     "concurrently": "^7.1.0",
     "current-git-branch": "^1.1.0",
     "eslint": "7.x",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
       babel-plugin-transform-async-to-promises: ^0.8.18
       babel-preset-solid: ^1.5.4
       bundlewatch: ^0.3.2
-      chalk: ^5.2.0
+      chalk: ^4.1.2
       concurrently: ^7.1.0
       current-git-branch: ^1.1.0
       eslint: 7.x
@@ -105,7 +105,7 @@ importers:
       babel-plugin-transform-async-to-promises: 0.8.18
       babel-preset-solid: 1.5.4_@babel+core@7.19.1
       bundlewatch: 0.3.3
-      chalk: 5.2.0
+      chalk: 4.1.2
       concurrently: 7.2.2
       current-git-branch: 1.1.0
       eslint: 7.32.0
@@ -8674,11 +8674,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  /chalk/5.2.0:
-    resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: true
 
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}


### PR DESCRIPTION
see: https://stackoverflow.com/questions/70309135/chalk-error-err-require-esm-require-of-es-module