### PR TITLE
Enhancing Dehydration and Hydration Mechanisms for Query Options

### DIFF
--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -33,6 +33,7 @@ interface DehydratedQuery {
   queryHash: string
   queryKey: QueryKey
   state: QueryState
+  options: QueryOptions
 }
 
 export interface DehydratedState {
@@ -60,6 +61,7 @@ function dehydrateMutation(mutation: Mutation): DehydratedMutation {
 function dehydrateQuery(query: Query): DehydratedQuery {
   return {
     state: query.state,
+    options: JSON.parse(JSON.stringify(query.options)), // To remove properties that are functions or other non-serializable types
     queryKey: query.queryKey,
     queryHash: query.queryHash,
   }
@@ -162,6 +164,7 @@ export function hydrate(
       client,
       {
         ...options?.defaultOptions?.queries,
+        ...dehydratedQuery.options,
         queryKey: dehydratedQuery.queryKey,
         queryHash: dehydratedQuery.queryHash,
       },

--- a/packages/query-core/src/tests/hydration.test.tsx
+++ b/packages/query-core/src/tests/hydration.test.tsx
@@ -106,7 +106,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test.only('should be able to provide default options for the hydrated queries', async () => {
+  test('should be able to provide default options for the hydrated queries', async () => {
     const queryCache = new QueryCache()
     const queryClient = createQueryClient({ queryCache })
     await queryClient.prefetchQuery(['string'], () => fetchData('string'))


### PR DESCRIPTION
I'm proposing a fix concerning the dehydration process of queries that currently does not consider individual query options. This omission results in a problematic behavior, particularly when a query with unique options like `cacheTime` or others is dehydrated and subsequently rehydrated. The query loses its initial options settings, reverting to the defaults defined in `defaultOptions`.

Here's an illustrative example:

```ts
useQuery({
    queryKey: [queryKeys.cities, request],
    queryFn: async () => await citiesApi.getCities(),
    cacheTime: ONE_HOUR * 2,
    staleTime: ONE_HOUR,
  });
```

In this scenario, if the query undergoes dehydration and hydration, both `cacheTime` and `staleTime` values are mistakenly reset to their `defaultOptions`. This becomes evident when incorporating `PersistQueryClientProvider` into an application. Here, `cacheTime` and `staleTime` will unexpectedly reset to default values following a page refresh.

Additionally, we've defined a custom option `isPersistedCache` to persist specific queries:

```ts
useQuery({
    queryKey: [queryKeys.cities, request],
    queryFn: async () => await citiesApi.getCities(),
    cacheTime: ONE_HOUR * 2,
    staleTime: ONE_HOUR,
    isPersistedCache: true,
  });
```

Subsequently, when setting up the `PersistQueryClientProvider`:

```tsx
<PersistQueryClientProvider
      client={queryClient}
      persistOptions={{
        persister,
        dehydrateOptions: {
          dehydrateQueries: true,
          shouldDehydrateQuery: query =>
            Boolean((query.options as QueryOptions).isPersistedCache),
        },
      }}
    >
....

</PersistQueryClientProvider>
```

We also extended the `QueryOptions` interface accordingly:

```ts
declare module "@tanstack/react-query" {
  export interface QueryOptions {
    isPersistedCache?: boolean;
  }
}
```

However, due to the existing limitation that the dehydration and hydration processes do not account for custom options, the proposed solution is not functional under the current system.