### PR TITLE
fix: codemods build command

### DIFF
--- a/docs/react/guides/migrating-to-v5.md
+++ b/docs/react/guides/migrating-to-v5.md
@@ -108,7 +108,7 @@ If you want to run it against `.js` or `.jsx` files, please use the command belo
 ```
 npx jscodeshift ./path/to/src/ \
   --extensions=js,jsx \
-  --transform=./node_modules/@tanstack/react-query/build/codemods/v5/remove-overloads/remove-overloads.js
+  --transform=./node_modules/@tanstack/react-query/build/codemods/src/v5/remove-overloads/remove-overloads.js
 ```
 
 If you want to run it against `.ts` or `.tsx` files, please use the command below:
@@ -117,7 +117,7 @@ If you want to run it against `.ts` or `.tsx` files, please use the command belo
 npx jscodeshift ./path/to/src/ \
   --extensions=ts,tsx \
   --parser=tsx \
-  --transform=./node_modules/@tanstack/react-query/build/codemods/v5/remove-overloads/remove-overloads.js
+  --transform=./node_modules/@tanstack/react-query/build/codemods/src/v5/remove-overloads/remove-overloads.js
 ```
 
 Please note in the case of `TypeScript` you need to use `tsx` as the parser; otherwise, the codemod won't be applied properly!

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -37,12 +37,13 @@
     "test:build": "publint --strict && attw --pack",
     "build": "pnpm build:tsup && pnpm build:codemods",
     "build:tsup": "tsup",
-    "build:codemods": "cpy ../codemods/src/**/* ./build/codemods"
+    "build:codemods": "cpy ../codemods/* ./build/codemods"
   },
   "files": [
     "build",
     "src",
-    "!build/codemods/jest.config.js",
+    "!build/codemods/node_modules",
+    "!build/codemods/vitest.config.ts",
     "!build/codemods/**/__testfixtures__",
     "!build/codemods/**/__tests__"
   ],


### PR DESCRIPTION
This fixes a few issues I had when trying out the new v5 codemods.

The whole codemods package needs to be copied because:
- package.json `"type": "commonjs"` is needed so codemods are interpreted as cjs.
- _src/utils/_ was not copied before but is required by `remove-overloads.js` for example