### PR TITLE
docs(query-cancellation): reflect AbortController is now required

### DIFF
--- a/docs/react/guides/query-cancellation.md
+++ b/docs/react/guides/query-cancellation.md
@@ -3,9 +3,9 @@ id: query-cancellation
 title: Query Cancellation
 ---
 
-TanStack Query provides each query function with an [`AbortSignal` instance](https://developer.mozilla.org/docs/Web/API/AbortSignal), **if it's available in your runtime environment**. When a query becomes out-of-date or inactive, this `signal` will become aborted. This means that all queries are cancellable, and you can respond to the cancellation inside your query function if desired. The best part about this is that it allows you to continue to use normal async/await syntax while getting all the benefits of automatic cancellation.
+TanStack Query provides each query function with an [`AbortSignal` instance](https://developer.mozilla.org/docs/Web/API/AbortSignal). When a query becomes out-of-date or inactive, this `signal` will become aborted. This means that all queries are cancellable, and you can respond to the cancellation inside your query function if desired. The best part about this is that it allows you to continue to use normal async/await syntax while getting all the benefits of automatic cancellation.
 
-The `AbortController` API is available in [most runtime environments](https://developer.mozilla.org/docs/Web/API/AbortController#browser_compatibility), but if the runtime environment does not support it then the query function will receive `undefined` in its place. You may choose to polyfill the `AbortController` API if you wish, there are [several available](https://www.npmjs.com/search?q=abortcontroller%20polyfill).
+The `AbortController` API is available in [most runtime environments](https://developer.mozilla.org/docs/Web/API/AbortController#browser_compatibility), but if your runtime environment does not support it, you will need to provide a polyfill. There are [several available](https://www.npmjs.com/search?q=abortcontroller%20polyfill).
 
 ## Default behavior
 


### PR DESCRIPTION
This closes #5837 

The text changes have been kept conservative, mainly involving minor deletions. Or does it make sense to remove the paragraph about AbortController compatibility altogether? Because this could be just one case of problems about browser compatibility, and these kinds of problems might belong to https://tanstack.com/query/v5/docs/react/installation#requirements.