### PR TITLE
chore: update options of actions/setup-node@v3 in .github/workflows/*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,10 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
           registry-url: https://registry.npmjs.org/
-          cache: 'pnpm'
+          node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter query --prefer-offline install
       - name: Run Tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
-          cache: 'pnpm'
+          node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter query --prefer-offline install
       - name: Get appropriate base and head commits for `nx affected` commands
@@ -68,8 +69,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
-          cache: 'pnpm'
+          node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter query --prefer-offline install
       - name: Start Nx Agent ${{ matrix.agent }}
@@ -88,8 +90,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
-          cache: 'pnpm'
+          node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter query --prefer-offline install
       - name: Run prettier
@@ -108,8 +111,9 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
-          cache: 'pnpm'
+          node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter query --prefer-offline install
       - name: Derive appropriate SHAs for base and head for `nx affected` commands


### PR DESCRIPTION
# Update actions/setup-node@v3 in .github/workflows/*

1. [follow .nvmrc for node-version for workflows](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file)
I think if we are using .nvmrc, we can follow only the node version specified in .nvmrc without manually updating all actions/setup-node@v3 in .github/workflows.

2. [cache dependency path](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data)

### [see GitHub Actions](https://github.com/TanStack/query/actions/runs/5602800157/jobs/10248537852?pr=5744)
we can check this is working

<img width="465" alt="image" src="https://github.com/TanStack/query/assets/61593290/de03d3eb-c7ca-4eda-80f1-261ef241e7a8">

