### PR TITLE
Select with a transform may break when refetchInterval is set to a function

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -5887,4 +5887,41 @@ describe('useQuery', () => {
     fireEvent.click(fetchBtn)
     await waitFor(() => rendered.getByText('data: 3'))
   })
+
+  it('combines refetchInterval with select', async () => {
+    function Page() {
+      useQuery(
+        ['my-query'],
+        function (ctx) {
+          return { foo: 1 }
+        },
+        {
+          refetchInterval(data, query) {
+            // ^ should not produce a type error
+            return 10000
+          },
+          select(data) {
+            return data.foo
+          },
+        },
+      )
+      useQuery({
+        queryKey: ['my-query'],
+        queryFn(ctx) {
+          return { foo: 1 }
+        },
+        refetchInterval(data, query) {
+          // ^ should not produce a type error
+          return 10000
+        },
+        select(data) {
+          return data.foo
+        },
+      })
+
+      return <div />
+    }
+
+    renderWithClient(queryClient, <Page />)
+  })
 })

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -5892,11 +5892,11 @@ describe('useQuery', () => {
     function Page() {
       useQuery(
         ['my-query'],
-        function (ctx) {
+        function () {
           return { foo: 1 }
         },
         {
-          refetchInterval(data, query) {
+          refetchInterval(data) {
             // ^ should not produce a type error
             return 10000
           },
@@ -5907,10 +5907,10 @@ describe('useQuery', () => {
       )
       useQuery({
         queryKey: ['my-query'],
-        queryFn(ctx) {
+        queryFn() {
           return { foo: 1 }
         },
-        refetchInterval(data, query) {
+        refetchInterval(data) {
           // ^ should not produce a type error
           return 10000
         },


### PR DESCRIPTION
#5310 

This may affect more than just refetchInterval, it appears to be from usage of a `data` variable alongside select changing the type of that variable