### PR TITLE
feat: queryOptions helper for solid-query

### DIFF
--- a/packages/solid-query/src/__tests__/createQuery.types.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.types.test.tsx
@@ -1,3 +1,4 @@
+import { queryOptions } from '../createQuery'
 import { createQuery } from '../index'
 
 export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
@@ -25,6 +26,26 @@ describe('initialData', () => {
             wow: true,
           },
         }))
+
+        const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+        return result
+      })
+    })
+
+    it('TData should be defined when passed through queryOptions', () => {
+      doNotExecute(() => {
+        const options = queryOptions(() => ({
+          queryKey: ['key'],
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          initialData: {
+            wow: true,
+          },
+        }))
+        const { data } = createQuery(options)
 
         const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
         return result

--- a/packages/solid-query/src/__tests__/createQuery.types.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.types.test.tsx
@@ -1,5 +1,4 @@
-import { queryOptions } from '../createQuery'
-import { createQuery } from '../index'
+import { createQuery, queryOptions } from '../index'
 
 export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
   T,

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -34,6 +34,28 @@ type DefinedInitialDataOptions<
   }
 >
 
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
+
+export function queryOptions(options: unknown) {
+  return options
+}
+
 export function createQuery<
   TQueryFnData = unknown,
   TError = DefaultError,

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -15,7 +15,7 @@ export type {
   QueryClientConfig,
   InfiniteQueryObserverOptions,
 } from './QueryClient'
-export { createQuery } from './createQuery'
+export { createQuery, queryOptions } from './createQuery'
 export {
   QueryClientContext,
   QueryClientProvider,


### PR DESCRIPTION
Regarding this pr: https://github.com/TanStack/query/pull/5153

This adds `queryOptions` helper function for solid-query as-well, the use is about the same:

```ts
const queryOpts = queryOptions(() => ({
  queryKey: ['myQuery', 'key', 1],
}))

createQuery(queryOpts)
createQuery(() => queryOpts())
```