### PR TITLE
fix(solid-query): Remove unserializable values

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -91,8 +91,9 @@ export function createBaseQuery<
           // copying over the missing properties from state in order to support hydration
           dataUpdateCount: query.state.dataUpdateCount,
           fetchFailureCount: query.state.fetchFailureCount,
-          fetchFailureReason: query.state.fetchFailureReason,
-          fetchMeta: query.state.fetchMeta,
+          // Removing these properties since they might not be serializable
+          // fetchFailureReason: query.state.fetchFailureReason,
+          // fetchMeta: query.state.fetchMeta,
           isInvalidated: query.state.isInvalidated,
         }
 


### PR DESCRIPTION
This fix removes potentially unserializable values from `createBaseQuery`. They also are not needed for hydrating queries