### PR TITLE
 feat(react-query): v5: Export `DefinedInitialDataOptions` and `UndefinedInitialDataOptions`

### DIFF
--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -11,6 +11,10 @@ export { useQuery } from './useQuery'
 export { useSuspenseQuery } from './useSuspenseQuery'
 export { useSuspenseInfiniteQuery } from './useSuspenseInfiniteQuery'
 export { queryOptions } from './queryOptions'
+export type {
+  DefinedInitialDataOptions,
+  UndefinedInitialDataOptions,
+} from './queryOptions'
 export { infiniteQueryOptions } from './infiniteQueryOptions'
 export {
   QueryClientContext,


### PR DESCRIPTION
I'm upgrading to v5 in my app. Love it. The only issue I've run into is that I have to use the unexported type `UndefinedInitialDataOptions` to make this helper for the options. I have some wrappers for `useQuery` that constrain the args to the methods and params of my API, and I want them to take all the options for `useQuery` except `queryKey` and `queryFn`.

```ts
/**
 * `queryKey` and `queryFn` are always constructed by our helper hooks, so we
 * only allow the rest of the options.
 */
type UseQueryOtherOptions<T, E = DefaultError> = Omit<
  UndefinedInitialDataOptions<T, E>,
  'queryKey' | 'queryFn'
>
```