### PR TITLE
fix(react-query): types for useSuspenseQuery

### DIFF
--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -12,6 +12,7 @@ import type {
   QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
+  QueryObserverSuccessResult,
   WithRequired,
 } from '@tanstack/query-core'
 
@@ -34,6 +35,16 @@ export interface UseQueryOptions<
 > extends WithRequired<
     UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
     'queryKey'
+  > {}
+
+export interface UseSuspenseQueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> extends Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'enabled' | 'suspense' | 'throwOnError' | 'placeholderData'
   > {}
 
 export interface UseInfiniteQueryOptions<
@@ -64,6 +75,11 @@ export type UseQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = UseBaseQueryResult<TData, TError>
+
+export type UseSuspenseQueryResult<
+  TData = unknown,
+  TError = DefaultError,
+> = Omit<QueryObserverSuccessResult<TData, TError>, 'isPlaceholderData'>
 
 export type DefinedUseQueryResult<
   TData = unknown,

--- a/packages/react-query/src/useSuspenseQuery.ts
+++ b/packages/react-query/src/useSuspenseQuery.ts
@@ -1,9 +1,8 @@
 'use client'
 import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type { UseQueryOptions } from './types'
+import type { UseSuspenseQueryOptions, UseSuspenseQueryResult } from './types'
 import type { DefaultError, QueryClient, QueryKey } from '@tanstack/query-core'
-import type { DefinedUseQueryResult } from './types'
 
 export function useSuspenseQuery<
   TQueryFnData = unknown,
@@ -11,12 +10,9 @@ export function useSuspenseQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: Omit<
-    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-    'enabled' | 'suspense' | 'throwOnError' | 'placeholderData'
-  >,
+  options: UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): Omit<DefinedUseQueryResult<TData, TError>, 'isPlaceholderData'> {
+): UseSuspenseQueryResult<TData, TError> {
   return useBaseQuery(
     {
       ...options,
@@ -26,5 +22,5 @@ export function useSuspenseQuery<
     },
     QueryObserver,
     queryClient,
-  ) as DefinedUseQueryResult<TData, TError>
+  ) as UseSuspenseQueryResult<TData, TError>
 }


### PR DESCRIPTION
# Add types for useSuspenseQuery like useQuery
1. UseSuspenseQueryOptions
2. UseSuspenseQueryResult