### PR TITLE
fix(svelte-query-devtools): Fix issue parsing JSX

### DIFF
--- a/packages/svelte-query-devtools/tsconfig.json
+++ b/packages/svelte-query-devtools/tsconfig.json
@@ -24,12 +24,7 @@
     "strict": true,
     "strictNullChecks": true,
     "target": "esnext",
-    "tsBuildInfoFile": "./build/.tsbuildinfo",
-    "paths": {
-      "@tanstack/query-core": ["../query-core/src"],
-      "@tanstack/query-devtools": ["../query-devtools/src"],
-      "@tanstack/svelte-query": ["../svelte-query/src"]
-    }
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
   "include": ["src", "src/**/*.svelte"]
 }

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./build",
-    "test:types": "svelte-check --tsconfig ./tsconfig.json",
+    "test:types": "svelte-check --tsconfig ./tsconfig.json && pnpm build",
     "test:eslint": "eslint --ext .svelte,.ts ./src",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",

--- a/packages/svelte-query/tsconfig.json
+++ b/packages/svelte-query/tsconfig.json
@@ -25,10 +25,7 @@
     "strictNullChecks": true,
     "target": "esnext",
     "tsBuildInfoFile": "./build/.tsbuildinfo",
-    "types": ["vitest/globals", "@testing-library/jest-dom"],
-    "paths": {
-      "@tanstack/query-core": ["../query-core/src"]
-    }
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "src/**/*.svelte"]
 }


### PR DESCRIPTION
Since svelte uses it's own tsc alternative which can parse svelte files, it is running into an issue using path aliases to read the `query-devtools` project which contains JSX. This is a temp fix which only reads build outputs from other projects via pnpm/node resolution.