### PR TITLE
refactor(query-core): replace `indexOf` with `includes`

### DIFF
--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -129,7 +129,7 @@ export class Mutation<
   }
 
   addObserver(observer: MutationObserver<any, any, any, any>): void {
-    if (this.observers.indexOf(observer) === -1) {
+    if (!this.observers.includes(observer)) {
       this.observers.push(observer)
 
       // Stop the mutation from being garbage collected

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -282,7 +282,7 @@ export class Query<
   }
 
   addObserver(observer: QueryObserver<any, any, any, any, any>): void {
-    if (this.observers.indexOf(observer) === -1) {
+    if (!this.observers.includes(observer)) {
       this.observers.push(observer)
 
       // Stop the query from being garbage collected
@@ -293,7 +293,7 @@ export class Query<
   }
 
   removeObserver(observer: QueryObserver<any, any, any, any, any>): void {
-    if (this.observers.indexOf(observer) !== -1) {
+    if (this.observers.includes(observer)) {
       this.observers = this.observers.filter((x) => x !== observer)
 
       if (!this.observers.length) {

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -88,7 +88,7 @@ export function isValidTimeout(value: unknown): value is number {
 }
 
 export function difference<T>(array1: T[], array2: T[]): T[] {
-  return array1.filter((x) => array2.indexOf(x) === -1)
+  return array1.filter((x) => !array2.includes(x))
 }
 
 export function replaceAt<T>(array: T[], index: number, value: T): T[] {


### PR DESCRIPTION
This PR replaces the use of `.indexOf` with `.includes` for cases where the method is used to check if an array contains a particular element. This results in improved code readability and better adherence to modern JavaScript best practices.

The replaced code snippets include:

	- `.indexOf(...) === -1`
	- `.indexOf(...) !== -1`

There is a `prefer-includes` rule [^1] that enforces this, but it is in the `strict` preset.

[^1]: https://typescript-eslint.io/rules/prefer-includes/