### PR TITLE
fix: basic-graphql-request link in v3 docs

### DIFF
--- a/docs/react/graphql.md
+++ b/docs/react/graphql.md
@@ -13,4 +13,4 @@ You can use [GraphQL-Codegen](https://graphql-code-generator.com/) to generate r
 
 ## Examples
 
-- [basic-graphql-request](../docs/examples/basic-graphql-request) (The "basic" example, but implemented with [`graphql-request`](https://github.com/prisma-labs/graphql-request))
+- [basic-graphql-request](./examples/basic-graphql-request) (The "basic" example, but implemented with [`graphql-request`](https://github.com/prisma-labs/graphql-request))


### PR DESCRIPTION
The example link on this page doesn't work currently:
https://tanstack.com/query/v3/docs/react/graphql