### PR TITLE
fix: Simplify exports in solidjs packages

### DIFF
--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "types": "./build/types/index.d.ts",
-      "solid": "./build/source/index.jsx",
+      "solid": "./build/lib/index.js",
       "import": "./build/lib/index.js",
       "require": "./build/lib/index.cjs",
       "default": "./build/lib/index.cjs"
@@ -32,7 +32,7 @@
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",
     "build:rollup": "rollup --config rollup.config.js",
-    "build:types": "tsc"
+    "build:types": "tsc --emitDeclarationOnly"
   },
   "files": [
     "build",

--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -11,12 +11,12 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/types/index.d.ts",
+  "types": "build/lib/index.d.ts",
   "main": "build/lib/index.cjs",
   "module": "build/lib/index.js",
   "exports": {
     ".": {
-      "types": "./build/types/index.d.ts",
+      "types": "./build/lib/index.d.ts",
       "solid": "./build/lib/index.js",
       "import": "./build/lib/index.js",
       "require": "./build/lib/index.cjs",

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declarationDir": "./build/types",
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "outDir": "./build/source",
+    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -16,7 +16,7 @@
   "module": "build/lib/index.js",
   "exports": {
     ".": {
-      "types": "./build/types/index.d.ts",
+      "types": "./build/lib/index.d.ts",
       "solid": "./build/lib/index.js",
       "import": "./build/lib/index.js",
       "require": "./build/lib/index.cjs",

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/types/index.d.ts",
+  "types": "build/lib/index.d.ts",
   "main": "build/lib/index.cjs",
   "module": "build/lib/index.js",
   "exports": {

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -17,14 +17,9 @@
   "exports": {
     ".": {
       "types": "./build/types/index.d.ts",
-      "solid": "./build/source/index.js",
+      "solid": "./build/lib/index.js",
       "import": "./build/lib/index.js",
-      "browser": {
-        "import": "./build/lib/index.js",
-        "require": "./build/lib/index.cjs"
-      },
       "require": "./build/lib/index.cjs",
-      "node": "./build/lib/index.cjs",
       "default": "./build/lib/index.cjs"
     },
     "./package.json": "./package.json"
@@ -40,7 +35,7 @@
     "test:lib:dev": "pnpm run test:lib --watch",
     "build": "pnpm build:rollup && pnpm build:types",
     "build:rollup": "rollup --config rollup.config.js",
-    "build:types": "tsc"
+    "build:types": "tsc --emitDeclarationOnly"
   },
   "files": [
     "build",

--- a/packages/solid-query/tsconfig.json
+++ b/packages/solid-query/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declarationDir": "./build/types",
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "outDir": "./build/source",
+    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/svelte-query-devtools/svelte.config.js
+++ b/packages/svelte-query-devtools/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+const config = {
+  preprocess: vitePreprocess(),
+}
+
+export default config


### PR DESCRIPTION
Also added a missing svelte.config.js that somehow wasn't causing build issues? A plugin was crashing without it.