### PR TITLE
Docs: fix visible comment in query-keys.md

### DIFF
--- a/docs/react/guides/query-keys.md
+++ b/docs/react/guides/query-keys.md
@@ -91,7 +91,7 @@ function Todos({ todoId }) {
 
 [//]: # 'Example5'
 
-Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically* (depending on your `staleTime` settings). (See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.)
+Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, *queries will be refetched automatically* (depending on your `staleTime` settings). See the [exhaustive-deps](../eslint/exhaustive-deps) section for more information and examples.
 
 [//]: # 'Materials'
 


### PR DESCRIPTION
It appears that, somewhere in the course of [this](https://github.com/TanStack/query/pull/5653/files) PR, a comment got bumped such that it's now visible in the production docs. This fixes that, as well as excludes a parenthetic that I believe was accidentally included from an italicized section, and removes some parentheses which, with the addition of a parenthetic before them via a CR suggestion, now feel confusing rather than helpful.

![image](https://github.com/TanStack/query/assets/35735666/5657a647-9c35-4517-8df7-018256e8a2fe)
