### PR TITLE
Preserve 'use client' directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "react-dom-17": "npm:react-dom@^17.0.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.70.2",
+    "rollup-plugin-preserve-directives": "^0.1.0",
     "rollup-plugin-size": "^0.2.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-dom-17": "npm:react-dom@^17.0.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.70.2",
-    "rollup-plugin-preserve-directives": "^0.1.0",
+    "rollup-plugin-preserve-directives": "0.1.0",
     "rollup-plugin-size": "^0.2.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.6.0",

--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -1,3 +1,4 @@
+'use client'
 import type {
   DefaultedQueryObserverOptions,
   Query,

--- a/packages/react-query/src/reactBatchedUpdates.ts
+++ b/packages/react-query/src/reactBatchedUpdates.ts
@@ -1,2 +1,3 @@
+'use client'
 import * as ReactDOM from 'react-dom'
 export const unstable_batchedUpdates = ReactDOM.unstable_batchedUpdates

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -1,3 +1,4 @@
+'use client'
 import type {
   QueryObserver,
   QueryFunction,

--- a/packages/react-query/src/useIsFetching.ts
+++ b/packages/react-query/src/useIsFetching.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import type { QueryKey, QueryFilters } from '@tanstack/query-core'
 import { notifyManager, parseFilterArgs } from '@tanstack/query-core'

--- a/packages/react-query/src/useIsMutating.ts
+++ b/packages/react-query/src/useIsMutating.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -1,3 +1,4 @@
+'use client'
 import type { QueryFunction, QueryKey } from '@tanstack/query-core'
 import { parseQueryArgs, QueryObserver } from '@tanstack/query-core'
 import type {

--- a/packages/react-query/src/useSyncExternalStore.ts
+++ b/packages/react-query/src/useSyncExternalStore.ts
@@ -1,3 +1,4 @@
+'use client'
 // Temporary workaround due to an issue with react-native uSES - https://github.com/TanStack/query/pull/3601
 import { useSyncExternalStore as uSES } from 'use-sync-external-store/shim/index.js'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
       react-dom-17: npm:react-dom@^17.0.2
       rimraf: ^3.0.2
       rollup: ^2.70.2
-      rollup-plugin-preserve-directives: ^0.1.0
+      rollup-plugin-preserve-directives: 0.1.0
       rollup-plugin-size: ^0.2.2
       rollup-plugin-terser: ^7.0.2
       rollup-plugin-visualizer: ^5.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,7 @@ importers:
       react-dom-17: npm:react-dom@^17.0.2
       rimraf: ^3.0.2
       rollup: ^2.70.2
+      rollup-plugin-preserve-directives: ^0.1.0
       rollup-plugin-size: ^0.2.2
       rollup-plugin-terser: ^7.0.2
       rollup-plugin-visualizer: ^5.6.0
@@ -138,6 +139,7 @@ importers:
       react-dom-17: /react-dom/17.0.2_react@18.2.0
       rimraf: 3.0.2
       rollup: 2.78.1
+      rollup-plugin-preserve-directives: 0.1.0_rollup@2.78.1
       rollup-plugin-size: 0.2.2
       rollup-plugin-terser: 7.0.2_rollup@2.78.1
       rollup-plugin-visualizer: 5.6.0_rollup@2.78.1
@@ -15699,6 +15701,14 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+
+  /rollup-plugin-preserve-directives/0.1.0_rollup@2.78.1:
+    resolution: {integrity: sha512-fgzIK3hwF/afa6L1Qdsvshn0JlCHZRx0Sh9l0jjUgz3VK0unMFuEB4uqL3Vdae4OXkn+MBYCeNEN9vm81IteiA==}
+    peerDependencies:
+      rollup: 2.x || 3.x
+    dependencies:
+      rollup: 2.78.1
+    dev: true
 
   /rollup-plugin-size/0.2.2:
     resolution: {integrity: sha512-XIQpfwp1dLXzr4qCopY5ZSEEPB3bgZLkGw2BB3+TXmfH2jxGSmuN/+sRxnA5MvJe+Z4atW0x0qTQz5EuTQy01Q==}

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -7,6 +7,7 @@ import replace from '@rollup/plugin-replace'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import commonJS from '@rollup/plugin-commonjs'
 import path from 'path'
+import preserveDirectives from 'rollup-plugin-preserve-directives'
 
 type Options = {
   input: string | string[]
@@ -285,6 +286,7 @@ function mjs({
       commonJS(),
       nodeResolve({ extensions: ['.ts', '.tsx', '.native.ts'] }),
       forceDevEnv ? forceEnvPlugin('development') : undefined,
+      preserveDirectives(),
     ],
   }
 }
@@ -324,6 +326,7 @@ function esm({
       commonJS(),
       nodeResolve({ extensions: ['.ts', '.tsx', '.native.ts'] }),
       forceDevEnv ? forceEnvPlugin('development') : undefined,
+      preserveDirectives(),
     ],
   }
 }
@@ -375,6 +378,7 @@ function cjs({
         preventAssignment: true,
         delimiters: ['', ''],
       }),
+      preserveDirectives(),
     ],
   }
 }


### PR DESCRIPTION
Fixes #4933

* Pulls in `rollup-plugin-preserve-directives` and adds it to all un-bundled builds to preserve 'use client' directives
  * See rollup issue https://github.com/rollup/rollup/issues/4699
* Adds `'use client'` to all files that should have it (I think)

This makes everything work as documented with Next app router, that is, developers should no longer need to:

* Wrap our imports in `"use client"` themselves (just import and use `Hydrate` directly for example)
* Import from `@tanstack/query-core` in RSCs (can now import directly from `@tanstack/react-query`)

> For anyone reading along: Note that React Query-support for the Next app router is still experimental!

I tested it like this (basically quick version of the docs):

```jsx
// Providers.jsx
// This wraps the entire app in root layout.jsx
"use client";

import { useState } from "react";
import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

export default function Providers({ children }) {
  const [queryClient] = useState(() => new QueryClient());

  return (
    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
  );
}
```

```tsx
// page.jsx
import { dehydrate, Hydrate, QueryClient } from "@tanstack/react-query";
import ClientComponent from "./ClientComponent";

export default async function ReactQuery() {
  const queryClient = new QueryClient();

  await queryClient.fetchQuery({
    queryKey: ["1"],
    queryFn: () => "Server",
  });

  return (
    <Hydrate state={dehydrate(queryClient)}>
      <ClientComponent />
    </Hydrate>
  );
}
```

```jsx
// ClientComponent.jsx
"use client";

import { useQuery } from "@tanstack/react-query";

export default function ClientComponent() {
  const { data } = useQuery({
    queryKey: ["1"],
    queryFn: () => "Client",
    // Set staleTime to see that we get the "Server" output,
    // can later switch tabs to trigger revalidation and see we
    // get the "Client" output
    staleTime: 10000,
  });

  return <div>{data}</div>;
}
```