### PR TITLE
perf(vue-query): avoid unnecessary deep watch 

### DIFF
--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -65,6 +65,8 @@ export function useBaseQuery<
       : 'optimistic'
 
     if ('queryClient' in defaulted) {
+      // @ts-ignore
+      // The `queryClient` property does exist; it lacks type definition.
       delete defaulted.queryClient
     }
 

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -64,6 +64,10 @@ export function useBaseQuery<
       ? 'isRestoring'
       : 'optimistic'
 
+    if ('queryClient' in defaulted) {
+      delete defaulted.queryClient
+    }
+
     return defaulted
   })
 

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -64,12 +64,6 @@ export function useBaseQuery<
       ? 'isRestoring'
       : 'optimistic'
 
-    if ('queryClient' in defaulted) {
-      // @ts-ignore
-      // The `queryClient` property does exist; it lacks type definition.
-      delete defaulted.queryClient
-    }
-
     return defaulted
   })
 
@@ -94,14 +88,10 @@ export function useBaseQuery<
     { immediate: true },
   )
 
-  watch(
-    defaultedOptions,
-    () => {
-      observer.setOptions(defaultedOptions.value)
-      updateState(state, observer.getCurrentResult())
-    },
-    { deep: true },
-  )
+  watch(defaultedOptions, () => {
+    observer.setOptions(defaultedOptions.value)
+    updateState(state, observer.getCurrentResult())
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -29,7 +29,7 @@ export function useIsFetching(
 
   const source = () => {
     const deps = filters.value
-    if ('queryClient' in filters) delete filters.queryClient
+    if ('queryClient' in deps) delete deps.queryClient
     return deps
   }
 

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -27,19 +27,9 @@ export function useIsFetching(
     isFetching.value = queryClient.isFetching(filters)
   })
 
-  const source = () => {
-    const deps = filters.value
-    if ('queryClient' in deps) delete deps.queryClient
-    return deps
-  }
-
-  watch(
-    source,
-    () => {
-      isFetching.value = queryClient.isFetching(filters)
-    },
-    { deep: true },
-  )
+  watch(filters, () => {
+    isFetching.value = queryClient.isFetching(filters)
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -27,8 +27,14 @@ export function useIsFetching(
     isFetching.value = queryClient.isFetching(filters)
   })
 
+  const source = () => {
+    const deps = filters.value
+    if ('queryClient' in filters) delete filters.queryClient
+    return deps
+  }
+
   watch(
-    filters,
+    source,
     () => {
       isFetching.value = queryClient.isFetching(filters)
     },

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -29,7 +29,7 @@ export function useIsMutating(
 
   const source = () => {
     const deps = filters.value
-    if ('queryClient' in filters) delete filters.queryClient
+    if ('queryClient' in deps) delete deps.queryClient
     return deps
   }
 

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -27,8 +27,14 @@ export function useIsMutating(
     isMutating.value = queryClient.isMutating(filters)
   })
 
+  const source = () => {
+    const deps = filters.value
+    if ('queryClient' in filters) delete filters.queryClient
+    return deps
+  }
+
   watch(
-    filters,
+    source,
     () => {
       isMutating.value = queryClient.isMutating(filters)
     },

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -27,19 +27,9 @@ export function useIsMutating(
     isMutating.value = queryClient.isMutating(filters)
   })
 
-  const source = () => {
-    const deps = filters.value
-    if ('queryClient' in deps) delete deps.queryClient
-    return deps
-  }
-
-  watch(
-    source,
-    () => {
-      isMutating.value = queryClient.isMutating(filters)
-    },
-    { deep: true },
-  )
+  watch(filters, () => {
+    isMutating.value = queryClient.isMutating(filters)
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -167,19 +167,9 @@ export function useMutation<
     })
   }
 
-  const source = () => {
-    const deps = options.value
-    if ('queryClient' in deps) delete deps.queryClient
-    return deps
-  }
-
-  watch(
-    source,
-    () => {
-      observer.setOptions(queryClient.defaultMutationOptions(options.value))
-    },
-    { deep: true },
-  )
+  watch(options, () => {
+    observer.setOptions(queryClient.defaultMutationOptions(options.value))
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -167,8 +167,14 @@ export function useMutation<
     })
   }
 
+  const source = () => {
+    const deps = options.value
+    if ('queryClient' in deps) delete deps.queryClient
+    return deps
+  }
+
   watch(
-    options,
+    source,
     () => {
       observer.setOptions(queryClient.defaultMutationOptions(options.value))
     },

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -191,8 +191,18 @@ export function useQueries<T extends any[]>({
     { immediate: true },
   )
 
+  const source = () => {
+    const deps = defaultedQueries.value
+    deps.forEach((options) => {
+      if ('queryClient' in options) {
+        delete options.queryClient
+      }
+    })
+    return deps
+  }
+
   watch(
-    unreffedQueries,
+    source,
     () => {
       observer.setQueries(defaultedQueries.value)
       state.splice(0, state.length, ...observer.getCurrentResult())

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -191,26 +191,10 @@ export function useQueries<T extends any[]>({
     { immediate: true },
   )
 
-  const source = () => {
-    const deps = defaultedQueries.value
-    deps.forEach((options) => {
-      if ('queryClient' in options) {
-        // @ts-ignore
-        // The `queryClient` property does exist; it lacks type definition.
-        delete options.queryClient
-      }
-    })
-    return deps
-  }
-
-  watch(
-    source,
-    () => {
-      observer.setQueries(defaultedQueries.value)
-      state.splice(0, state.length, ...observer.getCurrentResult())
-    },
-    { deep: true },
-  )
+  watch(defaultedQueries, () => {
+    observer.setQueries(defaultedQueries.value)
+    state.splice(0, state.length, ...observer.getCurrentResult())
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -195,6 +195,8 @@ export function useQueries<T extends any[]>({
     const deps = defaultedQueries.value
     deps.forEach((options) => {
       if ('queryClient' in options) {
+        // @ts-ignore
+        // The `queryClient` property does exist; it lacks type definition.
         delete options.queryClient
       }
     })

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -1,4 +1,4 @@
-import { isVue2, markRaw } from 'vue-demi'
+import { isVue2 } from 'vue-demi'
 import { isServer } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
@@ -56,8 +56,6 @@ export const VueQueryPlugin = {
         client = new QueryClient(clientConfig)
       }
     }
-
-    client = markRaw(client)
 
     if (!isServer) {
       client.mount()

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -1,4 +1,4 @@
-import { isVue2 } from 'vue-demi'
+import { isVue2, markRaw } from 'vue-demi'
 import { isServer } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
@@ -56,6 +56,8 @@ export const VueQueryPlugin = {
         client = new QueryClient(clientConfig)
       }
     }
+
+    client = markRaw(client)
 
     if (!isServer) {
       client.mount()


### PR DESCRIPTION
According to the follow issue:
- #5031

I have spent some time identifying the root cause of this performance issue, and here are the reasons I found along with the proposed solution.

In `useBaseQuery`, `useIsFetching`, `useMutating`, `useMutation`, and `useQueries` of vue-query, deep watching the parsed `options/filters` is performed. When `queryClient` is included in these options, the watch will traverse each property of the object deeply, which is causing the performance overhead.

https://github.com/vuejs/core/blob/3be4e3cbe34b394096210897c1be8deeb6d748d8/packages/runtime-core/src/apiWatch.ts#L441-L443

Currently, there are two feasible solutions:

1. During the installation of the vue-query plugin, mark `queryClient` as raw. The Vue watch API will skip objects marked as raw during traversal.
2. Remove `queryClient` before performing the deep watch to avoid unnecessary tracking.

In this PR, I have chosen the second solution.

While the first solution is simple and effective, it may not directly help scenarios like #5031. Users adopting such an approach would still need to manually mark `queryClient` as raw:

```ts
const queryClient = markRaw(new QueryClient({ ... }));
const query = useQuery(..., ..., {
    queryClient,
});
```

I'm not sure which one is better. If you think the first approach is more concise and powerful, I can modify the PR to use the first approach.

Below are two solutions along with the performance comparison with the previous version.

|![current verson][current-version-src]|![first solution][first-solution-src]|![second solution][second-solution-src]|
| :--: | :--: | :--: |
| current verson | first solution | **second solution** |

- Browser: Chrome v115
- Version: @tanstack/vue-query v4.29.25, vue v3.3.4
- Test Code:

```ts
const queryClient = useQueryClient();

Array.from({ length: 2000 }, (_, index) => {
  useQuery({
    queryClient,
    queryKey: ['TODO', index],
    queryFn() {
      return new Promise(resolve => setTimeout(resolve, 1000, index));
    },
  });
});
```

---

## Update 2023/07/24

This is the third solution: using `computed()`. Computed properties recompute and produce completely new data after any of their collected dependencies are updated. In this case, there is no need for deep `watch()` to trigger updates.

Moreover, this approach helps reduce the performance overhead of `watch()` when traversing objects.

<img width="327" alt="solution 3" src="https://github.com/TanStack/query/assets/39984251/c272a006-576b-42b4-bdb6-d273e8549afb">

In @tanstack/vue-query, deep cloning has already been used to allow computed properties to collect all reactive dependencies. Therefore, I believe this method might be better than the previous two approaches.

https://github.com/TanStack/query/blob/118801df342881021c2bb6c8add5bb11b6dd944a/packages/vue-query/src/utils.ts#L30-L62

I'm not sure if the team would prefer to adopt a specific solution. If there are any suggestions or other approaches, I am more than willing to assist. Thank you for your excellent work.

[current-version-src]: https://github.com/TanStack/query/assets/39984251/3207446e-2975-4f8b-a756-40427446dea7
[first-solution-src]: https://github.com/TanStack/query/assets/39984251/eaa9f2c0-0b72-44b5-9913-75584331333a
[second-solution-src]: https://github.com/TanStack/query/assets/39984251/00e3552c-0610-4e51-9113-5a90c3ee4ca8