### PR TITLE
refactor(types): export query-cache related types

### DIFF
--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -1,7 +1,8 @@
 /* istanbul ignore file */
 
 export { CancelledError } from './retryer'
-export { QueryCache, QueryCacheNotifyEvent } from './queryCache'
+export { QueryCache } from './queryCache'
+export type { QueryCacheNotifyEvent } from './queryCache'
 export { QueryClient } from './queryClient'
 export { QueryObserver } from './queryObserver'
 export { QueriesObserver } from './queriesObserver'

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
 export { CancelledError } from './retryer'
-export { QueryCache } from './queryCache'
+export { QueryCache, QueryCacheNotifyEvent } from './queryCache'
 export { QueryClient } from './queryClient'
 export { QueryObserver } from './queryObserver'
 export { QueriesObserver } from './queriesObserver'

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -63,7 +63,7 @@ interface NotifyEventQueryObserverOptionsUpdated extends NotifyEvent {
   observer: QueryObserver<any, any, any, any, any>
 }
 
-type QueryCacheNotifyEvent =
+export type QueryCacheNotifyEvent =
   | NotifyEventQueryAdded
   | NotifyEventQueryRemoved
   | NotifyEventQueryUpdated


### PR DESCRIPTION
Closes #5599 

export queryCache-related types for better DevX.