### PR TITLE
fix(useQuery): add support for  RN such as useSyncExternalStore in ESM mode

### DIFF
--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -12,11 +12,11 @@
   },
   "types": "build/lib/index.d.ts",
   "main": "build/lib/index.js",
-  "module": "build/lib/index.esm.js",
+  "module": "build/esm/index.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",
-      "import": "./build/lib/index.mjs",
+      "import": "./build/esm/index.js",
       "default": "./build/lib/index.js"
     },
     "./package.json": "./package.json"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -302,18 +302,18 @@ function esm({
 }: Options): RollupOptions {
   const bundleOutput: OutputOptions = {
     format: 'esm',
-    file: `${packageDir}/build/lib/${outputFile}.esm.js`,
+    file: `${packageDir}/build/esm/${outputFile}.js`,
     sourcemap: true,
     banner,
   }
 
   const normalOutput: OutputOptions = {
     format: 'esm',
-    dir: `${packageDir}/build/lib`,
+    dir: `${packageDir}/build/esm`,
     sourcemap: true,
     banner,
     preserveModules: true,
-    entryFileNames: '[name].esm.js',
+    entryFileNames: '[name].js',
   }
 
   return {
@@ -326,6 +326,16 @@ function esm({
       commonJS(),
       nodeResolve({ extensions: ['.ts', '.tsx', '.native.ts'] }),
       forceDevEnv ? forceEnvPlugin('development') : undefined,
+      replace({
+        // TODO: figure out a better way to produce extensionless esm imports
+        "from './logger.js'": "from './logger'",
+        "from './reactBatchedUpdates.js'":
+          "from './reactBatchedUpdates'",
+        "from './useSyncExternalStore.js'":
+          "from './useSyncExternalStore'",
+        preventAssignment: true,
+        delimiters: ['', ''],
+      }),
       preserveDirectives(),
     ],
   }


### PR DESCRIPTION
The original code imports the useSyncExternalStore from the web version in ESM mode, which causes the useQuery to fail to send requests in React Native.
<img width="920" alt="image" src="https://user-images.githubusercontent.com/11458892/233604944-c7d0ecf8-caee-4037-932d-1880948b4777.png">

Modify the ESM code to be placed in a unified directory without the .esm suffix, so that React Native can correctly find the .native.js file.
