### PR TITLE
fix: a11y - adding titles to the video iframes

### DIFF
--- a/docs/react/videos.md
+++ b/docs/react/videos.md
@@ -6,7 +6,7 @@ title: Videos & Talks
 <iframe
   width="280"
   height="400"
-  title="React Query: It’s Time to Break up with your &quot;Global State&quot;! –Tanner Linsley"
+  title="React Query: It’s Time to Break up with your Global State! –Tanner Linsley"
   src="https://www.youtube.com/embed/seU46c6Jz7E"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"

--- a/docs/react/videos.md
+++ b/docs/react/videos.md
@@ -6,6 +6,7 @@ title: Videos & Talks
 <iframe
   width="280"
   height="400"
+  title="React Query: It’s Time to Break up with your &quot;Global State&quot;! –Tanner Linsley"
   src="https://www.youtube.com/embed/seU46c6Jz7E"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
@@ -20,6 +21,7 @@ title: Videos & Talks
 <iframe
   width="280"
   height="400"
+  title="All About React Query (with Tanner Linsley) — Learn With Jason"
   src="https://www.youtube.com/embed/DocXo3gqGdI"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
@@ -32,6 +34,7 @@ title: Videos & Talks
 <iframe
   width="280"
   height="400"
+  title="Hooks for Fetching with ReactQuery Creator Tanner Linsley aka @tannerlinsley"
   src="https://www.youtube.com/embed/PPvWXbSCtBU"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
@@ -44,6 +47,7 @@ title: Videos & Talks
 <iframe
   width="280"
   height="400"
+  title="React Query - Open Source Friday stream with Tanner Linsley from"
   src="https://www.youtube.com/embed/B3cJDT3j19I"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
@@ -56,6 +60,7 @@ title: Videos & Talks
 <iframe
   width="280"
   height="400"
+  title="React Query Presentation - Tanner Linsley"
   src="https://www.youtube.com/embed/_ehibado6rU"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"

--- a/docs/react/videos.md
+++ b/docs/react/videos.md
@@ -6,7 +6,7 @@ title: Videos & Talks
 <iframe
   width="280"
   height="400"
-  title="React Query: It’s Time to Break up with your Global State! –Tanner Linsley"
+  title="React Query: It’s Time to Break up with your Global State! – Tanner Linsley"
   src="https://www.youtube.com/embed/seU46c6Jz7E"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
Hey, just a quick accessibility fix to add titles to the video iFrames on the videos page, according to this rule:

https://dequeuniversity.com/rules/axe/4.7/frame-title

I just used the titles of the videos, figured that made the most sense :). (I'm not quite sure how all screen readers might handle `&quot;` so I just removed the quotes)