### PR TITLE
refactor(subscribable): do not create subscribe method for each instance

### DIFF
--- a/packages/query-core/src/subscribable.ts
+++ b/packages/query-core/src/subscribable.ts
@@ -5,11 +5,10 @@ export class Subscribable<TListener extends Function = Listener> {
 
   constructor() {
     this.listeners = []
-    this.subscribe = this.subscribe.bind(this)
   }
 
   subscribe(listener: TListener): () => void {
-    this.listeners.push(listener as TListener)
+    this.listeners.push(listener)
 
     this.onSubscribe()
 


### PR DESCRIPTION
Hello, we don't need create `subscribe` method for each instance of `Subscribable`.