### PR TITLE
perf(vue-query): avoid unnecessary deep watch

### DIFF
--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -137,7 +137,7 @@ export function useBaseQuery<
 
         run()
 
-        stopWatch = watch(defaultedOptions, run, { deep: true })
+        stopWatch = watch(defaultedOptions, run)
       },
     )
   }

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -21,13 +21,9 @@ export function useIsFetching(
     isFetching.value = client.isFetching(filters)
   })
 
-  watch(
-    filters,
-    () => {
-      isFetching.value = client.isFetching(filters)
-    },
-    { deep: true },
-  )
+  watch(filters, () => {
+    isFetching.value = client.isFetching(filters)
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -84,13 +84,9 @@ export function useMutation<
     })
   }
 
-  watch(
-    options,
-    () => {
-      observer.setOptions(options.value)
-    },
-    { deep: true },
-  )
+  watch(options, () => {
+    observer.setOptions(options.value)
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useMutationState.ts
+++ b/packages/vue-query/src/useMutationState.ts
@@ -65,13 +65,9 @@ export function useMutationState<TResult = MutationState>(
     state.value = result
   })
 
-  watch(
-    filters,
-    () => {
-      state.value = getResult(mutationCache, options)
-    },
-    { deep: true },
-  )
+  watch(filters, () => {
+    state.value = getResult(mutationCache, options)
+  })
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -207,20 +207,16 @@ export function useQueries<
     { immediate: true },
   )
 
-  watch(
-    [defaultedQueries],
-    () => {
-      observer.setQueries(
-        defaultedQueries.value,
-        options as QueriesObserverOptions<TCombinedResult>,
-      )
-      const [, getCombinedResultPersisted] = observer.getOptimisticResult(
-        defaultedQueries.value,
-      )
-      state.value = getCombinedResultPersisted()
-    },
-    { deep: true },
-  )
+  watch(defaultedQueries, () => {
+    observer.setQueries(
+      defaultedQueries.value,
+      options as QueriesObserverOptions<TCombinedResult>,
+    )
+    const [, getCombinedResultPersisted] = observer.getOptimisticResult(
+      defaultedQueries.value,
+    )
+    state.value = getCombinedResultPersisted()
+  })
 
   onScopeDispose(() => {
     unsubscribe()


### PR DESCRIPTION
The reason for this PR is the same as RP #5764, although the `beta` version does not have the `queryClient` performance issue, deep watch still makes the options traversed.

Also, I'm not sure why the watch source in `useQueries` is an array, and I didn't find multiple watch sources in it, so I removed the array.