### PR TITLE
chore: Fix Nx parallelisation for vue-query tests

### DIFF
--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -42,6 +42,15 @@
     "build:rollup": "rollup --config rollup.config.js",
     "build:types": "tsc --emitDeclarationOnly"
   },
+  "nx": {
+    "targets": {
+      "test:lib": {
+        "dependsOn": [
+          "test:types"
+        ]
+      }
+    }
+  },
   "files": [
     "build/lib/*",
     "src"


### PR DESCRIPTION
If `vue-query:test:lib` and `vue-query:test:types` run in parallel (which they commonly do), `vue-demi` temporarily modifies `node_modules` which alters type resolution, causing the typecheck to fail. This PR makes sure these two tests never run at the same time by forcing one to run before the other.