### PR TITLE
chore: Improve eslint/tsconfig setup in svelte packages

### DIFF
--- a/packages/svelte-query-devtools/.eslintrc.cjs
+++ b/packages/svelte-query-devtools/.eslintrc.cjs
@@ -1,11 +1,9 @@
-// @ts-check
-
 /** @type {import('eslint').Linter.Config} */
 const config = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
     sourceType: 'module',
     extraFileExtensions: ['.svelte'],
   },
@@ -13,7 +11,7 @@ const config = {
     'react-hooks/rules-of-hooks': 'off',
   },
   extends: ['plugin:svelte/recommended', '../../.eslintrc'],
-  ignorePatterns: ['*.config.*', '**/build/*', '**/.svelte-kit/*'],
+  ignorePatterns: ['*.config.*', '*.setup.*', '**/build/*'],
   overrides: [
     {
       files: ['*.svelte'],

--- a/packages/svelte-query-devtools/tsconfig.eslint.json
+++ b/packages/svelte-query-devtools/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", "**/*.svelte", "./.eslintrc.cjs"]
-}

--- a/packages/svelte-query-devtools/tsconfig.json
+++ b/packages/svelte-query-devtools/tsconfig.json
@@ -26,5 +26,5 @@
     "target": "esnext",
     "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "include": ["src", "src/**/*.svelte"]
+  "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.svelte", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/svelte-query-devtools/vite.config.ts
+++ b/packages/svelte-query-devtools/vite.config.ts
@@ -1,8 +1,8 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path from 'path';
-import type { UserConfig } from 'vite';
+import { defineConfig } from 'vite';
 
-const config: UserConfig = {
+export default defineConfig({
   plugins: [svelte()],
   resolve: {
     alias: {
@@ -11,6 +11,4 @@ const config: UserConfig = {
       "@tanstack/svelte-query": path.resolve(__dirname, '..', 'svelte-query', 'src'),
     }
   }
-};
-
-export default config;
+});

--- a/packages/svelte-query/.eslintrc.cjs
+++ b/packages/svelte-query/.eslintrc.cjs
@@ -1,11 +1,9 @@
-// @ts-check
-
 /** @type {import('eslint').Linter.Config} */
 const config = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
     sourceType: 'module',
     extraFileExtensions: ['.svelte'],
   },
@@ -13,7 +11,7 @@ const config = {
     'react-hooks/rules-of-hooks': 'off',
   },
   extends: ['plugin:svelte/recommended', '../../.eslintrc'],
-  ignorePatterns: ['*.config.*', '**/build/*', '**/.svelte-kit/*'],
+  ignorePatterns: ['*.config.*', '*.setup.*', '**/build/*'],
   overrides: [
     {
       files: ['*.svelte'],

--- a/packages/svelte-query/.gitignore
+++ b/packages/svelte-query/.gitignore
@@ -1,9 +1,0 @@
-.DS_Store
-node_modules
-/build
-/.svelte-kit
-/package
-.env
-.env.*
-!.env.example
-!lib/

--- a/packages/svelte-query/tsconfig.eslint.json
+++ b/packages/svelte-query/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", "**/*.svelte", "./.eslintrc.cjs"]
-}

--- a/packages/svelte-query/tsconfig.json
+++ b/packages/svelte-query/tsconfig.json
@@ -27,5 +27,5 @@
     "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "src/**/*.svelte"]
+  "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.svelte", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/svelte-query/vite.config.ts
+++ b/packages/svelte-query/vite.config.ts
@@ -1,8 +1,8 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path from 'path';
-import type { UserConfig } from 'vite';
+import { defineConfig } from 'vite';
 
-const config: UserConfig = {
+export default defineConfig({
   plugins: [svelte()],
   resolve: {
     alias: {
@@ -17,6 +17,4 @@ const config: UserConfig = {
     include: ['src/**/*.{test,spec}.{js,ts}'],
     setupFiles: ['vitest.setup.ts']
   }
-};
-
-export default config;
+});


### PR DESCRIPTION
Since `noEmit` is already true in `tsconfig.json`, the separate `tsconfig.eslint.json` file isn't necessary. This has also allowed me to make `.eslintrc.cjs` and `vite.config.ts` type-checked by adding them to `include`, which fixes annoying errors in the IDE.