### PR TITLE
feat(solid-query): Add `reconcile` option

### DIFF
--- a/packages/solid-query/src/QueryClient.ts
+++ b/packages/solid-query/src/QueryClient.ts
@@ -1,0 +1,84 @@
+import type {
+  QueryClientConfig as QueryCoreClientConfig,
+  DefaultOptions as CoreDefaultOptions,
+  QueryObserverOptions as QueryCoreObserverOptions,
+  InfiniteQueryObserverOptions as QueryCoreInfiniteQueryObserverOptions,
+  DefaultError,
+  QueryKey,
+} from '@tanstack/query-core'
+import { QueryClient as QueryCoreClient } from '@tanstack/query-core'
+
+export interface QueryObserverOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = never,
+> extends Omit<
+    QueryCoreObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey,
+      TPageParam
+    >,
+    'structuralSharing'
+  > {
+  /**
+   * Set this to a reconciliation key to enable reconciliation between query results.
+   * Set this to `false` to disable reconciliation between query results.
+   * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom reconciliation logic.
+   * Defaults reconciliation key to `id`.
+   */
+  reconcile?:
+    | string
+    | false
+    | ((oldData: TData | undefined, newData: TData) => TData)
+}
+
+export interface InfiniteQueryObserverOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+> extends Omit<
+    QueryCoreInfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey,
+      TPageParam
+    >,
+    'structuralSharing'
+  > {
+  /**
+   * Set this to a reconciliation key to enable reconciliation between query results.
+   * Set this to `false` to disable reconciliation between query results.
+   * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom reconciliation logic.
+   * Defaults reconciliation key to `id`.
+   */
+  reconcile?:
+    | string
+    | false
+    | ((oldData: TData | undefined, newData: TData) => TData)
+}
+
+export interface DefaultOptions<TError = DefaultError>
+  extends CoreDefaultOptions<TError> {
+  queries?: QueryObserverOptions<unknown, TError>
+}
+
+export interface QueryClientConfig extends QueryCoreClientConfig {
+  defaultOptions?: DefaultOptions
+}
+
+export class QueryClient extends QueryCoreClient {
+  constructor(config: QueryClientConfig = {}) {
+    super(config)
+  }
+}

--- a/packages/solid-query/src/QueryClientProvider.tsx
+++ b/packages/solid-query/src/QueryClientProvider.tsx
@@ -1,4 +1,4 @@
-import type { QueryClient } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import type { JSX } from 'solid-js'
 import { createContext, useContext, onMount, onCleanup } from 'solid-js'
 

--- a/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
@@ -10,6 +10,7 @@ import {
   Index,
   Match,
   Switch,
+  on,
 } from 'solid-js'
 import type {
   CreateInfiniteQueryResult,
@@ -193,7 +194,8 @@ describe('useInfiniteQuery', () => {
 
   it('should keep the previous data when placeholderData is set', async () => {
     const key = queryKey()
-    const states: CreateInfiniteQueryResult<InfiniteData<string>>[] = []
+    const states: Partial<CreateInfiniteQueryResult<InfiniteData<string>>>[] =
+      []
 
     function Page() {
       const [order, setOrder] = createSignal('desc')
@@ -212,7 +214,16 @@ describe('useInfiniteQuery', () => {
       }))
 
       createRenderEffect(() => {
-        states.push({ ...state })
+        states.push({
+          data: state.data ? JSON.parse(JSON.stringify(state.data)) : undefined,
+          hasNextPage: state.hasNextPage,
+          hasPreviousPage: state.hasPreviousPage,
+          isFetching: state.isFetching,
+          isFetchingNextPage: state.isFetchingNextPage,
+          isFetchingPreviousPage: state.isFetchingPreviousPage,
+          isSuccess: state.isSuccess,
+          isPlaceholderData: state.isPlaceholderData,
+        })
       })
 
       return (
@@ -375,7 +386,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to reverse the data', async () => {
     const key = queryKey()
-    const states: CreateInfiniteQueryResult<InfiniteData<number>>[] = []
+    const states: Partial<CreateInfiniteQueryResult<InfiniteData<number>>>[] =
+      []
 
     function Page() {
       const state = createInfiniteQuery(() => ({
@@ -394,9 +406,19 @@ describe('useInfiniteQuery', () => {
         defaultPageParam: 0,
       }))
 
-      createRenderEffect(() => {
-        states.push({ ...state })
-      })
+      createRenderEffect(
+        on(
+          () => ({ ...state }),
+          () => {
+            states.push({
+              data: state.data
+                ? JSON.parse(JSON.stringify(state.data))
+                : undefined,
+              isSuccess: state.isSuccess,
+            })
+          },
+        ),
+      )
 
       return (
         <div>
@@ -439,7 +461,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to fetch a previous page', async () => {
     const key = queryKey()
-    const states: CreateInfiniteQueryResult<InfiniteData<number>>[] = []
+    const states: Partial<CreateInfiniteQueryResult<InfiniteData<number>>>[] =
+      []
 
     function Page() {
       const start = 10
@@ -456,7 +479,15 @@ describe('useInfiniteQuery', () => {
       }))
 
       createRenderEffect(() => {
-        states.push({ ...state })
+        states.push({
+          data: state.data ? JSON.parse(JSON.stringify(state.data)) : undefined,
+          hasNextPage: state.hasNextPage,
+          hasPreviousPage: state.hasPreviousPage,
+          isFetching: state.isFetching,
+          isFetchingNextPage: state.isFetchingNextPage,
+          isFetchingPreviousPage: state.isFetchingPreviousPage,
+          isSuccess: state.isSuccess,
+        })
       })
 
       createEffect(() => {
@@ -518,7 +549,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to refetch when providing page params automatically', async () => {
     const key = queryKey()
-    const states: CreateInfiniteQueryResult<InfiniteData<number>>[] = []
+    const states: Partial<CreateInfiniteQueryResult<InfiniteData<number>>>[] =
+      []
 
     function Page() {
       const state = createInfiniteQuery(() => ({
@@ -535,7 +567,13 @@ describe('useInfiniteQuery', () => {
       }))
 
       createRenderEffect(() => {
-        states.push({ ...state })
+        states.push({
+          data: state.data ? JSON.parse(JSON.stringify(state.data)) : undefined,
+          isFetching: state.isFetching,
+          isFetchingNextPage: state.isFetchingNextPage,
+          isRefetching: state.isRefetching,
+          isFetchingPreviousPage: state.isFetchingPreviousPage,
+        })
       })
 
       return (
@@ -632,7 +670,8 @@ describe('useInfiniteQuery', () => {
 
   it('should silently cancel any ongoing fetch when fetching more', async () => {
     const key = queryKey()
-    const states: CreateInfiniteQueryResult<InfiniteData<number>>[] = []
+    const states: Partial<CreateInfiniteQueryResult<InfiniteData<number>>>[] =
+      []
 
     function Page() {
       const start = 10
@@ -649,7 +688,13 @@ describe('useInfiniteQuery', () => {
       }))
 
       createRenderEffect(() => {
-        states.push({ ...state })
+        states.push({
+          hasNextPage: state.hasNextPage,
+          data: state.data ? JSON.parse(JSON.stringify(state.data)) : undefined,
+          isFetching: state.isFetching,
+          isFetchingNextPage: state.isFetchingNextPage,
+          isSuccess: state.isSuccess,
+        })
       })
 
       createEffect(() => {
@@ -978,7 +1023,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to set new pages with the query client', async () => {
     const key = queryKey()
-    const states: CreateInfiniteQueryResult<InfiniteData<number>>[] = []
+    const states: Partial<CreateInfiniteQueryResult<InfiniteData<number>>>[] =
+      []
 
     function Page() {
       const [firstPage, setFirstPage] = createSignal(0)
@@ -996,7 +1042,13 @@ describe('useInfiniteQuery', () => {
       }))
 
       createRenderEffect(() => {
-        states.push({ ...state })
+        states.push({
+          hasNextPage: state.hasNextPage,
+          data: state.data ? JSON.parse(JSON.stringify(state.data)) : undefined,
+          isFetching: state.isFetching,
+          isFetchingNextPage: state.isFetchingNextPage,
+          isSuccess: state.isSuccess,
+        })
       })
 
       createEffect(() => {
@@ -1066,7 +1118,8 @@ describe('useInfiniteQuery', () => {
 
   it('should only refetch the first page when initialData is provided', async () => {
     const key = queryKey()
-    const states: CreateInfiniteQueryResult<InfiniteData<number>>[] = []
+    const states: Partial<CreateInfiniteQueryResult<InfiniteData<number>>>[] =
+      []
 
     function Page() {
       const state = createInfiniteQuery(() => ({
@@ -1083,7 +1136,13 @@ describe('useInfiniteQuery', () => {
       }))
 
       createRenderEffect(() => {
-        states.push({ ...state })
+        states.push({
+          data: JSON.parse(JSON.stringify(state.data)),
+          hasNextPage: state.hasNextPage,
+          isFetching: state.isFetching,
+          isFetchingNextPage: state.isFetchingNextPage,
+          isSuccess: state.isSuccess,
+        })
       })
 
       createEffect(() => {

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1282,7 +1282,6 @@ describe('createQuery', () => {
           count++
           return count === 1 ? result1 : result2
         },
-        notifyOnChangeProps: 'all',
       }))
 
       createRenderEffect(() => {
@@ -1322,9 +1321,8 @@ describe('createQuery', () => {
 
     expect(todos).toEqual(result1)
     expect(newTodos).toEqual(result2)
-    expect(newTodos).not.toBe(todos)
     expect(newTodo1).toBe(todo1)
-    expect(newTodo2).not.toBe(todo2)
+    expect(newTodo2).toBe(todo2)
 
     return null
   })
@@ -3257,7 +3255,7 @@ describe('createQuery', () => {
 
   it('should keep initial data when the query key changes', async () => {
     const key = queryKey()
-    const states: DefinedCreateQueryResult<{ count: number }>[] = []
+    const states: Partial<DefinedCreateQueryResult<{ count: number }>>[] = []
 
     function Page() {
       const [count, setCount] = createSignal(0)
@@ -3266,6 +3264,7 @@ describe('createQuery', () => {
         queryFn: () => ({ count: 10 }),
         staleTime: Infinity,
         initialData: () => ({ count: count() }),
+        reconcile: false,
       }))
       createRenderEffect(() => {
         states.push({ ...state })

--- a/packages/solid-query/src/__tests__/utils.tsx
+++ b/packages/solid-query/src/__tests__/utils.tsx
@@ -1,5 +1,5 @@
 import type { QueryClientConfig } from '@tanstack/query-core'
-import { QueryClient } from '@tanstack/query-core'
+import { QueryClient } from '../QueryClient'
 import type { ParentProps } from 'solid-js'
 import { createEffect, createSignal, onCleanup, Show } from 'solid-js'
 import { vi } from 'vitest'

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -3,11 +3,11 @@
 // in solid-js/web package. I'll create a GitHub issue with them to see
 // why that happens.
 import type {
-  QueryClient,
   QueryKey,
   QueryObserver,
   QueryObserverResult,
 } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import { hydrate } from '@tanstack/query-core'
 import { notifyManager } from '@tanstack/query-core'
 import type { Accessor } from 'solid-js'
@@ -19,10 +19,27 @@ import {
   on,
   onCleanup,
 } from 'solid-js'
-import { createStore, unwrap } from 'solid-js/store'
+import { createStore, reconcile, unwrap } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
 import type { CreateBaseQueryOptions } from './types'
 import { shouldThrowError } from './utils'
+
+function reconcileFn<TData, TError>(
+  store: QueryObserverResult<TData, TError>,
+  result: QueryObserverResult<TData, TError>,
+  reconcileOption:
+    | string
+    | false
+    | ((oldData: TData | undefined, newData: TData) => TData),
+): QueryObserverResult<TData, TError> {
+  if (reconcileOption === false) return result
+  if (typeof reconcileOption === 'function') {
+    const newData = reconcileOption(store.data, result.data as TData)
+    return { ...result, data: newData } as typeof result
+  }
+  const newData = reconcile(result.data, { key: reconcileOption })(store.data)
+  return { ...result, data: newData } as typeof result
+}
 
 // Base Query Function that is used to create the query.
 export function createBaseQuery<
@@ -42,6 +59,7 @@ export function createBaseQuery<
 
   const defaultedOptions = client().defaultQueryOptions(options())
   defaultedOptions._optimisticResults = 'optimistic'
+  defaultedOptions.structuralSharing = false
   if (isServer) {
     defaultedOptions.retry = false
     defaultedOptions.throwErrors = true
@@ -96,18 +114,28 @@ export function createBaseQuery<
   const createClientSubscriber = () => {
     return observer.subscribe((result) => {
       notifyManager.batchCalls(() => {
-        const unwrappedResult = { ...unwrap(result) }
+        // @ts-expect-error - This will error because the reconcile option does not
+        // exist on the query-core QueryObserverResult type
+        const reconcileOptions = observer.options.reconcile
         // If the query has data we dont suspend but instead mutate the resource
         // This could happen when placeholderData/initialData is defined
-        if (
-          queryResource()?.data &&
-          unwrappedResult.data &&
-          !queryResource.loading
-        ) {
-          setState(unwrappedResult)
+        if (queryResource()?.data && result.data && !queryResource.loading) {
+          setState((store) => {
+            return reconcileFn(
+              store,
+              result,
+              reconcileOptions === undefined ? 'id' : reconcileOptions,
+            )
+          })
           mutate(state)
         } else {
-          setState(unwrappedResult)
+          setState((store) => {
+            return reconcileFn(
+              store,
+              result,
+              reconcileOptions === undefined ? 'id' : reconcileOptions,
+            )
+          })
           refetch()
         }
       })()

--- a/packages/solid-query/src/createInfiniteQuery.ts
+++ b/packages/solid-query/src/createInfiniteQuery.ts
@@ -1,10 +1,10 @@
 import type {
   QueryObserver,
   QueryKey,
-  QueryClient,
   DefaultError,
   InfiniteData,
 } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import type {
   CreateInfiniteQueryOptions,

--- a/packages/solid-query/src/createMutation.ts
+++ b/packages/solid-query/src/createMutation.ts
@@ -1,4 +1,5 @@
-import type { QueryClient, DefaultError } from '@tanstack/query-core'
+import type { DefaultError } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import { MutationObserver } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -1,11 +1,11 @@
 import type {
   QueriesPlaceholderDataFunction,
-  QueryClient,
   QueryFunction,
   QueryKey,
   DefaultError,
 } from '@tanstack/query-core'
 import { notifyManager, QueriesObserver } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import type { Accessor } from 'solid-js'
 import { createComputed, onCleanup, onMount } from 'solid-js'
 import { createStore, unwrap } from 'solid-js/store'

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -1,5 +1,6 @@
-import type { QueryClient, QueryKey, DefaultError } from '@tanstack/query-core'
+import type { QueryKey, DefaultError } from '@tanstack/query-core'
 import { QueryObserver } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import type { Accessor } from 'solid-js'
 import { createMemo } from 'solid-js'
 import { createBaseQuery } from './createBaseQuery'

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -8,6 +8,13 @@ export * from '@tanstack/query-core'
 
 // Solid Query
 export * from './types'
+export { QueryClient } from './QueryClient'
+export type {
+  QueryObserverOptions,
+  DefaultOptions,
+  QueryClientConfig,
+  InfiniteQueryObserverOptions,
+} from './QueryClient'
 export { createQuery } from './createQuery'
 export {
   QueryClientContext,

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -2,17 +2,19 @@
 
 import type {
   QueryKey,
-  QueryObserverOptions,
   QueryObserverResult,
   MutateFunction,
   MutationObserverOptions,
   MutationObserverResult,
   DefinedQueryObserverResult,
-  InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
   WithRequired,
   DefaultError,
 } from '@tanstack/query-core'
+import type {
+  QueryObserverOptions,
+  InfiniteQueryObserverOptions,
+} from './QueryClient'
 
 export type FunctionedParams<T> = () => T
 

--- a/packages/solid-query/src/useIsFetching.ts
+++ b/packages/solid-query/src/useIsFetching.ts
@@ -1,4 +1,5 @@
-import type { QueryClient, QueryFilters } from '@tanstack/query-core'
+import type { QueryFilters } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import type { Accessor } from 'solid-js'
 import { createMemo, createSignal, onCleanup } from 'solid-js'
 import { useQueryClient } from './QueryClientProvider'

--- a/packages/solid-query/src/useIsMutating.ts
+++ b/packages/solid-query/src/useIsMutating.ts
@@ -1,4 +1,5 @@
-import type { MutationFilters, QueryClient } from '@tanstack/query-core'
+import type { MutationFilters } from '@tanstack/query-core'
+import type { QueryClient } from './QueryClient'
 import { useQueryClient } from './QueryClientProvider'
 import type { Accessor } from 'solid-js'
 import { createSignal, onCleanup, createMemo } from 'solid-js'

--- a/packages/solid-query/tsconfig.json
+++ b/packages/solid-query/tsconfig.json
@@ -11,7 +11,7 @@
     "emitDeclarationOnly": false,
     "types": ["vitest/globals"]
   },
-  "include": ["src"],
+  "include": ["src", "createInfiniteQuery.test.tsx", "suspense.test.tsx"],
   "exclude": ["node_modules", "build"],
   "references": [{ "path": "../query-core" }]
 }


### PR DESCRIPTION
This pull request proposes a new feature for `solid-query` that allows for more precise updates to query data. The new `reconcile` option enables updates to be made between state updates, while the structuralSharing option is removed since it doesn't work well with `solid-js'` data diffing patterns.

## Visualisation

### Before
![shapes](https://user-images.githubusercontent.com/45807386/232956618-6a936d75-ed8b-4e46-832b-f3033ea40012.png)

Consider this following example that fetches data for a users list with createQuery.
```tsx
interface User {
  id: number
  name: string
  last_online: string
}

const usersList = createQuery(() => ({
  queryKey: ['users_list'],
  queryFn: async () => {
    const users = await fetch(`${API_URL}/users`).then(res => res.json()) 
    return users as User[]
  },
}))

return (
  <div>
    <button onClick={usersList.refetch}>Refetch</button>
    <For each={usersList.data}>
      {user => (
        <div>
          <div>{user.name}</div>
          <div>{user.last_online}</div>
        </div>
      )}
    </For>
  </div>
)
```
Currently, every time a user clicks the `Refetch` button, the `queryFn` is re-run, and a new array reference of the updated users list is returned. As a result, new DOM nodes are created every time the query data updates, which can quickly become expensive.

With the proposed feature, whenever the query data updates, the previous data will be transformed into the shape of the new data while preserving referential equality of the data array between updates. This will allow for fine-grained updates to the already created DOM nodes.

### After

![shapes (1)](https://user-images.githubusercontent.com/45807386/232961372-41ea9829-78f6-4e6d-8513-8165a03094a3.png)

```tsx
interface User {
  id: number
  name: string
  last_online: string
}

const usersList = createQuery(() => ({
  queryKey: ['users_list'],
  queryFn: async () => {
    const users = await fetch(`${API_URL}/users`).then(res => res.json()) 
    return users as User[]
  },
  reconcile: 'id', // Not needed since reconcile defaults to `id`
}))

return (
  <div>
    <button onClick={usersList.refetch}>Refetch</button>
    <For each={usersList.data}>
      {user => (
        <div>
          <div>{user.name}</div>
          <div>{user.last_online}</div>
        </div>
      )}
    </For>
  </div>
)
```

The diagram illustrates how the reconcile option can enable fine-grained updates. Whenever the `queryFn` is re-run, the `id` reconcile key can help solid-query identify which objects in the array have been updated, allowing for precise updates to those objects while preserving their referential equality.

This feature can be compared to the `key` prop used in React, which allows for efficient updates of lists by identifying unique keys for each element. The `reconcile` option in solid-query works similarly but operates at a more granular level, allowing for precise updates to individual elements within an array.

Overall, this feature can significantly improve the efficiency of applications and reduce the cost of updates by enabling precise and efficient updates to query data.



## API reference
The `reconcile` option in solid-query can be used in multiple ways.

### Option 1: `reconcile` key
```ts
interface Fruit {
  name: string;
  emoji: string;
}

const fruits = createQuery(() => ({
  queryKey: ['fruits'],
  queryFn: async () => {
    const fruitsResponse = await fetch(`${API_URL}/fruits`).then(res => res.json()) 
    return fruitsResponse as Fruit[]
  },
  reconcile: 'name',
}))
```
Similar to the example above. The `reconcile` option can take any `string` value that will act as a key for the data returned by `createQuery`. In the example above, the reconcile option is set to `name`, which means that `solid-query` will use the `name` property of each fruit object to reconcile updates to the query data.

## Option 2: `reconcile` function
```ts
import { produce } from "solid-js/store";

interface Fruit {
  name: string;
  emoji: string;
}

const fruits = createQuery(() => ({
  queryKey: ['fruits'],
  queryFn: async () => {
    const fruitsResponse = await fetch(`${API_URL}/fruits`).then(res => res.json()) 
    return fruitsResponse as Fruit[]
  },
  reconcile(oldData, newData) {
    if (!oldData) return newData;
    return produce((draft: Fruit[]) => {
      draft.forEach((fruit) => {
        const newFruit = newData.find(f => f.name === fruit.name)
        if (newFruit) {
          fruit.emoji = newFruit.emoji
        }
      })
    })(oldData)
  },
}))
```
Another way to use the `reconcile` option in solid-query is by providing a callback function that receives both the previous data and the new data returned by createQuery. This function allows users to provide their own reconciliation logic based on the data being updated.

In the code snippet above, the `reconcile` function takes two arguments: oldData and newData. If there is no `oldData`, the function returns the `newData` as is. If there is `oldData`, the function uses the `produce` function from the `solid-js/store` library to create a mutable copy of the old data. It then iterates over each fruit object in the old data, checks if there is a matching fruit object in the new data based on the name property, and updates the emoji property of the old object if a match is found.

## Option 3: disable `reconcile` logic
```ts
interface Fruit {
  name: string;
  emoji: string;
}

const fruits = createQuery(() => ({
  queryKey: ['fruits'],
  queryFn: async () => {
    const fruitsResponse = await fetch(`${API_URL}/fruits`).then(res => res.json()) 
    return fruitsResponse as Fruit[]
  },
  reconcile: false,
}))
```
If users don't want to perform fine-grained updates to the data, they can disable the `reconcile` option by setting it to `false`. This will bypass any reconciliation logic and perform immutable updates between query updates.


I believe this change makes `solid-query` even more powerful and intuitive by allowing users to optimize the performance of their applications while providing a smooth user experience.

As always, we encourage everyone to test out this new feature and provide feedback and concerns in the comments. Thank you for your contributions!