### PR TITLE
fix: Skip queryClient context lookup when client is passed directly

### DIFF
--- a/packages/solid-query/src/QueryClientProvider.tsx
+++ b/packages/solid-query/src/QueryClientProvider.tsx
@@ -7,11 +7,10 @@ export const QueryClientContext = createContext<QueryClient | undefined>(
 )
 
 export const useQueryClient = (queryClient?: QueryClient) => {
-  const client = useContext(QueryClientContext)
-
   if (queryClient) {
     return queryClient
   }
+  const client = useContext(QueryClientContext)
 
   if (!client) {
     throw new Error('No QueryClient set, use QueryClientProvider to set one')

--- a/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
@@ -161,4 +161,21 @@ describe('QueryClientProvider', () => {
       consoleMock.mockRestore()
     })
   })
+
+  it('should not throw an error if user provides custom query client', () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    function Page() {
+      const client = createQueryClient()
+      useQueryClient(client)
+      return null
+    }
+
+    render(() => <Page />)
+    expect(consoleMock).not.toHaveBeenCalled()
+
+    consoleMock.mockRestore()
+  })
 })

--- a/packages/svelte-query/src/useQueryClient.ts
+++ b/packages/svelte-query/src/useQueryClient.ts
@@ -2,11 +2,6 @@ import type { QueryClient } from '@tanstack/query-core'
 import { getQueryClientContext } from './context'
 
 export function useQueryClient(queryClient?: QueryClient): QueryClient {
-  const client = getQueryClientContext()
-
-  if (queryClient) {
-    return queryClient
-  }
-
-  return client
+  if (queryClient) return queryClient
+  return getQueryClientContext()
 }


### PR DESCRIPTION
In svelte-query 5, you can now call createQuery() and useQueryClient with your own query client, rather than the one in context, like:
createQuery(options, myClient)
// or
useQueryClient(myClient)

This is super useful because it means we can write code that uses createQuery outside the context of a svelte component script.

However, in the useQueryClient implementation, it tries to load a query client from svelte context even if the user provides a client to use: https://github.com/TanStack/query/blob/alpha/packages/svelte-query/src/useQueryClient.ts#L4-L12

This will throw an error if used outside of a svelte component and defeats the purpose of having this new option to pass your own client in v5.

This PR makes an update to both svelte-query and solid-query to skip the context check if a custom query client is provided. This will prevent possible errors and open up use cases for createQuery outside of component scripts.

@lachlancollins, you mentioned that we should do this for react-query as well. I did not do that yet because in React, you can't optionally call `useContext` due to the rule of hooks. This means if we make this change in react-query's `useQueryClient()`, a user could potentially hit a bug if on one render they do not pass a custom query client but on the next render they do pass one. Please let me know what you think we should do here and I can add it to this PR.