### PR TITLE
feat: Add legacy rollup builds

### DIFF
--- a/docs/react/guides/migrating-to-v5.md
+++ b/docs/react/guides/migrating-to-v5.md
@@ -177,10 +177,6 @@ Custom loggers were already deprecated in 4 and have been removed in this versio
 
 We have updated our browserslist to produce a more modern, performant and smaller bundle. You can read about the requirements [here](../installation#requirements).
 
-### Supported Bundlers
-
-We have removed the legacy `.esm.js` output, which was used by bundlers which didn't recognise the modern `.mjs` extension such as Webpack v4. If you are still using Webpack v4, you can continue to use TanStack Query v4, or upgrade to Webpack v5 or another bundler.
-
 ### Private class fields and methods
 
 TanStack Query has always had private fields and methods on classes, but they weren't really private - they were just private in `TypeScript`. We now use [ECMAScript Private class features](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields), which means those fields are now truly private and can't be accessed from the outside at runtime.

--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query-devtools/rollup.config.js
+++ b/packages/react-query-devtools/rollup.config.js
@@ -4,12 +4,12 @@ import { defineConfig } from 'rollup'
 import { buildConfigs } from '../../scripts/getRollupConfig.js'
 
 export default defineConfig([
-  buildConfigs({
+  ...buildConfigs({
     name: 'react-query-devtools',
     outputFile: 'index',
     entryFile: './src/index.ts',
   }),
-  buildConfigs({
+  ...buildConfigs({
     name: 'react-query-devtools-prod',
     outputFile: 'index.prod',
     entryFile: './src/index.ts',

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -12,8 +12,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",

--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -16,8 +16,8 @@
   },
   "type": "module",
   "types": "build/lib/index.d.ts",
-  "main": "build/lib/index.cjs",
-  "module": "build/lib/index.js",
+  "main": "build/lib/index.legacy.cjs",
+  "module": "build/lib/index.legacy.js",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",


### PR DESCRIPTION
Kind of reverts #5507. The packages that use `buildConfigs` (i.e. not the svelte, solid or eslint packages) will also generate a legacy output (`.legacy.js` and `.legacy.cjs`). I've checked to make sure this works with Webpack 👍 