### PR TITLE
fix: Change `svelte-package` output directory

### DIFF
--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -29,14 +29,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "clean": "rimraf ./build && rimraf ./coverage",
+    "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc --noEmit",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "pnpm build:rollup",
-    "build:rollup": "rollup --config rollup.config.js"
+    "build": "rollup --config rollup.config.js"
   },
   "files": [
     "dist",

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "outDir": "./build/lib",
+    "outDir": "./dist",
     "types": ["vitest/globals"]
   },
   "include": ["src"]

--- a/packages/svelte-query-devtools/.eslintrc.cjs
+++ b/packages/svelte-query-devtools/.eslintrc.cjs
@@ -8,7 +8,7 @@ const config = {
     project: './tsconfig.json',
     extraFileExtensions: ['.svelte'],
   },
-  ignorePatterns: ['*.config.*', '*.setup.*', '**/build/*'],
+  ignorePatterns: ['*.config.*', '*.setup.*', '**/dist/*'],
   overrides: [
     {
       files: ['*.svelte'],

--- a/packages/svelte-query-devtools/package.json
+++ b/packages/svelte-query-devtools/package.json
@@ -11,28 +11,28 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/lib/index.d.ts",
-  "module": "build/lib/index.js",
-  "svelte": "./build/lib/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "svelte": "./dist/index.js",
   "exports": {
     ".": {
-      "types": "./build/lib/index.d.ts",
-      "svelte": "./build/lib/index.js",
-      "import": "./build/lib/index.js",
-      "default": "./build/lib/index.js"
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "files": [
-    "build/lib",
+    "dist",
     "src"
   ],
   "scripts": {
-    "clean": "rimraf ./build && rimraf ./coverage",
+    "clean": "rimraf ./dist && rimraf ./coverage",
     "test:types": "svelte-check --tsconfig ./tsconfig.json",
     "test:eslint": "eslint --ext .svelte,.ts ./src",
     "test:build": "publint --strict",
-    "build": "svelte-package --input ./src --output ./build/lib"
+    "build": "svelte-package --input ./src --output ./dist"
   },
   "dependencies": {
     "@tanstack/query-devtools": "^5.0.0-alpha.43",

--- a/packages/svelte-query/.eslintrc.cjs
+++ b/packages/svelte-query/.eslintrc.cjs
@@ -8,7 +8,7 @@ const config = {
     project: './tsconfig.json',
     extraFileExtensions: ['.svelte'],
   },
-  ignorePatterns: ['*.config.*', '*.setup.*', '**/build/*'],
+  ignorePatterns: ['*.config.*', '*.setup.*', '**/dist/*'],
   overrides: [
     {
       files: ['*.svelte'],

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -11,32 +11,32 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/lib/index.d.ts",
-  "module": "build/lib/index.js",
-  "svelte": "./build/lib/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "svelte": "./dist/index.js",
   "exports": {
     ".": {
-      "types": "./build/lib/index.d.ts",
-      "svelte": "./build/lib/index.js",
-      "import": "./build/lib/index.js",
-      "default": "./build/lib/index.js"
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "files": [
-    "build/lib",
+    "dist",
     "src",
-    "!build/lib/__tests__",
+    "!dist/__tests__",
     "!src/__tests__"
   ],
   "scripts": {
-    "clean": "rimraf ./build && rimraf ./coverage",
+    "clean": "rimraf ./dist && rimraf ./coverage",
     "test:types": "svelte-check --tsconfig ./tsconfig.json",
     "test:eslint": "eslint --ext .svelte,.ts ./src",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "svelte-package --input ./src --output ./build/lib"
+    "build": "svelte-package --input ./src --output ./dist"
   },
   "dependencies": {
     "@tanstack/query-core": "^5.0.0-alpha.43"


### PR DESCRIPTION
`query-devtools` does this because of `rollup-preset-solid`, and `dist` is the default for `svelte-package`, so I hope this is okay. Also a good test of the fixed publish script!