### PR TITLE
chore(use-queries): fix documented examples

### DIFF
--- a/docs/react/reference/useQueries.md
+++ b/docs/react/reference/useQueries.md
@@ -8,9 +8,9 @@ The `useQueries` hook can be used to fetch a variable number of queries:
 ```tsx
 const ids = [1,2,3]
 const results = useQueries({
-  queries: ids.map(id => [
+  queries: ids.map(id => (
     { queryKey: ['post', id], queryFn: () => fetchPost(id), staleTime: Infinity },
-  ]),
+  )),
 })
 ```
 
@@ -40,9 +40,9 @@ If you want to combine `data` (or other Query information) from the results into
 ```tsx
 const ids = [1,2,3]
 const combinedQueries = useQueries({
-  queries: ids.map(id => [
+  queries: ids.map(id => (
     { queryKey: ['post', id], queryFn: () => fetchPost(id) },
-  ]),
+  )),
   combine: (results) => {
     return ({
       data: results.map(result => result.data),


### PR DESCRIPTION
related: https://github.com/TanStack/query/issues/5897

**Documentation error _(not production bug)_**

useQueries code example has `[ ]` instead of `( )`

replace

```js
const ids = [1,2,3]
const results = useQueries({
  queries: ids.map(id => [
    { queryKey: ['post', id], queryFn: () => fetchPost(id), staleTime: Infinity },
  ]),
})
```
with

```js
const ids = [1,2,3]
const results = useQueries({
  queries: ids.map(id => (
    { queryKey: ['post', id], queryFn: () => fetchPost(id), staleTime: Infinity },
  )),
})
```