### PR TITLE
Add `Hydrate` + `useHydrate` to Solid Query

### DIFF
--- a/packages/solid-query/src/Hydrate.ts
+++ b/packages/solid-query/src/Hydrate.ts
@@ -1,0 +1,27 @@
+import type { JSX } from 'solid-js'
+import type { HydrateOptions } from '@tanstack/query-core'
+import { hydrate } from '@tanstack/query-core'
+import { useQueryClient } from './QueryClientProvider'
+import type { ContextOptions } from './types'
+
+export function useHydrate(
+  state: unknown,
+  options: HydrateOptions & ContextOptions = {},
+) {
+  const queryClient = useQueryClient({ context: options.context })
+
+  if (state) {
+    hydrate(queryClient, state, options)
+  }
+}
+
+export interface HydrateProps {
+  state?: unknown
+  options?: HydrateOptions
+  children?: JSX.Element
+}
+
+export const Hydrate = ({ children, options, state }: HydrateProps) => {
+  useHydrate(state, options)
+  return children as JSX.Element
+}

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -17,3 +17,5 @@ export { useIsMutating } from './useIsMutating'
 export { createMutation } from './createMutation'
 export { createInfiniteQuery } from './createInfiniteQuery'
 export { createQueries } from './createQueries'
+export { useHydrate } from "./useHydrate";
+export { Hydrate } from "./Hydrate"

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -17,5 +17,5 @@ export { useIsMutating } from './useIsMutating'
 export { createMutation } from './createMutation'
 export { createInfiniteQuery } from './createInfiniteQuery'
 export { createQueries } from './createQueries'
-export { useHydrate } from "./useHydrate";
-export { Hydrate } from "./Hydrate"
+export { useHydrate } from './useHydrate'
+export { Hydrate } from './Hydrate'

--- a/packages/solid-query/src/useHydrate.ts
+++ b/packages/solid-query/src/useHydrate.ts
@@ -1,0 +1,14 @@
+import {
+  type HydrateOptions,
+  type QueryClient,
+  hydrate,
+} from '@tanstack/query-core'
+import { useQueryClient } from './QueryClientProvider'
+
+export function useHydrate(state?: unknown, options?: HydrateOptions) {
+  const client: QueryClient = useQueryClient()
+
+  if (state) {
+    hydrate(client, state, options)
+  }
+}


### PR DESCRIPTION
The title pretty much says it all. These are direct clones of the functionality that already exists in React Query and Svelte Query.