### PR TITLE
Update React v5 docs about dependent-queries.md

### DIFF
--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -35,7 +35,7 @@ The `projects` query will start in:
 
 ```tsx
 status: 'pending'
-isLoading: false
+isPending: false
 fetchStatus: 'idle'
 ```
 
@@ -43,7 +43,7 @@ As soon as the `user` is available, the `projects` query will be `enabled` and w
 
 ```tsx
 status: 'pending'
-isLoading: true
+isPending: true
 fetchStatus: 'fetching'
 ```
 
@@ -51,6 +51,6 @@ Once we have the projects, it will go to:
 
 ```tsx
 status: 'success'
-isLoading: false
+isPending: false
 fetchStatus: 'idle'
 ```


### PR DESCRIPTION
I believe `isLoading` has been renamed to `isPending`