### PR TITLE
Update useMutation.md to remove mention of devtools with mutationKey

### DIFF
--- a/docs/react/reference/useMutation.md
+++ b/docs/react/reference/useMutation.md
@@ -51,7 +51,7 @@ mutate(variables, {
   - If set to `Infinity`, will disable garbage collection
 - `mutationKey: unknown[]`
   - Optional
-  - A mutation key can be set to inherit defaults set with `queryClient.setMutationDefaults` or to identify the mutation in the devtools.
+  - A mutation key can be set to inherit defaults set with `queryClient.setMutationDefaults`.
 - `networkMode: 'online' | 'always' | 'offlineFirst`
   - optional
   - defaults to `'online'`


### PR DESCRIPTION
As part of https://tanstack.com/query/v4/docs/react/devtools it mentions that mutations don't appear in the devtools, so we should remove this mention that the mutationKey is used in devtools