### PR TITLE
fix(react-query): types for useSuspenseInfiniteQuery

### DIFF
--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -6,6 +6,7 @@ import type {
   DefinedQueryObserverResult,
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
+  InfiniteQueryObserverSuccessResult,
   MutateFunction,
   MutationObserverOptions,
   MutationObserverResult,
@@ -66,6 +67,25 @@ export interface UseInfiniteQueryOptions<
     'queryKey'
   > {}
 
+export interface UseSuspenseInfiniteQueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+> extends Omit<
+    UseInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey,
+      TPageParam
+    >,
+    'enabled' | 'suspense' | 'throwOnError' | 'placeholderData'
+  > {}
+
 export type UseBaseQueryResult<
   TData = unknown,
   TError = DefaultError,
@@ -95,6 +115,11 @@ export type DefinedUseInfiniteQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = DefinedInfiniteQueryObserverResult<TData, TError>
+
+export type UseSuspenseInfiniteQueryResult<
+  TData = unknown,
+  TError = DefaultError,
+> = Omit<InfiniteQueryObserverSuccessResult<TData, TError>, 'isPlaceholderData'>
 
 export interface UseMutationOptions<
   TData = unknown,

--- a/packages/react-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/react-query/src/useSuspenseInfiniteQuery.ts
@@ -1,15 +1,20 @@
 'use client'
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type { QueryObserver } from '@tanstack/query-core'
+import type {
+  InfiniteQueryObserverSuccessResult,
+  QueryObserver,
+} from '@tanstack/query-core'
 import type {
   DefaultError,
   InfiniteData,
   QueryClient,
   QueryKey,
 } from '@tanstack/query-core'
-import type { DefinedUseInfiniteQueryResult } from './types'
-import type { UseInfiniteQueryOptions } from './types'
+import type {
+  UseSuspenseInfiniteQueryOptions,
+  UseSuspenseInfiniteQueryResult,
+} from './types'
 
 export function useSuspenseInfiniteQuery<
   TQueryFnData,
@@ -18,19 +23,16 @@ export function useSuspenseInfiniteQuery<
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 >(
-  options: Omit<
-    UseInfiniteQueryOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryFnData,
-      TQueryKey,
-      TPageParam
-    >,
-    'enabled' | 'suspense' | 'throwOnError' | 'placeholderData'
+  options: UseSuspenseInfiniteQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey,
+    TPageParam
   >,
   queryClient?: QueryClient,
-): Omit<DefinedUseInfiniteQueryResult<TData, TError>, 'isPlaceholderData'> {
+): UseSuspenseInfiniteQueryResult<TData, TError> {
   return useBaseQuery(
     {
       ...options,
@@ -41,5 +43,5 @@ export function useSuspenseInfiniteQuery<
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     InfiniteQueryObserver as typeof QueryObserver,
     queryClient,
-  ) as DefinedUseInfiniteQueryResult<TData, TError>
+  ) as InfiniteQueryObserverSuccessResult<TData, TError>
 }


### PR DESCRIPTION
related with https://github.com/TanStack/query/pull/5739

# Add types for useSuspenseInfiniteQuery like useSuspenseQuery
1. UseSuspenseInfiniteQueryOptions
2. UseSuspenseInfiniteQueryResult