### PR TITLE
chore: Validate "exports" field in package.json

### DIFF
--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -11,6 +11,13 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "main": "build/lib/index.js",
+  "exports": {
+    ".": {
+      "require": "./build/lib/index.js",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "clean": "rimraf ./build",
     "dev": "tsup --watch --sourcemap",

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "types": "build/lib/index.d.ts",
   "module": "build/lib/index.js",
-  "svelte": "./build/lib/index.js",
+  "svelte": "build/lib/index.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -2,7 +2,7 @@
   "name": "@tanstack/svelte-query",
   "version": "4.29.5",
   "description": "Primitives for managing, caching and syncing asynchronous and remote data in Svelte",
-  "author": "Dre Johnson",
+  "author": "Lachlan Collins",
   "license": "MIT",
   "repository": "tanstack/query",
   "homepage": "https://tanstack.com/query",
@@ -10,16 +10,29 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "types": "build/lib/index.d.ts",
-  "module": "build/lib/index.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js",
+      "svelte": "./build/lib/index.js",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "build/lib",
+    "src",
+    "!build/lib/__tests__",
+    "!src/__tests__"
+  ],
   "scripts": {
     "clean": "rimraf ./build",
     "test:types": "svelte-check --tsconfig ./tsconfig.json",
     "test:eslint": "eslint --ext .svelte,.ts ./src",
     "test:lib": "vitest run --coverage true",
     "test:lib:dev": "vitest watch",
-    "build": "svelte-package --input ./src --output ./build/lib && rimraf ./build/lib/__tests__"
+    "build": "svelte-package --input ./src --output ./build/lib"
   },
   "devDependencies": {
     "@sveltejs/package": "^2.0.2",
@@ -40,14 +53,5 @@
   },
   "peerDependencies": {
     "svelte": "^3.54.0"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": "./build/lib/index.js"
-  },
-  "svelte": "./build/lib/index.js",
-  "files": [
-    "build/lib/*",
-    "src"
-  ]
+  }
 }

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
+  "types": "build/lib/index.d.ts",
+  "module": "build/lib/index.js",
+  "svelte": "./build/lib/index.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/svelte-query/src/__tests__/CreateMutation.svelte
+++ b/packages/svelte-query/src/__tests__/CreateMutation.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import {
-    createMutation,
-    QueryClient,
-    type CreateMutationOptions,
-  } from '../index'
+  import { QueryClient } from '@tanstack/query-core'
   import { setQueryClientContext } from '../context'
+  import { createMutation } from '../createMutation'
+  import type { CreateMutationOptions } from '../types'
 
   export let options: CreateMutationOptions
 

--- a/packages/svelte-query/src/__tests__/CreateQueries.svelte
+++ b/packages/svelte-query/src/__tests__/CreateQueries.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { createQueries, QueryClient } from '../index'
+  import { QueryClient } from '@tanstack/query-core'
   import { setQueryClientContext } from '../context'
+  import { createQueries } from '../createQueries'
   import type { QueriesOptions } from '../createQueries'
 
   export let options: readonly [...QueriesOptions<any>]

--- a/packages/svelte-query/src/__tests__/CreateQuery.svelte
+++ b/packages/svelte-query/src/__tests__/CreateQuery.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { createQuery, QueryClient, type CreateQueryOptions } from '../index'
+  import { QueryClient } from '@tanstack/query-core'
   import { setQueryClientContext } from '../context'
+  import { createQuery } from '../createQuery'
+  import type { CreateQueryOptions } from '../types'
 
   export let options: CreateQueryOptions
 

--- a/packages/svelte-query/src/__tests__/createMutation.test.ts
+++ b/packages/svelte-query/src/__tests__/createMutation.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/svelte'
+import { fireEvent, render, waitFor } from '@testing-library/svelte'
 import CreateMutation from './CreateMutation.svelte'
-import { sleep } from './utils'
 
 describe('createMutation', () => {
   it('Call mutate and check function runs', async () => {
     const mutationFn = vi.fn()
 
-    render(CreateMutation, {
+    const rendered = render(CreateMutation, {
       props: {
         options: {
           mutationFn,
@@ -15,10 +14,10 @@ describe('createMutation', () => {
       },
     })
 
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(rendered.getByRole('button'))
 
-    await sleep(20)
-
-    expect(mutationFn).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(mutationFn).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/svelte-query/src/__tests__/createQueries.test.ts
+++ b/packages/svelte-query/src/__tests__/createQueries.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/svelte'
+import { render, waitFor } from '@testing-library/svelte'
 import CreateQueries from './CreateQueries.svelte'
 import { sleep } from './utils'
 
 describe('createQueries', () => {
   it('Render and wait for success', async () => {
-    render(CreateQueries, {
+    const rendered = render(CreateQueries, {
       props: {
         options: [
           {
@@ -26,12 +26,14 @@ describe('createQueries', () => {
       },
     })
 
-    expect(screen.queryByText('Success 1')).not.toBeInTheDocument()
-    expect(screen.queryByText('Success 2')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(rendered.queryByText('Success 1')).not.toBeInTheDocument()
+      expect(rendered.queryByText('Success 2')).not.toBeInTheDocument()
+    })
 
-    await sleep(20)
-
-    expect(screen.queryByText('Success 1')).toBeInTheDocument()
-    expect(screen.queryByText('Success 2')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(rendered.queryByText('Success 1')).toBeInTheDocument()
+      expect(rendered.queryByText('Success 2')).toBeInTheDocument()
+    })
   })
 })

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -61,7 +61,7 @@ export const packages: Package[] = [
     name: '@tanstack/svelte-query',
     packageDir: 'svelte-query',
     srcDir: 'src',
-    entries: [],
+    entries: ['module', 'svelte', 'types'],
   },
   {
     name: '@tanstack/vue-query',

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -3,57 +3,77 @@ import type { BranchConfig, Package } from './types'
 
 // TODO: List your npm packages here. The first package will be used as the versioner.
 export const packages: Package[] = [
-  { name: '@tanstack/query-core', packageDir: 'query-core', srcDir: 'src' },
+  {
+    name: '@tanstack/query-core',
+    packageDir: 'query-core',
+    srcDir: 'src',
+    entries: ['main', 'module', 'types'],
+  },
   {
     name: '@tanstack/query-persist-client-core',
     packageDir: 'query-persist-client-core',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-async-storage-persister',
     packageDir: 'query-async-storage-persister',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-broadcast-client-experimental',
     packageDir: 'query-broadcast-client-experimental',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-sync-storage-persister',
     packageDir: 'query-sync-storage-persister',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
-  { name: '@tanstack/react-query', packageDir: 'react-query', srcDir: 'src' },
+  {
+    name: '@tanstack/react-query',
+    packageDir: 'react-query',
+    srcDir: 'src',
+    entries: ['main', 'module', 'types'],
+  },
   {
     name: '@tanstack/react-query-devtools',
     packageDir: 'react-query-devtools',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/react-query-persist-client',
     packageDir: 'react-query-persist-client',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/solid-query',
     packageDir: 'solid-query',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/svelte-query',
     packageDir: 'svelte-query',
     srcDir: 'src',
+    entries: [],
   },
   {
     name: '@tanstack/vue-query',
     packageDir: 'vue-query',
     srcDir: 'src',
+    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/eslint-plugin-query',
     packageDir: 'eslint-plugin-query',
     srcDir: 'src',
+    entries: ['main'],
   },
 ]
 

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -38,7 +38,7 @@ export type Package = {
   name: string
   packageDir: string
   srcDir: string
-  entries: Array<'main' | 'module' | 'types'>
+  entries: Array<'main' | 'module' | 'svelte' | 'types'>
 }
 
 export type BranchConfig = {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -38,6 +38,7 @@ export type Package = {
   name: string
   packageDir: string
   srcDir: string
+  entries: Array<'main' | 'module' | 'types'>
 }
 
 export type BranchConfig = {

--- a/scripts/validate-packages.ts
+++ b/scripts/validate-packages.ts
@@ -19,14 +19,14 @@ async function run() {
         pkg.name === '@tanstack/eslint-plugin-query'
           ? (['main'] as const)
           : pkg.name === '@tanstack/svelte-query'
-          ? (['types', 'module'] as const)
+          ? ([] as const)
           : (['main', 'types', 'module'] as const)
 
       await Promise.all(
         entries.map(async (entryKey) => {
-          const entry = pkgJson[entryKey] as string
+          const entry = pkgJson[entryKey] as unknown
 
-          if (!entry) {
+          if (typeof entry !== 'string') {
             throw new Error(
               `Missing entry for "${entryKey}" in ${pkg.packageDir}/package.json!`,
             )
@@ -46,6 +46,27 @@ async function run() {
           }
         }),
       )
+      
+      const defaultExport = pkgJson.exports?.['.']?.['default'] as unknown
+
+      if (typeof defaultExport !== 'string') {
+        throw new Error(
+          `Missing exports['.']['default'] in ${pkg.packageDir}/package.json!`,
+        )
+      }
+
+      const filePath = path.resolve(
+        rootDir,
+        'packages',
+        pkg.packageDir,
+        defaultExport,
+      )
+
+      try {
+        await fsp.access(filePath)
+      } catch (err) {
+        failedValidations.push(`Missing build file: ${filePath}`)
+      }
     }),
   )
   console.info('')

--- a/scripts/validate-packages.ts
+++ b/scripts/validate-packages.ts
@@ -15,15 +15,8 @@ async function run() {
         path.resolve(rootDir, 'packages', pkg.packageDir, 'package.json'),
       )
 
-      const entries =
-        pkg.name === '@tanstack/eslint-plugin-query'
-          ? (['main'] as const)
-          : pkg.name === '@tanstack/svelte-query'
-          ? ([] as const)
-          : (['main', 'types', 'module'] as const)
-
       await Promise.all(
-        entries.map(async (entryKey) => {
+        pkg.entries.map(async (entryKey) => {
           const entry = pkgJson[entryKey] as unknown
 
           if (typeof entry !== 'string') {


### PR DESCRIPTION
According to [publint](https://publint.dev/@tanstack/svelte-query@4.29.5):

`This entrypoint has types at build/lib/index.d.ts but it is not exported from pkg.exports. Consider adding it to pkg.exports["."].types to be compatible with TypeScript's "moduleResolution": "bundler" compiler option. ([More info](https://publint.dev/rules.html#types_not_exported))`

This _was_ actually working with bundler mode because the `.d.ts` files are adjacent to the `.js` files. However, this is obviously more correct, and the other query packages do this already.

I've added a check to validate-packages.ts to look for exports['.']['default'], and also moved the entries logic into config.ts. In the future, it might be possible to add publint to this file - however I ran into a CJS/ESM error which I will investigate at a later time.