### PR TITLE
refactor: Sort imports with eslint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,7 @@ const config = {
   extends: [
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
     'plugin:import/typescript',
     'prettier',
   ],
@@ -41,15 +42,38 @@ const config = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'error',
+    '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/no-inferrable-types': [
       'error',
       { ignoreParameters: true },
     ],
+    'import/default': 'off',
+    'import/export': 'off',
+    'import/namespace': 'off',
+    'import/newline-after-import': 'error',
     'import/no-cycle': 'error',
+    'import/no-duplicates': 'off',
+    'import/no-named-as-default-member': 'off',
     'import/no-unresolved': ['error', { ignore: ['^@tanstack/'] }],
     'import/no-unused-modules': ['off', { unusedExports: true }],
+    'import/order': [
+      'error',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+          'object',
+          'type',
+        ],
+      },
+    ],
     'no-redeclare': 'off',
     'no-shadow': 'error',
+    'sort-imports': ['error', { ignoreDeclarationSort: true }],
   },
   overrides: [
     {

--- a/packages/eslint-plugin-query/src/configs/index.ts
+++ b/packages/eslint-plugin-query/src/configs/index.ts
@@ -1,5 +1,5 @@
-import type { TSESLint } from '@typescript-eslint/utils'
 import { rules } from '../rules'
+import type { TSESLint } from '@typescript-eslint/utils'
 
 function generateRecommendedConfig(
   allRules: Record<string, TSESLint.RuleModule<any, any>>,

--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.rule.ts
@@ -1,9 +1,9 @@
-import type { TSESLint } from '@typescript-eslint/utils'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { ASTUtils } from '../../utils/ast-utils'
 import { createRule } from '../../utils/create-rule'
 import { uniqueBy } from '../../utils/unique-by'
 import { ExhaustiveDepsUtils } from './exhaustive-deps.utils'
+import type { TSESLint } from '@typescript-eslint/utils'
 
 const QUERY_KEY = 'queryKey'
 const QUERY_FN = 'queryFn'

--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.utils.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.utils.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from '@typescript-eslint/utils'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { ASTUtils } from '../../utils/ast-utils'
+import type { TSESLint } from '@typescript-eslint/utils'
 
 export const ExhaustiveDepsUtils = {
   isRelevantReference(params: {

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
@@ -1,6 +1,6 @@
-import { rule, name } from './prefer-query-object-syntax'
-import { normalizeIndent } from '../../utils/test-utils'
 import { ESLintUtils } from '@typescript-eslint/utils'
+import { normalizeIndent } from '../../utils/test-utils'
+import { name, rule } from './prefer-query-object-syntax'
 
 const ruleTester = new ESLintUtils.RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
@@ -1,8 +1,8 @@
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import { createRule } from '../../utils/create-rule'
 import { ASTUtils } from '../../utils/ast-utils'
 import { objectKeys } from '../../utils/object-utils'
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 
 const QUERY_CALLS = {
   useQuery: { key: 'queryKey', fn: 'queryFn', type: 'query' },

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -1,8 +1,8 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { uniqueBy } from './unique-by'
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import type TSESLintScopeManager from '@typescript-eslint/scope-manager'
-import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 import type { RuleContext } from '@typescript-eslint/utils/dist/ts-eslint'
-import { uniqueBy } from './unique-by'
 
 export const ASTUtils = {
   isNodeOfOneOf<T extends AST_NODE_TYPES>(

--- a/packages/eslint-plugin-query/src/utils/create-rule.ts
+++ b/packages/eslint-plugin-query/src/utils/create-rule.ts
@@ -1,6 +1,6 @@
 import { ESLintUtils } from '@typescript-eslint/utils'
-import type { EnhancedCreate } from './detect-react-query-imports'
 import { detectTanstackQueryImports } from './detect-react-query-imports'
+import type { EnhancedCreate } from './detect-react-query-imports'
 
 const getDocsUrl = (ruleName: string): string =>
   `https://tanstack.com/query/v4/docs/eslint/${ruleName}`

--- a/packages/query-async-storage-persister/src/index.ts
+++ b/packages/query-async-storage-persister/src/index.ts
@@ -1,9 +1,9 @@
+import { asyncThrottle } from './asyncThrottle'
 import type {
   PersistedClient,
   Persister,
   Promisable,
 } from '@tanstack/query-persist-client-core'
-import { asyncThrottle } from './asyncThrottle'
 
 interface AsyncStorage {
   getItem: (key: string) => Promise<string | null>

--- a/packages/query-core/src/infiniteQueryObserver.ts
+++ b/packages/query-core/src/infiniteQueryObserver.ts
@@ -1,3 +1,9 @@
+import { QueryObserver } from './queryObserver'
+import {
+  hasNextPage,
+  hasPreviousPage,
+  infiniteQueryBehavior,
+} from './infiniteQueryBehavior'
 import type {
   DefaultedInfiniteQueryObserverOptions,
   FetchNextPageOptions,
@@ -9,12 +15,6 @@ import type {
 } from './types'
 import type { QueryClient } from './queryClient'
 import type { NotifyOptions, ObserverFetchOptions } from './queryObserver'
-import { QueryObserver } from './queryObserver'
-import {
-  hasNextPage,
-  hasPreviousPage,
-  infiniteQueryBehavior,
-} from './infiniteQueryBehavior'
 import type { Query } from './query'
 
 type InfiniteQueryObserverListener<TData, TError> = (

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -1,12 +1,12 @@
-import type { MutationOptions, MutationStatus, MutationMeta } from './types'
-import type { MutationCache } from './mutationCache'
-import type { MutationObserver } from './mutationObserver'
-import type { Logger } from './logger'
 import { defaultLogger } from './logger'
 import { notifyManager } from './notifyManager'
 import { Removable } from './removable'
-import type { Retryer } from './retryer'
 import { canFetch, createRetryer } from './retryer'
+import type { MutationMeta, MutationOptions, MutationStatus } from './types'
+import type { MutationCache } from './mutationCache'
+import type { MutationObserver } from './mutationObserver'
+import type { Logger } from './logger'
+import type { Retryer } from './retryer'
 
 // TYPES
 

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -1,12 +1,12 @@
+import { notifyManager } from './notifyManager'
+import { Mutation } from './mutation'
+import { matchMutation, noop } from './utils'
+import { Subscribable } from './subscribable'
 import type { MutationObserver } from './mutationObserver'
 import type { MutationOptions, NotifyEvent } from './types'
 import type { QueryClient } from './queryClient'
-import { notifyManager } from './notifyManager'
 import type { Action, MutationState } from './mutation'
-import { Mutation } from './mutation'
 import type { MutationFilters } from './utils'
-import { matchMutation, noop } from './utils'
-import { Subscribable } from './subscribable'
 
 // TYPES
 

--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -1,15 +1,15 @@
-import type { Action, Mutation } from './mutation'
 import { getDefaultState } from './mutation'
 import { notifyManager } from './notifyManager'
-import type { QueryClient } from './queryClient'
 import { Subscribable } from './subscribable'
+import { shallowEqualObjects } from './utils'
+import type { QueryClient } from './queryClient'
 import type {
   MutateOptions,
   MutationObserverBaseResult,
-  MutationObserverResult,
   MutationObserverOptions,
+  MutationObserverResult,
 } from './types'
-import { shallowEqualObjects } from './utils'
+import type { Action, Mutation } from './mutation'
 
 // TYPES
 

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -1,14 +1,14 @@
 import { difference, replaceAt } from './utils'
 import { notifyManager } from './notifyManager'
+import { QueryObserver } from './queryObserver'
+import { Subscribable } from './subscribable'
 import type {
+  DefaultedQueryObserverOptions,
   QueryObserverOptions,
   QueryObserverResult,
-  DefaultedQueryObserverOptions,
 } from './types'
 import type { QueryClient } from './queryClient'
 import type { NotifyOptions } from './queryObserver'
-import { QueryObserver } from './queryObserver'
-import { Subscribable } from './subscribable'
 
 type QueriesObserverListener = (result: QueryObserverResult[]) => void
 

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -1,23 +1,23 @@
 import { getAbortController, noop, replaceData, timeUntilStale } from './utils'
+import { defaultLogger } from './logger'
+import { notifyManager } from './notifyManager'
+import { canFetch, createRetryer, isCancelledError } from './retryer'
+import { Removable } from './removable'
 import type {
+  CancelOptions,
+  FetchStatus,
   InitialDataFunction,
+  QueryFunctionContext,
   QueryKey,
+  QueryMeta,
   QueryOptions,
   QueryStatus,
-  QueryFunctionContext,
-  QueryMeta,
-  CancelOptions,
   SetDataOptions,
-  FetchStatus,
 } from './types'
 import type { QueryCache } from './queryCache'
 import type { QueryObserver } from './queryObserver'
 import type { Logger } from './logger'
-import { defaultLogger } from './logger'
-import { notifyManager } from './notifyManager'
 import type { Retryer } from './retryer'
-import { isCancelledError, canFetch, createRetryer } from './retryer'
-import { Removable } from './removable'
 
 // TYPES
 

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -1,11 +1,11 @@
-import type { QueryFilters } from './utils'
 import { hashQueryKeyByOptions, matchQuery, parseFilterArgs } from './utils'
-import type { Action, QueryState } from './query'
 import { Query } from './query'
-import type { NotifyEvent, QueryKey, QueryOptions } from './types'
 import { notifyManager } from './notifyManager'
-import type { QueryClient } from './queryClient'
 import { Subscribable } from './subscribable'
+import type { QueryFilters } from './utils'
+import type { Action, QueryState } from './query'
+import type { NotifyEvent, QueryKey, QueryOptions } from './types'
+import type { QueryClient } from './queryClient'
 import type { QueryObserver } from './queryObserver'
 
 // TYPES

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -1,15 +1,23 @@
-import type { QueryFilters, Updater, MutationFilters } from './utils'
 import {
+  functionalUpdate,
   hashQueryKey,
+  hashQueryKeyByOptions,
   noop,
   parseFilterArgs,
   parseQueryArgs,
   partialMatchKey,
-  hashQueryKeyByOptions,
-  functionalUpdate,
 } from './utils'
+import { QueryCache } from './queryCache'
+import { MutationCache } from './mutationCache'
+import { focusManager } from './focusManager'
+import { onlineManager } from './onlineManager'
+import { notifyManager } from './notifyManager'
+import { infiniteQueryBehavior } from './infiniteQueryBehavior'
+import { defaultLogger } from './logger'
+import type { CancelOptions, DefaultedQueryObserverOptions } from './types'
+import type { Logger } from './logger'
+import type { QueryState } from './query'
 import type {
-  QueryClientConfig,
   DefaultOptions,
   FetchInfiniteQueryOptions,
   FetchQueryOptions,
@@ -19,6 +27,7 @@ import type {
   MutationKey,
   MutationObserverOptions,
   MutationOptions,
+  QueryClientConfig,
   QueryFunction,
   QueryKey,
   QueryObserverOptions,
@@ -30,16 +39,7 @@ import type {
   SetDataOptions,
   WithRequired,
 } from './types'
-import type { QueryState } from './query'
-import { QueryCache } from './queryCache'
-import { MutationCache } from './mutationCache'
-import { focusManager } from './focusManager'
-import { onlineManager } from './onlineManager'
-import { notifyManager } from './notifyManager'
-import { infiniteQueryBehavior } from './infiniteQueryBehavior'
-import type { CancelOptions, DefaultedQueryObserverOptions } from './types'
-import type { Logger } from './logger'
-import { defaultLogger } from './logger'
+import type { MutationFilters, QueryFilters, Updater } from './utils'
 
 // TYPES
 

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -1,4 +1,3 @@
-import type { DefaultedQueryObserverOptions, RefetchPageFilters } from './types'
 import {
   isServer,
   isValidTimeout,
@@ -8,6 +7,9 @@ import {
   timeUntilStale,
 } from './utils'
 import { notifyManager } from './notifyManager'
+import { focusManager } from './focusManager'
+import { Subscribable } from './subscribable'
+import { canFetch, isCancelledError } from './retryer'
 import type {
   PlaceholderDataFunction,
   QueryKey,
@@ -17,11 +19,9 @@ import type {
   QueryOptions,
   RefetchOptions,
 } from './types'
-import type { Query, QueryState, Action, FetchOptions } from './query'
+import type { Action, FetchOptions, Query, QueryState } from './query'
 import type { QueryClient } from './queryClient'
-import { focusManager } from './focusManager'
-import { Subscribable } from './subscribable'
-import { canFetch, isCancelledError } from './retryer'
+import type { DefaultedQueryObserverOptions, RefetchPageFilters } from './types'
 
 type QueryObserverListener<TData, TError> = (
   result: QueryObserverResult<TData, TError>,

--- a/packages/query-core/src/tests/hydration.test.tsx
+++ b/packages/query-core/src/tests/hydration.test.tsx
@@ -1,11 +1,11 @@
+import { QueryCache } from '../queryCache'
+import { dehydrate, hydrate } from '../hydration'
 import {
   createQueryClient,
   executeMutation,
   mockNavigatorOnLine,
   sleep,
 } from './utils'
-import { QueryCache } from '../queryCache'
-import { dehydrate, hydrate } from '../hydration'
 
 async function fetchData<TData>(value: TData, ms?: number): Promise<TData> {
   await sleep(ms || 0)

--- a/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
@@ -1,11 +1,11 @@
 import { waitFor } from '@testing-library/react'
-import type {
-  QueryClient,
-  InfiniteQueryObserverResult,
-  QueryCache,
-} from '@tanstack/query-core'
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { createQueryClient, queryKey } from './utils'
+import type {
+  InfiniteQueryObserverResult,
+  QueryCache,
+  QueryClient,
+} from '@tanstack/query-core'
 
 describe('InfiniteQueryBehavior', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
@@ -1,6 +1,6 @@
+import { InfiniteQueryObserver } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryClient } from '..'
-import { InfiniteQueryObserver } from '..'
 
 describe('InfiniteQueryObserver', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/mutationCache.test.tsx
+++ b/packages/query-core/src/tests/mutationCache.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react'
-import { queryKey, sleep, executeMutation, createQueryClient } from './utils'
 import { MutationCache, MutationObserver } from '..'
+import { createQueryClient, executeMutation, queryKey, sleep } from './utils'
 
 describe('mutationCache', () => {
   describe('MutationCacheConfig error callbacks', () => {

--- a/packages/query-core/src/tests/mutationObserver.test.tsx
+++ b/packages/query-core/src/tests/mutationObserver.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react'
+import { MutationObserver } from '..'
 import { createQueryClient, sleep } from './utils'
 import type { QueryClient } from '..'
-import { MutationObserver } from '..'
 
 describe('mutationObserver', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/mutations.test.tsx
+++ b/packages/query-core/src/tests/mutations.test.tsx
@@ -1,8 +1,8 @@
-import type { QueryClient } from '..'
-import { createQueryClient, executeMutation, queryKey, sleep } from './utils'
-import type { MutationState } from '../mutation'
-import { MutationObserver } from '../mutationObserver'
 import { waitFor } from '@testing-library/react'
+import { MutationObserver } from '../mutationObserver'
+import { createQueryClient, executeMutation, queryKey, sleep } from './utils'
+import type { QueryClient } from '..'
+import type { MutationState } from '../mutation'
 
 describe('mutations', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/queriesObserver.test.tsx
+++ b/packages/query-core/src/tests/queriesObserver.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react'
-import { sleep, queryKey, createQueryClient, mockLogger } from './utils'
-import type { QueryClient, QueryObserverResult } from '..'
 import { QueriesObserver, QueryObserver } from '..'
+import { createQueryClient, mockLogger, queryKey, sleep } from './utils'
+import type { QueryClient, QueryObserverResult } from '..'
 import type { QueryKey } from '..'
 
 describe('queriesObserver', () => {

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -1,9 +1,11 @@
+import { waitFor } from '@testing-library/react'
+import { QueryObserver, isCancelledError, isError, onlineManager } from '..'
 import {
-  sleep,
-  queryKey,
-  mockVisibilityState,
-  mockLogger,
   createQueryClient,
+  mockLogger,
+  mockVisibilityState,
+  queryKey,
+  sleep,
 } from './utils'
 import type {
   QueryCache,
@@ -11,8 +13,6 @@ import type {
   QueryFunctionContext,
   QueryObserverResult,
 } from '..'
-import { QueryObserver, isCancelledError, isError, onlineManager } from '..'
-import { waitFor } from '@testing-library/react'
 
 describe('query', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -1,8 +1,8 @@
-import { sleep, queryKey, createQueryClient } from './utils'
-import type { QueryClient } from '..'
-import { QueryCache, QueryObserver } from '..'
-import type { Query } from '.././query'
 import { waitFor } from '@testing-library/react'
+import { QueryCache, QueryObserver } from '..'
+import { createQueryClient, queryKey, sleep } from './utils'
+import type { QueryClient } from '..'
+import type { Query } from '.././query'
 
 describe('queryCache', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -1,16 +1,16 @@
 import { waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
-import { sleep, queryKey, mockLogger, createQueryClient } from './utils'
+import { InfiniteQueryObserver, MutationObserver, QueryObserver } from '..'
+import { focusManager, onlineManager } from '..'
+import { noop } from '../utils'
+import { createQueryClient, mockLogger, queryKey, sleep } from './utils'
 import type {
   QueryCache,
   QueryClient,
   QueryFunction,
   QueryObserverOptions,
 } from '..'
-import { InfiniteQueryObserver, MutationObserver, QueryObserver } from '..'
-import { focusManager, onlineManager } from '..'
-import { noop } from '../utils'
 
 describe('queryClient', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -1,12 +1,12 @@
+import { QueryObserver, focusManager } from '..'
 import {
-  sleep,
-  queryKey,
+  createQueryClient,
   expectType,
   mockLogger,
-  createQueryClient,
+  queryKey,
+  sleep,
 } from './utils'
 import type { QueryClient, QueryObserverResult } from '..'
-import { QueryObserver, focusManager } from '..'
 
 describe('queryObserver', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/tests/utils.test.tsx
+++ b/packages/query-core/src/tests/utils.test.tsx
@@ -1,12 +1,12 @@
 import {
-  replaceEqualDeep,
-  partialDeepEqual,
+  isPlainArray,
   isPlainObject,
-  parseMutationArgs,
   matchMutation,
+  parseMutationArgs,
+  partialDeepEqual,
+  replaceEqualDeep,
   scheduleMicrotask,
   sleep,
-  isPlainArray,
 } from '../utils'
 import { Mutation } from '../mutation'
 import { createQueryClient } from './utils'

--- a/packages/query-core/src/tests/utils.ts
+++ b/packages/query-core/src/tests/utils.ts
@@ -1,8 +1,8 @@
 import { act } from '@testing-library/react'
 
-import type { MutationOptions, QueryClientConfig } from '@tanstack/query-core'
 import { QueryClient } from '@tanstack/query-core'
 import * as utils from '../utils'
+import type { MutationOptions, QueryClientConfig } from '@tanstack/query-core'
 
 export function createQueryClient(config?: QueryClientConfig): QueryClient {
   jest.spyOn(console, 'error').mockImplementation(() => undefined)

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1,8 +1,8 @@
 /* istanbul ignore file */
 
 import type { MutationState } from './mutation'
-import type { QueryBehavior, Query } from './query'
-import type { RetryValue, RetryDelayValue } from './retryer'
+import type { Query, QueryBehavior } from './query'
+import type { RetryDelayValue, RetryValue } from './retryer'
 import type { QueryFilters, QueryTypeFilter } from './utils'
 import type { QueryCache } from './queryCache'
 import type { MutationCache } from './mutationCache'

--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -1,10 +1,10 @@
+import { QueriesObserver } from '@tanstack/query-core'
+import { persistQueryClientSubscribe } from '../persist'
 import {
+  createMockPersister,
   createQueryClient,
   createSpyablePersister,
-  createMockPersister,
 } from './utils'
-import { persistQueryClientSubscribe } from '../persist'
-import { QueriesObserver } from '@tanstack/query-core'
 
 describe('persistQueryClientSubscribe', () => {
   test('should persist mutations', async () => {

--- a/packages/query-persist-client-core/src/__tests__/utils.ts
+++ b/packages/query-persist-client-core/src/__tests__/utils.ts
@@ -1,8 +1,8 @@
-import type { QueryClientConfig } from '@tanstack/query-core'
 import { QueryClient } from '@tanstack/query-core'
+import type { QueryClientConfig } from '@tanstack/query-core'
 import type {
-  Persister,
   PersistedClient,
+  Persister,
 } from '@tanstack/query-persist-client-core'
 
 export function createQueryClient(config?: QueryClientConfig): QueryClient {

--- a/packages/query-persist-client-core/src/persist.ts
+++ b/packages/query-persist-client-core/src/persist.ts
@@ -1,10 +1,10 @@
-import type {
-  QueryClient,
-  DehydratedState,
-  DehydrateOptions,
-  HydrateOptions,
-} from '@tanstack/query-core'
 import { dehydrate, hydrate } from '@tanstack/query-core'
+import type {
+  DehydrateOptions,
+  DehydratedState,
+  HydrateOptions,
+  QueryClient,
+} from '@tanstack/query-core'
 import type { NotifyEventType } from '@tanstack/query-core'
 
 export type Promisable<T> = T | PromiseLike<T>

--- a/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
+++ b/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
@@ -1,8 +1,8 @@
 import {
-  dehydrate,
   MutationCache,
   QueryCache,
   QueryClient,
+  dehydrate,
 } from '@tanstack/query-core'
 import { removeOldestQuery } from '@tanstack/query-persist-client-core'
 import { createSyncStoragePersister } from '../index'

--- a/packages/query-sync-storage-persister/src/index.ts
+++ b/packages/query-sync-storage-persister/src/index.ts
@@ -1,7 +1,7 @@
 import type {
+  PersistRetryer,
   PersistedClient,
   Persister,
-  PersistRetryer,
 } from '@tanstack/query-persist-client-core'
 
 interface Storage {

--- a/packages/react-query-devtools/src/Explorer.tsx
+++ b/packages/react-query-devtools/src/Explorer.tsx
@@ -1,8 +1,8 @@
 'use client'
 import * as React from 'react'
 
-import { displayValue, styled } from './utils'
 import superjson from 'superjson'
+import { displayValue, styled } from './utils'
 
 export const Entry = styled('div', {
   fontFamily: 'Menlo, monospace',

--- a/packages/react-query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/Explorer.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen, act } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import * as React from 'react'
 
-import { chunkArray, CopyButton, DefaultRenderer } from '../Explorer'
+import { CopyButton, DefaultRenderer, chunkArray } from '../Explorer'
 import { displayValue } from '../utils'
 
 describe('Explorer', () => {

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react'
-import { fireEvent, screen, waitFor, act } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary'
 import '@testing-library/jest-dom'
-import type { QueryClient } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
+import UserEvent from '@testing-library/user-event'
 import { defaultPanelSize, sortFns } from '../utils'
 import {
+  createQueryClient,
   getByTextContent,
   renderWithClient,
   sleep,
-  createQueryClient,
 } from './utils'
-import UserEvent from '@testing-library/user-event'
+import type { QueryClient } from '@tanstack/react-query'
 
 // TODO: This should be removed with the types for react-error-boundary get updated.
 declare module 'react-error-boundary' {

--- a/packages/react-query-devtools/src/__tests__/utils.tsx
+++ b/packages/react-query-devtools/src/__tests__/utils.tsx
@@ -1,12 +1,12 @@
-import { render, type RenderOptions } from '@testing-library/react'
+import { type RenderOptions, render } from '@testing-library/react'
 import * as React from 'react'
-import { ReactQueryDevtools } from '../devtools'
-
 import {
+  QueryCache,
   QueryClient,
   QueryClientProvider,
-  QueryCache,
 } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '../devtools'
+
 
 export function renderWithClient(
   client: QueryClient,

--- a/packages/react-query-devtools/src/__tests__/utils.tsx
+++ b/packages/react-query-devtools/src/__tests__/utils.tsx
@@ -7,7 +7,6 @@ import {
 } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '../devtools'
 
-
 export function renderWithClient(
   client: QueryClient,
   ui: React.ReactElement,

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -1,48 +1,48 @@
 'use client'
 import * as React from 'react'
-import { useSyncExternalStore } from './useSyncExternalStore'
-import type {
-  QueryCache,
-  QueryClient,
-  QueryKey as QueryKeyType,
-  ContextOptions,
-  Query,
-} from '@tanstack/react-query'
 import {
-  useQueryClient,
-  onlineManager,
   notifyManager,
+  onlineManager,
+  useQueryClient,
 } from '@tanstack/react-query'
 import { rankItem } from '@tanstack/match-sorter-utils'
+import { useMemo } from 'react'
+import { useSyncExternalStore } from './useSyncExternalStore'
 import useLocalStorage from './useLocalStorage'
 import {
-  isVerticalSide,
-  sortFns,
-  useIsMounted,
-  getSidePanelStyle,
-  minPanelSize,
-  getResizeHandleStyle,
-  getSidedProp,
   defaultPanelSize,
   displayValue,
+  getResizeHandleStyle,
+  getSidePanelStyle,
+  getSidedProp,
+  isVerticalSide,
+  minPanelSize,
+  sortFns,
+  useIsMounted,
 } from './utils'
-import type { Corner, Side } from './utils'
 import {
-  Panel,
-  QueryKeys,
-  QueryKey,
+  ActiveQueryPanel,
   Button,
   Code,
   Input,
+  Panel,
+  QueryKey,
+  QueryKeys,
   Select,
-  ActiveQueryPanel,
 } from './styledComponents'
 import ScreenReader from './screenreader'
 import { ThemeProvider, defaultTheme as theme } from './theme'
-import { getQueryStatusLabel, getQueryStatusColor } from './utils'
+import { getQueryStatusColor, getQueryStatusLabel } from './utils'
 import Explorer from './Explorer'
 import Logo from './Logo'
-import { useMemo } from 'react'
+import type { Corner, Side } from './utils'
+import type {
+  ContextOptions,
+  Query,
+  QueryCache,
+  QueryClient,
+  QueryKey as QueryKeyType,
+} from '@tanstack/react-query'
 
 export interface DevToolsErrorType {
   /**

--- a/packages/react-query-devtools/src/utils.ts
+++ b/packages/react-query-devtools/src/utils.ts
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import type { Query } from '@tanstack/react-query'
 import SuperJSON from 'superjson'
 
-import type { Theme } from './theme'
 import { useTheme } from './theme'
 import useMediaQuery from './useMediaQuery'
+import type { Theme } from './theme'
+import type { Query } from '@tanstack/react-query'
 
 type StyledComponent<T> = T extends 'button'
   ? React.DetailedHTMLProps<

--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -1,10 +1,10 @@
 'use client'
 import * as React from 'react'
 
-import type { PersistQueryClientOptions } from '@tanstack/query-persist-client-core'
 import { persistQueryClient } from '@tanstack/query-persist-client-core'
+import { IsRestoringProvider, QueryClientProvider } from '@tanstack/react-query'
+import type { PersistQueryClientOptions } from '@tanstack/query-persist-client-core'
 import type { QueryClientProviderProps } from '@tanstack/react-query'
-import { QueryClientProvider, IsRestoringProvider } from '@tanstack/react-query'
 
 export type PersistQueryClientProviderProps = QueryClientProviderProps & {
   persistOptions: Omit<PersistQueryClientOptions, 'queryClient'>

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react'
 import { render, waitFor } from '@testing-library/react'
 
-import type {
-  UseQueryResult,
-  DefinedUseQueryResult,
-} from '@tanstack/react-query'
-import { QueryClient, useQuery, useQueries } from '@tanstack/react-query'
+import { QueryClient, useQueries, useQuery } from '@tanstack/react-query'
+import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
+
+import { PersistQueryClientProvider } from '../PersistQueryClientProvider'
+import { createQueryClient, mockLogger, queryKey, sleep } from './utils'
 import type {
   PersistedClient,
   Persister,
 } from '@tanstack/query-persist-client-core'
-import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
-
-import { createQueryClient, mockLogger, queryKey, sleep } from './utils'
-import { PersistQueryClientProvider } from '../PersistQueryClientProvider'
+import type {
+  DefinedUseQueryResult,
+  UseQueryResult,
+} from '@tanstack/react-query'
 
 const createMockPersister = (): Persister => {
   let storedState: PersistedClient | undefined

--- a/packages/react-query-persist-client/src/__tests__/utils.ts
+++ b/packages/react-query-persist-client/src/__tests__/utils.ts
@@ -1,7 +1,7 @@
 import { act } from '@testing-library/react'
 
-import type { QueryClientConfig } from '@tanstack/query-core'
 import { QueryClient } from '@tanstack/query-core'
+import type { QueryClientConfig } from '@tanstack/query-core'
 
 export function createQueryClient(config?: QueryClientConfig): QueryClient {
   jest.spyOn(console, 'error').mockImplementation(() => undefined)

--- a/packages/react-query/src/Hydrate.tsx
+++ b/packages/react-query/src/Hydrate.tsx
@@ -1,9 +1,9 @@
 'use client'
 import * as React from 'react'
 
-import type { HydrateOptions } from '@tanstack/query-core'
 import { hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
+import type { HydrateOptions } from '@tanstack/query-core'
 import type { ContextOptions } from './types'
 
 export function useHydrate(

--- a/packages/react-query/src/__tests__/Hydrate.test.tsx
+++ b/packages/react-query/src/__tests__/Hydrate.test.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react'
 import { render } from '@testing-library/react'
 
+import * as coreModule from '@tanstack/query-core'
 import {
+  Hydrate,
+  QueryCache,
   QueryClient,
   QueryClientProvider,
-  QueryCache,
-  useQuery,
   dehydrate,
   useHydrate,
-  Hydrate,
+  useQuery,
 } from '@tanstack/react-query'
 import { createQueryClient, sleep } from './utils'
-import * as coreModule from '@tanstack/query-core'
 
 describe('React hydration', () => {
   const fetchData: (value: string) => Promise<string> = (value) =>

--- a/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
@@ -2,14 +2,14 @@ import * as React from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
 
-import { sleep, queryKey, createQueryClient } from './utils'
 import {
+  QueryCache,
   QueryClient,
   QueryClientProvider,
-  QueryCache,
   useQuery,
   useQueryClient,
 } from '..'
+import { createQueryClient, queryKey, sleep } from './utils'
 
 describe('QueryClientProvider', () => {
   test('sets a specific cache for all queries to use', async () => {

--- a/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, waitFor } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary'
 import * as React from 'react'
 
-import { createQueryClient, queryKey, renderWithClient, sleep } from './utils'
 import { QueryCache, QueryErrorResetBoundary, useQueries, useQuery } from '..'
+import { createQueryClient, queryKey, renderWithClient, sleep } from './utils'
 
 // TODO: This should be removed with the types for react-error-boundary get updated.
 declare module 'react-error-boundary' {

--- a/packages/react-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/react-query/src/__tests__/ssr-hydration.test.tsx
@@ -6,11 +6,11 @@ import ReactDOMServer from 'react-dom/server'
 import type {} from 'react-dom/next'
 
 import {
-  useQuery,
-  QueryClientProvider,
   QueryCache,
+  QueryClientProvider,
   dehydrate,
   hydrate,
+  useQuery,
 } from '..'
 import { createQueryClient, setIsServer, sleep } from './utils'
 

--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -6,8 +6,8 @@ import * as React from 'react'
 // @ts-ignore
 import { renderToString } from 'react-dom/server'
 
-import { sleep, queryKey, createQueryClient } from './utils'
-import { useQuery, QueryClientProvider, QueryCache, useInfiniteQuery } from '..'
+import { QueryCache, QueryClientProvider, useInfiniteQuery, useQuery } from '..'
+import { createQueryClient, queryKey, sleep } from './utils'
 
 describe('Server Side Rendering', () => {
   it('should not trigger fetch', () => {

--- a/packages/react-query/src/__tests__/suspense.test.tsx
+++ b/packages/react-query/src/__tests__/suspense.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import type { UseInfiniteQueryResult, UseQueryResult } from '..'
 import {
   QueryCache,
   QueryErrorResetBoundary,
@@ -11,6 +10,7 @@ import {
   useQueryErrorResetBoundary,
 } from '..'
 import { createQueryClient, queryKey, renderWithClient, sleep } from './utils'
+import type { UseInfiniteQueryResult, UseQueryResult } from '..'
 
 describe("useQuery's in Suspense mode", () => {
   const queryCache = new QueryCache()

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
 
+import { QueryCache, useInfiniteQuery } from '..'
 import {
   createQueryClient,
   queryKey,
@@ -13,7 +14,6 @@ import type {
   QueryFunctionContext,
   UseInfiniteQueryResult,
 } from '..'
-import { QueryCache, useInfiniteQuery } from '..'
 
 interface Result {
   items: number[]

--- a/packages/react-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/react-query/src/__tests__/useIsFetching.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
+import { QueryCache, useIsFetching, useQuery } from '..'
 import {
   createQueryClient,
   queryKey,
@@ -10,7 +11,6 @@ import {
   sleep,
 } from './utils'
 import type { QueryClient } from '..'
-import { QueryCache, useIsFetching, useQuery } from '..'
 
 describe('useIsFetching', () => {
   // See https://github.com/tannerlinsley/react-query/issues/105

--- a/packages/react-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/react-query/src/__tests__/useIsMutating.test.tsx
@@ -1,16 +1,16 @@
 import { fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import { QueryClient } from '@tanstack/query-core'
 import { useIsMutating } from '../useIsMutating'
 import { useMutation } from '../useMutation'
+import * as MutationCacheModule from '../../../query-core/src/mutationCache'
 import {
   createQueryClient,
   renderWithClient,
   setActTimeout,
   sleep,
 } from './utils'
-import { ErrorBoundary } from 'react-error-boundary'
-import { QueryClient } from '@tanstack/query-core'
-import * as MutationCacheModule from '../../../query-core/src/mutationCache'
 
 describe('useIsMutating', () => {
   it('should return the number of fetching mutations', async () => {

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -3,9 +3,7 @@ import '@testing-library/jest-dom'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
-import type { QueryClient } from '..'
 import { MutationCache, QueryCache, useMutation } from '..'
-import type { UseMutationResult } from '../types'
 import {
   createQueryClient,
   mockNavigatorOnLine,
@@ -14,6 +12,8 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
+import type { QueryClient } from '..'
+import type { UseMutationResult } from '../types'
 
 describe('useMutation', () => {
   const queryCache = new QueryCache()

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from 'react-error-boundary'
 
 import * as QueriesObserverModule from '../../../query-core/src/queriesObserver'
 
+import { QueriesObserver, QueryCache, useQueries } from '..'
 import {
   createQueryClient,
   expectType,
@@ -20,7 +21,6 @@ import type {
   UseQueryOptions,
   UseQueryResult,
 } from '..'
-import { QueriesObserver, QueryCache, useQueries } from '..'
 import type { QueryFunctionContext } from '@tanstack/query-core'
 
 describe('useQueries', () => {

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -1,6 +1,8 @@
 import { act, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import * as React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import { QueryCache, useQuery } from '..'
 import {
   Blink,
   createQueryClient,
@@ -20,8 +22,6 @@ import type {
   UseQueryOptions,
   UseQueryResult,
 } from '..'
-import { QueryCache, useQuery } from '..'
-import { ErrorBoundary } from 'react-error-boundary'
 
 describe('useQuery', () => {
   const queryCache = new QueryCache()

--- a/packages/react-query/src/__tests__/utils.tsx
+++ b/packages/react-query/src/__tests__/utils.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import { act, render } from '@testing-library/react'
-import type { ContextOptions, QueryClientConfig, MutationOptions } from '..'
-import { QueryClient, QueryClientProvider } from '..'
 import * as utils from '@tanstack/query-core'
+import { QueryClient, QueryClientProvider } from '..'
+import type { ContextOptions, MutationOptions, QueryClientConfig } from '..'
 
 export function renderWithClient(
   client: QueryClient,

--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -1,4 +1,6 @@
 'use client'
+import * as React from 'react'
+import { shouldThrowError } from './utils'
 import type {
   DefaultedQueryObserverOptions,
   Query,
@@ -7,8 +9,6 @@ import type {
   UseErrorBoundary,
 } from '@tanstack/query-core'
 import type { QueryErrorResetBoundaryValue } from './QueryErrorResetBoundary'
-import * as React from 'react'
-import { shouldThrowError } from './utils'
 
 export const ensurePreventErrorBoundaryRetry = <
   TQueryFnData,

--- a/packages/react-query/src/reactBatchedUpdates.native.ts
+++ b/packages/react-query/src/reactBatchedUpdates.native.ts
@@ -1,4 +1,5 @@
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import { unstable_batchedUpdates } from 'react-native'
+
 export { unstable_batchedUpdates }

--- a/packages/react-query/src/reactBatchedUpdates.ts
+++ b/packages/react-query/src/reactBatchedUpdates.ts
@@ -1,3 +1,4 @@
 'use client'
 import * as ReactDOM from 'react-dom'
+
 export const unstable_batchedUpdates = ReactDOM.unstable_batchedUpdates

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -2,15 +2,15 @@
 
 import type * as React from 'react'
 import type {
+  DefinedQueryObserverResult,
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
+  MutateFunction,
+  MutationObserverOptions,
   MutationObserverResult,
+  QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
-  QueryKey,
-  MutationObserverOptions,
-  MutateFunction,
-  DefinedQueryObserverResult,
 } from '@tanstack/query-core'
 import type { QueryClient } from '@tanstack/query-core'
 

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -1,19 +1,19 @@
 'use client'
 import * as React from 'react'
-import { useSyncExternalStore } from './useSyncExternalStore'
 
-import type { QueryKey, QueryObserver } from '@tanstack/query-core'
 import { notifyManager } from '@tanstack/query-core'
+import { useSyncExternalStore } from './useSyncExternalStore'
 import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import { useQueryClient } from './QueryClientProvider'
-import type { UseBaseQueryOptions } from './types'
 import { useIsRestoring } from './isRestoring'
 import {
   ensurePreventErrorBoundaryRetry,
   getHasError,
   useClearResetErrorBoundary,
 } from './errorBoundaryUtils'
-import { ensureStaleTime, shouldSuspend, fetchOptimistic } from './suspense'
+import { ensureStaleTime, fetchOptimistic, shouldSuspend } from './suspense'
+import type { QueryKey, QueryObserver } from '@tanstack/query-core'
+import type { UseBaseQueryOptions } from './types'
 
 export function useBaseQuery<
   TQueryFnData,

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -1,12 +1,12 @@
 'use client'
+import { InfiniteQueryObserver, parseQueryArgs } from '@tanstack/query-core'
+import { useBaseQuery } from './useBaseQuery'
 import type {
-  QueryObserver,
   QueryFunction,
   QueryKey,
+  QueryObserver,
 } from '@tanstack/query-core'
-import { InfiniteQueryObserver, parseQueryArgs } from '@tanstack/query-core'
 import type { UseInfiniteQueryOptions, UseInfiniteQueryResult } from './types'
-import { useBaseQuery } from './useBaseQuery'
 
 // HOOK
 

--- a/packages/react-query/src/useIsFetching.ts
+++ b/packages/react-query/src/useIsFetching.ts
@@ -1,11 +1,11 @@
 'use client'
 import * as React from 'react'
-import type { QueryKey, QueryFilters } from '@tanstack/query-core'
 import { notifyManager, parseFilterArgs } from '@tanstack/query-core'
 
 import { useSyncExternalStore } from './useSyncExternalStore'
-import type { ContextOptions } from './types'
 import { useQueryClient } from './QueryClientProvider'
+import type { ContextOptions } from './types'
+import type { QueryFilters, QueryKey } from '@tanstack/query-core'
 
 interface Options extends ContextOptions {}
 

--- a/packages/react-query/src/useIsMutating.ts
+++ b/packages/react-query/src/useIsMutating.ts
@@ -1,11 +1,11 @@
 'use client'
 import * as React from 'react'
+import { notifyManager, parseMutationFilterArgs } from '@tanstack/query-core'
 import { useSyncExternalStore } from './useSyncExternalStore'
 
-import type { MutationKey, MutationFilters } from '@tanstack/query-core'
-import { notifyManager, parseMutationFilterArgs } from '@tanstack/query-core'
-import type { ContextOptions } from './types'
 import { useQueryClient } from './QueryClientProvider'
+import type { MutationFilters, MutationKey } from '@tanstack/query-core'
+import type { ContextOptions } from './types'
 
 interface Options extends ContextOptions {}
 

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -1,20 +1,20 @@
 'use client'
 import * as React from 'react'
-import { useSyncExternalStore } from './useSyncExternalStore'
-
-import type { MutationFunction, MutationKey } from '@tanstack/query-core'
 import {
+  MutationObserver,
   notifyManager,
   parseMutationArgs,
-  MutationObserver,
 } from '@tanstack/query-core'
+import { useSyncExternalStore } from './useSyncExternalStore'
+
 import { useQueryClient } from './QueryClientProvider'
+import { shouldThrowError } from './utils'
+import type { MutationFunction, MutationKey } from '@tanstack/query-core'
 import type {
   UseMutateFunction,
   UseMutationOptions,
   UseMutationResult,
 } from './types'
-import { shouldThrowError } from './utils'
 
 // HOOK
 

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -1,11 +1,9 @@
 'use client'
 import * as React from 'react'
-import { useSyncExternalStore } from './useSyncExternalStore'
 
-import type { QueryKey, QueryFunction } from '@tanstack/query-core'
-import { notifyManager, QueriesObserver } from '@tanstack/query-core'
+import { QueriesObserver, notifyManager } from '@tanstack/query-core'
+import { useSyncExternalStore } from './useSyncExternalStore'
 import { useQueryClient } from './QueryClientProvider'
-import type { UseQueryOptions, UseQueryResult } from './types'
 import { useIsRestoring } from './isRestoring'
 import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import {
@@ -15,10 +13,12 @@ import {
 } from './errorBoundaryUtils'
 import {
   ensureStaleTime,
-  shouldSuspend,
   fetchOptimistic,
+  shouldSuspend,
   willFetch,
 } from './suspense'
+import type { QueryFunction, QueryKey } from '@tanstack/query-core'
+import type { UseQueryOptions, UseQueryResult } from './types'
 
 // This defines the `UseQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
 // - `context` is omitted as it is passed as a root-level option to `useQueries` instead.

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -1,12 +1,12 @@
 'use client'
+import { QueryObserver, parseQueryArgs } from '@tanstack/query-core'
+import { useBaseQuery } from './useBaseQuery'
 import type { QueryFunction, QueryKey } from '@tanstack/query-core'
-import { parseQueryArgs, QueryObserver } from '@tanstack/query-core'
 import type {
   DefinedUseQueryResult,
   UseQueryOptions,
   UseQueryResult,
 } from './types'
-import { useBaseQuery } from './useBaseQuery'
 
 // HOOK
 

--- a/packages/solid-query/src/QueryClientProvider.tsx
+++ b/packages/solid-query/src/QueryClientProvider.tsx
@@ -1,12 +1,12 @@
-import type { QueryClient } from '@tanstack/query-core'
-import type { Context, JSX } from 'solid-js'
 import {
   createContext,
-  useContext,
-  onMount,
-  onCleanup,
   mergeProps,
+  onCleanup,
+  onMount,
+  useContext,
 } from 'solid-js'
+import type { QueryClient } from '@tanstack/query-core'
+import type { Context, JSX } from 'solid-js'
 import type { ContextOptions } from './types'
 
 declare global {

--- a/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen, waitFor } from 'solid-testing-library'
-import { queryKey } from './utils'
 
 import { QueryCache, QueryClient } from '@tanstack/query-core'
-import type { Context } from 'solid-js'
 import { createContext, useContext } from 'solid-js'
 import { renderToString } from 'solid-js/web'
-import { createQuery, QueryClientProvider, useQueryClient } from '..'
+import { QueryClientProvider, createQuery, useQueryClient } from '..'
+import { queryKey } from './utils'
 import { createQueryClient, sleep } from './utils'
+import type { Context } from 'solid-js'
 
 describe('QueryClientProvider', () => {
   it('sets a specific cache for all queries to use', async () => {

--- a/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 
-
 import {
   For,
   Index,

--- a/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
@@ -1,23 +1,23 @@
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 
-import { createQueryClient, sleep } from './utils'
 
 import {
-  createEffect,
-  createRenderEffect,
-  createSignal,
   For,
   Index,
   Match,
   Switch,
+  createEffect,
+  createRenderEffect,
+  createSignal,
 } from 'solid-js'
+import { QueryCache, QueryClientProvider, createInfiniteQuery } from '..'
+import { createQueryClient, sleep } from './utils'
+import { Blink, queryKey, setActTimeout } from './utils'
 import type {
   CreateInfiniteQueryResult,
   InfiniteData,
   QueryFunctionContext,
 } from '..'
-import { createInfiniteQuery, QueryCache, QueryClientProvider } from '..'
-import { Blink, queryKey, setActTimeout } from './utils'
 
 interface Result {
   items: number[]

--- a/packages/solid-query/src/__tests__/createMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/createMutation.test.tsx
@@ -1,20 +1,18 @@
 import '@testing-library/jest-dom'
 import {
+  ErrorBoundary,
   createContext,
   createEffect,
   createRenderEffect,
   createSignal,
-  ErrorBoundary,
 } from 'solid-js'
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
-import type { QueryClient } from '..'
 import {
-  createMutation,
   MutationCache,
   QueryCache,
   QueryClientProvider,
+  createMutation,
 } from '..'
-import type { CreateMutationResult } from '../types'
 import {
   createQueryClient,
   mockNavigatorOnLine,
@@ -22,6 +20,8 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
+import type { QueryClient } from '..'
+import type { CreateMutationResult } from '../types'
 
 describe('useMutation', () => {
   const queryCache = new QueryCache()

--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -1,28 +1,19 @@
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 
-import * as QueriesObserverModule from '../../../query-core/src/queriesObserver'
-
-import type { QueryFunctionContext } from '@tanstack/query-core'
 import {
+  ErrorBoundary,
   createContext,
   createMemo,
   createRenderEffect,
   createSignal,
-  ErrorBoundary,
 } from 'solid-js'
-import type {
-  CreateQueryOptions,
-  CreateQueryResult,
-  QueryClient,
-  QueryFunction,
-  QueryObserverResult,
-  SolidQueryKey,
-} from '..'
+import * as QueriesObserverModule from '../../../query-core/src/queriesObserver'
+
 import {
-  createQueries,
   QueriesObserver,
   QueryCache,
   QueryClientProvider,
+  createQueries,
 } from '..'
 import {
   createQueryClient,
@@ -31,6 +22,15 @@ import {
   queryKey,
   sleep,
 } from './utils'
+import type { QueryFunctionContext } from '@tanstack/query-core'
+import type {
+  CreateQueryOptions,
+  CreateQueryResult,
+  QueryClient,
+  QueryFunction,
+  QueryObserverResult,
+  SolidQueryKey,
+} from '..'
 
 describe('useQueries', () => {
   const queryCache = new QueryCache()

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1,23 +1,16 @@
 import '@testing-library/jest-dom'
-import type { JSX } from 'solid-js'
 import {
+  ErrorBoundary,
+  Match,
+  Switch,
   createEffect,
   createMemo,
   createRenderEffect,
   createSignal,
-  ErrorBoundary,
-  Match,
   on,
-  Switch,
 } from 'solid-js'
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
-import type {
-  CreateQueryOptions,
-  CreateQueryResult,
-  DefinedCreateQueryResult,
-  QueryFunction,
-} from '..'
-import { createQuery, QueryCache, QueryClientProvider } from '..'
+import { QueryCache, QueryClientProvider, createQuery } from '..'
 import {
   Blink,
   createQueryClient,
@@ -29,6 +22,13 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
+import type {
+  CreateQueryOptions,
+  CreateQueryResult,
+  DefinedCreateQueryResult,
+  QueryFunction,
+} from '..'
+import type { JSX } from 'solid-js'
 
 describe('createQuery', () => {
   const queryCache = new QueryCache()

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -1,21 +1,21 @@
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 
 import {
-  createRenderEffect,
-  createSignal,
   ErrorBoundary,
-  on,
   Show,
   Suspense,
+  createRenderEffect,
+  createSignal,
+  on,
 } from 'solid-js'
-import type { CreateInfiniteQueryResult, CreateQueryResult } from '..'
 import {
-  createInfiniteQuery,
-  createQuery,
   QueryCache,
   QueryClientProvider,
+  createInfiniteQuery,
+  createQuery,
 } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
+import type { CreateInfiniteQueryResult, CreateQueryResult } from '..'
 
 describe("useQuery's in Suspense mode", () => {
   const queryCache = new QueryCache()

--- a/packages/solid-query/src/__tests__/transition.test.tsx
+++ b/packages/solid-query/src/__tests__/transition.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 
-import { createSignal, Show, startTransition, Suspense } from 'solid-js'
-import { createQuery, QueryCache, QueryClientProvider } from '..'
+import { Show, Suspense, createSignal, startTransition } from 'solid-js'
+import { QueryCache, QueryClientProvider, createQuery } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 
 describe("useQuery's in Suspense mode with transitions", () => {

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -1,16 +1,16 @@
 import { fireEvent, render, screen, waitFor } from 'solid-testing-library'
 
 import {
+  ErrorBoundary,
+  Show,
   createContext,
   createEffect,
   createRenderEffect,
   createSignal,
-  ErrorBoundary,
-  Show,
 } from 'solid-js'
-import type { QueryClient } from '..'
-import { createQuery, QueryCache, QueryClientProvider, useIsFetching } from '..'
+import { QueryCache, QueryClientProvider, createQuery, useIsFetching } from '..'
 import { createQueryClient, queryKey, setActTimeout, sleep } from './utils'
+import type { QueryClient } from '..'
 
 describe('useIsFetching', () => {
   // See https://github.com/tannerlinsley/react-query/issues/105

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -1,22 +1,22 @@
 import { fireEvent, screen, waitFor } from 'solid-testing-library'
-import {
-  createMutation,
-  QueryClient,
-  QueryClientProvider,
-  useIsMutating,
-} from '..'
-import { createQueryClient, sleep } from './utils'
 
 import {
+  ErrorBoundary,
+  Show,
   createContext,
   createEffect,
   createRenderEffect,
   createSignal,
-  ErrorBoundary,
-  Show,
 } from 'solid-js'
 import { render } from 'solid-testing-library'
+import {
+  QueryClient,
+  QueryClientProvider,
+  createMutation,
+  useIsMutating,
+} from '..'
 import * as MutationCacheModule from '../../../query-core/src/mutationCache'
+import { createQueryClient, sleep } from './utils'
 import { setActTimeout } from './utils'
 
 describe('useIsMutating', () => {

--- a/packages/solid-query/src/__tests__/utils.tsx
+++ b/packages/solid-query/src/__tests__/utils.tsx
@@ -1,7 +1,7 @@
-import type { QueryClientConfig } from '@tanstack/query-core'
 import { QueryClient } from '@tanstack/query-core'
+import { Show, createEffect, createSignal, onCleanup } from 'solid-js'
+import type { QueryClientConfig } from '@tanstack/query-core'
 import type { ParentProps } from 'solid-js'
-import { createEffect, createSignal, onCleanup, Show } from 'solid-js'
 
 let queryKeyCount = 0
 export function queryKey(): () => Array<string> {

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -1,17 +1,17 @@
-import type { QueryObserver } from '@tanstack/query-core'
-import type { QueryKey, QueryObserverResult } from '@tanstack/query-core'
-import type { CreateBaseQueryOptions } from './types'
-import { useQueryClient } from './QueryClientProvider'
 import {
-  onMount,
-  onCleanup,
+  batch,
   createComputed,
   createResource,
   on,
-  batch,
+  onCleanup,
+  onMount,
 } from 'solid-js'
 import { createStore, unwrap } from 'solid-js/store'
+import { useQueryClient } from './QueryClientProvider'
 import { shouldThrowError } from './utils'
+import type { QueryObserver } from '@tanstack/query-core'
+import type { QueryKey, QueryObserverResult } from '@tanstack/query-core'
+import type { CreateBaseQueryOptions } from './types'
 
 // Base Query Function that is used to create the query.
 export function createBaseQuery<

--- a/packages/solid-query/src/createInfiniteQuery.ts
+++ b/packages/solid-query/src/createInfiniteQuery.ts
@@ -1,18 +1,18 @@
-import type {
-  QueryObserver,
-  QueryFunction,
-  QueryOptions,
-} from '@tanstack/query-core'
 import { InfiniteQueryObserver } from '@tanstack/query-core'
+import { createComputed } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { createBaseQuery } from './createBaseQuery'
+import { parseQueryArgs } from './utils'
 import type {
   CreateInfiniteQueryOptions,
   CreateInfiniteQueryResult,
   SolidQueryKey,
 } from './types'
-import { createBaseQuery } from './createBaseQuery'
-import { createComputed } from 'solid-js'
-import { createStore } from 'solid-js/store'
-import { parseQueryArgs } from './utils'
+import type {
+  QueryFunction,
+  QueryObserver,
+  QueryOptions,
+} from '@tanstack/query-core'
 
 export function createInfiniteQuery<
   TQueryFnData = unknown,

--- a/packages/solid-query/src/createMutation.ts
+++ b/packages/solid-query/src/createMutation.ts
@@ -1,14 +1,14 @@
-import type { MutationFunction, MutationKey } from '@tanstack/query-core'
-import { parseMutationArgs, MutationObserver } from '@tanstack/query-core'
+import { MutationObserver, parseMutationArgs } from '@tanstack/query-core'
+import { createComputed, on, onCleanup } from 'solid-js'
+import { createStore } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
+import { shouldThrowError } from './utils'
 import type {
   CreateMutateFunction,
   CreateMutationOptions,
   CreateMutationResult,
 } from './types'
-import { createComputed, onCleanup, on } from 'solid-js'
-import { createStore } from 'solid-js/store'
-import { shouldThrowError } from './utils'
+import type { MutationFunction, MutationKey } from '@tanstack/query-core'
 
 // HOOK
 export function createMutation<

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -1,14 +1,14 @@
 import { createComputed, onCleanup, onMount } from 'solid-js'
-import type { QueryFunction } from '@tanstack/query-core'
 import { QueriesObserver } from '@tanstack/query-core'
+import { createStore, unwrap } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
+import { scheduleMicrotask } from './utils'
 import type {
   CreateQueryOptions,
   CreateQueryResult,
   SolidQueryKey,
 } from './types'
-import { createStore, unwrap } from 'solid-js/store'
-import { scheduleMicrotask } from './utils'
+import type { QueryFunction } from '@tanstack/query-core'
 
 // This defines the `UseQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
 // - `context` is omitted as it is passed as a root-level option to `useQueries` instead.

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -1,15 +1,15 @@
-import type { QueryFunction, QueryOptions } from '@tanstack/query-core'
 import { QueryObserver } from '@tanstack/query-core'
+import { createComputed } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { parseQueryArgs } from './utils'
+import { createBaseQuery } from './createBaseQuery'
 import type {
   CreateQueryOptions,
   CreateQueryResult,
   DefinedCreateQueryResult,
   SolidQueryKey,
 } from './types'
-import { createComputed } from 'solid-js'
-import { createStore } from 'solid-js/store'
-import { parseQueryArgs } from './utils'
-import { createBaseQuery } from './createBaseQuery'
+import type { QueryFunction, QueryOptions } from '@tanstack/query-core'
 
 // There are several ways to create a query.
 // 1. createQuery(options: CreateQueryOptions)

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -2,17 +2,17 @@
 
 import type { Context } from 'solid-js'
 import type {
-  QueryClient,
-  QueryKey,
-  QueryObserverOptions,
-  QueryObserverResult,
-  MutateFunction,
-  MutationObserverOptions,
-  MutationObserverResult,
   DefinedQueryObserverResult,
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
+  MutateFunction,
+  MutationObserverOptions,
+  MutationObserverResult,
+  QueryClient,
   QueryFilters,
+  QueryKey,
+  QueryObserverOptions,
+  QueryObserverResult,
   QueryOptions,
 } from '@tanstack/query-core'
 

--- a/packages/solid-query/src/useIsFetching.ts
+++ b/packages/solid-query/src/useIsFetching.ts
@@ -1,10 +1,10 @@
+import { createComputed, createMemo, createSignal, onCleanup } from 'solid-js'
+import { useQueryClient } from './QueryClientProvider'
+import { parseFilterArgs } from './utils'
 import type { QueryFilters } from '@tanstack/query-core'
 
-import type { ContextOptions, SolidQueryKey, SolidQueryFilters } from './types'
-import { useQueryClient } from './QueryClientProvider'
+import type { ContextOptions, SolidQueryFilters, SolidQueryKey } from './types'
 import type { Accessor } from 'solid-js'
-import { createSignal, onCleanup, createComputed, createMemo } from 'solid-js'
-import { parseFilterArgs } from './utils'
 
 interface Options extends ContextOptions {}
 

--- a/packages/solid-query/src/useIsMutating.ts
+++ b/packages/solid-query/src/useIsMutating.ts
@@ -1,9 +1,9 @@
-import type { MutationKey, MutationFilters } from '@tanstack/query-core'
 import { parseMutationFilterArgs } from '@tanstack/query-core'
-import type { ContextOptions } from './types'
-import { useQueryClient } from './QueryClientProvider'
-import type { Accessor } from 'solid-js'
 import { createSignal, onCleanup } from 'solid-js'
+import { useQueryClient } from './QueryClientProvider'
+import type { MutationFilters, MutationKey } from '@tanstack/query-core'
+import type { ContextOptions } from './types'
+import type { Accessor } from 'solid-js'
 
 interface Options extends ContextOptions {}
 

--- a/packages/solid-query/src/utils.ts
+++ b/packages/solid-query/src/utils.ts
@@ -1,8 +1,8 @@
 import type {
-  SolidQueryKey,
-  SolidQueryFilters,
   ParseFilterArgs,
   ParseQueryArgs,
+  SolidQueryFilters,
+  SolidQueryKey,
 } from './types'
 import type { QueryFunction, QueryOptions } from '@tanstack/query-core'
 

--- a/packages/svelte-query/src/Hydrate.svelte
+++ b/packages/svelte-query/src/Hydrate.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { DehydratedState, HydrateOptions } from '@tanstack/query-core'
   import { useHydrate } from './useHydrate'
+  import type { DehydratedState, HydrateOptions } from '@tanstack/query-core'
 
   export let state: DehydratedState
   export let options: HydrateOptions | undefined = undefined

--- a/packages/svelte-query/src/QueryClientProvider.svelte
+++ b/packages/svelte-query/src/QueryClientProvider.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte'
+  import { onDestroy, onMount } from 'svelte'
   import { QueryClient } from '@tanstack/query-core'
   import { setQueryClientContext } from './context'
 

--- a/packages/svelte-query/src/__tests__/createMutation.test.ts
+++ b/packages/svelte-query/src/__tests__/createMutation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, waitFor } from '@testing-library/svelte'
 import CreateMutation from './CreateMutation.svelte'
 

--- a/packages/svelte-query/src/__tests__/createQueries.test.ts
+++ b/packages/svelte-query/src/__tests__/createQueries.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { render, waitFor } from '@testing-library/svelte'
 import CreateQueries from './CreateQueries.svelte'
 import { sleep } from './utils'

--- a/packages/svelte-query/src/__tests__/createQuery.test.ts
+++ b/packages/svelte-query/src/__tests__/createQuery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { render, waitFor } from '@testing-library/svelte'
 import CreateQuery from './CreateQuery.svelte'
 import { sleep } from './utils'

--- a/packages/svelte-query/src/__tests__/utils.ts
+++ b/packages/svelte-query/src/__tests__/utils.ts
@@ -1,9 +1,9 @@
 import { vi } from 'vitest'
 import { act } from '@testing-library/svelte'
 import {
+  type MutationOptions,
   QueryClient,
   type QueryClientConfig,
-  type MutationOptions,
 } from '../index'
 
 export function createQueryClient(config?: QueryClientConfig): QueryClient {

--- a/packages/svelte-query/src/context.ts
+++ b/packages/svelte-query/src/context.ts
@@ -1,4 +1,4 @@
-import { setContext, getContext } from 'svelte'
+import { getContext, setContext } from 'svelte'
 import type { QueryClient } from '@tanstack/query-core'
 
 const _contextKey = '$$_queryClient'

--- a/packages/svelte-query/src/createBaseQuery.ts
+++ b/packages/svelte-query/src/createBaseQuery.ts
@@ -1,11 +1,11 @@
 import {
-  notifyManager,
   type QueryKey,
   type QueryObserver,
+  notifyManager,
 } from '@tanstack/query-core'
-import type { CreateBaseQueryOptions, CreateBaseQueryResult } from './types'
-import { useQueryClient } from './useQueryClient'
 import { derived, readable } from 'svelte/store'
+import { useQueryClient } from './useQueryClient'
+import type { CreateBaseQueryOptions, CreateBaseQueryResult } from './types'
 
 export function createBaseQuery<
   TQueryFnData,

--- a/packages/svelte-query/src/createInfiniteQuery.ts
+++ b/packages/svelte-query/src/createInfiniteQuery.ts
@@ -1,15 +1,15 @@
 import {
   InfiniteQueryObserver,
-  parseQueryArgs,
-  type QueryObserver,
   type QueryFunction,
   type QueryKey,
+  type QueryObserver,
+  parseQueryArgs,
 } from '@tanstack/query-core'
+import { createBaseQuery } from './createBaseQuery'
 import type {
   CreateInfiniteQueryOptions,
   CreateInfiniteQueryResult,
 } from './types'
-import { createBaseQuery } from './createBaseQuery'
 
 export function createInfiniteQuery<
   TQueryFnData = unknown,

--- a/packages/svelte-query/src/createMutation.ts
+++ b/packages/svelte-query/src/createMutation.ts
@@ -1,4 +1,4 @@
-import { readable, derived } from 'svelte/store'
+import { derived, readable } from 'svelte/store'
 import {
   type MutationFunction,
   type MutationKey,
@@ -6,12 +6,12 @@ import {
   notifyManager,
   parseMutationArgs,
 } from '@tanstack/query-core'
+import { useQueryClient } from './useQueryClient'
 import type {
   CreateMutateFunction,
   CreateMutationOptions,
   CreateMutationResult,
 } from './types'
-import { useQueryClient } from './useQueryClient'
 
 export function createMutation<
   TData = unknown,

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -1,15 +1,15 @@
+
+import { QueriesObserver, notifyManager } from '@tanstack/query-core'
+import { type Readable, readable } from 'svelte/store'
+
+import { useQueryClient } from './useQueryClient'
+import type { CreateQueryOptions } from './types'
 import type {
-  QueryKey,
-  QueryFunction,
   QueryClient,
+  QueryFunction,
+  QueryKey,
   QueryObserverResult,
 } from '@tanstack/query-core'
-
-import { notifyManager, QueriesObserver } from '@tanstack/query-core'
-import { readable, type Readable } from 'svelte/store'
-
-import type { CreateQueryOptions } from './types'
-import { useQueryClient } from './useQueryClient'
 
 // This defines the `CreateQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
 // - `context` is omitted as it is passed as a root-level option to `createQueries` instead.

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -1,4 +1,3 @@
-
 import { QueriesObserver, notifyManager } from '@tanstack/query-core'
 import { type Readable, readable } from 'svelte/store'
 

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -1,10 +1,10 @@
 import { QueryObserver, parseQueryArgs } from '@tanstack/query-core'
-import type { QueryFunction, QueryKey } from '@tanstack/query-core'
 import { createBaseQuery } from './createBaseQuery'
+import type { QueryFunction, QueryKey } from '@tanstack/query-core'
 import type {
-  DefinedCreateQueryResult,
   CreateQueryOptions,
   CreateQueryResult,
+  DefinedCreateQueryResult,
 } from './types'
 
 export function createQuery<

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -1,13 +1,13 @@
 import type {
+  DefinedQueryObserverResult,
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
+  MutateFunction,
+  MutationObserverOptions,
   MutationObserverResult,
+  QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
-  QueryKey,
-  MutationObserverOptions,
-  MutateFunction,
-  DefinedQueryObserverResult,
 } from '@tanstack/query-core'
 import type { QueryClient } from '@tanstack/query-core'
 import type { Readable } from 'svelte/store'

--- a/packages/svelte-query/src/useIsFetching.ts
+++ b/packages/svelte-query/src/useIsFetching.ts
@@ -1,9 +1,9 @@
 import {
+  type QueryClient,
   type QueryFilters,
   type QueryKey,
-  type QueryClient,
-  parseFilterArgs,
   notifyManager,
+  parseFilterArgs,
 } from '@tanstack/query-core'
 import { type Readable, readable } from 'svelte/store'
 import { useQueryClient } from './useQueryClient'

--- a/packages/svelte-query/src/useQueryClient.ts
+++ b/packages/svelte-query/src/useQueryClient.ts
@@ -1,5 +1,5 @@
-import type { QueryClient } from '@tanstack/query-core'
 import { getQueryClientContext } from './context'
+import type { QueryClient } from '@tanstack/query-core'
 
 export function useQueryClient(): QueryClient {
   const queryClient = getQueryClientContext()

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
@@ -1,5 +1,5 @@
-import { infiniteFetcher, flushPromises } from './test-utils'
 import { useInfiniteQuery } from '../useInfiniteQuery'
+import { flushPromises, infiniteFetcher } from './test-utils'
 
 jest.mock('../useQueryClient')
 

--- a/packages/vue-query/src/__tests__/useIsFetching.test.ts
+++ b/packages/vue-query/src/__tests__/useIsFetching.test.ts
@@ -1,8 +1,8 @@
 import { onScopeDispose, reactive, ref } from 'vue-demi'
 
-import { flushPromises, simpleFetcher } from './test-utils'
 import { useQuery } from '../useQuery'
 import { parseFilterArgs, useIsFetching } from '../useIsFetching'
+import { flushPromises, simpleFetcher } from './test-utils'
 
 jest.mock('../useQueryClient')
 

--- a/packages/vue-query/src/__tests__/useIsMutating.test.ts
+++ b/packages/vue-query/src/__tests__/useIsMutating.test.ts
@@ -1,9 +1,9 @@
 import { onScopeDispose, reactive, ref } from 'vue-demi'
 
-import { flushPromises, successMutator } from './test-utils'
 import { useMutation } from '../useMutation'
 import { parseFilterArgs, useIsMutating } from '../useIsMutating'
 import { useQueryClient } from '../useQueryClient'
+import { flushPromises, successMutator } from './test-utils'
 
 jest.mock('../useQueryClient')
 

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -1,7 +1,7 @@
 import { reactive, ref } from 'vue-demi'
-import { errorMutator, flushPromises, successMutator } from './test-utils'
 import { parseMutationArgs, useMutation } from '../useMutation'
 import { useQueryClient } from '../useQueryClient'
+import { errorMutator, flushPromises, successMutator } from './test-utils'
 
 jest.mock('../useQueryClient')
 

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -1,14 +1,14 @@
 import { onScopeDispose, reactive } from 'vue-demi'
 
-import {
-  flushPromises,
-  rejectFetcher,
-  simpleFetcher,
-  getSimpleFetcherWithReturnData,
-} from './test-utils'
 import { useQueries } from '../useQueries'
 import { useQueryClient } from '../useQueryClient'
 import { QueryClient } from '../queryClient'
+import {
+  flushPromises,
+  getSimpleFetcherWithReturnData,
+  rejectFetcher,
+  simpleFetcher,
+} from './test-utils'
 
 jest.mock('../useQueryClient')
 

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -1,20 +1,20 @@
 import {
   computed,
+  getCurrentInstance,
+  onScopeDispose,
   reactive,
   ref,
-  onScopeDispose,
-  getCurrentInstance,
 } from 'vue-demi'
 import { QueryObserver } from '@tanstack/query-core'
 
-import {
-  flushPromises,
-  rejectFetcher,
-  simpleFetcher,
-  getSimpleFetcherWithReturnData,
-} from './test-utils'
 import { useQuery } from '../useQuery'
 import { parseQueryArgs, useBaseQuery } from '../useBaseQuery'
+import {
+  flushPromises,
+  getSimpleFetcherWithReturnData,
+  rejectFetcher,
+  simpleFetcher,
+} from './test-utils'
 
 jest.mock('../useQueryClient')
 jest.mock('../useBaseQuery')

--- a/packages/vue-query/src/__tests__/utils.test.ts
+++ b/packages/vue-query/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
-import { isQueryKey, updateState, cloneDeep, cloneDeepUnref } from '../utils'
 import { reactive, ref } from 'vue-demi'
+import { cloneDeep, cloneDeepUnref, isQueryKey, updateState } from '../utils'
 
 describe('utils', () => {
   describe('isQueryKey', () => {

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -1,13 +1,13 @@
-import type { App, ComponentOptions } from 'vue'
 import { isVue2, isVue3, ref } from 'vue-demi'
 
 import { QueryClient } from '../queryClient'
 import { VueQueryPlugin } from '../vueQueryPlugin'
 import { VUE_QUERY_CLIENT } from '../utils'
 import { setupDevtools } from '../devtools/devtools'
-import { flushPromises } from './test-utils'
 import { useQuery } from '../useQuery'
 import { useQueries } from '../useQueries'
+import { flushPromises } from './test-utils'
+import type { App, ComponentOptions } from 'vue'
 
 jest.mock('../devtools/devtools')
 jest.mock('../useQueryClient')

--- a/packages/vue-query/src/devtools/devtools.ts
+++ b/packages/vue-query/src/devtools/devtools.ts
@@ -1,16 +1,16 @@
 /* istanbul ignore file */
 
 import { setupDevtoolsPlugin } from '@vue/devtools-api'
-import type { CustomInspectorNode } from '@vue/devtools-api'
 import { rankItem } from '@tanstack/match-sorter-utils'
-import type { Query, QueryCacheNotifyEvent } from '@tanstack/query-core'
-import type { QueryClient } from '../queryClient'
 import {
   getQueryStateLabel,
   getQueryStatusBg,
   getQueryStatusFg,
   sortFns,
 } from './utils'
+import type { CustomInspectorNode } from '@vue/devtools-api'
+import type { Query, QueryCacheNotifyEvent } from '@tanstack/query-core'
+import type { QueryClient } from '../queryClient'
 
 const pluginId = 'vue-query'
 const pluginName = 'Vue Query'

--- a/packages/vue-query/src/mutationCache.ts
+++ b/packages/vue-query/src/mutationCache.ts
@@ -1,7 +1,7 @@
 import { MutationCache as MC } from '@tanstack/query-core'
+import { cloneDeepUnref } from './utils'
 import type { Mutation, MutationFilters } from '@tanstack/query-core'
 import type { MaybeRefDeep } from './types'
-import { cloneDeepUnref } from './utils'
 
 export class MutationCache extends MC {
   find<TData = unknown, TError = unknown, TVariables = any, TContext = unknown>(

--- a/packages/vue-query/src/queryCache.ts
+++ b/packages/vue-query/src/queryCache.ts
@@ -1,7 +1,7 @@
 import { QueryCache as QC } from '@tanstack/query-core'
-import type { Query, QueryKey, QueryFilters } from '@tanstack/query-core'
-import type { MaybeRefDeep } from './types'
 import { cloneDeepUnref, isQueryKey } from './utils'
+import type { Query, QueryFilters, QueryKey } from '@tanstack/query-core'
+import type { MaybeRefDeep } from './types'
 
 export class QueryCache extends QC {
   find<TQueryFnData = unknown, TError = unknown, TData = TQueryFnData>(

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -1,33 +1,33 @@
 import { ref } from 'vue-demi'
 import { QueryClient as QC } from '@tanstack/query-core'
-import type {
-  QueryKey,
-  QueryClientConfig,
-  SetDataOptions,
-  ResetQueryFilters,
-  ResetOptions,
-  CancelOptions,
-  InvalidateQueryFilters,
-  InvalidateOptions,
-  RefetchQueryFilters,
-  RefetchOptions,
-  FetchQueryOptions,
-  QueryFunction,
-  FetchInfiniteQueryOptions,
-  InfiniteData,
-  DefaultOptions,
-  QueryObserverOptions,
-  MutationKey,
-  MutationObserverOptions,
-  QueryFilters,
-  MutationFilters,
-  QueryState,
-  Updater,
-} from '@tanstack/query-core'
-import type { MaybeRefDeep } from './types'
 import { cloneDeepUnref, isQueryKey } from './utils'
 import { QueryCache } from './queryCache'
 import { MutationCache } from './mutationCache'
+import type { MaybeRefDeep } from './types'
+import type {
+  CancelOptions,
+  DefaultOptions,
+  FetchInfiniteQueryOptions,
+  FetchQueryOptions,
+  InfiniteData,
+  InvalidateOptions,
+  InvalidateQueryFilters,
+  MutationFilters,
+  MutationKey,
+  MutationObserverOptions,
+  QueryClientConfig,
+  QueryFilters,
+  QueryFunction,
+  QueryKey,
+  QueryObserverOptions,
+  QueryState,
+  RefetchOptions,
+  RefetchQueryFilters,
+  ResetOptions,
+  ResetQueryFilters,
+  SetDataOptions,
+  Updater,
+} from '@tanstack/query-core'
 
 export class QueryClient extends QC {
   constructor(config: MaybeRefDeep<QueryClientConfig> = {}) {

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -1,9 +1,9 @@
 /* istanbul ignore file */
 
 import type {
+  InfiniteQueryObserverOptions,
   QueryKey,
   QueryObserverOptions,
-  InfiniteQueryObserverOptions,
 } from '@tanstack/query-core'
 import type { Ref, UnwrapRef } from 'vue-demi'
 import type { QueryClient } from './queryClient'

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -1,22 +1,22 @@
 import {
-  onScopeDispose,
-  toRefs,
-  readonly,
-  reactive,
-  watch,
   computed,
+  onScopeDispose,
+  reactive,
+  readonly,
+  toRefs,
   unref,
+  watch,
 } from 'vue-demi'
+import { useQueryClient } from './useQueryClient'
+import { cloneDeepUnref, isQueryKey, updateState } from './utils'
 import type { ToRefs, UnwrapRef } from 'vue-demi'
 import type {
-  QueryObserver,
+  QueryFunction,
   QueryKey,
+  QueryObserver,
   QueryObserverOptions,
   QueryObserverResult,
-  QueryFunction,
 } from '@tanstack/query-core'
-import { useQueryClient } from './useQueryClient'
-import { updateState, isQueryKey, cloneDeepUnref } from './utils'
 import type { MaybeRef, WithQueryClientKey } from './types'
 import type { UseQueryOptions } from './useQuery'
 import type { UseInfiniteQueryOptions } from './useInfiniteQuery'

--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -1,19 +1,19 @@
 import { InfiniteQueryObserver } from '@tanstack/query-core'
+import { useBaseQuery } from './useBaseQuery'
 import type { UnwrapRef } from 'vue-demi'
 import type {
-  QueryObserver,
+  InfiniteQueryObserverResult,
   QueryFunction,
   QueryKey,
-  InfiniteQueryObserverResult,
+  QueryObserver,
 } from '@tanstack/query-core'
 
-import { useBaseQuery } from './useBaseQuery'
 import type { UseQueryReturnType } from './useBaseQuery'
 
 import type {
-  WithQueryClientKey,
-  VueInfiniteQueryObserverOptions,
   DistributiveOmit,
+  VueInfiniteQueryObserverOptions,
+  WithQueryClientKey,
 } from './types'
 
 export type UseInfiniteQueryOptions<

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -1,9 +1,9 @@
-import { computed, unref, onScopeDispose, ref, watch } from 'vue-demi'
-import type { Ref } from 'vue-demi'
-import type { QueryKey, QueryFilters as QF } from '@tanstack/query-core'
-
+import { computed, onScopeDispose, ref, unref, watch } from 'vue-demi'
 import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref, isQueryKey } from './utils'
+import type { Ref } from 'vue-demi'
+import type { QueryFilters as QF, QueryKey } from '@tanstack/query-core'
+
 import type { MaybeRef, MaybeRefDeep, WithQueryClientKey } from './types'
 
 export type QueryFilters = MaybeRefDeep<WithQueryClientKey<QF>>

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -1,9 +1,9 @@
-import { computed, unref, onScopeDispose, ref, watch } from 'vue-demi'
-import type { Ref } from 'vue-demi'
-import type { MutationKey, MutationFilters as MF } from '@tanstack/query-core'
-
+import { computed, onScopeDispose, ref, unref, watch } from 'vue-demi'
 import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref, isQueryKey } from './utils'
+import type { Ref } from 'vue-demi'
+import type { MutationFilters as MF, MutationKey } from '@tanstack/query-core'
+
 import type { MaybeRef, MaybeRefDeep, WithQueryClientKey } from './types'
 
 export type MutationFilters = MaybeRefDeep<WithQueryClientKey<MF>>

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -1,30 +1,30 @@
 import {
+  computed,
   onScopeDispose,
   reactive,
   readonly,
   toRefs,
-  watch,
-  computed,
   unref,
+  watch,
 } from 'vue-demi'
+import { MutationObserver } from '@tanstack/query-core'
+import { cloneDeepUnref, isMutationKey, updateState } from './utils'
+import { useQueryClient } from './useQueryClient'
 import type { ToRefs } from 'vue-demi'
 import type {
+  MutateFunction,
   MutateOptions,
   MutationFunction,
   MutationKey,
-  MutateFunction,
-  MutationObserverResult,
   MutationObserverOptions,
+  MutationObserverResult,
 } from '@tanstack/query-core'
 import type {
-  WithQueryClientKey,
+  DistributiveOmit,
   MaybeRef,
   MaybeRefDeep,
-  DistributiveOmit,
+  WithQueryClientKey,
 } from './types'
-import { MutationObserver } from '@tanstack/query-core'
-import { cloneDeepUnref, updateState, isMutationKey } from './utils'
-import { useQueryClient } from './useQueryClient'
 
 type MutationResult<TData, TError, TVariables, TContext> = DistributiveOmit<
   MutationObserverResult<TData, TError, TVariables, TContext>,

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { QueriesObserver } from '@tanstack/query-core'
 import { computed, onScopeDispose, reactive, readonly, watch } from 'vue-demi'
+import { useQueryClient } from './useQueryClient'
+import { cloneDeepUnref } from './utils'
 import type { Ref } from 'vue-demi'
 
 import type { QueryFunction, QueryObserverResult } from '@tanstack/query-core'
 
-import { useQueryClient } from './useQueryClient'
-import { cloneDeepUnref } from './utils'
 import type { UseQueryOptions } from './useQuery'
 import type { QueryClient } from './queryClient'
 

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -1,17 +1,17 @@
-import type { ToRefs, UnwrapRef } from 'vue-demi'
 import { QueryObserver } from '@tanstack/query-core'
+import { useBaseQuery } from './useBaseQuery'
+import type { ToRefs, UnwrapRef } from 'vue-demi'
 import type {
+  DefinedQueryObserverResult,
   QueryFunction,
   QueryKey,
   QueryObserverResult,
-  DefinedQueryObserverResult,
 } from '@tanstack/query-core'
-import { useBaseQuery } from './useBaseQuery'
 import type { UseQueryReturnType as UQRT } from './useBaseQuery'
 import type {
-  WithQueryClientKey,
-  VueQueryObserverOptions,
   DistributiveOmit,
+  VueQueryObserverOptions,
+  WithQueryClientKey,
 } from './types'
 
 export type UseQueryReturnType<TData, TError> = DistributiveOmit<

--- a/packages/vue-query/src/useQueryClient.ts
+++ b/packages/vue-query/src/useQueryClient.ts
@@ -1,7 +1,7 @@
 import { getCurrentInstance, inject } from 'vue-demi'
 
-import type { QueryClient } from './queryClient'
 import { getClientKey } from './utils'
+import type { QueryClient } from './queryClient'
 
 export function useQueryClient(id = ''): QueryClient {
   const vm = getCurrentInstance()?.proxy

--- a/packages/vue-query/src/utils.ts
+++ b/packages/vue-query/src/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { QueryKey, MutationKey } from '@tanstack/query-core'
 import { isRef, unref } from 'vue-demi'
+import type { MutationKey, QueryKey } from '@tanstack/query-core'
 import type { UnwrapRef } from 'vue-demi'
 
 export const VUE_QUERY_CLIENT = 'VUE_QUERY_CLIENT'

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -1,10 +1,10 @@
 import { isVue2 } from 'vue-demi'
 import { isServer } from '@tanstack/query-core'
-import type { QueryClientConfig } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
 import { getClientKey } from './utils'
 import { setupDevtools } from './devtools/devtools'
+import type { QueryClientConfig } from '@tanstack/query-core'
 import type { MaybeRefDeep } from './types'
 
 declare global {


### PR DESCRIPTION
I personally find imports sorted in a consistent order easier to approach, just like how prettier formats code in a consistent way. The rules here are totally flexible but would mean all packages follow the same structure.