### PR TITLE
fix: Add missing peer dependencies

### DIFF
--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -52,6 +52,8 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "workspace:*"
+    "@tanstack/react-query": "workspace:*",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }


### PR DESCRIPTION
tsup looks at dependencies and peerDependencies (not devDependencies) to determine if a package should be considered external. Since react was missing from peerDeps, it must have interpreted react as an internal module, so it was rewriting imports to "react.js".

Fixes #5777 