### PR TITLE
Support user-specified `options.behavior` in `InfiniteQueryObserver`

### DIFF
--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -7,11 +7,11 @@ import type {
   RefetchQueryFilters,
 } from './types'
 
-export function infiniteQueryBehavior<
-  TQueryFnData,
-  TError,
-  TData,
->(): QueryBehavior<TQueryFnData, TError, InfiniteData<TData>> {
+export function infiniteQueryBehavior<TQueryFnData, TError, TData>(
+  behaviorFromOptions:
+    | QueryBehavior<TQueryFnData, TError, InfiniteData<TData>>
+    | undefined,
+): QueryBehavior<TQueryFnData, TError, InfiniteData<TData>> {
   return {
     onFetch: (context) => {
       context.fetchFn = () => {
@@ -159,6 +159,7 @@ export function infiniteQueryBehavior<
 
         return finalPromise
       }
+      behaviorFromOptions?.onFetch(context)
     },
   }
 }

--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -1,4 +1,4 @@
-import type { QueryBehavior } from './query'
+import type { FetchContext, QueryBehavior } from './query'
 
 import type {
   InfiniteData,
@@ -12,156 +12,162 @@ export function infiniteQueryBehavior<TQueryFnData, TError, TData>(
     | QueryBehavior<TQueryFnData, TError, InfiniteData<TData>>
     | undefined,
 ): QueryBehavior<TQueryFnData, TError, InfiniteData<TData>> {
-  return {
-    onFetch: (context) => {
-      context.fetchFn = () => {
-        const refetchPage: RefetchQueryFilters['refetchPage'] | undefined =
-          context.fetchOptions?.meta?.refetchPage
-        const fetchMore = context.fetchOptions?.meta?.fetchMore
-        const pageParam = fetchMore?.pageParam
-        const isFetchingNextPage = fetchMore?.direction === 'forward'
-        const isFetchingPreviousPage = fetchMore?.direction === 'backward'
-        const oldPages = context.state.data?.pages || []
-        const oldPageParams = context.state.data?.pageParams || []
-        let newPageParams = oldPageParams
-        let cancelled = false
+  const onFetchFromOptions = behaviorFromOptions?.onFetch
+  const onFetch = (
+    context: FetchContext<TQueryFnData, TError, InfiniteData<TData>>,
+  ) => {
+    context.fetchFn = () => {
+      const refetchPage: RefetchQueryFilters['refetchPage'] | undefined =
+        context.fetchOptions?.meta?.refetchPage
+      const fetchMore = context.fetchOptions?.meta?.fetchMore
+      const pageParam = fetchMore?.pageParam
+      const isFetchingNextPage = fetchMore?.direction === 'forward'
+      const isFetchingPreviousPage = fetchMore?.direction === 'backward'
+      const oldPages = context.state.data?.pages || []
+      const oldPageParams = context.state.data?.pageParams || []
+      let newPageParams = oldPageParams
+      let cancelled = false
 
-        const addSignalProperty = (object: unknown) => {
-          Object.defineProperty(object, 'signal', {
-            enumerable: true,
-            get: () => {
-              if (context.signal?.aborted) {
+      const addSignalProperty = (object: unknown) => {
+        Object.defineProperty(object, 'signal', {
+          enumerable: true,
+          get: () => {
+            if (context.signal?.aborted) {
+              cancelled = true
+            } else {
+              context.signal?.addEventListener('abort', () => {
                 cancelled = true
-              } else {
-                context.signal?.addEventListener('abort', () => {
-                  cancelled = true
-                })
-              }
-              return context.signal
-            },
+              })
+            }
+            return context.signal
+          },
+        })
+      }
+
+      // Get query function
+      const queryFn =
+        context.options.queryFn || (() => Promise.reject('Missing queryFn'))
+
+      const buildNewPages = (
+        pages: unknown[],
+        param: unknown,
+        page: unknown,
+        previous?: boolean,
+      ) => {
+        newPageParams = previous
+          ? [param, ...newPageParams]
+          : [...newPageParams, param]
+        return previous ? [page, ...pages] : [...pages, page]
+      }
+
+      // Create function to fetch a page
+      const fetchPage = (
+        pages: unknown[],
+        manual?: boolean,
+        param?: unknown,
+        previous?: boolean,
+      ): Promise<unknown[]> => {
+        if (cancelled) {
+          return Promise.reject('Cancelled')
+        }
+
+        if (typeof param === 'undefined' && !manual && pages.length) {
+          return Promise.resolve(pages)
+        }
+
+        const queryFnContext: QueryFunctionContext = {
+          queryKey: context.queryKey,
+          pageParam: param,
+          meta: context.options.meta,
+        }
+
+        addSignalProperty(queryFnContext)
+
+        const queryFnResult = queryFn(queryFnContext)
+
+        const promise = Promise.resolve(queryFnResult).then((page) =>
+          buildNewPages(pages, param, page, previous),
+        )
+
+        return promise
+      }
+
+      let promise: Promise<unknown[]>
+
+      // Fetch first page?
+      if (!oldPages.length) {
+        promise = fetchPage([])
+      }
+
+      // Fetch next page?
+      else if (isFetchingNextPage) {
+        const manual = typeof pageParam !== 'undefined'
+        const param = manual
+          ? pageParam
+          : getNextPageParam(context.options, oldPages)
+        promise = fetchPage(oldPages, manual, param)
+      }
+
+      // Fetch previous page?
+      else if (isFetchingPreviousPage) {
+        const manual = typeof pageParam !== 'undefined'
+        const param = manual
+          ? pageParam
+          : getPreviousPageParam(context.options, oldPages)
+        promise = fetchPage(oldPages, manual, param, true)
+      }
+
+      // Refetch pages
+      else {
+        newPageParams = []
+
+        const manual = typeof context.options.getNextPageParam === 'undefined'
+
+        const shouldFetchFirstPage =
+          refetchPage && oldPages[0]
+            ? refetchPage(oldPages[0], 0, oldPages)
+            : true
+
+        // Fetch first page
+        promise = shouldFetchFirstPage
+          ? fetchPage([], manual, oldPageParams[0])
+          : Promise.resolve(buildNewPages([], oldPageParams[0], oldPages[0]))
+
+        // Fetch remaining pages
+        for (let i = 1; i < oldPages.length; i++) {
+          promise = promise.then((pages) => {
+            const shouldFetchNextPage =
+              refetchPage && oldPages[i]
+                ? refetchPage(oldPages[i], i, oldPages)
+                : true
+
+            if (shouldFetchNextPage) {
+              const param = manual
+                ? oldPageParams[i]
+                : getNextPageParam(context.options, pages)
+              return fetchPage(pages, manual, param)
+            }
+            return Promise.resolve(
+              buildNewPages(pages, oldPageParams[i], oldPages[i]),
+            )
           })
         }
-
-        // Get query function
-        const queryFn =
-          context.options.queryFn || (() => Promise.reject('Missing queryFn'))
-
-        const buildNewPages = (
-          pages: unknown[],
-          param: unknown,
-          page: unknown,
-          previous?: boolean,
-        ) => {
-          newPageParams = previous
-            ? [param, ...newPageParams]
-            : [...newPageParams, param]
-          return previous ? [page, ...pages] : [...pages, page]
-        }
-
-        // Create function to fetch a page
-        const fetchPage = (
-          pages: unknown[],
-          manual?: boolean,
-          param?: unknown,
-          previous?: boolean,
-        ): Promise<unknown[]> => {
-          if (cancelled) {
-            return Promise.reject('Cancelled')
-          }
-
-          if (typeof param === 'undefined' && !manual && pages.length) {
-            return Promise.resolve(pages)
-          }
-
-          const queryFnContext: QueryFunctionContext = {
-            queryKey: context.queryKey,
-            pageParam: param,
-            meta: context.options.meta,
-          }
-
-          addSignalProperty(queryFnContext)
-
-          const queryFnResult = queryFn(queryFnContext)
-
-          const promise = Promise.resolve(queryFnResult).then((page) =>
-            buildNewPages(pages, param, page, previous),
-          )
-
-          return promise
-        }
-
-        let promise: Promise<unknown[]>
-
-        // Fetch first page?
-        if (!oldPages.length) {
-          promise = fetchPage([])
-        }
-
-        // Fetch next page?
-        else if (isFetchingNextPage) {
-          const manual = typeof pageParam !== 'undefined'
-          const param = manual
-            ? pageParam
-            : getNextPageParam(context.options, oldPages)
-          promise = fetchPage(oldPages, manual, param)
-        }
-
-        // Fetch previous page?
-        else if (isFetchingPreviousPage) {
-          const manual = typeof pageParam !== 'undefined'
-          const param = manual
-            ? pageParam
-            : getPreviousPageParam(context.options, oldPages)
-          promise = fetchPage(oldPages, manual, param, true)
-        }
-
-        // Refetch pages
-        else {
-          newPageParams = []
-
-          const manual = typeof context.options.getNextPageParam === 'undefined'
-
-          const shouldFetchFirstPage =
-            refetchPage && oldPages[0]
-              ? refetchPage(oldPages[0], 0, oldPages)
-              : true
-
-          // Fetch first page
-          promise = shouldFetchFirstPage
-            ? fetchPage([], manual, oldPageParams[0])
-            : Promise.resolve(buildNewPages([], oldPageParams[0], oldPages[0]))
-
-          // Fetch remaining pages
-          for (let i = 1; i < oldPages.length; i++) {
-            promise = promise.then((pages) => {
-              const shouldFetchNextPage =
-                refetchPage && oldPages[i]
-                  ? refetchPage(oldPages[i], i, oldPages)
-                  : true
-
-              if (shouldFetchNextPage) {
-                const param = manual
-                  ? oldPageParams[i]
-                  : getNextPageParam(context.options, pages)
-                return fetchPage(pages, manual, param)
-              }
-              return Promise.resolve(
-                buildNewPages(pages, oldPageParams[i], oldPages[i]),
-              )
-            })
-          }
-        }
-
-        const finalPromise = promise.then((pages) => ({
-          pages,
-          pageParams: newPageParams,
-        }))
-
-        return finalPromise
       }
-      behaviorFromOptions?.onFetch(context)
-    },
+
+      const finalPromise = promise.then((pages) => ({
+        pages,
+        pageParams: newPageParams,
+      }))
+
+      return finalPromise
+    }
+    onFetchFromOptions?.(context)
   }
+  if (behaviorFromOptions != null) {
+    behaviorFromOptions.onFetch = onFetch
+    return behaviorFromOptions
+  }
+  return { onFetch }
 }
 
 export function getNextPageParam(

--- a/packages/query-core/src/infiniteQueryObserver.ts
+++ b/packages/query-core/src/infiniteQueryObserver.ts
@@ -80,7 +80,7 @@ export class InfiniteQueryObserver<
     super.setOptions(
       {
         ...options,
-        behavior: infiniteQueryBehavior(),
+        behavior: infiniteQueryBehavior(options?.behavior),
       },
       notifyOptions,
     )
@@ -95,7 +95,7 @@ export class InfiniteQueryObserver<
       TQueryKey
     >,
   ): InfiniteQueryObserverResult<TData, TError> {
-    options.behavior = infiniteQueryBehavior()
+    options.behavior = infiniteQueryBehavior(options.behavior)
     return super.getOptimisticResult(options) as InfiniteQueryObserverResult<
       TData,
       TError

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -540,11 +540,9 @@ export class QueryClient {
     arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   ): Promise<InfiniteData<TData>> {
     const parsedOptions = parseQueryArgs(arg1, arg2, arg3)
-    parsedOptions.behavior = infiniteQueryBehavior<
-      TQueryFnData,
-      TError,
-      TData
-    >()
+    parsedOptions.behavior = infiniteQueryBehavior<TQueryFnData, TError, TData>(
+      parsedOptions.behavior,
+    )
     return this.fetchQuery(parsedOptions)
   }
 


### PR DESCRIPTION
Fixes #5331 and #5336.