### PR TITLE
docs(useMutation): fix incorrect `mutationKey` types

### DIFF
--- a/docs/react/reference/QueryClient.md
+++ b/docs/react/reference/QueryClient.md
@@ -547,7 +547,7 @@ function Component() {
 
 **Options**
 
-- `mutationKey: string | unknown[]`
+- `mutationKey: unknown[]`
 - `options: MutationOptions`
 
 > Similar to [`setQueryDefaults`](#queryclientsetquerydefaults), the order of registration does matter here.

--- a/docs/react/reference/useMutation.md
+++ b/docs/react/reference/useMutation.md
@@ -49,7 +49,7 @@ mutate(variables, {
 - `cacheTime: number | Infinity`
   - The time in milliseconds that unused/inactive cache data remains in memory. When a mutation's cache becomes unused or inactive, that cache data will be garbage collected after this duration. When different cache times are specified, the longest one will be used.
   - If set to `Infinity`, will disable garbage collection
-- `mutationKey: string`
+- `mutationKey: unknown[]`
   - Optional
   - A mutation key can be set to inherit defaults set with `queryClient.setMutationDefaults` or to identify the mutation in the devtools.
 - `networkMode: 'online' | 'always' | 'offlineFirst`


### PR DESCRIPTION
I think this has not been updated for v4. 

In source code https://github.com/TanStack/query/blob/accecddd167545fd8b8e78af5ed1ec677c3cbb27/packages/query-core/src/types.ts#L543 type of `mutationKey` is always an array