### PR TITLE
perf(useQueries): optimize findMatchingObservers fn in queriesObserver for large datasets

### DIFF
--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -131,7 +131,9 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
     queries: QueryObserverOptions[],
   ): QueryObserverMatch[] {
     const prevObservers = this.observers
-    const prevObserversMap = new Map(prevObservers.map(observer => [observer.options.queryHash, observer]));
+    const prevObserversMap = new Map(
+      prevObservers.map((observer) => [observer.options.queryHash, observer]),
+    )
 
     const defaultedQueryOptions = queries.map((options) =>
       this.client.defaultQueryOptions(options),
@@ -146,17 +148,18 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
         return []
       })
 
-    const matchedQueryHashes = new Set(matchingObservers.map(
-      (match) => match.defaultedQueryOptions.queryHash,
-    ))
+    const matchedQueryHashes = new Set(
+      matchingObservers.map((match) => match.defaultedQueryOptions.queryHash),
+    )
     const unmatchedQueries = defaultedQueryOptions.filter(
-      (defaultedOptions) =>
-        !matchedQueryHashes.has(defaultedOptions.queryHash),
+      (defaultedOptions) => !matchedQueryHashes.has(defaultedOptions.queryHash),
     )
 
+    const matchingObserversSet = new Set(
+      matchingObservers.map((match) => match.observer),
+    )
     const unmatchedObservers = prevObservers.filter(
-      (prevObserver) =>
-        !matchingObservers.some((match) => match.observer === prevObserver),
+      (prevObserver) => !matchingObserversSet.has(prevObserver),
     )
 
     const getObserver = (options: QueryObserverOptions): QueryObserver => {

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -131,28 +131,27 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
     queries: QueryObserverOptions[],
   ): QueryObserverMatch[] {
     const prevObservers = this.observers
+    const prevObserversMap = new Map(prevObservers.map(observer => [observer.options.queryHash, observer]));
+
     const defaultedQueryOptions = queries.map((options) =>
       this.client.defaultQueryOptions(options),
     )
 
     const matchingObservers: QueryObserverMatch[] =
       defaultedQueryOptions.flatMap((defaultedOptions) => {
-        const match = prevObservers.find(
-          (observer) =>
-            observer.options.queryHash === defaultedOptions.queryHash,
-        )
+        const match = prevObserversMap.get(defaultedOptions.queryHash)
         if (match != null) {
           return [{ defaultedQueryOptions: defaultedOptions, observer: match }]
         }
         return []
       })
 
-    const matchedQueryHashes = matchingObservers.map(
+    const matchedQueryHashes = new Set(matchingObservers.map(
       (match) => match.defaultedQueryOptions.queryHash,
-    )
+    ))
     const unmatchedQueries = defaultedQueryOptions.filter(
       (defaultedOptions) =>
-        !matchedQueryHashes.includes(defaultedOptions.queryHash),
+        !matchedQueryHashes.has(defaultedOptions.queryHash),
     )
 
     const unmatchedObservers = prevObservers.filter(


### PR DESCRIPTION
This optimizes the `findMatchingObservers` function in `queriesObserver` which becomes very slow on large data sets in `useQueries`. 

Below are the results with latest react query without this change on a dataset of 5000 objects.

![image](https://user-images.githubusercontent.com/47536525/230802845-64b61acd-78c2-4af7-b8c8-d6988089a793.png)



We can see it takes 1.3 seconds only inside the `findMatchingObservers` function, which leads to a very laggy UX.
The majority of this time is spent inside 2 functions in `findMatchingObservers`.

- The first function `.flatMap` is O(n*m) as it runs Array.find on every single element in `defaultedQueryOptions`. By using a map we bring this down to O(m), where m is the number of elements in `defaultedQueryOptions`. Yes using a map will add more space complexity but the overhead is extremely minimal compared to the performance gain.
- The second function is where we check for `matchedQueryHashes` which uses Array.includes and is again a O(n*m) function which can be brought down to O(m) by using a Set.

Measurements:
The following is setup with 5000 queries in `useQueries` with unique keys and everything matching documentation. When invalidating one query, the following happens:

- Before the fix, it takes 1.28 seconds only inside `findMatchingObservers`
![image](https://user-images.githubusercontent.com/47536525/230803293-f1913ff5-026c-4c1f-b76f-00114f5fd338.png)

- After the fix, it only takes 47ms! Nearly a 30x performance improvement for a dataset of 5000 objects.
![image](https://user-images.githubusercontent.com/47536525/230803414-1da49ac0-1c52-4b36-b7b2-dd99245ac3a9.png)

If required & the very minimal changes are not justified, I can provide codesandbox for both comparisons.

