### PR TITLE
fix(types): initialData function that returns undefined should still discriminate after isSuccess check

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.types.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.types.test.tsx
@@ -111,6 +111,26 @@ describe('initialData', () => {
         return result
       })
     })
+
+    it('TData should be narrowed after an isSuccess check when initialData is provided as a function which can return undefined', () => {
+      doNotExecute(() => {
+        const { data, isSuccess } = useQuery({
+          queryKey: ['key'],
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          initialData: () => undefined as { wow: boolean } | undefined,
+        })
+
+        if (isSuccess) {
+          const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+          return result
+        }
+        return false
+      })
+    })
   })
 
   describe('custom hook', () => {

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -10,13 +10,17 @@ export type UndefinedInitialDataOptions<
   initialData?: undefined
 }
 
+type NonUndefinedGuard<T> = T extends undefined ? never : T
+
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  initialData: TQueryFnData | (() => TQueryFnData)
+  initialData:
+    | NonUndefinedGuard<TQueryFnData>
+    | (() => NonUndefinedGuard<TQueryFnData>)
 }
 
 export function queryOptions<


### PR DESCRIPTION
closes #5870