### PR TITLE
fix(*): Update repository information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "query",
-  "repository": "https://github.com/tanstack/query.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git"
+  },
   "packageManager": "pnpm@8.5.1",
   "scripts": {
     "clean": "pnpm --filter \"./packages/**\" run clean",

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -4,7 +4,11 @@
   "description": "ESLint plugin for TanStack Query",
   "author": "Eliya Cohen",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/eslint-plugin-query"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -4,7 +4,11 @@
   "description": "A persister for asynchronous storages, to be used with TanStack/Query",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/query-async-storage-persister"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -4,7 +4,11 @@
   "description": "An experimental plugin to for broadcasting the state of your queryClient between browser tabs/windows",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/query-broadcast-client-experimental"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -4,7 +4,11 @@
   "description": "The framework agnostic core that powers TanStack Query",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/query-core"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -4,7 +4,11 @@
   "description": "Set of utilities for interacting with persisters, which can save your queryClient for later use",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/query-persist-client-core"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -4,7 +4,11 @@
   "description": "A persister for synchronous storages, to be used with TanStack/Query",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/query-persist-client-core"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -4,7 +4,11 @@
   "description": "Developer tools to interact with and visualize the TanStack/react-query cache",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/react-query-devtools"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -4,7 +4,11 @@
   "description": "React bindings to work with persisters in TanStack/react-query",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/react-query-persist-client"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -4,7 +4,11 @@
   "description": "Hooks for managing, caching and syncing asynchronous and remote data in React",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/react-query"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -4,7 +4,11 @@
   "description": "Primitives for managing, caching and syncing asynchronous and remote data in Solid",
   "author": "tannerlinsley",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/solid-query"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -4,7 +4,11 @@
   "description": "Primitives for managing, caching and syncing asynchronous and remote data in Svelte",
   "author": "Lachlan Collins",
   "license": "MIT",
-  "repository": "tanstack/query",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/query.git",
+    "directory": "packages/svelte-query"
+  },
   "homepage": "https://tanstack.com/query",
   "funding": {
     "type": "github",


### PR DESCRIPTION
Update repository information to support monorepo structure. This should help unblock automated dependency update tools like Renovate and Dependabot to group together all the packages from this monorepo.

Follow up to https://github.com/TanStack/query/discussions/5818