### PR TITLE
fix(devtools): Update ESM export extension

### DIFF
--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -12,11 +12,11 @@
   },
   "types": "build/types/index.d.ts",
   "main": "build/umd/index.js",
-  "module": "build/esm/index.js",
+  "module": "build/esm/index.mjs",
   "exports": {
     ".": {
       "types": "./build/types/index.d.ts",
-      "import": "./build/esm/index.js",
+      "import": "./build/esm/index.mjs",
       "require": "./build/umd/index.js",
       "default": "./build/umd/index.js"
     },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -499,6 +499,10 @@ function createTanstackQueryDevtoolsConfig() {
   outputs.forEach((output) => {
     const format = output.format
     output.dir = `${packageDir}/build/${format}`
+    if (output.format === 'esm') {
+      output.dir = undefined
+      output.file = `${packageDir}/build/${format}/index.mjs`
+    }
   })
 
   solidRollupOptions.external = []


### PR DESCRIPTION
This updates the esm export to have an `mjs` extension to allow compatibility with Next.js