### PR TITLE
fix: Add missing extensions to ESM imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "cpy-cli": "^4.2.0",
     "current-git-branch": "^1.1.0",
     "esbuild": "^0.18.13",
+    "esbuild-plugin-file-path-extensions": "^1.0.0",
     "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-typescript": "^3.5.5",

--- a/packages/eslint-plugin-query/tsup.config.js
+++ b/packages/eslint-plugin-query/tsup.config.js
@@ -4,5 +4,5 @@ import { defineConfig } from 'tsup'
 import { legacyConfig } from '../../scripts/getTsupConfig.js'
 
 export default defineConfig([
-  legacyConfig({ entry: ['src/*.ts', 'src/*.tsx'], bundle: true }),
+  legacyConfig({ entry: ['src/*.ts', 'src/*.tsx'] }),
 ])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       esbuild:
         specifier: ^0.18.13
         version: 0.18.13
+      esbuild-plugin-file-path-extensions:
+        specifier: ^1.0.0
+        version: 1.0.0
       eslint:
         specifier: ^8.34.0
         version: 8.34.0
@@ -8648,6 +8651,11 @@ packages:
     os: [openbsd]
     requiresBuild: true
     optional: true
+
+  /esbuild-plugin-file-path-extensions@1.0.0:
+    resolution: {integrity: sha512-v5LpSkml+CbsC0+xAaETEGDECdvKp1wKkD4aXMdI4zLjXP0EYfK4GjGhphumt4N+kjR3A8Q+DIkpgxX1XTqO4Q==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+    dev: true
 
   /esbuild-plugin-solid@0.4.2(esbuild@0.14.54)(solid-js@1.6.13):
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}

--- a/scripts/getTsupConfig.js
+++ b/scripts/getTsupConfig.js
@@ -1,9 +1,10 @@
 // @ts-check
 
+import { esbuildPluginFilePathExtensions } from 'esbuild-plugin-file-path-extensions'
+
 /**
  * @param {Object} opts - Options for building configurations.
  * @param {string[]} opts.entry - The entry array.
- * @param {boolean} [opts.bundle] - Whether to bundle the output.
  * @returns {import('tsup').Options}
  */
 export function modernConfig(opts) {
@@ -12,18 +13,16 @@ export function modernConfig(opts) {
     format: ['cjs', 'esm'],
     target: ['chrome91', 'firefox90', 'edge91', 'safari15', 'ios15', 'opera77'],
     outDir: 'build/modern',
-    bundle: opts.bundle || false,
-    splitting: opts.bundle || false,
     dts: true,
     sourcemap: true,
     clean: true,
+    esbuildPlugins: [esbuildPluginFilePathExtensions({ esmExtension: 'js' })],
   }
 }
 
 /**
  * @param {Object} opts - Options for building configurations.
  * @param {string[]} opts.entry - The entry array.
- * @param {boolean} [opts.bundle] - Whether to bundle the output.
  * @returns {import('tsup').Options}
  */
 export function legacyConfig(opts) {
@@ -32,10 +31,9 @@ export function legacyConfig(opts) {
     format: ['cjs', 'esm'],
     target: ['es2020', 'node16'],
     outDir: 'build/legacy',
-    bundle: opts.bundle || false,
-    splitting: opts.bundle || false,
     dts: true,
     sourcemap: true,
     clean: true,
+    esbuildPlugins: [esbuildPluginFilePathExtensions({ esmExtension: 'js' })],
   }
 }


### PR DESCRIPTION
Rollup adds file extensions to relative imports in ESM context automatically - it seems like esbuild doesn't (https://github.com/evanw/esbuild/issues/622).

This adds a very simple esbuild plugin that fixes this. I might see if there is interest in adding this to the tsup package by default since I would've thought it's necessary.