### PR TITLE
refactor(query): add more context to "Missing queryFn" error

### DIFF
--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -47,7 +47,7 @@ export function infiniteQueryBehavior<
           context.options.queryFn ||
           (() =>
             Promise.reject(
-              `Missing queryFn for queryKey '${context.queryKey}'`,
+              `Missing queryFn for queryKey '${context.options.queryHash}'`,
             ))
 
         const buildNewPages = (

--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -44,7 +44,11 @@ export function infiniteQueryBehavior<
 
         // Get query function
         const queryFn =
-          context.options.queryFn || (() => Promise.reject('Missing queryFn'))
+          context.options.queryFn ||
+          (() =>
+            Promise.reject(
+              `Missing queryFn for queryKey '${context.queryKey}'`,
+            ))
 
         const buildNewPages = (
           pages: unknown[],

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -392,7 +392,7 @@ export class Query<
     // Create fetch function
     const fetchFn = () => {
       if (!this.options.queryFn) {
-        return Promise.reject('Missing queryFn')
+        return Promise.reject(`Missing queryFn for queryKey '${this.queryKey}'`)
       }
       this.abortSignalConsumed = false
       return this.options.queryFn(queryFnContext)

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -392,7 +392,9 @@ export class Query<
     // Create fetch function
     const fetchFn = () => {
       if (!this.options.queryFn) {
-        return Promise.reject(`Missing queryFn for queryKey '${this.queryKey}'`)
+        return Promise.reject(
+          `Missing queryFn for queryKey '${this.options.queryHash}'`,
+        )
       }
       this.abortSignalConsumed = false
       return this.options.queryFn(queryFnContext)

--- a/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
@@ -2,15 +2,18 @@ import { waitFor } from '@testing-library/react'
 import type {
   QueryClient,
   InfiniteQueryObserverResult,
+  QueryCache,
 } from '@tanstack/query-core'
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { createQueryClient, queryKey } from './utils'
 
 describe('InfiniteQueryBehavior', () => {
   let queryClient: QueryClient
+  let queryCache: QueryCache
 
   beforeEach(() => {
     queryClient = createQueryClient()
+    queryCache = queryClient.getQueryCache()
     queryClient.mount()
   })
 
@@ -35,9 +38,10 @@ describe('InfiniteQueryBehavior', () => {
     })
 
     await waitFor(() => {
+      const query = queryCache.find(key)!
       return expect(observerResult).toMatchObject({
         isError: true,
-        error: `Missing queryFn for queryKey '${key}'`,
+        error: `Missing queryFn for queryKey '${query.queryHash}'`,
       })
     })
 

--- a/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
@@ -37,7 +37,7 @@ describe('InfiniteQueryBehavior', () => {
     await waitFor(() => {
       return expect(observerResult).toMatchObject({
         isError: true,
-        error: 'Missing queryFn',
+        error: `Missing queryFn for queryKey '${key}'`,
       })
     })
 

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -795,7 +795,9 @@ describe('query', () => {
 
     const unsubscribe = observer.subscribe(() => undefined)
     await sleep(10)
-    expect(mockLogger.error).toHaveBeenCalledWith('Missing queryFn')
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      `Missing queryFn for queryKey '${key}'`,
+    )
 
     unsubscribe()
   })

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -794,9 +794,11 @@ describe('query', () => {
     })
 
     const unsubscribe = observer.subscribe(() => undefined)
+
     await sleep(10)
+    const query = queryCache.find(key)!
     expect(mockLogger.error).toHaveBeenCalledWith(
-      `Missing queryFn for queryKey '${key}'`,
+      `Missing queryFn for queryKey '${query.queryHash}'`,
     )
 
     unsubscribe()


### PR DESCRIPTION
For now, we display the queryKey for which a queryFn is missing.