### PR TITLE
react ssr streaming example

### DIFF
--- a/examples/react/ssr-streaming/package.json
+++ b/examples/react/ssr-streaming/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tanstack/query-example-ssr-streaming",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite-node src/server.ts -w"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.0.0-beta.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.14",
+    "@vitejs/plugin-react": "^4.0.3",
+    "isbot": "^3.6.5",
+    "vite": "^4.4.7",
+    "vite-node": "~0.30.1",
+    "compression": "^1.7.4",
+    "express": "^4.18.2",
+    "serve-static": "^1.15.0"
+  }
+}

--- a/examples/react/ssr-streaming/src/App.tsx
+++ b/examples/react/ssr-streaming/src/App.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query'
+import { Suspense } from 'react'
+
+export function App() {
+  return (
+    <div className="p-10">
+      <h1 className="font-bold pb-2">App</h1>
+
+      <div>
+        Note that the logs from "waitFn" are only on the server - the queries
+        are not made on the client.
+      </div>
+
+      <div className="py-3">
+        <hr />
+      </div>
+
+      <Suspense fallback={<div>{`outer waiting...`}</div>}>
+        <WaiterInner wait={2000} deferStream />
+
+        <Waiter wait={1000} />
+        <Waiter wait={4000} />
+        <Waiter wait={6000} />
+      </Suspense>
+    </div>
+  )
+}
+
+const Waiter = (props: { wait: number }) => {
+  return (
+    <Suspense fallback={<div>{`waiting ${props.wait}...`}</div>}>
+      <WaiterInner {...props} />
+    </Suspense>
+  )
+}
+
+const WaiterInner = ({
+  wait,
+  deferStream,
+}: {
+  wait: number
+  deferStream?: boolean
+}) => {
+  const query = useQuery({
+    queryKey: ['wait', wait],
+    queryFn: () => waitFn(wait),
+    meta: {
+      deferStream,
+    },
+  })
+
+  return (
+    <div>
+      result: {query.data?.msg}
+      {deferStream ? ' (deferred stream)' : ''}
+    </div>
+  )
+}
+
+const waitFn = async (wait: number) => {
+  console.log(`waitFn for ${wait}ms`)
+
+  await new Promise((r) => setTimeout(r, wait))
+
+  return {
+    msg: `waited ${wait}ms`,
+  }
+}

--- a/examples/react/ssr-streaming/src/Root.tsx
+++ b/examples/react/ssr-streaming/src/Root.tsx
@@ -1,0 +1,17 @@
+import { App } from './App'
+
+export function Root() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Vite App</title>
+        <script src="https://cdn.tailwindcss.com"></script>
+      </head>
+      <body>
+        <App />
+      </body>
+    </html>
+  )
+}

--- a/examples/react/ssr-streaming/src/data-injector.ts
+++ b/examples/react/ssr-streaming/src/data-injector.ts
@@ -1,0 +1,67 @@
+import {
+  DehydrateOptions,
+  HydrateOptions,
+  QueryClient,
+  defaultShouldDehydrateQuery,
+  dehydrate,
+} from '@tanstack/react-query'
+import { injectIntoStream } from './transform-stream'
+
+export const createDataInjector = ({
+  blockingQueries,
+  trackedQueries,
+  queryClient,
+  options,
+  serialize,
+}: {
+  trackedQueries: Set<string>
+  blockingQueries: Map<string, Promise<void>>
+  queryClient: QueryClient
+  options?: {
+    hydrate?: HydrateOptions
+    dehydrate?: DehydrateOptions
+  }
+  serialize?: (object: any) => any
+}) => {
+  return injectIntoStream({
+    emitToDocumentHead() {
+      const html: string[] = [`$TQD = [];`, `$TQS = data => $TQD.push(data);`]
+
+      return `<script>${html.join('')}</script>`
+    },
+
+    async emitBeforeSsrChunk() {
+      // If there are any queries marked with deferStream, block the stream until they are completed
+      if (blockingQueries.size) {
+        await Promise.allSettled(blockingQueries.values())
+        blockingQueries.clear()
+      }
+
+      if (!trackedQueries.size) return ''
+
+      /**
+       * Dehydrated state of the client where we only include the queries that were added/updated since the last flush
+       */
+      const shouldDehydrate =
+        options?.dehydrate?.shouldDehydrateQuery ?? defaultShouldDehydrateQuery
+
+      const dehydratedState = dehydrate(queryClient, {
+        ...options?.dehydrate,
+        shouldDehydrateQuery(query) {
+          return trackedQueries.has(query.queryHash) && shouldDehydrate(query)
+        },
+      })
+      trackedQueries.clear()
+
+      if (!dehydratedState.queries.length) return ''
+
+      const dehydratedString = JSON.stringify(
+        serialize ? serialize(dehydratedState) : dehydratedState,
+      )
+
+      const html: string[] = [`$TQS(${dehydratedString})`]
+
+      return `<script>${html.join('')}</script>`
+    },
+  })
+}

--- a/examples/react/ssr-streaming/src/entry-client.tsx
+++ b/examples/react/ssr-streaming/src/entry-client.tsx
@@ -1,0 +1,17 @@
+import ReactDOM from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
+
+import { Root } from './Root'
+import { createQueryClient } from './query-client'
+
+import { hydrateStreamingData } from './hydrate-streaming-data'
+
+const queryClient = createQueryClient()
+hydrateStreamingData({ queryClient })
+
+ReactDOM.hydrateRoot(
+  document,
+  <QueryClientProvider client={queryClient}>
+    <Root />
+  </QueryClientProvider>,
+)

--- a/examples/react/ssr-streaming/src/entry-server.tsx
+++ b/examples/react/ssr-streaming/src/entry-server.tsx
@@ -1,0 +1,20 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { Root } from './Root'
+import { createQueryClient } from './query-client'
+
+export function render() {
+  /**
+   * Create a new router on every request - cannot share caches on server.
+   */
+  const trackedQueries = new Set<string>()
+  const blockingQueries = new Map<string, Promise<void>>()
+  const queryClient = createQueryClient({ trackedQueries, blockingQueries })
+
+  const app = (
+    <QueryClientProvider client={queryClient}>
+      <Root />
+    </QueryClientProvider>
+  )
+
+  return { app, trackedQueries, blockingQueries, queryClient }
+}

--- a/examples/react/ssr-streaming/src/hydrate-streaming-data.ts
+++ b/examples/react/ssr-streaming/src/hydrate-streaming-data.ts
@@ -1,0 +1,28 @@
+import { DehydratedState, QueryClient, hydrate } from '@tanstack/react-query'
+
+declare global {
+  export let $TQD: DehydratedState[]
+  export let $TQS: (data: DehydratedState) => void
+}
+
+export const hydrateStreamingData = ({
+  queryClient,
+}: {
+  queryClient: QueryClient
+}) => {
+  function hydrateData(data: DehydratedState) {
+    hydrate(queryClient, data)
+  }
+
+  // Insert data that was already streamed before this point
+  // @ts-expect-error
+  ;(globalThis.$TQD ?? []).map(hydrateData)
+
+  // Delete the global variable so that it doesn't get serialized again
+  // @ts-expect-error
+  delete globalThis.$TQD
+
+  // From now on, insert data directly
+  // @ts-expect-error
+  globalThis.$TQS = hydrateData
+}

--- a/examples/react/ssr-streaming/src/query-client.ts
+++ b/examples/react/ssr-streaming/src/query-client.ts
@@ -1,0 +1,63 @@
+import { QueryCache, QueryClient } from '@tanstack/react-query'
+
+type CreateQueryClientOpts = {
+  trackedQueries?: Set<string>
+  blockingQueries?: Map<string, Promise<void>>
+}
+
+export const createQueryClient = ({
+  trackedQueries,
+  blockingQueries,
+}: CreateQueryClientOpts = {}) => {
+  const blockingQueryResolvers = new Map<string, () => void>()
+
+  const queryCache = blockingQueries
+    ? new QueryCache({
+        onSettled(data, error, query) {
+          const blockingQuery = blockingQueryResolvers.get(query.queryHash)
+          if (blockingQuery) {
+            // resolve it
+            blockingQuery()
+          }
+        },
+      })
+    : undefined
+
+  const queryClient: QueryClient = new QueryClient({
+    queryCache,
+    defaultOptions: {
+      queries: {
+        suspense: true,
+        retry: false,
+        staleTime: 1000 * 30,
+        refetchOnReconnect: true,
+        refetchOnWindowFocus: true,
+      },
+    },
+  })
+
+  if (trackedQueries && import.meta.env.SSR) {
+    // Do we need to care about unsubscribing? I don't think so to be honest
+    queryClient.getQueryCache().subscribe((event) => {
+      // console.log('META', event.query.meta);
+      const defer = event.query.meta?.['deferStream']
+
+      switch (event.type) {
+        case 'added':
+        case 'updated':
+          trackedQueries.add(event.query.queryHash)
+
+          if (event.type === 'added' && defer) {
+            blockingQueries?.set(
+              event.query.queryHash,
+              new Promise((r) =>
+                blockingQueryResolvers.set(event.query.queryHash, r),
+              ),
+            )
+          }
+      }
+    })
+  }
+
+  return queryClient
+}

--- a/examples/react/ssr-streaming/src/server.ts
+++ b/examples/react/ssr-streaming/src/server.ts
@@ -1,0 +1,106 @@
+import express from 'express'
+import { renderToReadableStream } from 'react-dom/server'
+import { Readable } from 'node:stream'
+import { createServer as createViteServer } from 'vite'
+
+import { createDataInjector } from './data-injector.js'
+
+export async function createServer(
+  root = process.cwd(),
+  isProd = process.env.NODE_ENV === 'production',
+  hmrPort?: number,
+) {
+  const app = express()
+
+  /**
+   * @type {import('vite').ViteDevServer}
+   */
+  const viteDevServer = await createViteServer({
+    root,
+    logLevel: 'info',
+    appType: 'custom',
+    server: {
+      middlewareMode: true,
+      hmr: {
+        port: hmrPort,
+      },
+      watch: {
+        usePolling: true,
+        interval: 100,
+      },
+    },
+  })
+
+  // use vite's connect instance as middleware
+  app.use(viteDevServer.middlewares)
+
+  app.use('*', async (req, res) => {
+    try {
+      const entry = await (async () => {
+        if (!isProd) {
+          return viteDevServer.ssrLoadModule('/src/entry-server.tsx')
+        } else {
+          // @ts-expect-error ignore
+          return import('./dist/server/entry-server.tsx')
+        }
+      })()
+
+      const {
+        app: reactApp,
+        queryClient,
+        blockingQueries,
+        trackedQueries,
+      } = entry.render()
+
+      const appStream = await renderToReadableStream(reactApp, {
+        bootstrapModules: ['/@vite/client', '/src/entry-client.tsx'],
+        bootstrapScriptContent: [addFastRefreshPreamble()].join('\n'),
+      })
+
+      const injector = createDataInjector({
+        blockingQueries,
+        queryClient,
+        trackedQueries,
+      })
+
+      // @ts-expect-error
+      Readable.fromWeb(appStream.pipeThrough(injector)).pipe(res)
+    } catch (e: any) {
+      !isProd && viteDevServer.ssrFixStacktrace(e)
+      console.log(e.stack)
+      res.status(500).end(e.stack)
+    }
+  })
+
+  return { app, viteDevServer }
+}
+
+const { app, viteDevServer } = await createServer()
+
+const server = app.listen(3000, () => {
+  console.log('Client Server: http://localhost:3000')
+})
+
+if (import.meta.hot) {
+  import.meta.hot.on('vite:beforeFullReload', () => {
+    server.close()
+    return viteDevServer.close()
+  })
+}
+
+const addFastRefreshPreamble = () => {
+  return `
+  var script = document.createElement("script");
+  script.type = "module";
+  script.text = ${JSON.stringify(fastRefreshPreamble)};
+  document.body.appendChild(script);
+`.trim()
+}
+
+const fastRefreshPreamble = `
+import RefreshRuntime from "/@react-refresh"
+RefreshRuntime.injectIntoGlobalHook(window)
+window.$RefreshReg$ = () => {}
+window.$RefreshSig$ = () => (type) => type
+window.__vite_plugin_react_preamble_installed__ = true
+`.trim()

--- a/examples/react/ssr-streaming/src/transform-stream.ts
+++ b/examples/react/ssr-streaming/src/transform-stream.ts
@@ -1,0 +1,75 @@
+type InjectIntoStreamOpts = {
+  emitToDocumentHead?: () => string
+  emitBeforeSsrChunk: () => Promise<string>
+}
+
+const encoder = /* #__PURE__ */ new TextEncoder()
+const decoder = /* #__PURE__ */ new TextDecoder()
+
+export function injectIntoStream({
+  emitToDocumentHead,
+  emitBeforeSsrChunk,
+}: InjectIntoStreamOpts) {
+  // regex pattern for matching closing body and html tags
+  const patternHead = /(<\/head>)/
+  const patternBody = /(<\/body>)/
+
+  let leftover = ''
+  let headMatched = false
+
+  return new TransformStream({
+    async transform(chunk, controller) {
+      const chunkString = leftover + decoder.decode(chunk)
+
+      let processed = chunkString
+
+      if (emitToDocumentHead && !headMatched) {
+        const strToInject = emitToDocumentHead().trim()
+        if (strToInject) {
+          const headMatch = processed.match(patternHead)
+          if (headMatch) {
+            const headIndex = headMatch.index!
+            headMatched = true
+            const headChunk =
+              processed.slice(0, headIndex) +
+              emitToDocumentHead() +
+              processed.slice(headIndex, headMatch[0].length)
+            controller.enqueue(encoder.encode(headChunk))
+            processed = processed.slice(headIndex + headMatch[0].length)
+          }
+        }
+      }
+
+      const bodyMatch = processed.match(patternBody)
+      if (bodyMatch) {
+        // If a </body> sequence was found
+        const bodyIndex = bodyMatch.index!
+
+        const html = await emitBeforeSsrChunk()
+        // console.log('BODY MATCH', html);
+
+        // Add the arbitrary HTML before the closing body tag
+        processed =
+          processed.slice(0, bodyIndex) + html + processed.slice(bodyIndex)
+
+        controller.enqueue(encoder.encode(processed))
+        leftover = ''
+      } else {
+        const html = await emitBeforeSsrChunk()
+        // console.log('ARBITRARY MATCH', html, processed);
+
+        if (html) {
+          processed = html + processed
+        }
+
+        controller.enqueue(encoder.encode(processed))
+      }
+    },
+    flush(controller) {
+      if (leftover) {
+        // console.log('flush', leftover);
+        controller.enqueue(encoder.encode(leftover))
+      }
+    },
+  })
+}

--- a/examples/react/ssr-streaming/tsconfig.json
+++ b/examples/react/ssr-streaming/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/examples/react/ssr-streaming/vite-env.d.ts
+++ b/examples/react/ssr-streaming/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/react/ssr-streaming/vite.config.js
+++ b/examples/react/ssr-streaming/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    /**
+     * Without this react won't give us renderToReadableStream even when the node version supports web streams...
+     */
+    conditions: ['workerd', 'worker', 'browser'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,43 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4(@types/node@18.16.0)
 
+  examples/react/ssr-streaming:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.0.0-beta.0
+        version: link:../../../packages/react-query
+      express:
+        specifier: ^4.18.2
+        version: 4.18.2(supports-color@6.1.0)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.14
+        version: 4.17.17
+      '@vitejs/plugin-react':
+        specifier: ^4.0.3
+        version: 4.0.3(vite@4.4.7)
+      compression:
+        specifier: ^1.7.4
+        version: 1.7.4(supports-color@6.1.0)
+      isbot:
+        specifier: ^3.6.5
+        version: 3.6.5
+      serve-static:
+        specifier: ^1.15.0
+        version: 1.15.0(supports-color@6.1.0)
+      vite:
+        specifier: ^4.4.7
+        version: 4.4.7(@types/node@18.16.0)
+      vite-node:
+        specifier: ~0.30.1
+        version: 0.30.1(@types/node@18.16.0)
+
   examples/react/star-wars:
     dependencies:
       '@emotion/react':
@@ -1512,7 +1549,7 @@ importers:
         version: 2.0.1(esbuild@0.18.13)(solid-js@1.7.8)(tsup@7.1.0)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.7)
 
   packages/query-persist-client-core:
     dependencies:
@@ -1642,7 +1679,7 @@ importers:
         version: 2.0.1(esbuild@0.18.13)(solid-js@1.7.8)(tsup@7.1.0)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.8)(vite@4.4.4)
+        version: 2.7.0(solid-js@1.7.8)(vite@4.4.7)
 
   packages/svelte-query:
     dependencies:
@@ -1655,7 +1692,7 @@ importers:
         version: 2.2.0(svelte@4.0.0)(typescript@5.1.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.4.2
-        version: 2.4.2(svelte@4.0.0)(vite@4.4.4)
+        version: 2.4.2(svelte@4.0.0)(vite@4.4.7)
       '@testing-library/svelte':
         specifier: ^4.0.3
         version: 4.0.3(svelte@4.0.0)
@@ -1683,7 +1720,7 @@ importers:
         version: 2.2.0(svelte@4.0.0)(typescript@5.1.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.4.2
-        version: 2.4.2(svelte@4.0.0)(vite@4.4.4)
+        version: 2.4.2(svelte@4.0.0)(vite@4.4.7)
       '@tanstack/svelte-query':
         specifier: workspace:*
         version: link:../svelte-query
@@ -3991,7 +4028,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-react-jsx-source@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==}
@@ -4010,7 +4046,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
@@ -7704,6 +7739,22 @@ packages:
       - supports-color
     dev: true
 
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.0.0)(vite@4.4.7):
+    resolution: {integrity: sha512-Khdl5jmmPN6SUsVuqSXatKpQTMIifoQPDanaxC84m9JxIibWvSABJyHpyys0Z+1yYrxY5TTEQm+6elh0XCMaOA==}
+    engines: {node: ^14.18.0 || >= 16}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^2.2.0
+      svelte: ^3.54.0 || ^4.0.0
+      vite: ^4.0.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.0.0)(vite@4.4.7)
+      debug: 4.3.4(supports-color@6.1.0)
+      svelte: 4.0.0
+      vite: 4.4.7(@types/node@18.16.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@sveltejs/vite-plugin-svelte@2.4.0(svelte@4.0.0)(vite@4.4.4):
     resolution: {integrity: sha512-OdKTMNZTb4OPrXY0IAJiOG5krQcgEaDtqjLNFj5KInyzn3/HNVuXx9egAneMMhStqk1K5Nf7DIG40e9HeBxeOA==}
     engines: {node: ^14.18.0 || >= 16}
@@ -7740,6 +7791,26 @@ packages:
       svelte-hmr: 0.15.2(svelte@4.0.0)
       vite: 4.4.4(@types/node@18.16.0)
       vitefu: 0.2.4(vite@4.4.4)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@sveltejs/vite-plugin-svelte@2.4.2(svelte@4.0.0)(vite@4.4.7):
+    resolution: {integrity: sha512-ePfcC48ftMKhkT0OFGdOyycYKnnkT6i/buzey+vHRTR/JpQvuPzzhf1PtKqCDQfJRgoPSN2vscXs6gLigx/zGw==}
+    engines: {node: ^14.18.0 || >= 16}
+    peerDependencies:
+      svelte: ^3.54.0 || ^4.0.0
+      vite: ^4.0.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.0.0)(vite@4.4.7)
+      debug: 4.3.4(supports-color@6.1.0)
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.0
+      svelte: 4.0.0
+      svelte-hmr: 0.15.2(svelte@4.0.0)
+      vite: 4.4.7(@types/node@18.16.0)
+      vitefu: 0.2.4(vite@4.4.7)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8029,7 +8100,6 @@ packages:
     dependencies:
       '@types/connect': 3.4.35
       '@types/node': 18.16.0
-    dev: false
 
   /@types/bonjour@3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
@@ -8058,7 +8128,6 @@ packages:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
       '@types/node': 18.16.0
-    dev: false
 
   /@types/cookie@0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
@@ -8104,7 +8173,6 @@ packages:
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
-    dev: false
 
   /@types/express@4.17.17:
     resolution: {integrity: sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==}
@@ -8113,7 +8181,6 @@ packages:
       '@types/express-serve-static-core': 4.17.35
       '@types/qs': 6.9.7
       '@types/serve-static': 1.15.2
-    dev: false
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -8142,7 +8209,6 @@ packages:
 
   /@types/http-errors@2.0.1:
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
-    dev: false
 
   /@types/http-proxy@1.17.11:
     resolution: {integrity: sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==}
@@ -8199,11 +8265,9 @@ packages:
 
   /@types/mime@1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
-    dev: false
 
   /@types/mime@3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
-    dev: false
 
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
@@ -8239,11 +8303,9 @@ packages:
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
-    dev: false
 
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
-    dev: false
 
   /@types/react-dom@18.2.4:
     resolution: {integrity: sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==}
@@ -8318,7 +8380,6 @@ packages:
     dependencies:
       '@types/mime': 1.3.2
       '@types/node': 18.16.0
-    dev: false
 
   /@types/serve-index@1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==}
@@ -8332,7 +8393,6 @@ packages:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
       '@types/node': 18.16.0
-    dev: false
 
   /@types/set-cookie-parser@2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
@@ -8501,7 +8561,7 @@ packages:
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
-      semver: 7.5.1
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@5.1.3)
       typescript: 5.1.3
     transitivePeerDependencies:
@@ -8981,6 +9041,21 @@ packages:
       vite: 4.4.4(@types/node@18.16.0)
     transitivePeerDependencies:
       - supports-color
+
+  /@vitejs/plugin-react@4.0.3(vite@4.4.7):
+    resolution: {integrity: sha512-pwXDog5nwwvSIzwrvYYmA2Ljcd/ZNlcsSG2Q9CNDBwnsd55UGAyr2doXtB5j+2uymRCnCfExlznzzSFbBRcoCg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.9)
+      react-refresh: 0.14.0
+      vite: 4.4.7(@types/node@18.16.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@vitejs/plugin-vue@4.2.3(vite@4.4.4)(vue@3.2.47):
     resolution: {integrity: sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==}
@@ -12798,7 +12873,6 @@ packages:
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-    dev: false
 
   /deprecated-react-native-prop-types@3.0.1:
     resolution: {integrity: sha512-J0jCJcsk4hMlIb7xwOZKLfMpuJn6l8UtrPEzzQV5ewz5gvKNYakhBuq9h2rWX7YwHHJZFhU5W8ye7dB9oN8VcQ==}
@@ -12822,7 +12896,6 @@ packages:
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dev: false
 
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -14504,7 +14577,6 @@ packages:
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -15303,7 +15375,6 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
@@ -16082,7 +16153,6 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
-    dev: false
 
   /http-parser-js@0.5.8:
     resolution: {integrity: sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==}
@@ -16906,6 +16976,11 @@ packages:
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  /isbot@3.6.5:
+    resolution: {integrity: sha512-BchONELXt6yMad++BwGpa0oQxo/uD0keL7N15cYVf0A1oMIoNQ79OqeYdPMFWDrNhCqCbRuw9Y9F3QBjvAxZ5g==}
+    engines: {node: '>=12'}
+    dev: true
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -19881,7 +19956,6 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -20811,7 +20885,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       ee-first: 1.1.1
-    dev: false
 
   /on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
@@ -23149,7 +23222,6 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /raw-body@2.5.1:
     resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
@@ -24790,7 +24862,6 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
@@ -24851,7 +24922,6 @@ packages:
       send: 0.18.0(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -24883,7 +24953,6 @@ packages:
 
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-    dev: false
 
   /sha.js@2.4.11:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
@@ -25423,7 +25492,6 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
-    dev: false
 
   /std-env@3.3.3:
     resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
@@ -26422,7 +26490,6 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-    dev: false
 
   /totalist@3.0.0:
     resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
@@ -27052,6 +27119,28 @@ packages:
     resolution: {integrity: sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==}
     dev: false
 
+  /vite-node@0.30.1(@types/node@18.16.0):
+    resolution: {integrity: sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@6.1.0)
+      mlly: 1.4.0
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 4.4.7(@types/node@18.16.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@0.33.0(@types/node@18.16.0):
     resolution: {integrity: sha512-19FpHYbwWWxDr73ruNahC+vtEdza52kA90Qb3La98yZ0xULqV8A5JLNPUff0f5zID4984tW7l3DH2przTJUZSw==}
     engines: {node: '>=v14.18.0'}
@@ -27062,7 +27151,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.4(@types/node@18.16.0)
+      vite: 4.4.7(@types/node@18.16.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -27110,6 +27199,25 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /vite-plugin-solid@2.7.0(solid-js@1.7.8)(vite@4.4.7):
+    resolution: {integrity: sha512-avp/Jl5zOp/Itfo67xtDB2O61U7idviaIp4mLsjhCa13PjKNasz+IID0jYTyqUp9SFx6/PmBr6v4KgDppqompg==}
+    peerDependencies:
+      solid-js: ^1.7.2
+      vite: ^3.0.0 || ^4.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/preset-typescript': 7.21.5(@babel/core@7.22.9)
+      '@types/babel__core': 7.20.1
+      babel-preset-solid: 1.7.7(@babel/core@7.22.9)
+      merge-anything: 5.1.7
+      solid-js: 1.7.8
+      solid-refresh: 0.5.3(solid-js@1.7.8)
+      vite: 4.4.7(@types/node@18.16.0)
+      vitefu: 0.2.4(vite@4.4.7)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vite@4.4.4(@types/node@18.16.0):
     resolution: {integrity: sha512-4mvsTxjkveWrKDJI70QmelfVqTm+ihFAb6+xf4sjEU2TmUCTlVX87tmg/QooPEMQb/lM9qGHT99ebqPziEd3wg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -27145,6 +27253,42 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /vite@4.4.7(@types/node@18.16.0):
+    resolution: {integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.16.0
+      esbuild: 0.18.13
+      postcss: 8.4.26
+      rollup: 3.26.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /vitefu@0.2.4(vite@4.4.4):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
@@ -27154,6 +27298,17 @@ packages:
         optional: true
     dependencies:
       vite: 4.4.4(@types/node@18.16.0)
+
+  /vitefu@0.2.4(vite@4.4.7):
+    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 4.4.7(@types/node@18.16.0)
+    dev: true
 
   /vitest@0.33.0(jsdom@22.0.0):
     resolution: {integrity: sha512-1CxaugJ50xskkQ0e969R/hW47za4YXDUfWJDxip1hwbnhUjYolpfUn2AMOulqG/Dtd9WYAtkHmM/m3yKVrEejQ==}


### PR DESCRIPTION
Inspired by @tannerlinsley's work with the tanstack router streaming example, and the recent nextjs streaming package, I thought I'd put together a streaming example that doesn't require nextjs.

Marking as a draft because I've mostly done this as an exercise to see how easy/hard this is to implement with the current RQ API. In part I'm hoping that this might provide a basis for ideas re how to make this simpler - perhaps via some additions to react-query itself?

I have also implemented `deferQuery` - similar to solidjs's deferQuery option - when set, that query will pause the stream. The use case here is critical queries that, for example, fetch data required for meta tags.

![2023-07-25 15 52 39](https://github.com/TanStack/query/assets/847542/45942376-7211-48ec-b0c3-2052c94c6516)