### PR TITLE
fix(solid-query): hydrate preloaded data correctly

### DIFF
--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -7,12 +7,15 @@
     "start": "solid-start start"
   },
   "type": "module",
+  "resolutions": {
+    "solid-js": "^1.7.7"
+  },
   "dependencies": {
-    "@tanstack/solid-query": "^5.0.0-alpha.38",
-    "@solidjs/meta": "^0.28.2",
-    "@solidjs/router": "^0.7.0",
-    "solid-js": "^1.6.13",
-    "solid-start": "^0.2.23",
+    "@tanstack/solid-query": "5.0.0-alpha.75",
+    "@solidjs/meta": "~0.28.5",
+    "@solidjs/router": "~0.8.2",
+    "solid-js": "^1.7.7",
+    "solid-start": "~0.2.26",
     "undici": "^5.22.1"
   },
   "devDependencies": {

--- a/examples/solid/solid-start-streaming/src/components/user-info.tsx
+++ b/examples/solid/solid-start-streaming/src/components/user-info.tsx
@@ -11,15 +11,18 @@ export interface UserInfoProps {
   simulateError?: boolean
 }
 
+export const userInfoQueryOpts = (props?: UserInfoProps) => ({
+  queryKey: ['user'],
+  queryFn: () => fetchUser(props),
+  deferStream: props?.deferStream,
+})
+
 export const UserInfo: Component<UserInfoProps> = (props) => {
   const [simulateError, setSimulateError] = createSignal(props.simulateError)
 
-  const query = createQuery(() => ({
-    queryKey: ['user'],
-    queryFn: () =>
-      fetchUser({ sleep: props.sleep, simulateError: simulateError() }),
-    deferStream: props.deferStream,
-  }))
+  const query = createQuery(() =>
+    userInfoQueryOpts({ ...props, simulateError: simulateError() }),
+  )
 
   return (
     <Example
@@ -49,6 +52,13 @@ export const UserInfo: Component<UserInfoProps> = (props) => {
             <div>id: {user.id}</div>
             <div>name: {user.name}</div>
             <div>queryTime: {user.queryTime}</div>
+            <button
+              onClick={() => {
+                query.refetch()
+              }}
+            >
+              refetch
+            </button>
           </>
         )}
       </QueryBoundary>

--- a/examples/solid/solid-start-streaming/src/root.tsx
+++ b/examples/solid/solid-start-streaming/src/root.tsx
@@ -21,6 +21,7 @@ export default function Root() {
     defaultOptions: {
       queries: {
         retry: false,
+        staleTime: 5000,
       },
     },
   })
@@ -38,12 +39,13 @@ export default function Root() {
             <Suspense
               fallback={<div>loading... [root.tsx suspense boundary]</div>}
             >
-              <A href="/">Index</A>
+              <A href="/">Home</A>
               <A href="/streamed">Streamed</A>
               <A href="/deferred">Deferred</A>
               <A href="/mixed">Mixed</A>
               <A href="/with-error">With Error</A>
               <A href="/hydration">Hydration</A>
+              <A href="/prefetch">Prefetch</A>
 
               <Routes>
                 <FileRoutes />

--- a/examples/solid/solid-start-streaming/src/routes/prefetch.tsx
+++ b/examples/solid/solid-start-streaming/src/routes/prefetch.tsx
@@ -1,0 +1,36 @@
+import { useQueryClient } from '@tanstack/solid-query'
+import { isServer } from 'solid-js/web'
+import { Title } from 'solid-start'
+import { UserInfo, userInfoQueryOpts } from '~/components/user-info'
+
+export default function Prefetch() {
+  const queryClient = useQueryClient()
+
+  if (isServer) {
+    void queryClient.prefetchQuery(userInfoQueryOpts({ sleep: 500 }))
+  }
+
+  return (
+    <main>
+      <Title>Solid Query - Prefetch</Title>
+
+      <h1>Solid Query - Prefetch Example</h1>
+
+      <div class="description">
+        <p>
+          In some cases you may want to prefetch a query on the server before
+          the component with the relevant `createQuery` call is mounted. A major
+          use case for this is in router data loaders, in order to avoid request
+          waterfalls.
+        </p>
+        <p>
+          In this example we prefetch the user query (on the server only). There
+          should be no extra `fetchUser.start` and `fetchUser.done` logs in the
+          console on the client when refreshing the page.
+        </p>
+      </div>
+
+      <UserInfo sleep={500} deferStream />
+    </main>
+  )
+}

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -36,7 +36,7 @@
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc --noEmit",
     "test:lib": "vitest run --coverage",
-    "test:lib:dev": "pnpm run test:lib --watch",
+    "test:lib:dev": "vitest watch --coverage",
     "test:build": "publint --strict",
     "build": "rollup --config rollup.config.js"
   },

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -59,14 +59,15 @@ const hydrateableObserverResult = <
   query: Query<TQueryFnData, TError, TData, TQueryKey>,
   result: QueryObserverResult<T2, TError>,
 ): HydrateableQueryState<T2, TError> => {
-  const { refetch, ...rest } = unwrap(result)
+  // Including the extra properties is only relevant on the server
+  if (!isServer) return result as HydrateableQueryState<T2, TError>
 
   return {
-    ...rest,
+    ...unwrap(result),
 
     // cast to refetch function should be safe, since we only remove it on the server,
     // and refetch is not relevant on the server
-    refetch: (isServer ? undefined : refetch) as HydrateableQueryState<
+    refetch: undefined as unknown as HydrateableQueryState<
       T2,
       TError
     >['refetch'],
@@ -79,8 +80,8 @@ const hydrateableObserverResult = <
     isInvalidated: query.state.isInvalidated,
 
     // Unsetting these properties on the server since they might not be serializable
-    fetchFailureReason: isServer ? null : query.state.fetchFailureReason,
-    fetchMeta: isServer ? null : query.state.fetchMeta,
+    fetchFailureReason: null,
+    fetchMeta: null,
   }
 }
 

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -3,9 +3,11 @@
 // in solid-js/web package. I'll create a GitHub issue with them to see
 // why that happens.
 import type {
+  Query,
   QueryKey,
   QueryObserver,
   QueryObserverResult,
+  QueryState,
 } from '@tanstack/query-core'
 import type { QueryClient } from './QueryClient'
 import { hydrate, notifyManager } from '@tanstack/query-core'
@@ -40,6 +42,48 @@ function reconcileFn<TData, TError>(
   return { ...result, data: newData } as typeof result
 }
 
+type HydrateableQueryState<TData, TError> = QueryObserverResult<TData, TError> &
+  QueryState<TData, TError>
+
+/**
+ * Solid's `onHydrated` functionality will silently "fail" (hydrate with an empty object)
+ * if the resource data is not serializable.
+ */
+const hydrateableObserverResult = <
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryKey extends QueryKey,
+  T2,
+>(
+  query: Query<TQueryFnData, TError, TData, TQueryKey>,
+  result: QueryObserverResult<T2, TError>,
+): HydrateableQueryState<T2, TError> => {
+  const { refetch, ...rest } = unwrap(result)
+
+  return {
+    ...rest,
+
+    // cast to refetch function should be safe, since we only remove it on the server,
+    // and refetch is not relevant on the server
+    refetch: (isServer ? undefined : refetch) as HydrateableQueryState<
+      T2,
+      TError
+    >['refetch'],
+
+    // hydrate() expects a QueryState object, which is similar but not
+    // quite the same as a QueryObserverResult object. Thus, for now, we're
+    // copying over the missing properties from state in order to support hydration
+    dataUpdateCount: query.state.dataUpdateCount,
+    fetchFailureCount: query.state.fetchFailureCount,
+    isInvalidated: query.state.isInvalidated,
+
+    // Unsetting these properties on the server since they might not be serializable
+    fetchFailureReason: isServer ? null : query.state.fetchFailureReason,
+    fetchMeta: isServer ? null : query.state.fetchMeta,
+  }
+}
+
 // Base Query Function that is used to create the query.
 export function createBaseQuery<
   TQueryFnData,
@@ -54,6 +98,10 @@ export function createBaseQuery<
   Observer: typeof QueryObserver,
   queryClient?: Accessor<QueryClient>,
 ) {
+  type ResourceData =
+    | HydrateableQueryState<TData, TError>
+    | QueryObserverResult<TData, TError>
+
   const client = createMemo(() => useQueryClient(queryClient?.()))
 
   const defaultedOptions = client().defaultQueryOptions(options())
@@ -71,30 +119,14 @@ export function createBaseQuery<
 
   const createServerSubscriber = (
     resolve: (
-      data:
-        | QueryObserverResult<TData, TError>
-        | PromiseLike<QueryObserverResult<TData, TError> | undefined>
-        | undefined,
+      data: ResourceData | PromiseLike<ResourceData | undefined> | undefined,
     ) => void,
     reject: (reason?: any) => void,
   ) => {
     return observer.subscribe((result) => {
       notifyManager.batchCalls(() => {
         const query = observer.getCurrentQuery()
-        const { refetch, ...rest } = unwrap(result)
-        const unwrappedResult = {
-          ...rest,
-
-          // hydrate() expects a QueryState object, which is similar but not
-          // quite the same as a QueryObserverResult object. Thus, for now, we're
-          // copying over the missing properties from state in order to support hydration
-          dataUpdateCount: query.state.dataUpdateCount,
-          fetchFailureCount: query.state.fetchFailureCount,
-          // Removing these properties since they might not be serializable
-          // fetchFailureReason: query.state.fetchFailureReason,
-          // fetchMeta: query.state.fetchMeta,
-          isInvalidated: query.state.isInvalidated,
-        }
+        const unwrappedResult = hydrateableObserverResult(query, result)
 
         if (unwrappedResult.isError) {
           if (process.env['NODE_ENV'] === 'development') {
@@ -105,7 +137,7 @@ export function createBaseQuery<
         if (unwrappedResult.isSuccess) {
           // Use of any here is fine
           // We cannot include refetch since it is not serializable
-          resolve(unwrappedResult as any)
+          resolve(unwrappedResult)
         }
       })()
     })
@@ -148,7 +180,7 @@ export function createBaseQuery<
   let unsubscribe: (() => void) | null = null
 
   const [queryResource, { refetch, mutate }] = createResource<
-    QueryObserverResult<TData, TError> | undefined
+    ResourceData | undefined
   >(
     () => {
       return new Promise((resolve, reject) => {
@@ -159,8 +191,10 @@ export function createBaseQuery<
             unsubscribe = createClientSubscriber()
           }
         }
+
         if (!state.isLoading) {
-          resolve(state)
+          const query = observer.getCurrentQuery()
+          resolve(hydrateableObserverResult(query, state))
         }
       })
     },

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -130,14 +130,8 @@ export function createBaseQuery<
         const unwrappedResult = hydrateableObserverResult(query, result)
 
         if (unwrappedResult.isError) {
-          if (process.env['NODE_ENV'] === 'development') {
-            console.error(unwrappedResult.error)
-          }
           reject(unwrappedResult.error)
-        }
-        if (unwrappedResult.isSuccess) {
-          // Use of any here is fine
-          // We cannot include refetch since it is not serializable
+        } else {
           resolve(unwrappedResult)
         }
       })()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -979,20 +979,20 @@ importers:
   examples/solid/solid-start-streaming:
     dependencies:
       '@solidjs/meta':
-        specifier: ^0.28.2
-        version: 0.28.2(solid-js@1.6.13)
+        specifier: ~0.28.5
+        version: 0.28.5(solid-js@1.7.7)
       '@solidjs/router':
-        specifier: ^0.7.0
-        version: 0.7.0(solid-js@1.6.13)
+        specifier: ~0.8.2
+        version: 0.8.2(solid-js@1.7.7)
       '@tanstack/solid-query':
-        specifier: ^5.0.0-alpha.38
+        specifier: 5.0.0-alpha.75
         version: link:../../../packages/solid-query
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.7
+        version: 1.7.7
       solid-start:
-        specifier: ^0.2.23
-        version: 0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.6.13)(solid-start-node@0.2.0)(vite@4.2.0)
+        specifier: ~0.2.26
+        version: 0.2.26(@solidjs/meta@0.28.5)(@solidjs/router@0.8.2)(solid-js@1.7.7)(solid-start-node@0.2.0)(vite@4.2.0)
       undici:
         specifier: ^5.22.1
         version: 5.22.1
@@ -1008,7 +1008,7 @@ importers:
         version: 8.4.23
       solid-start-node:
         specifier: ^0.2.0
-        version: 0.2.0(solid-start@0.2.23)(undici@5.22.1)(vite@4.2.0)
+        version: 0.2.0(solid-start@0.2.26)(undici@5.22.1)(vite@4.2.0)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1768,11 +1768,6 @@ packages:
     dependencies:
       '@babel/highlight': 7.22.5
 
-  /@babel/compat-data@7.19.1:
-    resolution: {integrity: sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==}
-    engines: {node: '>=6.9.0'}
-    dev: false
-
   /@babel/compat-data@7.22.5:
     resolution: {integrity: sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==}
     engines: {node: '>=6.9.0'}
@@ -1813,14 +1808,6 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/generator@7.19.0:
-    resolution: {integrity: sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.19.0
-      '@jridgewell/gen-mapping': 0.3.2
-      jsesc: 2.5.2
-
   /@babel/generator@7.22.5:
     resolution: {integrity: sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==}
     engines: {node: '>=6.9.0'}
@@ -1848,19 +1835,6 @@ packages:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
       '@babel/types': 7.19.0
-
-  /@babel/helper-compilation-targets@7.19.1(@babel/core@7.21.8):
-    resolution: {integrity: sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.19.1
-      '@babel/core': 7.21.8
-      '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.4
-      semver: 6.3.0
-    dev: false
 
   /@babel/helper-compilation-targets@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==}
@@ -1965,8 +1939,8 @@ packages:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
-      '@babel/types': 7.19.0
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
 
   /@babel/helper-function-name@7.22.5:
     resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
@@ -1979,7 +1953,7 @@ packages:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.22.5
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
@@ -1997,7 +1971,7 @@ packages:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.22.5
 
   /@babel/helper-member-expression-to-functions@7.22.5:
     resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
@@ -2036,7 +2010,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.22.5
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -2086,11 +2060,11 @@ packages:
     resolution: {integrity: sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.19.1
-      '@babel/types': 7.19.0
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2107,25 +2081,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helper-simple-access@7.18.6:
-    resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-    dev: false
-
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-
-  /@babel/helper-skip-transparent-expression-wrappers@7.18.6:
-    resolution: {integrity: sha512-4KoLhwGS9vGethZpAhYnMejWkX64wsnHPDwvOsKWU6Fg4+AlK2Jz3TyjQLMEPvz+1zemi/WBdkYxCD0bAfIkiw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.19.0
-    dev: false
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
@@ -2137,7 +2097,7 @@ packages:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.22.5
 
   /@babel/helper-split-export-declaration@7.22.5:
     resolution: {integrity: sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==}
@@ -2160,6 +2120,7 @@ packages:
   /@babel/helper-validator-option@7.18.6:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-validator-option@7.22.5:
     resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
@@ -2293,7 +2254,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-default-from': 7.18.6(@babel/core@7.21.8)
     dev: false
 
@@ -2347,20 +2308,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.8)
 
-  /@babel/plugin-proposal-object-rest-spread@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-9yuM6wr4rIsKa1wlUAbZEazkCrgw2sMPEXCr4Rnwetu7cEW1NydkCWytLuYletbf8vFxdJxFhwEZqMpOx2eZyw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.19.1
-      '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.19.1(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.21.8)
-    dev: false
-
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
@@ -2383,18 +2330,6 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.8)
-
-  /@babel/plugin-proposal-optional-chaining@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-PatI6elL5eMzoypFAiYDpYQyMtXTn+iMhuxxQt5mAXD4fEmKorpSI3PHd+i3JXBJN3xyA6MvJv7at23HffFHwA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.6
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
-    dev: false
 
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
@@ -2493,7 +2428,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.21.8):
@@ -2622,16 +2557,6 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-typescript@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
-
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
     engines: {node: '>=6.9.0'}
@@ -2640,16 +2565,6 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
 
   /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
@@ -2682,16 +2597,6 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.19.0
 
-  /@babel/plugin-transform-block-scoping@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-pRqwb91C42vs1ahSAWJkxOxU1RHWDn16XAa6ggQ72wjLlWyYeAcLvTtE0aM8ph3KNydy9CQF2nLYcjq1WysgxQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
-
   /@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==}
     engines: {node: '>=6.9.0'}
@@ -2700,25 +2605,6 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-transform-classes@7.18.8(@babel/core@7.21.8):
-    resolution: {integrity: sha512-RySDoXdF6hgHSHuAW4aLGyVQdmvEX/iJtjVre52k0pxRq4hzqze+rAVP++NmNv596brBpYmaiKgTZby7ziBnVg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-replace-supers': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/plugin-transform-classes@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-2edQhLfibpWpsVBx2n/GKOz6JdGQvLruZQfGr9l1qes2KQaWswjBzhQF7UDUZMNaMMQeYnQzxwOMPsbYF7wqPQ==}
@@ -2739,16 +2625,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-transform-computed-properties@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-9repI4BhNrR0KenoR9vm3/cIc1tSBIo+u1WVjKCAynahj25O8zfbiE6JtAtHPGQSs4yZ+bA8mRasRP+qc+2R5A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
-
   /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
@@ -2758,16 +2634,6 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.5
-
-  /@babel/plugin-transform-destructuring@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-tgy3u6lRp17ilY8r1kP4i2+HDUwxlVqq3RTc943eAWSzGgpU1qhiKpqZ5CMyHReIYPHdo3Kg8v8edKtDqSVEyQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
 
   /@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==}
@@ -2817,16 +2683,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.21.8)
 
-  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.21.8):
-    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
-
   /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
     engines: {node: '>=6.9.0'}
@@ -2835,18 +2691,6 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-transform-function-name@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-kJha/Gbs5RjzIu0CxZwf5e3aTTSlhZnHMT8zPWnJMjNpLOUgqevg+PN5oMH68nMCXnfiMo4Bhgxqj59KHTlAnA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.19.1(@babel/core@7.21.8)
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
 
   /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
@@ -2858,16 +2702,6 @@ packages:
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.8)
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-transform-literals@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-x3HEw0cJZVDoENXOp20HlypIHfl0zMIhMVZEBVTfmqbObIpsMxMbmU5nOEO8R7LYT+z5RORKPlTI5Hj4OsO9/Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
 
   /@babel/plugin-transform-literals@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
@@ -2898,21 +2732,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-transform-modules-commonjs@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-module-transforms': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-simple-access': 7.18.6
-      babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
@@ -3005,16 +2824,6 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
 
-  /@babel/plugin-transform-parameters@7.18.8(@babel/core@7.21.8):
-    resolution: {integrity: sha512-ivfbE3X2Ss+Fj8nnXvKJS6sjRG4gzwPMsP+taZC+ZzEGjAYlvENixmt1sZ5Ca6tWls+BlKSGKPJ6OOXvXCbkFg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
-
   /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
@@ -3059,7 +2868,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.21.8):
@@ -3078,7 +2887,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-transform-react-jsx-source@7.22.5(@babel/core@7.21.8):
@@ -3113,17 +2922,6 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
-
-  /@babel/plugin-transform-regenerator@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-poqRI2+qiSdeldcz4wTSTXBRryoq3Gc70ye7m7UD5Ww0nE29IXqMl6r7Nd15WBgRd74vloEMlShtH6CKxVzfmQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-      regenerator-transform: 0.15.0
-    dev: false
 
   /@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==}
@@ -3165,17 +2963,6 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.19.0
 
-  /@babel/plugin-transform-spread@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-ayT53rT/ENF8WWexIRg9AiV9h0aIteyWn5ptfZTZQrjk/+f3WdrJGCY4c9wcgl2+MKkKPhzbYp97FTsquZpDCw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.6
-    dev: false
-
   /@babel/plugin-transform-spread@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
@@ -3195,16 +2982,6 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.19.0
 
-  /@babel/plugin-transform-template-literals@7.18.6(@babel/core@7.21.8):
-    resolution: {integrity: sha512-UuqlRrQmT2SWRvahW46cGSany0uTlcj8NYOS5sRGYi8FxPYPoLd5DDmMd32ZXEj2Jq+06uGVQKHxa/hJx2EzKw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
-
   /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
@@ -3222,20 +2999,6 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-transform-typescript@7.19.3(@babel/core@7.21.8):
-    resolution: {integrity: sha512-z6fnuK9ve9u/0X0rRvI9MY0xg+DOUaABDYOe+/SQTxtlptaBB/V9JIUxJn6xp3lMBeb9qe8xSFmHU35oZDXD+w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.21.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/plugin-transform-typescript@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-SMubA9S7Cb5sGSFFUlqxyClTA9zWJ8qGQrppNUm05LtFuN1ELRFNndkix4zUJrC9F+YivWwa1dHMSyo0e0N9dA==}
@@ -3451,14 +3214,6 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  /@babel/template@7.18.10:
-    resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.19.0
-
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
@@ -3472,7 +3227,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.19.0
+      '@babel/generator': 7.22.5
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
@@ -3910,6 +3665,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.15.18:
@@ -5824,19 +5580,19 @@ packages:
       solid-js: 1.6.13
     dev: false
 
-  /@solidjs/meta@0.28.2(solid-js@1.6.13):
-    resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
+  /@solidjs/meta@0.28.5(solid-js@1.7.7):
+    resolution: {integrity: sha512-52luJR6hVNMA1K8Od5OD0d8WVz/svqZG4is8lrDimiUGxdia3DzuLF+pK56dnEzbNt9cA42qVFL134U9LkC9Gg==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
-      solid-js: 1.6.13
+      solid-js: 1.7.7
 
-  /@solidjs/router@0.7.0(solid-js@1.6.13):
-    resolution: {integrity: sha512-8HI84twe5FjYRebSLMAhtkL9bRuTDIlxJK56kjfjU9WKGoUCTaWpCnkuj8Hqde1bWZ0X+GOZxKDfNkn1CjtjxA==}
+  /@solidjs/router@0.8.2(solid-js@1.7.7):
+    resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
     peerDependencies:
       solid-js: ^1.5.3
     dependencies:
-      solid-js: 1.6.13
+      solid-js: 1.7.7
 
   /@solidjs/testing-library@0.5.1(solid-js@1.6.13):
     resolution: {integrity: sha512-UVwYzSTRHwxiW7jdgKFP3NERbMtA748MIOQFzF1f4tg1XYl8ACybwlrVPqaiKnPevUCcM2ED+Wsp6Yd5JA//yg==}
@@ -7183,12 +6939,6 @@ packages:
     resolution: {integrity: sha512-3AN/9V/rKuv90NG65m4tTHsI04XrCKsWbztIcW7a8H5iIN7WlvWucRtVV0V/rT4QvtA11n5Vmp20fLwfMWqp6g==}
     dev: true
 
-  /babel-plugin-dynamic-import-node@2.3.3:
-    resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
-    dependencies:
-      object.assign: 4.1.4
-    dev: false
-
   /babel-plugin-jsx-dom-expressions@0.35.23(@babel/core@7.21.8):
     resolution: {integrity: sha512-KaBiZPm2riB5jyRUy5BVaz8TkKcyAx2frePOG2lj5vbYsBpZHIknQkUU/csWr+EeV75h/mRHIOzLo2mX4Dxq3g==}
     peerDependencies:
@@ -7200,6 +6950,7 @@ packages:
       '@babel/types': 7.22.5
       html-entities: 2.3.3
       validate-html-nesting: 1.2.2
+    dev: true
 
   /babel-plugin-jsx-dom-expressions@0.36.10(@babel/core@7.21.8):
     resolution: {integrity: sha512-QA2k/14WGw+RgcGGnEuLWwnu4em6CGhjeXtjvgOYyFHYS2a+CzPeaVQHDOlfuiBcjq/3hWMspHMIMnPEOIzdBg==}
@@ -7296,31 +7047,31 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-object-rest-spread': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.21.8)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.8)
       '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-block-scoping': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-classes': 7.18.8(@babel/core@7.21.8)
-      '@babel/plugin-transform-computed-properties': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-destructuring': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-classes': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-flow-strip-types': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.21.8)
-      '@babel/plugin-transform-function-name': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-literals': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-modules-commonjs': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.21.8)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.21.8)
       '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-spread': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-template-literals': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.21.8)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     transitivePeerDependencies:
       - supports-color
@@ -7333,6 +7084,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       babel-plugin-jsx-dom-expressions: 0.35.23(@babel/core@7.21.8)
+    dev: true
 
   /babel-preset-solid@1.7.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-tdxVzx3kgcIjNXAOmGRbzIhFBPeJjSakiN9yM+IYdL/+LtXNnbGqb0Va5tJb8Sjbk+QVEriovCyuzB5T7jeTvg==}
@@ -7468,17 +7220,6 @@ packages:
       p-queue: 6.6.2
       rimraf: 3.0.2
       unload: 2.4.1
-    dev: false
-
-  /browserslist@4.21.4:
-    resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001508
-      electron-to-chromium: 1.4.441
-      node-releases: 2.0.12
-      update-browserslist-db: 1.0.11(browserslist@4.21.4)
     dev: false
 
   /browserslist@4.21.9:
@@ -8475,6 +8216,7 @@ packages:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
+    dev: true
 
   /define-property@0.2.5:
     resolution: {integrity: sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==}
@@ -8632,7 +8374,7 @@ packages:
     dev: true
 
   /ee-first@1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   /electron-to-chromium@1.4.441:
     resolution: {integrity: sha512-LlCgQ8zgYZPymf5H4aE9itwiIWH4YlCiv1HFLmmcBeFYi5E+3eaIFnjHzYtcFQbaKfAW+CqZ9pgxo33DZuoqPg==}
@@ -8802,6 +8544,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-64@0.15.18:
@@ -8819,6 +8562,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-arm64@0.15.18:
@@ -8836,6 +8580,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-64@0.15.18:
@@ -8853,6 +8598,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-arm64@0.15.18:
@@ -8870,6 +8616,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-64@0.15.18:
@@ -8887,6 +8634,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-arm64@0.15.18:
@@ -8904,6 +8652,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-32@0.15.18:
@@ -8921,6 +8670,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-64@0.15.18:
@@ -8938,6 +8688,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm64@0.15.18:
@@ -8955,6 +8706,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm@0.15.18:
@@ -8972,6 +8724,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-mips64le@0.15.18:
@@ -8989,6 +8742,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-ppc64le@0.15.18:
@@ -9006,6 +8760,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-riscv64@0.15.18:
@@ -9023,6 +8778,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-s390x@0.15.18:
@@ -9040,6 +8796,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-netbsd-64@0.15.18:
@@ -9057,6 +8814,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-openbsd-64@0.15.18:
@@ -9068,17 +8826,17 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid@0.4.2(esbuild@0.14.54)(solid-js@1.6.13):
-    resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
+  /esbuild-plugin-solid@0.5.0(esbuild@0.17.19)(solid-js@1.7.7):
+    resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
     peerDependencies:
       esbuild: '>=0.12'
       solid-js: '>= 1.0'
     dependencies:
       '@babel/core': 7.21.8
       '@babel/preset-typescript': 7.21.5(@babel/core@7.21.8)
-      babel-preset-solid: 1.6.10(@babel/core@7.21.8)
-      esbuild: 0.14.54
-      solid-js: 1.6.13
+      babel-preset-solid: 1.7.7(@babel/core@7.21.8)
+      esbuild: 0.17.19
+      solid-js: 1.7.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9088,6 +8846,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-sunos-64@0.15.18:
@@ -9105,6 +8864,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-32@0.15.18:
@@ -9122,6 +8882,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-64@0.15.18:
@@ -9139,6 +8900,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-arm64@0.15.18:
@@ -9177,6 +8939,7 @@ packages:
       esbuild-windows-32: 0.14.54
       esbuild-windows-64: 0.14.54
       esbuild-windows-arm64: 0.14.54
+    dev: true
 
   /esbuild@0.15.18:
     resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
@@ -10628,6 +10391,7 @@ packages:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
       get-intrinsic: 1.2.1
+    dev: true
 
   /has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
@@ -12399,9 +12163,9 @@ packages:
       '@babel/core': 7.21.8
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-optional-chaining': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.21.8)
       '@babel/plugin-transform-flow-strip-types': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-modules-commonjs': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.21.8)
       '@babel/register': 7.18.6(@babel/core@7.21.8)
       escape-string-regexp: 1.0.5
     transitivePeerDependencies:
@@ -12599,40 +12363,40 @@ packages:
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-proposal-export-default-from': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-object-rest-spread': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.21.8)
       '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-optional-chaining': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.21.8)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
       '@babel/plugin-syntax-export-default-from': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.8)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-block-scoping': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-classes': 7.18.8(@babel/core@7.21.8)
-      '@babel/plugin-transform-computed-properties': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-destructuring': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-classes': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-transform-flow-strip-types': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.21.8)
-      '@babel/plugin-transform-function-name': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-literals': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-modules-commonjs': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-object-assign': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.21.8)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.21.8)
       '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-transform-react-jsx-source': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-regenerator': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-runtime': 7.9.0(@babel/core@7.21.8)
       '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-spread': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-template-literals': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-typescript': 7.19.3(@babel/core@7.21.8)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-typescript': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/template': 7.18.10
+      '@babel/template': 7.22.5
       react-refresh: 0.4.3
     transitivePeerDependencies:
       - supports-color
@@ -12812,8 +12576,8 @@ packages:
   /metro-source-map@0.64.0:
     resolution: {integrity: sha512-OCG2rtcp5cLEGYvAbfkl6mEc0J2FPRP4/UCEly+juBk7hawS9bCBMBfhJm/HIsvY1frk6nT2Vsl1O8YBbwyx2g==}
     dependencies:
-      '@babel/traverse': 7.19.1
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
       invariant: 2.2.4
       metro-symbolicate: 0.64.0
       nullthrows: 1.1.1
@@ -13756,6 +13520,7 @@ packages:
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /object-path@0.6.0:
     resolution: {integrity: sha512-fxrwsCFi3/p+LeLOAwo/wyRMODZxdGBtUlWRzsEpsUVrisZbEfZ21arxLGfaWfcnqb8oHPNihIb4XPE8CQPN5A==}
@@ -13777,6 +13542,7 @@ packages:
       define-properties: 1.2.0
       has-symbols: 1.0.3
       object-keys: 1.1.1
+    dev: true
 
   /object.entries@1.1.6:
     resolution: {integrity: sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==}
@@ -15025,7 +14791,7 @@ packages:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
     dependencies:
-      resolve: 1.22.1
+      resolve: 1.22.2
     dev: false
 
   /redent@3.0.0:
@@ -15070,12 +14836,6 @@ packages:
 
   /regenerator-runtime@0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
-    dev: false
-
-  /regenerator-transform@0.15.0:
-    resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
-    dependencies:
-      '@babel/runtime': 7.22.5
     dev: false
 
   /regenerator-transform@0.15.1:
@@ -15590,6 +15350,10 @@ packages:
       type-fest: 0.12.0
     dev: false
 
+  /seroval@0.5.1:
+    resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
+    engines: {node: '>=10'}
+
   /serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
     engines: {node: '>= 0.8.0'}
@@ -15605,9 +15369,6 @@ packages:
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: false
-
-  /set-cookie-parser@2.5.1:
-    resolution: {integrity: sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==}
 
   /set-cookie-parser@2.6.0:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
@@ -15793,6 +15554,12 @@ packages:
     dependencies:
       csstype: 3.1.0
 
+  /solid-js@1.7.7:
+    resolution: {integrity: sha512-SPdYVke/Z6Za24PBTbULyQYPrhGO1ZbPany76atO2zF2dmYn2pCotbsw1JtlgWnr9dK2JbwPGnA3ODTGPLhZNw==}
+    dependencies:
+      csstype: 3.1.2
+      seroval: 0.5.1
+
   /solid-refresh@0.4.1(solid-js@1.6.13):
     resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
     peerDependencies:
@@ -15804,7 +15571,7 @@ packages:
       solid-js: 1.6.13
     dev: true
 
-  /solid-refresh@0.5.3(solid-js@1.6.13):
+  /solid-refresh@0.5.3(solid-js@1.7.7):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
       solid-js: ^1.3
@@ -15812,9 +15579,9 @@ packages:
       '@babel/generator': 7.22.5
       '@babel/helper-module-imports': 7.22.5
       '@babel/types': 7.22.5
-      solid-js: 1.6.13
+      solid-js: 1.7.7
 
-  /solid-start-node@0.2.0(solid-start@0.2.23)(undici@5.22.1)(vite@4.2.0):
+  /solid-start-node@0.2.0(solid-start@0.2.26)(undici@5.22.1)(vite@4.2.0):
     resolution: {integrity: sha512-PBGm9HkzKrVf0cl3V2ViWmy51GgbrA1tklDAqbbMvhO7Dhh0TnkVRoySgJuahln9nX+1yoJw+uJST3+s0leQ9w==}
     peerDependencies:
       solid-start: '*'
@@ -15828,19 +15595,19 @@ packages:
       polka: 1.0.0-next.22
       rollup: 2.79.1
       sirv: 2.0.2
-      solid-start: 0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.6.13)(solid-start-node@0.2.0)(vite@4.2.0)
+      solid-start: 0.2.26(@solidjs/meta@0.28.5)(@solidjs/router@0.8.2)(solid-js@1.7.7)(solid-start-node@0.2.0)(vite@4.2.0)
       terser: 5.18.1
       undici: 5.22.1
       vite: 4.2.0(@types/node@18.13.0)
     transitivePeerDependencies:
       - supports-color
 
-  /solid-start@0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.6.13)(solid-start-node@0.2.0)(vite@4.2.0):
-    resolution: {integrity: sha512-dKTRFtpjskHFyLq9n6oJxqWHYL7H8w14y4+OgIR+57+lqb1N7289kZLTHrzWxWyzDkIG9V1s2MQtiDfIaBP/MQ==}
+  /solid-start@0.2.26(@solidjs/meta@0.28.5)(@solidjs/router@0.8.2)(solid-js@1.7.7)(solid-start-node@0.2.0)(vite@4.2.0):
+    resolution: {integrity: sha512-kne2HZlnSMzsirdnvNs1CsDqBl0L0uvKKt1t4de1CH7JIngyqoMcER97jTE0Ejr84KknANaKAdvJAzZcL7Ueng==}
     hasBin: true
     peerDependencies:
       '@solidjs/meta': ^0.28.0
-      '@solidjs/router': ^0.7.0
+      '@solidjs/router': ^0.8.2
       solid-js: ^1.6.2
       solid-start-aws: '*'
       solid-start-cloudflare-pages: '*'
@@ -15875,8 +15642,8 @@ packages:
       '@babel/preset-env': 7.21.5(@babel/core@7.21.8)
       '@babel/preset-typescript': 7.21.5(@babel/core@7.21.8)
       '@babel/template': 7.22.5
-      '@solidjs/meta': 0.28.2(solid-js@1.6.13)
-      '@solidjs/router': 0.7.0(solid-js@1.6.13)
+      '@solidjs/meta': 0.28.5(solid-js@1.7.7)
+      '@solidjs/router': 0.8.2(solid-js@1.7.7)
       '@types/cookie': 0.5.1
       chokidar: 3.5.3
       compression: 1.7.4
@@ -15885,8 +15652,8 @@ packages:
       dequal: 2.0.3
       dotenv: 16.3.1
       es-module-lexer: 1.3.0
-      esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2(esbuild@0.14.54)(solid-js@1.6.13)
+      esbuild: 0.17.19
+      esbuild-plugin-solid: 0.5.0(esbuild@0.17.19)(solid-js@1.7.7)
       fast-glob: 3.2.12
       get-port: 6.1.2
       parse-multipart-data: 1.5.0
@@ -15895,15 +15662,15 @@ packages:
       rollup-plugin-visualizer: 5.9.0(rollup@3.23.0)
       rollup-route-manifest: 1.0.0(rollup@3.23.0)
       sade: 1.8.1
-      set-cookie-parser: 2.5.1
-      sirv: 2.0.2
-      solid-js: 1.6.13
-      solid-start-node: 0.2.0(solid-start@0.2.23)(undici@5.22.1)(vite@4.2.0)
+      set-cookie-parser: 2.6.0
+      sirv: 2.0.3
+      solid-js: 1.7.7
+      solid-start-node: 0.2.0(solid-start@0.2.26)(undici@5.22.1)(vite@4.2.0)
       terser: 5.18.1
       undici: 5.22.1
       vite: 4.2.0(@types/node@18.13.0)
       vite-plugin-inspect: 0.7.29(rollup@3.23.0)(vite@4.2.0)
-      vite-plugin-solid: 2.7.0(solid-js@1.6.13)(vite@4.2.0)
+      vite-plugin-solid: 2.7.0(solid-js@1.7.7)(vite@4.2.0)
       wait-on: 6.0.1(debug@4.3.4)
     transitivePeerDependencies:
       - supports-color
@@ -17160,17 +16927,6 @@ packages:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
 
-  /update-browserslist-db@1.0.11(browserslist@4.21.4):
-    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.21.4
-      escalade: 3.1.1
-      picocolors: 1.0.0
-    dev: false
-
   /update-browserslist-db@1.0.11(browserslist@4.21.9):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
@@ -17356,7 +17112,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid@2.7.0(solid-js@1.6.13)(vite@4.2.0):
+  /vite-plugin-solid@2.7.0(solid-js@1.7.7)(vite@4.2.0):
     resolution: {integrity: sha512-avp/Jl5zOp/Itfo67xtDB2O61U7idviaIp4mLsjhCa13PjKNasz+IID0jYTyqUp9SFx6/PmBr6v4KgDppqompg==}
     peerDependencies:
       solid-js: ^1.7.2
@@ -17367,8 +17123,8 @@ packages:
       '@types/babel__core': 7.20.1
       babel-preset-solid: 1.7.7(@babel/core@7.21.8)
       merge-anything: 5.1.7
-      solid-js: 1.6.13
-      solid-refresh: 0.5.3(solid-js@1.6.13)
+      solid-js: 1.7.7
+      solid-refresh: 0.5.3(solid-js@1.7.7)
       vite: 4.2.0(@types/node@18.13.0)
       vitefu: 0.2.4(vite@4.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
Make sure that on the server we always resolve the resource data to a hydrate-able value, otherwise solid will silently call `onHydrated` on the client with an empty object which can cause a variety of problems.

The specific code branch we were missing was when `createQuery` is called and `observer.getOptimisticResult(defaultedOptions)` returns an already loaded query (if, for example, `preloadQuery` was called prior to the components mounting - for example with router data loaders).

---

As always, these SSR / hydration cases are difficult to test, so I added an example to the `solid-start-streaming` to manually verify for now. This example simply calls `preloadQuery` on the server, and then renders a component that uses that same query.

**Before 1**

This is with `deferStream: false` on the user query - note how the content ends up getting rendered twice, and in the dev console you can see that `onHydrated` is called with an empty object. Things work as expected after the changes in this PR.

<img width="1421" alt="Screenshot 2023-07-10 at 11 59 11 AM" src="https://github.com/TanStack/query/assets/847542/d43b1e88-1624-4efc-9006-3d463df62e99">

**Before 2**

This is with `deferStream: true` on the user query - note how it ends up calling the user query on the server AND on the client (see logs in dev console), and in the dev console you can see that `onHydrated` is called with an empty object (which causes the client to think that it needs to refetch, hence the client call).

<img width="1423" alt="Screenshot 2023-07-10 at 11 58 26 AM" src="https://github.com/TanStack/query/assets/847542/e91827b8-68df-4155-80c2-bc4f33a4240f">

**After**

<img width="1424" alt="Screenshot 2023-07-10 at 11 57 58 AM" src="https://github.com/TanStack/query/assets/847542/4efbbc29-db42-415f-a866-22dee096c009">