### PR TITLE
fix(vue-query): do not subscribe on server - nuxt2 memory leak fix

### DIFF
--- a/packages/vue-query/src/__mocks__/useQueryClient.ts
+++ b/packages/vue-query/src/__mocks__/useQueryClient.ts
@@ -1,11 +1,10 @@
 import { QueryClient } from '../queryClient'
+import { noop } from '../utils'
 
 const queryClient = new QueryClient({
   logger: {
     ...console,
-    error: () => {
-      // Noop
-    },
+    error: noop,
   },
   defaultOptions: {
     queries: { retry: false, cacheTime: Infinity },

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -15,6 +15,7 @@ import {
 } from './test-utils'
 import { useQuery } from '../useQuery'
 import { parseQueryArgs, useBaseQuery } from '../useBaseQuery'
+import { noop } from '../utils'
 
 jest.mock('../useQueryClient')
 jest.mock('../useBaseQuery')
@@ -116,9 +117,7 @@ describe('useQuery', () => {
 
   test('should update query on reactive options object change', async () => {
     const spy = jest.fn()
-    const onSuccess = ref(() => {
-      // Noop
-    })
+    const onSuccess = ref(noop)
     useQuery(
       ['key6'],
       simpleFetcher,

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -16,8 +16,9 @@ import type {
   QueryObserverResult,
   QueryFunction,
 } from '@tanstack/query-core'
+import { isServer } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient'
-import { updateState, isQueryKey, cloneDeepUnref } from './utils'
+import { updateState, isQueryKey, cloneDeepUnref, noop } from './utils'
 import type { MaybeRef, WithQueryClientKey } from './types'
 import type { UseQueryOptions } from './useQuery'
 import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
@@ -71,9 +72,7 @@ export function useBaseQuery<
   const observer = new Observer(queryClient, defaultedOptions.value)
   const state = reactive(observer.getCurrentResult())
 
-  const unsubscribe = ref(() => {
-    // noop
-  })
+  const unsubscribe = ref(noop)
 
   watch(
     queryClient.isRestoring,
@@ -81,9 +80,12 @@ export function useBaseQuery<
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!isRestoring) {
         unsubscribe.value()
-        unsubscribe.value = observer.subscribe((result) => {
-          updateState(state, result)
-        })
+        // Nuxt2 memory leak fix - do not subscribe on server
+        if (!isServer) {
+          unsubscribe.value = observer.subscribe((result) => {
+            updateState(state, result)
+          })
+        }
       }
     },
     { immediate: true },
@@ -104,9 +106,7 @@ export function useBaseQuery<
 
   const suspense = () => {
     return new Promise<QueryObserverResult<TData, TError>>((resolve) => {
-      let stopWatch = () => {
-        //noop
-      }
+      let stopWatch = noop
       const run = () => {
         if (defaultedOptions.value.enabled !== false) {
           const optimisticResult = observer.getOptimisticResult(

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -1,9 +1,10 @@
 import { computed, unref, onScopeDispose, ref, watch } from 'vue-demi'
 import type { Ref } from 'vue-demi'
 import type { MutationKey, MutationFilters as MF } from '@tanstack/query-core'
+import { isServer } from '@tanstack/query-core'
 
 import { useQueryClient } from './useQueryClient'
-import { cloneDeepUnref, isQueryKey } from './utils'
+import { cloneDeepUnref, isQueryKey, noop } from './utils'
 import type { MaybeRef, MaybeRefDeep, WithQueryClientKey } from './types'
 
 export type MutationFilters = MaybeRefDeep<WithQueryClientKey<MF>>
@@ -23,9 +24,12 @@ export function useIsMutating(
 
   const isMutating = ref(queryClient.isMutating(filters))
 
-  const unsubscribe = queryClient.getMutationCache().subscribe(() => {
-    isMutating.value = queryClient.isMutating(filters)
-  })
+  // Nuxt2 memory leak fix - do not subscribe on server
+  const unsubscribe = isServer
+    ? noop
+    : queryClient.getMutationCache().subscribe(() => {
+        isMutating.value = queryClient.isMutating(filters)
+      })
 
   watch(
     filters,

--- a/packages/vue-query/src/utils.ts
+++ b/packages/vue-query/src/utils.ts
@@ -69,3 +69,7 @@ function isPlainObject(value: unknown): value is Object {
   const prototype = Object.getPrototypeOf(value)
   return prototype === null || prototype === Object.prototype
 }
+
+export function noop(): void {
+  return undefined
+}

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -3,7 +3,7 @@ import { isServer } from '@tanstack/query-core'
 import type { QueryClientConfig } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
-import { getClientKey } from './utils'
+import { getClientKey, noop } from './utils'
 import { setupDevtools } from './devtools/devtools'
 import type { MaybeRefDeep } from './types'
 
@@ -61,9 +61,7 @@ export const VueQueryPlugin = {
       client.mount()
     }
 
-    let persisterUnmount = () => {
-      // noop
-    }
+    let persisterUnmount = noop
 
     if (options.clientPersister) {
       client.isRestoring.value = true


### PR DESCRIPTION
This should fix the memory leak on Nuxt2.
Nux2 has a different behavior than Nux3 which properly executes `onScopeDispose`.
And since we need to `await query.suspense()` to get data on server side, subscriptions should not be necessary on server environments.