### PR TITLE
fix(query-devtools): Bundle all dependencies

### DIFF
--- a/packages/query-devtools/rollup.config.js
+++ b/packages/query-devtools/rollup.config.js
@@ -8,9 +8,10 @@ export function createQueryDevtoolsConfig() {
     withSolid({
       input: `./src/index.tsx`,
       targets: ['esm', 'cjs'],
-      external: [],
     })
   )
+
+  solidRollupOptions.external = []
 
   const outputs = !solidRollupOptions.output
     ? []

--- a/packages/solid-query/rollup.config.js
+++ b/packages/solid-query/rollup.config.js
@@ -8,7 +8,6 @@ export function createSolidQueryConfig() {
     withSolid({
       input: `./src/index.ts`,
       targets: ['esm', 'cjs'],
-      external: ['@tanstack/query-core'],
     })
   )
 


### PR DESCRIPTION
Before #5527 and #5528 , all dependencies were bundled with `query-devtools`. It turns out the `rollup-preset-solid` ignores the rollup `external` option, so this was not preserved. This PR corrects this, and fixes #5671 