### PR TITLE
expose `Query` from @tanstack/query-core

### DIFF
--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -34,7 +34,8 @@ export {
 
 // Types
 export * from './types'
-export type { Query, QueryState } from './query'
+export type { QueryState } from './query'
+export { Query } from './query'
 export type { Mutation } from './mutation'
 export type { Logger } from './logger'
 export type {


### PR DESCRIPTION
The only thing that I'm not certain of, is the position of the import. Semantically, I believe it should live next to `QueryState`. Logically, it's under `// Types` which is wrong.