### PR TITLE
Docs: Fix unintentional visible comment in query-keys.md

### DIFF
--- a/docs/react/guides/query-keys.md
+++ b/docs/react/guides/query-keys.md
@@ -91,12 +91,15 @@ function Todos({ todoId }) {
 
 [//]: # 'Example5'
 
-Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically (depending on your `staleTime` settings).* (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
+Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically* (depending on your `staleTime` settings). (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
+
 [//]: # 'Materials'
 
 ## Further reading
 
 For tips on organizing Query Keys in larger applications, have a look at [Effective React Query Keys](../community/tkdodos-blog#8-effective-react-query-keys) and check the [Query Key Factory Package](../community/lukemorales-query-key-factory) from
 the Community Resources.
+
+[//]: # 'Materials'
 
 [//]: # 'Materials'


### PR DESCRIPTION
It appears that, somewhere in the course of [this](https://github.com/TanStack/query/pull/5653/files) PR, a comment got bumped such that it's now visible in the production docs. This fixes that, as well as excludes a parenthetic that I believe was accidentally included from an italicized section.