### PR TITLE
fix: Update solid dependencies

### DIFF
--- a/examples/solid/basic-graphql-request/package.json
+++ b/examples/solid/basic-graphql-request/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-query": "^5.0.0-alpha.81",
     "graphql": "^16.6.0",
     "graphql-request": "^6.1.0",
-    "solid-js": "^1.6.13"
+    "solid-js": "^1.7.8"
   },
   "devDependencies": {
     "typescript": "^5.0.4",

--- a/examples/solid/basic-graphql-request/package.json
+++ b/examples/solid/basic-graphql-request/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "typescript": "^5.0.4",
     "vite": "^4.4.4",
-    "vite-plugin-solid": "^2.5.0"
+    "vite-plugin-solid": "^2.7.0"
   }
 }

--- a/examples/solid/basic-typescript/package.json
+++ b/examples/solid/basic-typescript/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {
     "typescript": "^5.0.4",
     "vite": "^4.4.4",
-    "vite-plugin-solid": "^2.5.0"
+    "vite-plugin-solid": "^2.7.0"
   }
 }

--- a/examples/solid/basic-typescript/package.json
+++ b/examples/solid/basic-typescript/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@tanstack/solid-query": "^5.0.0-alpha.81",
-    "solid-js": "^1.6.13"
+    "solid-js": "^1.7.8"
   },
   "devDependencies": {
     "typescript": "^5.0.4",

--- a/examples/solid/default-query-function/package.json
+++ b/examples/solid/default-query-function/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {
     "typescript": "^5.0.4",
     "vite": "^4.4.4",
-    "vite-plugin-solid": "^2.5.0"
+    "vite-plugin-solid": "^2.7.0"
   }
 }

--- a/examples/solid/default-query-function/package.json
+++ b/examples/solid/default-query-function/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@tanstack/solid-query": "^5.0.0-alpha.81",
-    "solid-js": "^1.6.13"
+    "solid-js": "^1.7.8"
   },
   "devDependencies": {
     "typescript": "^5.0.4",

--- a/examples/solid/simple/package.json
+++ b/examples/solid/simple/package.json
@@ -16,6 +16,6 @@
     "@tanstack/eslint-plugin-query": "^5.0.0-alpha.74",
     "typescript": "^5.0.4",
     "vite": "^4.4.4",
-    "vite-plugin-solid": "^2.5.0"
+    "vite-plugin-solid": "^2.7.0"
   }
 }

--- a/examples/solid/simple/package.json
+++ b/examples/solid/simple/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@tanstack/solid-query": "^5.0.0-alpha.81",
-    "solid-js": "^1.6.13"
+    "solid-js": "^1.7.8"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.0.0-alpha.74",

--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -11,7 +11,7 @@
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.7.0",
     "@tanstack/solid-query": "^5.0.0-alpha.81",
-    "solid-js": "^1.6.13",
+    "solid-js": "^1.7.8",
     "solid-start": "^0.2.23",
     "undici": "^5.22.1"
   },

--- a/integrations/solid-vite/package.json
+++ b/integrations/solid-vite/package.json
@@ -9,6 +9,6 @@
     "@tanstack/solid-query": "workspace:*",
     "solid-js": "^1.7.8",
     "vite": "^4.4.4",
-    "vite-plugin-solid": "^2.5.0"
+    "vite-plugin-solid": "^2.7.0"
   }
 }

--- a/integrations/solid-vite/package.json
+++ b/integrations/solid-vite/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@tanstack/solid-query": "workspace:*",
-    "solid-js": "^1.6.13",
+    "solid-js": "^1.7.8",
     "vite": "^4.4.4",
     "vite-plugin-solid": "^2.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.1",
     "semver": "^7.5.1",
-    "solid-js": "^1.6.13",
+    "solid-js": "^1.7.8",
     "stream-to-array": "^2.3.0",
     "tsup": "^7.1.0",
     "type-fest": "^3.13.0",

--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -57,6 +57,6 @@
     "solid-transition-group": "^0.2.2",
     "superjson": "^1.12.4",
     "tsup-preset-solid": "^2.0.1",
-    "vite-plugin-solid": "^2.5.0"
+    "vite-plugin-solid": "^2.7.0"
   }
 }

--- a/packages/query-devtools/tsup.config.js
+++ b/packages/query-devtools/tsup.config.js
@@ -13,8 +13,8 @@ const preset_options = {
 }
 
 export default defineConfig(() => {
-  const parsed_options = parsePresetOptions(preset_options)
-  const tsup_options = generateTsupOptions(parsed_options)
+  const parsed_data = parsePresetOptions(preset_options)
+  const tsup_options = generateTsupOptions(parsed_data)
 
   tsup_options.forEach((tsup_option) => {
     tsup_option.outDir = 'build'

--- a/packages/query-devtools/tsup.config.js
+++ b/packages/query-devtools/tsup.config.js
@@ -1,28 +1,20 @@
 // @ts-check
 
 import { defineConfig } from 'tsup'
-import * as preset from 'tsup-preset-solid'
+import { generateTsupOptions, parsePresetOptions } from 'tsup-preset-solid'
 
 const preset_options = {
-  // array or single object
-  entries: [
-    // default entry (index)
-    {
-      // entries with '.tsx' extension will have `solid` export condition generated
-      entry: 'src/index.tsx',
-      // will generate a separate development entry
-      dev_entry: true,
-    },
-  ],
-  // Set to `true` to remove all `console.*` calls and `debugger` statements in prod builds
-  drop_console: true,
-  // Set to `true` to generate a CommonJS build alongside ESM
+  entries: {
+    entry: 'src/index.tsx',
+    dev_entry: true,
+  },
   cjs: true,
+  drop_console: true,
 }
 
 export default defineConfig(() => {
-  const parsed_options = preset.parsePresetOptions(preset_options)
-  const tsup_options = preset.generateTsupOptions(parsed_options)
+  const parsed_options = parsePresetOptions(preset_options)
+  const tsup_options = generateTsupOptions(parsed_options)
 
   tsup_options.forEach((tsup_option) => {
     tsup_option.outDir = 'build'

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "tsup-preset-solid": "^2.0.1",
-    "vite-plugin-solid": "^2.5.0"
+    "vite-plugin-solid": "^2.7.0"
   },
   "peerDependencies": {
     "solid-js": "^1.6.0"

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -50,13 +50,14 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/query-core": "workspace:*"
+    "@tanstack/query-core": "workspace:*",
+    "solid-js": "^1.7.8"
   },
   "devDependencies": {
-    "tsup-preset-solid": "^0.1.8",
+    "tsup-preset-solid": "^2.0.1",
     "vite-plugin-solid": "^2.5.0"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.13"
+    "solid-js": "^1.6.0"
   }
 }

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -16,22 +16,24 @@
   "types": "./build/index.d.ts",
   "browser": {},
   "exports": {
-    "solid": {
-      "development": "./build/dev.js",
-      "import": "./build/index.js"
-    },
     "development": {
       "import": {
         "types": "./build/index.d.ts",
         "default": "./build/dev.js"
       },
-      "require": "./build/dev.cjs"
+      "require": {
+        "types": "./build/index.d.cts",
+        "default": "./build/dev.cjs"
+      }
     },
     "import": {
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
-    "require": "./build/index.cjs"
+    "require": {
+      "types": "./build/index.d.cts",
+      "default": "./build/index.cjs"
+    }
   },
   "sideEffects": [
     "./src/setBatchUpdatesFn.ts"

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1452,7 +1452,7 @@ describe('createQuery', () => {
       return (
         <div>
           <h1>
-            data: {state.data}, count: {count}, isFetching:{' '}
+            data: {state.data}, count: {count()}, isFetching:{' '}
             {String(state.isFetching)}
           </h1>
           <button onClick={() => setCount(1)}>inc</button>
@@ -4265,7 +4265,7 @@ describe('createQuery', () => {
       return (
         <div>
           <h2>Data: {JSON.stringify(state.data)}</h2>
-          <h2>forceValue: {forceValue}</h2>
+          <h2>forceValue: {forceValue()}</h2>
           <button onClick={forceUpdate}>forceUpdate</button>
         </div>
       )
@@ -4320,7 +4320,7 @@ describe('createQuery', () => {
       return (
         <div>
           <h2>Data: {JSON.stringify(state.data)}</h2>
-          <h2>forceValue: {forceValue}</h2>
+          <h2>forceValue: {forceValue()}</h2>
           <button onClick={forceUpdate}>forceUpdate</button>
         </div>
       )

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -239,7 +239,7 @@ describe('useIsFetching', () => {
 
       return (
         <div>
-          <div>isFetching: {isFetching}</div>
+          <div>isFetching: {isFetching()}</div>
         </div>
       )
     }

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -175,7 +175,7 @@ describe('useIsMutating', () => {
       })
       return (
         <div>
-          <div>mutating: {isMutating}</div>
+          <div>mutating: {isMutating()}</div>
         </div>
       )
     }

--- a/packages/solid-query/tsup.config.js
+++ b/packages/solid-query/tsup.config.js
@@ -1,18 +1,24 @@
 // @ts-check
 
-import { defineConfig } from 'tsup-preset-solid'
+import { defineConfig } from 'tsup'
+import { generateTsupOptions, parsePresetOptions } from 'tsup-preset-solid'
 
-export default defineConfig(
-  {
+const preset_options = {
+  entries: {
     entry: 'src/index.ts',
-    devEntry: true,
+    dev_entry: true,
   },
-  {
-    dropConsole: true,
-    cjs: true,
-    tsupOptions: (config) => ({
-      ...config,
-      outDir: 'build',
-    }),
-  },
-)
+  cjs: true,
+  drop_console: true,
+}
+
+export default defineConfig(() => {
+  const parsed_options = parsePresetOptions(preset_options)
+  const tsup_options = generateTsupOptions(parsed_options)
+
+  tsup_options.forEach((tsup_option) => {
+    tsup_option.outDir = 'build'
+  })
+
+  return tsup_options
+})

--- a/packages/solid-query/tsup.config.js
+++ b/packages/solid-query/tsup.config.js
@@ -13,8 +13,8 @@ const preset_options = {
 }
 
 export default defineConfig(() => {
-  const parsed_options = parsePresetOptions(preset_options)
-  const tsup_options = generateTsupOptions(parsed_options)
+  const parsed_data = parsePresetOptions(preset_options)
+  const tsup_options = generateTsupOptions(parsed_data)
 
   tsup_options.forEach((tsup_option) => {
     tsup_option.outDir = 'build'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 17.6.5
       '@solidjs/testing-library':
         specifier: ^0.5.1
-        version: 0.5.1(solid-js@1.6.13)
+        version: 0.5.1(solid-js@1.7.8)
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -151,8 +151,8 @@ importers:
         specifier: ^7.5.1
         version: 7.5.1
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
       stream-to-array:
         specifier: ^2.3.0
         version: 2.3.0
@@ -904,8 +904,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(graphql@16.6.0)
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
     devDependencies:
       typescript:
         specifier: ^5.0.4
@@ -915,7 +915,7 @@ importers:
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
         specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.6.13)(vite@4.4.4)
+        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/basic-typescript:
     dependencies:
@@ -923,8 +923,8 @@ importers:
         specifier: ^5.0.0-alpha.81
         version: link:../../../packages/solid-query
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
     devDependencies:
       typescript:
         specifier: ^5.0.4
@@ -934,7 +934,7 @@ importers:
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
         specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.6.13)(vite@4.4.4)
+        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/default-query-function:
     dependencies:
@@ -942,8 +942,8 @@ importers:
         specifier: ^5.0.0-alpha.81
         version: link:../../../packages/solid-query
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
     devDependencies:
       typescript:
         specifier: ^5.0.4
@@ -953,7 +953,7 @@ importers:
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
         specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.6.13)(vite@4.4.4)
+        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/simple:
     dependencies:
@@ -961,8 +961,8 @@ importers:
         specifier: ^5.0.0-alpha.81
         version: link:../../../packages/solid-query
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
     devDependencies:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.0.0-alpha.74
@@ -975,25 +975,25 @@ importers:
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
         specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.6.13)(vite@4.4.4)
+        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/solid-start-streaming:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.28.2
-        version: 0.28.2(solid-js@1.6.13)
+        version: 0.28.2(solid-js@1.7.8)
       '@solidjs/router':
         specifier: ^0.7.0
-        version: 0.7.0(solid-js@1.6.13)
+        version: 0.7.0(solid-js@1.7.8)
       '@tanstack/solid-query':
         specifier: ^5.0.0-alpha.81
         version: link:../../../packages/solid-query
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
       solid-start:
         specifier: ^0.2.23
-        version: 0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.6.13)(solid-start-node@0.2.0)(vite@4.4.4)
+        version: 0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.7.8)(solid-start-node@0.2.0)(vite@4.4.4)
       undici:
         specifier: ^5.22.1
         version: 5.22.1
@@ -1400,14 +1400,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/solid-query
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
       vite:
         specifier: ^4.4.4
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
         specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.6.13)(vite@4.4.4)
+        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
 
   integrations/svelte-vite:
     devDependencies:
@@ -1634,15 +1634,15 @@ importers:
         specifier: workspace:*
         version: link:../query-core
       solid-js:
-        specifier: ^1.6.13
-        version: 1.6.13
+        specifier: ^1.7.8
+        version: 1.7.8
     devDependencies:
       tsup-preset-solid:
-        specifier: ^0.1.8
-        version: 0.1.8(esbuild@0.18.13)(solid-js@1.6.13)(tsup@6.7.0)
+        specifier: ^2.0.1
+        version: 2.0.1(esbuild@0.18.13)(solid-js@1.7.8)(tsup@7.1.0)
       vite-plugin-solid:
         specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.6.13)(vite@4.4.4)
+        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
 
   packages/svelte-query:
     dependencies:
@@ -5046,30 +5046,12 @@ packages:
   /@emotion/weak-memoize@0.3.1:
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
-  /@esbuild/android-arm64@0.17.19:
-    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm64@0.18.13:
     resolution: {integrity: sha512-j7NhycJUoUAG5kAzGf4fPWfd17N6SM3o1X6MlXVqfHvs2buFraCJzos9vbeWjLxOyBKHyPOnuCuipbhvbYtTAg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/android-arm@0.17.19:
-    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.18.13:
@@ -5080,30 +5062,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-x64@0.17.19:
-    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-x64@0.18.13:
     resolution: {integrity: sha512-M2eZkRxR6WnWfVELHmv6MUoHbOqnzoTVSIxgtsyhm/NsgmL+uTmag/VVzdXvmahak1I6sOb1K/2movco5ikDJg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.17.19:
-    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.18.13:
@@ -5114,30 +5078,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.19:
-    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/darwin-x64@0.18.13:
     resolution: {integrity: sha512-RIrxoKH5Eo+yE5BtaAIMZaiKutPhZjw+j0OCh8WdvKEKJQteacq0myZvBDLU+hOzQOZWJeDnuQ2xgSScKf1Ovw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.17.19:
-    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.13:
@@ -5148,30 +5094,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.19:
-    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/freebsd-x64@0.18.13:
     resolution: {integrity: sha512-pGzWWZJBInhIgdEwzn8VHUBang8UvFKsvjDkeJ2oyY5gZtAM6BaxK0QLCuZY+qoj/nx/lIaItH425rm/hloETA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.17.19:
-    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.18.13:
@@ -5182,30 +5110,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.19:
-    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-arm@0.18.13:
     resolution: {integrity: sha512-4iMxLRMCxGyk7lEvkkvrxw4aJeC93YIIrfbBlUJ062kilUUnAiMb81eEkVvCVoh3ON283ans7+OQkuy1uHW+Hw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.17.19:
-    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.18.13:
@@ -5224,30 +5134,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.19:
-    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-loong64@0.18.13:
     resolution: {integrity: sha512-8pcKDApAsKc6WW51ZEVidSGwGbebYw2qKnO1VyD8xd6JN0RN6EUXfhXmDk9Vc4/U3Y4AoFTexQewQDJGsBXBpg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.17.19:
-    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.18.13:
@@ -5258,30 +5150,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.19:
-    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-ppc64@0.18.13:
     resolution: {integrity: sha512-pfn/OGZ8tyR8YCV7MlLl5hAit2cmS+j/ZZg9DdH0uxdCoJpV7+5DbuXrR+es4ayRVKIcfS9TTMCs60vqQDmh+w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.17.19:
-    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.18.13:
@@ -5292,30 +5166,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.19:
-    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-s390x@0.18.13:
     resolution: {integrity: sha512-Pct1QwF2sp+5LVi4Iu5Y+6JsGaV2Z2vm4O9Dd7XZ5tKYxEHjFtb140fiMcl5HM1iuv6xXO8O1Vrb1iJxHlv8UA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-x64@0.17.19:
-    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.18.13:
@@ -5326,30 +5182,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.19:
-    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/netbsd-x64@0.18.13:
     resolution: {integrity: sha512-I6zs10TZeaHDYoGxENuksxE1sxqZpCp+agYeW039yqFwh3MgVvdmXL5NMveImOC6AtpLvE4xG5ujVic4NWFIDQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.17.19:
-    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.18.13:
@@ -5360,30 +5198,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.19:
-    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/sunos-x64@0.18.13:
     resolution: {integrity: sha512-X/xzuw4Hzpo/yq3YsfBbIsipNgmsm8mE/QeWbdGdTTeZ77fjxI2K0KP3AlhZ6gU3zKTw1bKoZTuKLnqcJ537qw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.17.19:
-    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.18.13:
@@ -5394,30 +5214,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.19:
-    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-ia32@0.18.13:
     resolution: {integrity: sha512-D+wKZaRhQI+MUGMH+DbEr4owC2D7XnF+uyGiZk38QbgzLcofFqIOwFs7ELmIeU45CQgfHNy9Q+LKW3cE8g37Kg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-x64@0.17.19:
-    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.18.13:
@@ -7766,28 +7568,28 @@ packages:
       solid-js: 1.7.8
     dev: true
 
-  /@solidjs/meta@0.28.2(solid-js@1.6.13):
+  /@solidjs/meta@0.28.2(solid-js@1.7.8):
     resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
-      solid-js: 1.6.13
+      solid-js: 1.7.8
 
-  /@solidjs/router@0.7.0(solid-js@1.6.13):
+  /@solidjs/router@0.7.0(solid-js@1.7.8):
     resolution: {integrity: sha512-8HI84twe5FjYRebSLMAhtkL9bRuTDIlxJK56kjfjU9WKGoUCTaWpCnkuj8Hqde1bWZ0X+GOZxKDfNkn1CjtjxA==}
     peerDependencies:
       solid-js: ^1.5.3
     dependencies:
-      solid-js: 1.6.13
+      solid-js: 1.7.8
 
-  /@solidjs/testing-library@0.5.1(solid-js@1.6.13):
+  /@solidjs/testing-library@0.5.1(solid-js@1.7.8):
     resolution: {integrity: sha512-UVwYzSTRHwxiW7jdgKFP3NERbMtA748MIOQFzF1f4tg1XYl8ACybwlrVPqaiKnPevUCcM2ED+Wsp6Yd5JA//yg==}
     engines: {node: '>= 14'}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
       '@testing-library/dom': 8.20.1
-      solid-js: 1.6.13
+      solid-js: 1.7.8
     dev: true
 
   /@surma/rollup-plugin-off-main-thread@1.4.2:
@@ -11257,16 +11059,6 @@ packages:
     dependencies:
       run-applescript: 5.0.0
 
-  /bundle-require@4.0.1(esbuild@0.17.19):
-    resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.17'
-    dependencies:
-      esbuild: 0.17.19
-      load-tsconfig: 0.2.3
-    dev: true
-
   /bundle-require@4.0.1(esbuild@0.18.13):
     resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -13627,7 +13419,7 @@ packages:
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /esbuild-plugin-solid@0.4.2(esbuild@0.14.54)(solid-js@1.6.13):
+  /esbuild-plugin-solid@0.4.2(esbuild@0.14.54)(solid-js@1.7.8):
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -13637,24 +13429,9 @@ packages:
       '@babel/preset-typescript': 7.21.5(@babel/core@7.22.9)
       babel-preset-solid: 1.7.7(@babel/core@7.22.9)
       esbuild: 0.14.54
-      solid-js: 1.6.13
+      solid-js: 1.7.8
     transitivePeerDependencies:
       - supports-color
-
-  /esbuild-plugin-solid@0.5.0(esbuild@0.18.13)(solid-js@1.6.13):
-    resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
-    peerDependencies:
-      esbuild: '>=0.12'
-      solid-js: '>= 1.0'
-    dependencies:
-      '@babel/core': 7.22.9
-      '@babel/preset-typescript': 7.21.5(@babel/core@7.22.9)
-      babel-preset-solid: 1.7.7(@babel/core@7.22.9)
-      esbuild: 0.18.13
-      solid-js: 1.6.13
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /esbuild-plugin-solid@0.5.0(esbuild@0.18.13)(solid-js@1.7.8):
     resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
@@ -13730,36 +13507,6 @@ packages:
       esbuild-windows-32: 0.14.54
       esbuild-windows-64: 0.14.54
       esbuild-windows-arm64: 0.14.54
-
-  /esbuild@0.17.19:
-    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.17.19
-      '@esbuild/android-arm64': 0.17.19
-      '@esbuild/android-x64': 0.17.19
-      '@esbuild/darwin-arm64': 0.17.19
-      '@esbuild/darwin-x64': 0.17.19
-      '@esbuild/freebsd-arm64': 0.17.19
-      '@esbuild/freebsd-x64': 0.17.19
-      '@esbuild/linux-arm': 0.17.19
-      '@esbuild/linux-arm64': 0.17.19
-      '@esbuild/linux-ia32': 0.17.19
-      '@esbuild/linux-loong64': 0.17.19
-      '@esbuild/linux-mips64el': 0.17.19
-      '@esbuild/linux-ppc64': 0.17.19
-      '@esbuild/linux-riscv64': 0.17.19
-      '@esbuild/linux-s390x': 0.17.19
-      '@esbuild/linux-x64': 0.17.19
-      '@esbuild/netbsd-x64': 0.17.19
-      '@esbuild/openbsd-x64': 0.17.19
-      '@esbuild/sunos-x64': 0.17.19
-      '@esbuild/win32-arm64': 0.17.19
-      '@esbuild/win32-ia32': 0.17.19
-      '@esbuild/win32-x64': 0.17.19
-    dev: true
 
   /esbuild@0.18.13:
     resolution: {integrity: sha512-vhg/WR/Oiu4oUIkVhmfcc23G6/zWuEQKFS+yiosSHe4aN6+DQRXIfeloYGibIfVhkr4wyfuVsGNLr+sQU1rWWw==}
@@ -25050,7 +24797,6 @@ packages:
   /seroval@0.5.1:
     resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
     engines: {node: '>=10'}
-    dev: true
 
   /serve-index@1.9.1(supports-color@6.1.0):
     resolution: {integrity: sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==}
@@ -25302,27 +25048,11 @@ packages:
       websocket-driver: 0.7.4
     dev: false
 
-  /solid-js@1.6.13:
-    resolution: {integrity: sha512-/zcyeect3QnmcD58754IpOU/SzX3s9N19RlRVoKRz3tNpzvel7QKO4FX/PpIFQH6n/pxWq6rSh6b9fwe20XUvw==}
-    dependencies:
-      csstype: 3.1.0
-
   /solid-js@1.7.8:
     resolution: {integrity: sha512-XHBWk1FvFd0JMKljko7FfhefJMTSgYEuVKcQ2a8hzRXfiuSJAGsrPPafqEo+f6l+e8Oe3cROSpIL6kbzjC1fjQ==}
     dependencies:
       csstype: 3.1.2
       seroval: 0.5.1
-    dev: true
-
-  /solid-refresh@0.4.1(solid-js@1.6.13):
-    resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
-    peerDependencies:
-      solid-js: ^1.3
-    dependencies:
-      '@babel/generator': 7.22.9
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/types': 7.22.5
-      solid-js: 1.6.13
 
   /solid-refresh@0.4.1(solid-js@1.7.8):
     resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
@@ -25333,9 +25063,8 @@ packages:
       '@babel/helper-module-imports': 7.22.5
       '@babel/types': 7.22.5
       solid-js: 1.7.8
-    dev: true
 
-  /solid-refresh@0.5.3(solid-js@1.6.13):
+  /solid-refresh@0.5.3(solid-js@1.7.8):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
       solid-js: ^1.3
@@ -25343,7 +25072,7 @@ packages:
       '@babel/generator': 7.22.9
       '@babel/helper-module-imports': 7.22.5
       '@babel/types': 7.22.5
-      solid-js: 1.6.13
+      solid-js: 1.7.8
 
   /solid-start-node@0.2.0(solid-start@0.2.23)(undici@5.22.1)(vite@4.4.4):
     resolution: {integrity: sha512-PBGm9HkzKrVf0cl3V2ViWmy51GgbrA1tklDAqbbMvhO7Dhh0TnkVRoySgJuahln9nX+1yoJw+uJST3+s0leQ9w==}
@@ -25359,14 +25088,14 @@ packages:
       polka: 1.0.0-next.22
       rollup: 2.79.1
       sirv: 2.0.2
-      solid-start: 0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.6.13)(solid-start-node@0.2.0)(vite@4.4.4)
+      solid-start: 0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.7.8)(solid-start-node@0.2.0)(vite@4.4.4)
       terser: 5.18.1
       undici: 5.22.1
       vite: 4.4.4(@types/node@18.16.0)
     transitivePeerDependencies:
       - supports-color
 
-  /solid-start@0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.6.13)(solid-start-node@0.2.0)(vite@4.4.4):
+  /solid-start@0.2.23(@solidjs/meta@0.28.2)(@solidjs/router@0.7.0)(solid-js@1.7.8)(solid-start-node@0.2.0)(vite@4.4.4):
     resolution: {integrity: sha512-dKTRFtpjskHFyLq9n6oJxqWHYL7H8w14y4+OgIR+57+lqb1N7289kZLTHrzWxWyzDkIG9V1s2MQtiDfIaBP/MQ==}
     hasBin: true
     peerDependencies:
@@ -25406,8 +25135,8 @@ packages:
       '@babel/preset-env': 7.21.5(@babel/core@7.21.8)
       '@babel/preset-typescript': 7.21.5(@babel/core@7.21.8)
       '@babel/template': 7.22.5
-      '@solidjs/meta': 0.28.2(solid-js@1.6.13)
-      '@solidjs/router': 0.7.0(solid-js@1.6.13)
+      '@solidjs/meta': 0.28.2(solid-js@1.7.8)
+      '@solidjs/router': 0.7.0(solid-js@1.7.8)
       '@types/cookie': 0.5.1
       chokidar: 3.5.3
       compression: 1.7.4(supports-color@6.1.0)
@@ -25417,7 +25146,7 @@ packages:
       dotenv: 16.3.1
       es-module-lexer: 1.3.0
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2(esbuild@0.14.54)(solid-js@1.6.13)
+      esbuild-plugin-solid: 0.4.2(esbuild@0.14.54)(solid-js@1.7.8)
       fast-glob: 3.2.12
       get-port: 6.1.2
       parse-multipart-data: 1.5.0
@@ -25428,13 +25157,13 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.5.1
       sirv: 2.0.2
-      solid-js: 1.6.13
+      solid-js: 1.7.8
       solid-start-node: 0.2.0(solid-start@0.2.23)(undici@5.22.1)(vite@4.4.4)
       terser: 5.18.1
       undici: 5.22.1
       vite: 4.4.4(@types/node@18.16.0)
       vite-plugin-inspect: 0.7.29(rollup@3.26.0)(vite@4.4.4)
-      vite-plugin-solid: 2.7.0(solid-js@1.6.13)(vite@4.4.4)
+      vite-plugin-solid: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
       wait-on: 6.0.1(debug@4.3.4)
     transitivePeerDependencies:
       - supports-color
@@ -26778,20 +26507,6 @@ packages:
   /tslib@2.5.2:
     resolution: {integrity: sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==}
 
-  /tsup-preset-solid@0.1.8(esbuild@0.18.13)(solid-js@1.6.13)(tsup@6.7.0):
-    resolution: {integrity: sha512-V5TZFEZY9emACO3AZvKyCRzdoyjUcuMEEbTGcJnCma7OVvGnSNVoewFff9g0CaveJ8cZcC3u2tW9gMaxmPZ71A==}
-    peerDependencies:
-      tsup: ^6.5.0
-    dependencies:
-      esbuild-plugin-solid: 0.5.0(esbuild@0.18.13)(solid-js@1.6.13)
-      tsup: 6.7.0(typescript@5.0.4)
-      type-fest: 3.13.0
-    transitivePeerDependencies:
-      - esbuild
-      - solid-js
-      - supports-color
-    dev: true
-
   /tsup-preset-solid@2.0.1(esbuild@0.18.13)(solid-js@1.7.8)(tsup@7.1.0):
     resolution: {integrity: sha512-gN0nD2h4909XvpMnSuqgeiKqv+Ao7Y0d1p4VuF0hnQvazBTXrFHX2ImULG4uCsvU73q2zzoDzk5Ei6iACQmk5w==}
     peerDependencies:
@@ -26803,42 +26518,6 @@ packages:
       - esbuild
       - solid-js
       - supports-color
-    dev: true
-
-  /tsup@6.7.0(typescript@5.0.4):
-    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.17.19)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4(supports-color@6.1.0)
-      esbuild: 0.17.19
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4(postcss@8.4.23)
-      resolve-from: 5.0.0
-      rollup: 3.26.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.32.0
-      tree-kill: 1.2.2
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
     dev: true
 
   /tsup@7.1.0(typescript@5.0.4):
@@ -27395,23 +27074,6 @@ packages:
       - rollup
       - supports-color
 
-  /vite-plugin-solid@2.5.0(solid-js@1.6.13)(vite@4.4.4):
-    resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
-    peerDependencies:
-      solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
-      vite: ^3.0.0 || ^4.0.0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/preset-typescript': 7.21.5(@babel/core@7.21.8)
-      babel-preset-solid: 1.6.10(@babel/core@7.21.8)
-      merge-anything: 5.1.7
-      solid-js: 1.6.13
-      solid-refresh: 0.4.1(solid-js@1.6.13)
-      vite: 4.4.4(@types/node@18.16.0)
-      vitefu: 0.2.4(vite@4.4.4)
-    transitivePeerDependencies:
-      - supports-color
-
   /vite-plugin-solid@2.5.0(solid-js@1.7.8)(vite@4.4.4):
     resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
     peerDependencies:
@@ -27428,9 +27090,8 @@ packages:
       vitefu: 0.2.4(vite@4.4.4)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /vite-plugin-solid@2.7.0(solid-js@1.6.13)(vite@4.4.4):
+  /vite-plugin-solid@2.7.0(solid-js@1.7.8)(vite@4.4.4):
     resolution: {integrity: sha512-avp/Jl5zOp/Itfo67xtDB2O61U7idviaIp4mLsjhCa13PjKNasz+IID0jYTyqUp9SFx6/PmBr6v4KgDppqompg==}
     peerDependencies:
       solid-js: ^1.7.2
@@ -27441,8 +27102,8 @@ packages:
       '@types/babel__core': 7.20.1
       babel-preset-solid: 1.7.7(@babel/core@7.22.9)
       merge-anything: 5.1.7
-      solid-js: 1.6.13
-      solid-refresh: 0.5.3(solid-js@1.6.13)
+      solid-js: 1.7.8
+      solid-refresh: 0.5.3(solid-js@1.7.8)
       vite: 4.4.4(@types/node@18.16.0)
       vitefu: 0.2.4(vite@4.4.4)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -914,8 +914,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
-        specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/basic-typescript:
     dependencies:
@@ -933,8 +933,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
-        specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/default-query-function:
     dependencies:
@@ -952,8 +952,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
-        specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/simple:
     dependencies:
@@ -974,8 +974,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
-        specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
 
   examples/solid/solid-start-streaming:
     dependencies:
@@ -1406,8 +1406,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4(@types/node@18.16.0)
       vite-plugin-solid:
-        specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
 
   integrations/svelte-vite:
     devDependencies:
@@ -1511,8 +1511,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(esbuild@0.18.13)(solid-js@1.7.8)(tsup@7.1.0)
       vite-plugin-solid:
-        specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
 
   packages/query-persist-client-core:
     dependencies:
@@ -1641,8 +1641,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(esbuild@0.18.13)(solid-js@1.7.8)(tsup@7.1.0)
       vite-plugin-solid:
-        specifier: ^2.5.0
-        version: 2.5.0(solid-js@1.7.8)(vite@4.4.4)
+        specifier: ^2.7.0
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
 
   packages/svelte-query:
     dependencies:
@@ -10219,18 +10219,6 @@ packages:
       '@types/babel__traverse': 7.17.1
     dev: false
 
-  /babel-plugin-jsx-dom-expressions@0.35.23(@babel/core@7.21.8):
-    resolution: {integrity: sha512-KaBiZPm2riB5jyRUy5BVaz8TkKcyAx2frePOG2lj5vbYsBpZHIknQkUU/csWr+EeV75h/mRHIOzLo2mX4Dxq3g==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.21.8)
-      '@babel/types': 7.22.5
-      html-entities: 2.3.3
-      validate-html-nesting: 1.2.2
-
   /babel-plugin-jsx-dom-expressions@0.36.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-QA2k/14WGw+RgcGGnEuLWwnu4em6CGhjeXtjvgOYyFHYS2a+CzPeaVQHDOlfuiBcjq/3hWMspHMIMnPEOIzdBg==}
     peerDependencies:
@@ -10658,14 +10646,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /babel-preset-solid@1.6.10(@babel/core@7.21.8):
-    resolution: {integrity: sha512-qBLjzeWmgY5jX11sJg/lriXABYdClfJrJJrIHaT6G5EuGhxhm6jn7XjqXjLBZHBgy5n/Z+iqJ5YfQj8KG2jKTA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.21.8
-      babel-plugin-jsx-dom-expressions: 0.35.23(@babel/core@7.21.8)
 
   /babel-preset-solid@1.7.7(@babel/core@7.22.9):
     resolution: {integrity: sha512-tdxVzx3kgcIjNXAOmGRbzIhFBPeJjSakiN9yM+IYdL/+LtXNnbGqb0Va5tJb8Sjbk+QVEriovCyuzB5T7jeTvg==}
@@ -25054,16 +25034,6 @@ packages:
       csstype: 3.1.2
       seroval: 0.5.1
 
-  /solid-refresh@0.4.1(solid-js@1.7.8):
-    resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
-    peerDependencies:
-      solid-js: ^1.3
-    dependencies:
-      '@babel/generator': 7.22.9
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/types': 7.22.5
-      solid-js: 1.7.8
-
   /solid-refresh@0.5.3(solid-js@1.7.8):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
@@ -27072,23 +27042,6 @@ packages:
       vite: 4.4.4(@types/node@18.16.0)
     transitivePeerDependencies:
       - rollup
-      - supports-color
-
-  /vite-plugin-solid@2.5.0(solid-js@1.7.8)(vite@4.4.4):
-    resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
-    peerDependencies:
-      solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
-      vite: ^3.0.0 || ^4.0.0
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/preset-typescript': 7.21.5(@babel/core@7.21.8)
-      babel-preset-solid: 1.6.10(@babel/core@7.21.8)
-      merge-anything: 5.1.7
-      solid-js: 1.7.8
-      solid-refresh: 0.4.1(solid-js@1.7.8)
-      vite: 4.4.4(@types/node@18.16.0)
-      vitefu: 0.2.4(vite@4.4.4)
-    transitivePeerDependencies:
       - supports-color
 
   /vite-plugin-solid@2.7.0(solid-js@1.7.8)(vite@4.4.4):


### PR DESCRIPTION
- Different versions were installed in solid-query and query-devtools
- This PR updates solid-js, tsup-preset-solid and vite-plugin-solid across all packages
- Removes dependency on esbuild 0.17 (esbuild 0.14 is still there because solid-start depends on it...)