### PR TITLE
fix(svelte): correct workspace version for svelte-query-devtools

### DIFF
--- a/examples/svelte/auto-refetching/package.json
+++ b/examples/svelte/auto-refetching/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",

--- a/examples/svelte/load-more-infinite-scroll/package.json
+++ b/examples/svelte/load-more-infinite-scroll/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",

--- a/examples/svelte/optimistic-updates-typescript/package.json
+++ b/examples/svelte/optimistic-updates-typescript/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",

--- a/examples/svelte/playground/package.json
+++ b/examples/svelte/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",

--- a/examples/svelte/simple/package.json
+++ b/examples/svelte/simple/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.4.0",

--- a/examples/svelte/ssr/package.json
+++ b/examples/svelte/ssr/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",

--- a/examples/svelte/star-wars/package.json
+++ b/examples/svelte/star-wars/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^5.0.0-alpha.38",
-    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.39"
+    "@tanstack/svelte-query-devtools": "workspace:5.0.0-alpha.43"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1007,7 +1007,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/adapter-auto':
@@ -1038,7 +1038,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/adapter-auto':
@@ -1069,7 +1069,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/adapter-auto':
@@ -1100,7 +1100,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/adapter-auto':
@@ -1131,7 +1131,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/adapter-auto':
@@ -1162,7 +1162,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
@@ -1193,7 +1193,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/adapter-auto':
@@ -1224,7 +1224,7 @@ importers:
         specifier: ^5.0.0-alpha.38
         version: link:../../../packages/svelte-query
       '@tanstack/svelte-query-devtools':
-        specifier: workspace:5.0.0-alpha.39
+        specifier: workspace:5.0.0-alpha.43
         version: link:../../../packages/svelte-query-devtools
     devDependencies:
       '@sveltejs/adapter-auto':


### PR DESCRIPTION
Hey there! 👋🏻 

When cloning the `alpha` branch, we cannot install dependencies because all Svelte packages use a no-longer-available version of `@tanstack/svelte-query-devtools`.

```
 ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE  In examples/svelte/auto-refetching: No matching version found for @tanstack/svelte-query-devtools@5.0.0-alpha.39 inside the workspace
```

This PR corrects the version required by those packages.
 
 