### PR TITLE
fix: Fix ESLint warnings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,6 +47,7 @@ const config = {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+    '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/no-inferrable-types': [
       'error',
       { ignoreParameters: true },

--- a/packages/query-devtools/src/Explorer.tsx
+++ b/packages/query-devtools/src/Explorer.tsx
@@ -1,5 +1,5 @@
 import { displayValue } from './utils'
-import superjson from 'superjson'
+import * as superjson from 'superjson'
 import { css, cx } from '@emotion/css'
 import { tokens } from './theme'
 import { createMemo, createSignal, Index, Match, Show, Switch } from 'solid-js'

--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -1,5 +1,5 @@
 import type { Query } from '@tanstack/query-core'
-import SuperJSON from 'superjson'
+import * as superjson from 'superjson'
 
 export function getQueryStatusLabel(query: Query) {
   return query.state.fetchStatus === 'fetching'
@@ -60,7 +60,7 @@ export function getQueryStatusColorByLabel(label: IQueryStatusLabel) {
  * @param {boolean} beautify Formats json to multiline
  */
 export const displayValue = (value: unknown, beautify: boolean = false) => {
-  const { json } = SuperJSON.serialize(value)
+  const { json } = superjson.serialize(value)
 
   return JSON.stringify(json, null, beautify ? 2 : undefined)
 }

--- a/packages/react-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/react-query/src/__tests__/ssr-hydration.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import ReactDOM from 'react-dom'
-import ReactDOMTestUtils from 'react-dom/test-utils'
-import ReactDOMServer from 'react-dom/server'
+import * as ReactDOMTestUtils from 'react-dom/test-utils'
+import * as ReactDOMServer from 'react-dom/server'
 // eslint-disable-next-line import/no-unresolved -- types only for module augmentation
 import type {} from 'react-dom/next'
 import { vi } from 'vitest'

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -167,17 +167,14 @@ async function run() {
   /** Uses packages and changedFiles to determine which packages have changed */
   const changedPackages = RELEASE_ALL
     ? packages
-    : changedFiles.reduce((acc, file) => {
-        const pkg = packages.find(
-          (p) =>
-            file.startsWith(path.join(p.packageDir, 'src')) ||
-            file.startsWith(path.join(p.packageDir, 'package.json')),
+    : packages.filter((pkg) => {
+        const changed = changedFiles.some(
+          (file) =>
+            file.startsWith(path.join(pkg.packageDir, 'src')) ||
+            file.startsWith(path.join(pkg.packageDir, 'package.json')),
         )
-        if (pkg && !acc.find((d) => d.name === pkg.name)) {
-          acc.push(pkg)
-        }
-        return acc
-      }, /** @type {import('./types').Package[]} */ ([]))
+        return changed
+      })
 
   // If a package has a dependency that has been updated, we need to update the
   // package that depends on it as well.


### PR DESCRIPTION
`@typescript-eslint/no-unused-vars` isn't needed since TS checks this and does a better job as it knows when a variable is defined just to help with another variable's type.