### PR TITLE
chore: remove createStore option

### DIFF
--- a/docs/react/guides/migrating-to-v5.md
+++ b/docs/react/guides/migrating-to-v5.md
@@ -443,16 +443,4 @@ Note that the infinite list must be bi-directional, which requires both `getNext
 
 See the [Typescript Docs](../typescript#typing-query-options) for more details.
 
-### CreateStore
-
-We are now exposing a way to customize how queries are stored internally. Per default, a `Map` is used but, with the new `createStore` function, you can now use any data structure you want.
-
-```ts
-const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    createStore: () => new Map()
-  }),
-})
-```
-
 [//]: # 'NewFeatures'

--- a/docs/react/reference/QueryCache.md
+++ b/docs/react/reference/QueryCache.md
@@ -43,9 +43,6 @@ Its available methods are:
 - `onSettled?:` (data: unknown | undefined, error: unknown | null, query: Query) => void
   - Optional
   - This function will be called if some query is settled (either successful or errored).
-- `createStore?: () => QueryStore`
-  - Optional
-  - This function will be called to create the store that will be used to store the queries. By default, a `Map` is used.
 
 ## Global callbacks
 

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -27,7 +27,6 @@ interface QueryCacheConfig {
     error: DefaultError | null,
     query: Query<unknown, unknown, unknown>,
   ) => void
-  createStore?: () => QueryStore
 }
 
 interface NotifyEventQueryAdded extends NotifyEvent {
@@ -95,7 +94,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
 
   constructor(public config: QueryCacheConfig = {}) {
     super()
-    this.#queries = config.createStore?.() ?? new Map<string, Query>()
+    this.#queries = new Map<string, Query>()
   }
 
   build<TQueryFnData, TError, TData, TQueryKey extends QueryKey>(

--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -329,23 +329,6 @@ describe('queryCache', () => {
     })
   })
 
-  describe('QueryCacheConfig.createStore', () => {
-    test('should call createStore', async () => {
-      const createStore = vi.fn().mockImplementation(() => new Map())
-      new QueryCache({ createStore })
-      expect(createStore).toHaveBeenCalledWith()
-    })
-
-    test('should use created store', async () => {
-      const store = new Map()
-      const spy = vi.spyOn(store, 'get')
-
-      new QueryCache({ createStore: () => store }).get('key')
-
-      expect(spy).toHaveBeenCalledTimes(1)
-    })
-  })
-
   describe('QueryCache.add', () => {
     test('should not try to add a query already added to the cache', async () => {
       const key = queryKey()


### PR DESCRIPTION
having the option to customize the internal store sound nice, but the problem is that the store holds Query instances, not data. So, the setter is only called once, not on every data update. This makes it relatively useless - every time we thought we could leverage createStore, it fell short of our requirements because of this.

The better way is usually to subscribe to the QueryCache directly