### PR TITLE
chore: Exclude react-query/build/codemods from pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,4 @@ packages:
   - 'examples/vue/**'
   - '!examples/vue/2*'
   - '!examples/vue/nuxt*'
+  - '!packages/react-query/build/**'


### PR DESCRIPTION
Fixes issue introduced in #5776 
