### PR TITLE
chore: Use nx watch command

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,7 +14,7 @@
           "test:build",
           "build"
         ],
-        "parallel": 3,
+        "parallel": 5,
         "accessToken": "ZDdkNDA4MGEtYjNmYi00MWI4LWE1N2QtYTdlNmYxMGJlZWM2fHJlYWQ="
       }
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:types": "nx affected --target=test:types",
     "build": "nx affected --target=build",
     "build:all": "nx run-many --exclude=examples/** --target=build",
-    "watch": "nx watch --all -- pnpm run build:all",
+    "watch": "pnpm run build:all && nx watch --all -- pnpm run build:all",
     "dev": "pnpm run watch",
     "prettier": "prettier --plugin-search-dir . \"{packages,examples,scripts}/**/*.{md,js,jsx,cjs,ts,tsx,json,vue,svelte}\"",
     "prettier:write": "pnpm run prettier --write",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:types": "nx affected --target=test:types",
     "build": "nx affected --target=build",
     "build:all": "nx run-many --exclude=examples/** --target=build",
-    "watch": "concurrently --kill-others \"pnpm -r build:rollup -w\" \"pnpm -r build:types --watch\"",
+    "watch": "nx watch --all -- pnpm run build:all",
     "dev": "pnpm run watch",
     "prettier": "prettier --plugin-search-dir . \"{packages,examples,scripts}/**/*.{md,js,jsx,cjs,ts,tsx,json,vue,svelte}\"",
     "prettier:write": "pnpm run prettier --write",


### PR DESCRIPTION
The current watch script doesn't watch every package, as not everything uses `build:rollup` and `build:types`.

`nx watch` allows running a command files are changed. Since Nx caches builds, we can run `pnpm run build:all` on any change and won't rebuild unchanged packages.

I've also bumped Nx up to 5 parallel tasks, as I only changed down to 3 to debug the distributed task execution bug.