### PR TITLE
docs: fix the react example for infinite queries

### DIFF
--- a/docs/react/guides/infinite-queries.md
+++ b/docs/react/guides/infinite-queries.md
@@ -74,7 +74,7 @@ function Projects() {
     <>
       {data.pages.map((group, i) => (
         <React.Fragment key={i}>
-          {group.projects.map((project) => (
+          {group.data.map((project) => (
             <p key={project.id}>{project.name}</p>
           ))}
         </React.Fragment>


### PR DESCRIPTION
The example talks about a projects API that returns data in the form of
```
{ data: [...], nextCursor: 3}
```

In the example though the data returned from the API is referred to as having a `projects` entry.
This commit uses the correct entry from the sample API.