### PR TITLE
fix: do not mutate input

### DIFF
--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -139,11 +139,11 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
   >(
     filters: MutationFilters,
   ): Mutation<TData, TError, TVariables, TContext> | undefined {
-    if (typeof filters.exact === 'undefined') {
-      filters.exact = true
-    }
+    const defaultedFilters = { exact: true, ...filters }
 
-    return this.#mutations.find((mutation) => matchMutation(filters, mutation))
+    return this.#mutations.find((mutation) =>
+      matchMutation(defaultedFilters, mutation),
+    )
   }
 
   findAll(filters: MutationFilters = {}): Mutation[] {

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -176,13 +176,11 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
   find<TQueryFnData = unknown, TError = DefaultError, TData = TQueryFnData>(
     filters: WithRequired<QueryFilters, 'queryKey'>,
   ): Query<TQueryFnData, TError, TData> | undefined {
-    if (typeof filters.exact === 'undefined') {
-      filters.exact = true
-    }
+    const defaultedFilters = { exact: true, ...filters }
 
-    return this.getAll().find((query) => matchQuery(filters, query)) as
-      | Query<TQueryFnData, TError, TData>
-      | undefined
+    return this.getAll().find((query) =>
+      matchQuery(defaultedFilters, query),
+    ) as Query<TQueryFnData, TError, TData> | undefined
   }
 
   findAll(filters: QueryFilters = {}): Query[] {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -212,14 +212,12 @@ export class QueryClient {
     filters: QueryFilters = {},
     cancelOptions: CancelOptions = {},
   ): Promise<void> {
-    if (typeof cancelOptions.revert === 'undefined') {
-      cancelOptions.revert = true
-    }
+    const defaultedCancelOptions = { revert: true, ...cancelOptions }
 
     const promises = notifyManager.batch(() =>
       this.#queryCache
         .findAll(filters)
-        .map((query) => query.cancel(cancelOptions)),
+        .map((query) => query.cancel(defaultedCancelOptions)),
     )
 
     return Promise.all(promises).then(noop).catch(noop)

--- a/packages/vue-query/src/__tests__/mutationCache.test.ts
+++ b/packages/vue-query/src/__tests__/mutationCache.test.ts
@@ -19,7 +19,6 @@ describe('MutationCache', () => {
       })
 
       expect(MutationCacheOrigin.prototype.find).toBeCalledWith({
-        exact: true,
         mutationKey: ['baz'],
       })
     })

--- a/packages/vue-query/src/__tests__/queryCache.test.ts
+++ b/packages/vue-query/src/__tests__/queryCache.test.ts
@@ -20,7 +20,6 @@ describe('QueryCache', () => {
 
       expect(QueryCacheOrigin.prototype.find).toBeCalledWith({
         queryKey: ['foo', 'bar'],
-        exact: true, //Exact is true, as `find` in QueryCacheOrigin sets exact to true in the passed filters if exact is undefined
       })
     })
   })


### PR DESCRIPTION
params passed to function from consumers should be treated as readonly and thus shouldn't be modified