### PR TITLE
Update vue basic example link to v5

### DIFF
--- a/docs/vue/installation.md
+++ b/docs/vue/installation.md
@@ -15,7 +15,7 @@ $ pnpm add @tanstack/vue-query
 $ yarn add @tanstack/vue-query
 ```
 
-> Wanna give it a spin before you download? Try out the [basic](/query/v4/docs/vue/examples/vue/basic) example!
+> Wanna give it a spin before you download? Try out the [basic](/query/v5/docs/vue/examples/vue/basic) example!
 
 Vue Query is compatible with Vue 2.x and 3.x
 


### PR DESCRIPTION
v4 was showing "Initializing Sandbox Containe" forever, so i tried to update link to v5, and it works fine.