### PR TITLE
update build task

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -10,7 +10,8 @@
           "build:types",
           "test:format",
           "test:build",
-          "build"
+          "build",
+          "rollup"
         ]
       }
     }

--- a/nx.json
+++ b/nx.json
@@ -56,12 +56,18 @@
       "inputs": ["default", "^public"]
     },
     "test:types": {
-      "outputs": ["{projectRoot}/build"],
+      "outputs": [
+        "{projectRoot}/build/**/*.d.ts",
+        "{projectRoot}/build/.tsbuildinfo"
+      ],
       "inputs": ["default", "^public"],
       "dependsOn": ["^test:types"]
     },
     "build:types": {
-      "outputs": ["{projectRoot}/build"],
+      "outputs": [
+        "{projectRoot}/build/**/*.d.ts",
+        "{projectRoot}/build/.tsbuildinfo"
+      ],
       "inputs": ["default", "^public"],
       "dependsOn": ["^build:types"]
     },

--- a/nx.json
+++ b/nx.json
@@ -8,8 +8,6 @@
           "test:eslint",
           "test:types",
           "build:types",
-          "test:format",
-          "test:build",
           "build",
           "rollup"
         ]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:lib:dev": "pnpm --filter \"./packages/**\" run test:lib:dev",
     "test:build": "nx test:build root",
     "test:types": "nx run-many --target=test:types --parallel=5",
-    "build": "nx build root",
+    "build": "nx run-many --target=build --projects=root",
     "build:types": "nx run-many --target=build:types --parallel=5",
     "watch": "concurrently --kill-others \"rollup --config rollup.config.js -w\" \"pnpm run build:types --watch\"",
     "dev": "pnpm run watch",

--- a/project.json
+++ b/project.json
@@ -10,14 +10,13 @@
     "rollup": {
       "command": "rollup --config rollup.config.js",
       "outputs": [
-        "{workspaceRoot}/packages/**/build/**/*(.cjs|.mjs|.js)*",
-        "{workspaceRoot}/packages/**/build/stats*",
-        "{workspaceRoot}/packages/**/build/**/*.svelte"
+        "{workspaceRoot}/packages/*/build/**/*(.cjs|.mjs|.js)*",
+        "{workspaceRoot}/packages/*/build/stats*",
+        "{workspaceRoot}/packages/*/build/**/*.svelte"
       ]
     },
     "build": {
       "command": "echo \"  @tanstack/query > All pacakges built! 📦\"",
-      "outputs": ["{workspaceRoot}/packages/**/build"],
       "dependsOn": ["rollup", "^build:types", "^build"]
     },
     "test:build": {

--- a/project.json
+++ b/project.json
@@ -7,18 +7,18 @@
       "command": "pnpm run prettier --check",
       "inputs": ["{workspaceRoot}/**/*"]
     },
+    "rollup": {
+      "command": "rollup --config rollup.config.js",
+      "outputs": [
+        "{workspaceRoot}/packages/**/build/**/*(.cjs|.mjs|.js)*",
+        "{workspaceRoot}/packages/**/build/stats*",
+        "{workspaceRoot}/packages/**/build/**/*.svelte"
+      ]
+    },
     "build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "rollup --config rollup.config.js",
-          "nx run-many --target=build:types",
-          "nx build @tanstack/eslint-plugin-query",
-          "nx build @tanstack/svelte-query"
-        ],
-        "parallel": true
-      },
-      "outputs": ["{workspaceRoot}/packages/**/build"]
+      "command": "echo \"  @tanstack/query > All pacakges built! 📦\"",
+      "outputs": ["{workspaceRoot}/packages/**/build"],
+      "dependsOn": ["rollup", "^build:types", "^build"]
     },
     "test:build": {
       "executor": "nx:run-commands",
@@ -28,5 +28,18 @@
       }
     }
   },
-  "implicitDependencies": ["**/*"]
+  "implicitDependencies": [
+    "@tanstack/eslint-plugin-query",
+    "@tanstack/query-async-storage-persister",
+    "@tanstack/query-broadcast-client-experimental",
+    "@tanstack/query-core",
+    "@tanstack/query-persist-client-core",
+    "@tanstack/query-sync-storage-persister",
+    "@tanstack/react-query",
+    "@tanstack/react-query-devtools",
+    "@tanstack/react-query-persist-client",
+    "@tanstack/solid-query",
+    "@tanstack/svelte-query",
+    "@tanstack/vue-query"
+  ]
 }


### PR DESCRIPTION
# What it does:

+ updates the build task to use `dependsOn` rather than `run-commands`.
  + I ended up using this for @tanstack/table, and I think I like this better
+ The splitting out of the rollup step to its own cacheable task makes the caching a bit better too (I believe prior, we were stashing everything in the `build` directory for both `build` and `build:types` steps)