### PR TITLE
fix: test:format task giving false positives

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -65,9 +65,6 @@
       "inputs": ["default", "^public"],
       "dependsOn": ["^build:types"]
     },
-    "test:format": {
-      "inputs": ["default"]
-    },
     "test:build": {
       "dependsOn": ["build"],
       "inputs": ["^public"]

--- a/project.json
+++ b/project.json
@@ -3,7 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "./",
   "targets": {
-    "test:format": { "command": "pnpm run prettier --check" },
+    "test:format": {
+      "command": "pnpm run prettier --check",
+      "inputs": ["{workspaceRoot}/**/*"]
+    },
     "build": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
<div align="left">
      <a href="https://www.youtube.com/watch?v=QetA8uiMcwM" target="blank">
         <img src="https://img.youtube.com/vi/QetA8uiMcwM/0.jpg" style="width:100%;">
      </a>
</div>

## What it does:

+ fixes issue with the `test:format` target, where touching some files was giving us a false cache hit
+ moves the `test:format` from the `nx.json` file specifically to the root `project.json` file, as the `test:format` task only exists at the root level.

