### PR TITLE
fix: Downgrade chalk to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "axios": "^1.4.0",
     "babel-preset-solid": "^1.6.10",
     "bundlewatch": "^0.3.3",
-    "chalk": "^5.2.0",
+    "chalk": "^4.1.2",
     "concurrently": "^8.0.1",
     "cpy-cli": "^4.2.0",
     "current-git-branch": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
       axios: ^1.4.0
       babel-preset-solid: ^1.6.10
       bundlewatch: ^0.3.3
-      chalk: ^5.2.0
+      chalk: ^4.1.2
       concurrently: ^8.0.1
       cpy-cli: ^4.2.0
       current-git-branch: ^1.1.0
@@ -102,7 +102,7 @@ importers:
       axios: 1.4.0
       babel-preset-solid: 1.6.10_@babel+core@7.21.8
       bundlewatch: 0.3.3
-      chalk: 5.2.0
+      chalk: 4.1.2
       concurrently: 8.0.1
       cpy-cli: 4.2.0
       current-git-branch: 1.1.0
@@ -6689,11 +6689,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  /chalk/5.2.0:
-    resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: true
 
   /chardet/0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}


### PR DESCRIPTION
v5 is ESM only, which would require additional tweaks to support. Might consider later on!