### PR TITLE
docs: Use svelte for prismjs codeblocks

### DIFF
--- a/docs/svelte/overview.md
+++ b/docs/svelte/overview.md
@@ -9,7 +9,7 @@ The `@tanstack/svelte-query` package offers a 1st-class API for using TanStack Q
 
 Include the QueryClientProvider near the root of your project:
 
-```markdown
+```svelte
 <script lang="ts">
   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query'
   import Example from './lib/Example.svelte'
@@ -24,7 +24,7 @@ Include the QueryClientProvider near the root of your project:
 
 Then call any function (e.g. createQuery) from any component:
 
-```markdown
+```svelte
 <script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
 

--- a/docs/svelte/reactivity.md
+++ b/docs/svelte/reactivity.md
@@ -7,7 +7,7 @@ Svelte uses a compiler to build your code which optimises rendering. By default,
 
 In the below example, the `refetchInterval` option is set from the variable `intervalMs`, which is edited by the input field. However, as the query is not told it should react to changes in `intervalMs`, `refetchInterval` will not change when the input value changes.
 
-```markdown
+```svelte
 <script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
 
@@ -27,7 +27,7 @@ In the below example, the `refetchInterval` option is set from the variable `int
 
 To solve this, you can prefix the query with `$: ` to tell the compiler it should be reactive.
 
-```markdown
+```svelte
 <script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
 

--- a/docs/svelte/ssr.md
+++ b/docs/svelte/ssr.md
@@ -11,7 +11,7 @@ The recommended way to achieve this is to use the `browser` module from SvelteKi
 
 **src/routes/+layout.svelte**
 
-```markdown
+```svelte
 <script lang="ts">
   import { browser } from '$app/environment'
   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query'
@@ -52,7 +52,7 @@ export const load: PageLoad = async () => {
 ```
 
 **src/routes/+page.svelte**
-```markdown
+```svelte
 <script>
   import { createQuery } from '@tanstack/svelte-query'
   import type { PageData } from './$types'
@@ -104,7 +104,7 @@ export const load: LayoutLoad = async () => {
 
 **src/routes/+layout.svelte**
 
-```markdown
+```svelte
 <script lang="ts">
   import { QueryClientProvider } from '@tanstack/svelte-query'
   import type { LayoutData } from './$types'
@@ -135,7 +135,7 @@ export const load: PageLoad = async ({ parent, fetch }) => {
 
 **src/routes/+page.svelte**
 
-```markdown
+```svelte
 <script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
 


### PR DESCRIPTION
For now, this does nothing as svelte is an alias to markup (https://github.com/TanStack/tanstack.com/pull/87). However, once https://github.com/TanStack/tanstack.com/pull/88 is merged, it will highlight correctly!