### PR TITLE
refactor(vue-query): reduce redundant `ref()`

### DIFF
--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -4,7 +4,6 @@ import {
   readonly,
   reactive,
   watch,
-  ref,
   computed,
   unref,
 } from 'vue-demi'
@@ -71,17 +70,17 @@ export function useBaseQuery<
   const observer = new Observer(queryClient, defaultedOptions.value)
   const state = reactive(observer.getCurrentResult())
 
-  const unsubscribe = ref(() => {
+  let unsubscribe = () => {
     // noop
-  })
+  }
 
   watch(
     queryClient.isRestoring,
     (isRestoring) => {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!isRestoring) {
-        unsubscribe.value()
-        unsubscribe.value = observer.subscribe((result) => {
+        unsubscribe()
+        unsubscribe = observer.subscribe((result) => {
           updateState(state, result)
         })
       }
@@ -99,7 +98,7 @@ export function useBaseQuery<
   )
 
   onScopeDispose(() => {
-    unsubscribe.value()
+    unsubscribe()
   })
 
   const suspense = () => {

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { QueriesObserver } from '@tanstack/query-core'
-import {
-  computed,
-  onScopeDispose,
-  reactive,
-  readonly,
-  watch,
-} from 'vue-demi'
+import { computed, onScopeDispose, reactive, readonly, watch } from 'vue-demi'
 import type { Ref } from 'vue-demi'
 
 import type { QueryFunction, QueryObserverResult } from '@tanstack/query-core'

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -5,7 +5,6 @@ import {
   onScopeDispose,
   reactive,
   readonly,
-  ref,
   watch,
 } from 'vue-demi'
 import type { Ref } from 'vue-demi'
@@ -175,16 +174,16 @@ export function useQueries<T extends any[]>({
   const observer = new QueriesObserver(queryClient, defaultedQueries.value)
   const state = reactive(observer.getCurrentResult())
 
-  const unsubscribe = ref(() => {
+  let unsubscribe = () => {
     // noop
-  })
+  }
 
   watch(
     queryClient.isRestoring,
     (isRestoring) => {
       if (!isRestoring) {
-        unsubscribe.value()
-        unsubscribe.value = observer.subscribe((result) => {
+        unsubscribe()
+        unsubscribe = observer.subscribe((result) => {
           state.splice(0, result.length, ...result)
         })
         // Subscription would not fire for persisted results
@@ -208,7 +207,7 @@ export function useQueries<T extends any[]>({
   )
 
   onScopeDispose(() => {
-    unsubscribe.value()
+    unsubscribe()
   })
 
   return readonly(state) as UseQueriesResults<T>


### PR DESCRIPTION
Currently, `unsubscribe` is internally converted into a reactive property using `ref`, as shown below:

```ts
const unsubscribe = ref(() => {
  // noop
})
```

However, there is no apparent usage of watch this reactive property update in the given context. Therefore, this PR proposes the removal of the `ref`.
