### PR TITLE
docs: update readme about suspense

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Still on **React Query v3**? No problem! Check out the v3 docs here: https://tan
 - Paginated + Cursor-based Queries
 - Load-More + Infinite Scroll Queries w/ Scroll Recovery
 - Request Cancellation
-- [React Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html) + Fetch-As-You-Render Query Prefetching
+- [React Suspense](https://17.reactjs.org/docs/concurrent-mode-suspense.html) + Fetch-As-You-Render Query Prefetching
 - Dedicated Devtools
 - <a href="https://bundlephobia.com/package/@tanstack/react-query@latest" target="\_parent">
   <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/react-query" />

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Still on **React Query v3**? No problem! Check out the v3 docs here: https://tan
 - Paginated + Cursor-based Queries
 - Load-More + Infinite Scroll Queries w/ Scroll Recovery
 - Request Cancellation
-- [React Suspense](https://17.reactjs.org/docs/concurrent-mode-suspense.html) + Fetch-As-You-Render Query Prefetching
+- [React Suspense](https://react.dev/reference/react/Suspense) + Fetch-As-You-Render Query Prefetching
 - Dedicated Devtools
 - <a href="https://bundlephobia.com/package/@tanstack/react-query@latest" target="\_parent">
   <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/react-query" />


### PR DESCRIPTION
# Update README.md about suspense
I thought this link is need to be updated.

## as is
https://reactjs.org/docs/concurrent-mode-suspense.html

## to be
https://17.reactjs.org/docs/concurrent-mode-suspense.html

### Other choices
1. https://react.dev/blog/2022/03/29/react-v18#suspense-in-data-frameworks
2. https://react.dev/reference/react/Suspense