### PR TITLE
feat: Remove svelte field from package.json

### DIFF
--- a/packages/svelte-query-devtools/package.json
+++ b/packages/svelte-query-devtools/package.json
@@ -13,12 +13,10 @@
   "type": "module",
   "types": "build/lib/index.d.ts",
   "module": "build/lib/index.js",
-  "svelte": "build/lib/index.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",
       "import": "./build/lib/index.js",
-      "svelte": "./build/lib/index.js",
       "default": "./build/lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -13,12 +13,10 @@
   "type": "module",
   "types": "build/lib/index.d.ts",
   "module": "build/lib/index.js",
-  "svelte": "build/lib/index.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",
       "import": "./build/lib/index.js",
-      "svelte": "./build/lib/index.js",
       "default": "./build/lib/index.js"
     },
     "./package.json": "./package.json"

--- a/scripts/config.mjs
+++ b/scripts/config.mjs
@@ -61,12 +61,12 @@ export const packages = [
   {
     name: '@tanstack/svelte-query',
     packageDir: 'packages/svelte-query',
-    entries: ['module', 'svelte', 'types'],
+    entries: ['module', 'types'],
   },
   {
     name: '@tanstack/svelte-query-devtools',
     packageDir: 'packages/svelte-query-devtools',
-    entries: ['module', 'svelte', 'types'],
+    entries: ['module', 'types'],
   },
   {
     name: '@tanstack/vue-query',

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -39,7 +39,7 @@ export type Parsed = {
 export type Package = {
   name: string
   packageDir: string
-  entries: Array<'main' | 'module' | 'svelte' | 'types'>
+  entries: Array<'main' | 'module' | 'types'>
 }
 
 export type BranchConfig = {


### PR DESCRIPTION
Shouldn't be needed, this was used by bundler plugins years ago but can now just use `module`.