### PR TITLE
chore(svelte-query): Update reactivity docs and tests

### DIFF
--- a/docs/svelte/reactivity.md
+++ b/docs/svelte/reactivity.md
@@ -3,17 +3,17 @@ id: reactivity
 title: Reactivity
 ---
 
-Svelte uses a compiler to build your code which optimises rendering. By default, variables will run once, unless they are referenced in your markup. To be able to react to changes in options you need to use [stores](https://svelte.dev/docs/svelte-store).
+Svelte uses a compiler to build your code which optimises rendering. By default, components run once, unless they are referenced in your markup. To be able to react to changes in options you need to use [stores](https://svelte.dev/docs/svelte-store).
 
-In the below example, the `refetchInterval` option is set from the variable `intervalMs`, which is edited by the input field. However, as the query is not told it should react to changes in `intervalMs`, `refetchInterval` will not change when the input value changes.
+In the below example, the `refetchInterval` option is set from the variable `intervalMs`, which is bound to the input field. However, as the query is not able to react to changes in `intervalMs`, `refetchInterval` will not change when the input value changes.
 
 ```markdown
-<script>
+<script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
 
-  let intervalMs = 1000
-
   const endpoint = 'http://localhost:5173/api/data'
+
+  let intervalMs = 1000
 
   const query = createQuery({
     queryKey: ['refetch'],
@@ -22,26 +22,28 @@ In the below example, the `refetchInterval` option is set from the variable `int
   })
 </script>
 
-<input bind:value={intervalMs} type="number" />
+<input type="number" bind:value={intervalMs} />
 ```
 
-To solve this, create a store for the options and use it as input for the query. Update the options store when the value changes and the query will react to the change.
+To solve this, we can convert `intervalMs` into a writable store. The query options can then be turned into a derived store, which will be passed into the function with true reactivity.
 
 ```markdown
-<script>
+<script lang="ts">
+  import { derived, writable } from 'svelte/store'
   import { createQuery } from '@tanstack/svelte-query'
-  import type { CreateQueryOptions } from '@tanstack/svelte-query'
 
   const endpoint = 'http://localhost:5173/api/data'
 
-  const queryOptions = writable({
-    queryKey: ['refetch'],
-    queryFn: async () => await fetch(endpoint).then((r) => r.json()),
-    refetchInterval: 1000,
-  }) satisfies CreateQueryOptions
+  const intervalMs = writable(1000)
 
-const query = createQuery(queryOptions)
+  const query = createQuery(
+    derived(intervalMs, ($intervalMs) => ({
+      queryKey: ['refetch'],
+      queryFn: async () => await fetch(endpoint).then((r) => r.json()),
+      refetchInterval: $intervalMs,
+    }))
+  )
 </script>
 
-<input type="number" bind:value={$queryOptions.refetchInterval} />
+<input type="number" bind:value={$intervalMs} />
 ```

--- a/packages/svelte-query/src/__tests__/CreateQuery.svelte
+++ b/packages/svelte-query/src/__tests__/CreateQuery.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
-  import { setQueryClientContext } from '../context'
   import { createQuery } from '../createQuery'
+  import type { QueryClient } from '@tanstack/query-core'
   import type { CreateQueryOptions } from '../types'
 
   export let options: CreateQueryOptions<any>
+  export let queryClient: QueryClient
 
-  const queryClient = new QueryClient()
-  setQueryClientContext(queryClient)
-
-  const query = createQuery(options)
+  const query = createQuery(options, queryClient)
 </script>
 
 {#if $query.isPending}
@@ -17,7 +14,7 @@
 {:else if $query.isError}
   <p>Error</p>
 {:else if $query.isSuccess}
-  <p>Success</p>
+  <p>{$query.data}</p>
 {/if}
 
 <ul>

--- a/packages/svelte-query/src/__tests__/CreateQuery.svelte
+++ b/packages/svelte-query/src/__tests__/CreateQuery.svelte
@@ -14,11 +14,11 @@
 {:else if $query.isError}
   <p>Error</p>
 {:else if $query.isSuccess}
-  <p>{$query.data}</p>
+  {#if Array.isArray($query.data)}
+    {#each $query.data as item}
+      <p>{item}</p>
+    {/each}
+  {:else}
+    <p>{$query.data}</p>
+  {/if}
 {/if}
-
-<ul>
-  {#each $query.data ?? [] as entry}
-    <li>id: {entry.id}</li>
-  {/each}
-</ul>

--- a/packages/svelte-query/src/__tests__/createQuery.test.ts
+++ b/packages/svelte-query/src/__tests__/createQuery.test.ts
@@ -112,7 +112,7 @@ describe('createQuery', () => {
       expect(rendered.queryByText('Success 2')).not.toBeInTheDocument()
     })
   })
-  
+
   test('Keep previous data when returned as placeholder data', async () => {
     const writableStore = writable<number[]>([1])
 


### PR DESCRIPTION
Use writable/derived stores in main example, which is a simpler pattern. Update tests to match this behaviour and check for #5682