### PR TITLE
refactor(query-core): change QueryMeta and MutationMeta to accept generic types

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -549,10 +549,11 @@ export type MutationKey = readonly unknown[]
 
 export type MutationStatus = 'idle' | 'loading' | 'success' | 'error'
 
+// @ts-expect-error
 export interface MutationMeta<
   TData = unknown,
   TError = unknown,
-  TVariables = void,
+  TVariables = unknown,
   TContext = unknown,
 > {
   [index: string]: unknown

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -48,7 +48,12 @@ export interface InfiniteData<TData> {
   pageParams: unknown[]
 }
 
-export interface QueryMeta {
+export interface QueryMeta<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> {
   [index: string]: unknown
 }
 
@@ -101,7 +106,7 @@ export interface QueryOptions<
    * Additional payload to be stored on each query.
    * Use this property to pass information that can be used in other places.
    */
-  meta?: QueryMeta
+  meta?: QueryMeta<TQueryFnData, TError, TData, TQueryKey>
 }
 
 export type UseErrorBoundary<
@@ -544,7 +549,12 @@ export type MutationKey = readonly unknown[]
 
 export type MutationStatus = 'idle' | 'loading' | 'success' | 'error'
 
-export interface MutationMeta {
+export interface MutationMeta<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown,
+> {
   [index: string]: unknown
 }
 
@@ -585,7 +595,7 @@ export interface MutationOptions<
   networkMode?: NetworkMode
   cacheTime?: number
   _defaulted?: boolean
-  meta?: MutationMeta
+  meta?: MutationMeta<TData, TError, TVariables, TContext>
 }
 
 export interface MutationObserverOptions<


### PR DESCRIPTION
Referring to https://github.com/TanStack/query/pull/4253 and https://tkdodo.eu/blog/breaking-react-querys-api-on-purpose.

Assuming I have a setup like this:
```
interface MyMeta {
  errorMessage: string | ((error: unknown, variables: unknown, context: unknown) => string);
}

declare module '@tanstack/react-query' {
  interface QueryMeta extends MyMeta {}
}

const queryClient = new QueryClient({
  mutationCache: new MutationCache({
    onError: (error, variables, context, mutation) => {
      if (query.meta.errorMessage) {
		const message = 
			typeof query.meta.errorMessage === 'function' 
				? query.meta.errorMessage(error, variables, context) 
				: query.meta.errorMessage;
        toast.error(message)
      }
    },
  }),
})

export function useDeleteTodo() {
  return useMutation({
    mutationFn: deleteTodo,
    meta: {
	  // I have to specify the type
      errorMessage: (_error, todo: Todo) => `Failed to delete ${todo.name}`
    },
  })
}
```

This PR enables you to infer the types correctly in meta field:

```
interface MyMeta<
  TData = unknown,
  TError = unknown,
  TVariables = void,
  TContext = unknown
> {
  errorMessage: string | ((error: TError, variables: TVariables, context: TContext) => string);
  // I can also infer the type of data correctly
  successMessage: string | ((data: TData, variables: TVariables, context: TContext) => string);
}

declare module '@tanstack/react-query' {
  interface QueryMeta<
    TData = unknown,
    TError = unknown,
    TVariables = void,
    TContext = unknown
  > extends MyMeta<TData, TError, TVariables, TContext> {}
}

const queryClient = new QueryClient({
  mutationCache: new MutationCache({
    onError: (error, variables, context, mutation) => {
      if (query.meta.errorMessage) {
		const message = 
			typeof query.meta.errorMessage === 'function' 
				? query.meta.errorMessage(error, variables, context) 
				: query.meta.errorMessage;
        toast.error(message)
      }
    },
  }),
})

export function useDeleteTodo() {
  return useMutation({
    mutationFn: deleteTodo,
    meta: {
	  // todo is inferred correctly now
      errorMessage: (_error, todo) => `Failed to delete ${todo.name}`
    },
  })
}
```

Besides inference this will catch type errors when refactoring - if we want to refactor deleteTodo from `function deleteTodo(todo: Todo): Promise<void>` to `function deleteTodo(options: {todo: Todo, projectId: string}): Promise<void>`, we'll get a type error, however, without inference we could easily miss this.


Is there any way to ignore the errors of unused types? 
Is there a docs section that I should update?