### PR TITLE
docs(query-keys): clarify query key refetching

### DIFF
--- a/docs/react/guides/query-keys.md
+++ b/docs/react/guides/query-keys.md
@@ -89,6 +89,8 @@ function Todos({ todoId }) {
 }
 ```
 
+Note that query keys act as dependency arrays for your query functions. Adding dependent variables to your query key will insure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically.* (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
+
 [//]: # 'Example5'
 [//]: # 'Materials'
 

--- a/docs/react/guides/query-keys.md
+++ b/docs/react/guides/query-keys.md
@@ -89,9 +89,9 @@ function Todos({ todoId }) {
 }
 ```
 
-Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically (depending on your `staleTime` settings).* (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
-
 [//]: # 'Example5'
+
+Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically (depending on your `staleTime` settings).* (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
 [//]: # 'Materials'
 
 ## Further reading

--- a/docs/react/guides/query-keys.md
+++ b/docs/react/guides/query-keys.md
@@ -89,7 +89,7 @@ function Todos({ todoId }) {
 }
 ```
 
-Note that query keys act as dependency arrays for your query functions. Adding dependent variables to your query key will insure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically.* (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
+Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically (depending on your `staleTime` settings).* (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
 
 [//]: # 'Example5'
 [//]: # 'Materials'


### PR DESCRIPTION

Update the query-key documentation to note that changing data included in a query key will automatically refetch the query data.

It took me awhile to find this information, and I expected to find it here. I consulted with another engineer on our team, and they agreed that they would expect to see it stated more clearly here. So we felt this addition would be helpful for people trying to onboard to React Query.