### PR TITLE
feat(solid-query): Better queryKey types support

### DIFF
--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -121,7 +121,7 @@ describe('createQuery', () => {
       expectType<unknown>(fromGenericOptionsQueryFn.error)
 
       type MyData = number
-      type MyQueryKey = readonly ['my-data', number]
+      type MyQueryKey = ['my-data', number]
 
       const getMyDataArrayKey: QueryFunction<MyData, MyQueryKey> = async ({
         queryKey: [, n],
@@ -130,7 +130,7 @@ describe('createQuery', () => {
       }
 
       createQuery(() => ({
-        queryKey: ['my-data', 100] as const,
+        queryKey: ['my-data', 100],
         queryFn: getMyDataArrayKey,
       }))
 
@@ -2423,12 +2423,12 @@ describe('createQuery', () => {
   it('should not pass stringified variables to query function', async () => {
     const key = queryKey()
     const variables = { number: 5, boolean: false, object: {}, array: [] }
-    type CustomQueryKey = readonly [typeof key, typeof variables]
+    type CustomQueryKey = [typeof key, typeof variables]
     const states: CreateQueryResult<CustomQueryKey, unknown>[] = []
 
     function Page() {
       const state = createQuery(() => ({
-        queryKey: [key, variables] as const,
+        queryKey: [key, variables],
         queryFn: async (ctx) => {
           await sleep(10)
           return ctx.queryKey
@@ -4650,10 +4650,9 @@ describe('createQuery', () => {
     const key = queryKey()
     const states: CreateQueryResult<string>[] = []
 
-    const queryFn: QueryFunction<
-      string,
-      readonly [typeof key, number]
-    > = async (ctx) => {
+    const queryFn: QueryFunction<string, [typeof key, number]> = async (
+      ctx,
+    ) => {
       const [, limit] = ctx.queryKey
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const value = limit % 2 && ctx.signal ? 'abort' : `data ${limit}`
@@ -4663,7 +4662,7 @@ describe('createQuery', () => {
 
     function Page(props: { limit: number }) {
       const state = createQuery(() => ({
-        queryKey: [key, props.limit] as const,
+        queryKey: [key, props.limit],
         queryFn,
       }))
       states[props.limit] = state

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -8,6 +8,7 @@ import type {
   CreateQueryResult,
   DefinedCreateQueryResult,
   FunctionedParams,
+  Narrow,
   SolidQueryOptions,
 } from './types'
 
@@ -17,7 +18,7 @@ type UndefinedInitialDataOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = FunctionedParams<
-  SolidQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  SolidQueryOptions<TQueryFnData, TError, TData, Narrow<TQueryKey>> & {
     initialData?: undefined
   }
 >
@@ -28,7 +29,7 @@ type DefinedInitialDataOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = FunctionedParams<
-  SolidQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  SolidQueryOptions<TQueryFnData, TError, TData, Narrow<TQueryKey>> & {
     initialData: TQueryFnData | (() => TQueryFnData)
   }
 >
@@ -58,7 +59,7 @@ export function createQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: CreateQueryOptions<TQueryFnData, TError, TData, Narrow<TQueryKey>>,
   queryClient?: Accessor<QueryClient>,
 ) {
   return createBaseQuery(

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -173,3 +173,24 @@ export type CreateMutationResult<
 > = CreateBaseMutationResult<TData, TError, TVariables, TContext>
 
 type Override<A, B> = { [K in keyof A]: K extends keyof B ? B[K] : A[K] }
+
+/* 
+  Copyright 2019 Pierre-Antoine Mills
+  Credits to the 'ts-toolbelt' NPM package for inspiring the 
+  implementation of the Narrow utility type below. 
+  This package offers a range of TypeScript utility types, and we acknowledge their contributions to this code. 
+  For more information, please see the 'ts-toolbelt' package documentation.
+  https://github.com/millsp/ts-toolbelt
+*/
+type Try<A1, A2, Catch = never> = A1 extends A2 ? A1 : Catch
+
+type Narrowable = string | number | bigint | boolean
+
+type NarrowRaw<A> =
+  | (A extends [] ? [] : never)
+  | (A extends Narrowable ? A : never)
+  | {
+      [K in keyof A]: A[K] extends Function ? A[K] : NarrowRaw<A[K]>
+    }
+
+export type Narrow<A> = Try<A, [], NarrowRaw<A>>


### PR DESCRIPTION
This change adds narrowed types for queryKey in createQuery.

Before:
```ts
const [count, setCount] = createSignal(1);
const query = createQuery(() => ({
  queryKey: ['pokemon', count()]
  queryFn: async ({ queryKey }) => {
     const [_, id] = queryKey;
     //              ^? queryKey: (string|number)[]
     return fetch(...)
  }
}))
```

After:
```ts
const [count, setCount] = createSignal(1);
const query = createQuery(() => ({
  queryKey: ['pokemon', count()]
  queryFn: async ({ queryKey }) => {
     const [_, id] = queryKey;
     //              ^? queryKey: ['pokemon', number]
     return fetch(...)
  }
}))
```