### PR TITLE
Update paginated-queries.md

### DIFF
--- a/docs/react/guides/paginated-queries.md
+++ b/docs/react/guides/paginated-queries.md
@@ -24,7 +24,7 @@ This experience is not optimal and unfortunately is how many tools today insist 
 
 Consider the following example where we would ideally want to increment a pageIndex (or cursor) for a query. If we were to use `useQuery`, **it would still technically work fine**, but the UI would jump in and out of the `success` and `loading` states as different queries are created and destroyed for each page or cursor. By setting `keepPreviousData` to `true` we get a few new things:
 
-- **The data from the last successful fetch available while new data is being requested, even though the query key has changed**.
+- **The data from the last successful fetch is available while new data is being requested, even though the query key has changed**.
 - When the new data arrives, the previous `data` is seamlessly swapped to show the new data.
 - `isPreviousData` is made available to know what data the query is currently providing you
 


### PR DESCRIPTION
Changed "**The data from the last successful fetch available** while new data is being requested, even though the query key has changed" to "**The data from the last successful fetch is available** while new data is being requested, even though the query key has changed"

*Grammatical error.