### PR TITLE
fix: Change pinned peerDeps to a range

### DIFF
--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -68,6 +68,6 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "@tanstack/react-query": "workspace:*"
+    "@tanstack/react-query": "workspace:^"
   }
 }

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -52,6 +52,6 @@
     "@tanstack/query-persist-client-core": "workspace:*"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "workspace:*"
+    "@tanstack/react-query": "workspace:^"
   }
 }


### PR DESCRIPTION
Peer Dependencies should be ranges to allow consumers to change versions more freely.

I only found two instances of peerDependencies that references other workspaces. Deps and devDeps were left alone. Follow up to https://github.com/TanStack/query/discussions/5832