### PR TITLE
chore: Simplify tsconfig

### DIFF
--- a/packages/codemods/.eslintrc.cjs
+++ b/packages/codemods/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
   overrides: [
     {

--- a/packages/codemods/tsconfig.eslint.json
+++ b/packages/codemods/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs"]
-}

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./build/lib"
-  },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs"]
 }

--- a/packages/eslint-plugin-query/.eslintrc.cjs
+++ b/packages/eslint-plugin-query/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -31,7 +31,7 @@
     "clean": "rimraf ./build && rimraf ./coverage",
     "dev": "tsup --watch --sourcemap",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/eslint-plugin-query/tsconfig.eslint.json
+++ b/packages/eslint-plugin-query/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/eslint-plugin-query/tsconfig.json
+++ b/packages/eslint-plugin-query/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-async-storage-persister/.eslintrc.cjs
+++ b/packages/query-async-storage-persister/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/query-async-storage-persister/tsconfig.eslint.json
+++ b/packages/query-async-storage-persister/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/query-async-storage-persister/tsconfig.json
+++ b/packages/query-async-storage-persister/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-broadcast-client-experimental/.eslintrc.cjs
+++ b/packages/query-broadcast-client-experimental/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:build": "publint --strict && attw --pack",
     "build": "tsup"
   },

--- a/packages/query-broadcast-client-experimental/tsconfig.eslint.json
+++ b/packages/query-broadcast-client-experimental/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/query-broadcast-client-experimental/tsconfig.json
+++ b/packages/query-broadcast-client-experimental/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./build/lib"
-  },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-core/.eslintrc.cjs
+++ b/packages/query-core/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/query-core/tsconfig.eslint.json
+++ b/packages/query-core/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-devtools/.eslintrc.cjs
+++ b/packages/query-devtools/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",

--- a/packages/query-devtools/tsconfig.eslint.json
+++ b/packages/query-devtools/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "rollup.config.js"]
-}

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "outDir": "./dist",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-persist-client-core/.eslintrc.cjs
+++ b/packages/query-persist-client-core/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/query-persist-client-core/tsconfig.eslint.json
+++ b/packages/query-persist-client-core/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/query-persist-client-core/tsconfig.json
+++ b/packages/query-persist-client-core/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-sync-storage-persister/.eslintrc.cjs
+++ b/packages/query-sync-storage-persister/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/query-sync-storage-persister/tsconfig.eslint.json
+++ b/packages/query-sync-storage-persister/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/query-sync-storage-persister/tsconfig.json
+++ b/packages/query-sync-storage-persister/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-devtools/.eslintrc.cjs
+++ b/packages/react-query-devtools/.eslintrc.cjs
@@ -5,7 +5,7 @@ const config = {
   extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack --ignore-rules no-resolution",

--- a/packages/react-query-devtools/tsconfig.eslint.json
+++ b/packages/react-query-devtools/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/react-query-devtools/tsconfig.json
+++ b/packages/react-query-devtools/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-next-experimental/.eslintrc.cjs
+++ b/packages/react-query-next-experimental/.eslintrc.cjs
@@ -5,7 +5,7 @@ const config = {
   extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],

--- a/packages/react-query-next-experimental/package.json
+++ b/packages/react-query-next-experimental/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage --passWithNoTests",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/react-query-next-experimental/tsconfig.eslint.json
+++ b/packages/react-query-next-experimental/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/react-query-next-experimental/tsconfig.json
+++ b/packages/react-query-next-experimental/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-persist-client/.eslintrc.cjs
+++ b/packages/react-query-persist-client/.eslintrc.cjs
@@ -5,7 +5,7 @@ const config = {
   extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/react-query-persist-client/tsconfig.eslint.json
+++ b/packages/react-query-persist-client/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/react-query-persist-client/tsconfig.json
+++ b/packages/react-query-persist-client/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query/.eslintrc.cjs
+++ b/packages/react-query/.eslintrc.cjs
@@ -5,7 +5,7 @@ const config = {
   extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/react-query/tsconfig.eslint.json
+++ b/packages/react-query/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/solid-query/.eslintrc.cjs
+++ b/packages/solid-query/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",

--- a/packages/solid-query/tsconfig.eslint.json
+++ b/packages/solid-query/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "rollup.config.js"]
-}

--- a/packages/solid-query/tsconfig.json
+++ b/packages/solid-query/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "outDir": "./dist",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/svelte-query-devtools/tsconfig.json
+++ b/packages/svelte-query-devtools/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
   "include": [
     "src/**/*.js",
     "src/**/*.ts",

--- a/packages/svelte-query/tsconfig.json
+++ b/packages/svelte-query/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
-  },
   "include": [
     "src/**/*.js",
     "src/**/*.ts",

--- a/packages/vue-query/.eslintrc.cjs
+++ b/packages/vue-query/.eslintrc.cjs
@@ -4,7 +4,7 @@
 const config = {
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
   },
 }
 

--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc",
     "test:lib": "pnpm run test:2 && pnpm run test:2.7 && pnpm run test:3",
     "test:2": "vue-demi-switch 2 vue2 && vitest",
     "test:2.7": "vue-demi-switch 2.7 vue2.7 && vitest",

--- a/packages/vue-query/tsconfig.eslint.json
+++ b/packages/vue-query/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
-}

--- a/packages/vue-query/tsconfig.json
+++ b/packages/vue-query/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/lib",
     "types": ["vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "isolatedModules": true,
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "Node", // TODO change this to Node16 or Bundler
+    "noEmit": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Since tsup (#5597) handles the build types independently from tsc, the tsconfig can now be simplified since noEmit is the default.