### PR TITLE
refactor(rect-query): prefer client-only import over 'use client'

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-dom-17": "npm:react-dom@^17.0.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.70.2",
-    "rollup-plugin-preserve-directives": "0.1.0",
+    "rollup-plugin-preserve-directives": "0.2.0",
     "rollup-plugin-size": "^0.2.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.6.0",

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -45,7 +45,8 @@
     "@tanstack/react-query": "workspace:*"
   },
   "dependencies": {
-    "@tanstack/query-persist-client-core": "workspace:*"
+    "@tanstack/query-persist-client-core": "workspace:*",
+    "client-only": "0.0.1"
   },
   "peerDependencies": {
     "@tanstack/react-query": "workspace:*"

--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import * as React from 'react'
 
 import type { PersistQueryClientOptions } from '@tanstack/query-persist-client-core'

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@tanstack/query-core": "workspace:*",
+    "client-only": "0.0.1",
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {

--- a/packages/react-query/src/QueryClientProvider.tsx
+++ b/packages/react-query/src/QueryClientProvider.tsx
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import * as React from 'react'
 
 import type { QueryClient } from '@tanstack/query-core'

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import type {
   QueryObserver,
   QueryFunction,

--- a/packages/react-query/src/useIsFetching.ts
+++ b/packages/react-query/src/useIsFetching.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import * as React from 'react'
 import type { QueryKey, QueryFilters } from '@tanstack/query-core'
 import { notifyManager, parseFilterArgs } from '@tanstack/query-core'

--- a/packages/react-query/src/useIsMutating.ts
+++ b/packages/react-query/src/useIsMutating.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import * as React from 'react'
 import { useSyncExternalStore } from './useSyncExternalStore'
 

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 import type { QueryFunction, QueryKey } from '@tanstack/query-core'
 import { parseQueryArgs, QueryObserver } from '@tanstack/query-core'
 import type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1295,6 +1295,9 @@ importers:
       '@tanstack/query-core':
         specifier: workspace:*
         version: link:../query-core
+      client-only:
+        specifier: 0.0.1
+        version: 0.0.1
       react-native:
         specifier: '*'
         version: 0.64.3(@babel/core@7.19.1)(@babel/preset-env@7.18.6)(react@18.2.0)
@@ -1378,6 +1381,9 @@ importers:
       '@tanstack/query-persist-client-core':
         specifier: workspace:*
         version: link:../query-persist-client-core
+      client-only:
+        specifier: 0.0.1
+        version: 0.0.1
     devDependencies:
       '@tanstack/react-query':
         specifier: workspace:*
@@ -8273,6 +8279,10 @@ packages:
   /cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
+    dev: false
+
+  /client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
 
   /cliui@6.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: ^2.70.2
         version: 2.78.1
       rollup-plugin-preserve-directives:
-        specifier: 0.1.0
-        version: 0.1.0(rollup@2.78.1)
+        specifier: 0.2.0
+        version: 0.2.0(rollup@2.78.1)
       rollup-plugin-size:
         specifier: ^0.2.2
         version: 0.2.2
@@ -15332,11 +15332,12 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-preserve-directives@0.1.0(rollup@2.78.1):
-    resolution: {integrity: sha512-fgzIK3hwF/afa6L1Qdsvshn0JlCHZRx0Sh9l0jjUgz3VK0unMFuEB4uqL3Vdae4OXkn+MBYCeNEN9vm81IteiA==}
+  /rollup-plugin-preserve-directives@0.2.0(rollup@2.78.1):
+    resolution: {integrity: sha512-KUwbBaFvD1zFIDNnOkR+u64sSod3m0l6q46/SzTOa4GTQ6hp6w0FRr2u7x99YkY9qhlna5panmTmuLWeJ/2KWw==}
     peerDependencies:
       rollup: 2.x || 3.x
     dependencies:
+      magic-string: 0.30.0
       rollup: 2.78.1
     dev: true
 


### PR DESCRIPTION
for things that cannot work on the server, like the QueryClientProvider or the hooks; this will give better error message when attempted to be used in a server component