### PR TITLE
fix(solid-query): Fix non hydrating queries

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -64,8 +64,9 @@ export function createBaseQuery<
     return observer.subscribe((result) => {
       notifyManager.batchCalls(() => {
         const query = observer.getCurrentQuery()
+        const { refetch, ...rest } = unwrap(result)
         const unwrappedResult = {
-          ...unwrap(result),
+          ...rest,
 
           // hydrate() expects a QueryState object, which is similar but not
           // quite the same as a QueryObserverResult object. Thus, for now, we're
@@ -84,7 +85,9 @@ export function createBaseQuery<
           reject(unwrappedResult.error)
         }
         if (unwrappedResult.isSuccess) {
-          resolve(unwrappedResult)
+          // Use of any here is fine
+          // We cannot include refetch since it is not serializable
+          resolve(unwrappedResult as any)
         }
       })()
     })


### PR DESCRIPTION
Noticed that the recent changes brought a regression that caused pre fetched server queries from hydrating. This issue happens because `refetch` is a function on the QueryObserverresult and functions are non-serializable. This causes the queryResource to skip hydrating the resource on the client. This fix removes the refetch function from the hydrating payload.