### PR TITLE
Fix: Infinite render loops in react-query v4.29.22 and up

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -834,7 +834,7 @@ function shouldAssignObserverCurrentProperties<
 
   // if the newly created result isn't what the observer is holding as current,
   // then we'll need to update the properties as well
-  if (observer.getCurrentResult() !== optimisticResult) {
+  if (!shallowEqualObjects(observer.getCurrentResult(), optimisticResult)) {
     return true
   }
 

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -6211,4 +6211,25 @@ describe('useQuery', () => {
     await waitFor(() => rendered.getByText('Rendered Id: 2'))
     expect(spy).toHaveBeenCalledTimes(1)
   })
+  it('should not cause an infinite render loop when using unstable callback ref', async () => {
+    const key = queryKey()
+
+    function Test() {
+      const [_, setRef] = React.useState<HTMLDivElement | null>()
+
+      const { data } = useQuery({
+        queryKey: [key],
+        queryFn: async () => {
+          await sleep(5)
+          return 'Works'
+        },
+      })
+
+      return <div ref={(value) => setRef(value)}>{data}</div>
+    }
+
+    const rendered = renderWithClient(queryClient, <Test />)
+
+    await waitFor(() => rendered.getByText('Works'))
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/TanStack/query/issues/5719. Shalow `!==` would always return `true`, because  https://github.com/TanStack/query/blob/9b8b5f0a81bc68552bbafbc3991e7e89a893ecbe/packages/query-core/src/queryObserver.ts#L243C19-L243C19 AFAIK always gives new object.