### PR TITLE
Add refetchInterval to QueryOptions

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -68,6 +68,7 @@ export interface QueryOptions<
    */
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
+  refetchInterval?: number;
   networkMode?: NetworkMode
   cacheTime?: number
   isDataEqual?: (oldData: TData | undefined, newData: TData) => boolean


### PR DESCRIPTION
This property is missing in the types, but is there when I do a console.log.