### PR TITLE
fix(eslint-plugin-query): Reorganise internal modules

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/configs.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/configs.test.ts
@@ -1,4 +1,4 @@
-import { configs } from './index'
+import { configs } from '../configs'
 
 describe('configs', () => {
   it('should match snapshot', () => {

--- a/packages/eslint-plugin-query/src/__tests__/exhaustive-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/exhaustive-deps.test.ts
@@ -1,6 +1,6 @@
 import { ESLintUtils } from '@typescript-eslint/utils'
-import { normalizeIndent } from '../../utils/test-utils'
-import { rule } from './exhaustive-deps.rule'
+import { normalizeIndent } from '../utils/test-utils'
+import { rule } from '../rules/exhaustive-deps.rule'
 
 const ruleTester = new ESLintUtils.RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin-query/src/configs.ts
+++ b/packages/eslint-plugin-query/src/configs.ts
@@ -1,4 +1,4 @@
-import { rules } from '../rules'
+import { rules } from './rules'
 import type { TSESLint } from '@typescript-eslint/utils'
 
 function generateRecommendedConfig(

--- a/packages/eslint-plugin-query/src/rules.ts
+++ b/packages/eslint-plugin-query/src/rules.ts
@@ -1,0 +1,5 @@
+import * as exhaustiveDeps from './rules/exhaustive-deps.rule'
+
+export const rules = {
+  [exhaustiveDeps.name]: exhaustiveDeps.rule,
+}

--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps.rule.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
-import { ASTUtils } from '../../utils/ast-utils'
-import { createRule } from '../../utils/create-rule'
-import { uniqueBy } from '../../utils/unique-by'
+import { ASTUtils } from '../utils/ast-utils'
+import { createRule } from '../utils/create-rule'
+import { uniqueBy } from '../utils/unique-by'
 import { ExhaustiveDepsUtils } from './exhaustive-deps.utils'
 import type { TSESLint } from '@typescript-eslint/utils'
 

--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps.utils.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps.utils.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
-import { ASTUtils } from '../../utils/ast-utils'
+import { ASTUtils } from '../utils/ast-utils'
 import type { TSESLint } from '@typescript-eslint/utils'
 
 export const ExhaustiveDepsUtils = {

--- a/packages/eslint-plugin-query/src/rules/index.ts
+++ b/packages/eslint-plugin-query/src/rules/index.ts
@@ -1,5 +1,0 @@
-import * as exhaustiveDeps from './exhaustive-deps/exhaustive-deps.rule'
-
-export const rules = {
-  [exhaustiveDeps.name]: exhaustiveDeps.rule,
-}


### PR DESCRIPTION
By default, tsup bundles all modules into chunks, and correctly adds ESM/CJS extensions to imported chunks. However, this is incompatible with `"use client"` directives, so we've added `esbuild-plugin-file-path-extensions`, which prevents modules getting bundled and adds ESM/CJS extensions.

However, this approach doesn't seem to work with presumed index imports (e.g. `./config` referring to `./config/index.js`). To fix this, I've re-organised the files in `esbuild-plugin-query` so that there are no presumed index imports. This seems to be the only package where this sort of import is used.

Fixes #5795