### PR TITLE
fix: Revert `test:types` changes

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -51,22 +51,26 @@
   },
   "targetDefaults": {
     "test:lib": {
-      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/coverage"],
       "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/coverage"]
+      "dependsOn": ["^build"]
     },
     "test:eslint": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"]
+      "inputs": ["default", "^public"],
+      "dependsOn": ["^build"]
     },
     "test:types": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"]
+      "outputs": [
+        "{projectRoot}/build/**/*.d.ts",
+        "{projectRoot}/build/.tsbuildinfo"
+      ],
+      "inputs": ["default", "^public"],
+      "dependsOn": ["^test:types"]
     },
     "build": {
-      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/build/**/*"],
       "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/build/**/*"]
+      "dependsOn": ["^build"]
     },
     "test:build": {
       "dependsOn": ["build"],

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -23,7 +23,7 @@
     "clean": "rimraf ./build && rimraf ./coverage",
     "dev": "tsup --watch --sourcemap",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --emitDeclarationOnly",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "tsup --minify"

--- a/packages/eslint-plugin-query/tsconfig.json
+++ b/packages/eslint-plugin-query/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/query-async-storage-persister/tsconfig.json
+++ b/packages/query-async-storage-persister/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "build": "pnpm build:rollup && pnpm build:types",
     "build:rollup": "rollup --config rollup.config.mjs",
     "build:types": "tsc --emitDeclarationOnly"

--- a/packages/query-broadcast-client-experimental/tsconfig.json
+++ b/packages/query-broadcast-client-experimental/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "declarationDir": "./build/types",
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "outDir": "./build/source",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/query-persist-client-core/tsconfig.json
+++ b/packages/query-persist-client-core/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/query-sync-storage-persister/tsconfig.json
+++ b/packages/query-sync-storage-persister/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/react-query-devtools/tsconfig.json
+++ b/packages/react-query-devtools/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "jsx": "react",
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/react-query-persist-client/tsconfig.json
+++ b/packages/react-query-persist-client/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "jsx": "react",
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:codemods && pnpm build:types",

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "jsx": "react",
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",

--- a/packages/solid-query/tsconfig.json
+++ b/packages/solid-query/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "declarationDir": "./build/types",
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "outDir": "./build/source",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src", "createInfiniteQuery.test.tsx", "suspense.test.tsx"]

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
-    "test:types": "svelte-check --tsconfig ./tsconfig.json",
+    "test:types": "svelte-check --tsconfig ./tsconfig.json && pnpm build",
     "test:eslint": "eslint --ext .svelte,.ts ./src",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",

--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "pnpm build:types",
     "test:lib": "pnpm run test:2 && pnpm run test:2.7 && pnpm run test:3",
     "test:2": "vue-demi-switch 2 vue2 && vitest",
     "test:2.7": "vue-demi-switch 2.7 vue2.7 && vitest",

--- a/packages/vue-query/tsconfig.json
+++ b/packages/vue-query/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./build/lib",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },
   "include": ["src"]


### PR DESCRIPTION
This PR seems to be where the Nx cache first started breaking the `vue-query` build unpredictably. Submitting this to test the GitHub workflow.