### PR TITLE
Add .vscode/settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ size-plugin.json
 stats-hydration.json
 stats.json
 stats.html
-.vscode/settings.json
 
 *.log
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.workingDirectories": [{ "pattern": "./packages/*/" }]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "eslint.workingDirectories": [{ "pattern": "./packages/*/" }]
+  "eslint.workingDirectories": [{ "pattern": "./packages/*/" }],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
With settings that make VSCode ESLint work with the project.

Fixes #5334.