### PR TITLE
perf(vue-query): reduce unnecessary `computed()`

### DIFF
--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -1,4 +1,4 @@
-import { onScopeDispose, ref, watchEffect } from 'vue-demi'
+import { onScopeDispose, ref, watchSyncEffect } from 'vue-demi'
 import { useQueryClient } from './useQueryClient'
 import type { Ref } from 'vue-demi'
 import type { QueryFilters as QF } from '@tanstack/query-core'
@@ -21,9 +21,7 @@ export function useIsFetching(
 
   const unsubscribe = client.getQueryCache().subscribe(listener)
 
-  watchEffect(listener, {
-    flush: 'sync',
-  })
+  watchSyncEffect(listener)
 
   onScopeDispose(() => {
     unsubscribe()

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -15,13 +15,13 @@ export function useIsFetching(
 
   const isFetching = ref()
 
-  const callback = () => {
+  const listener = () => {
     isFetching.value = client.isFetching(fetchingFilters)
   }
 
-  const unsubscribe = client.getQueryCache().subscribe(callback)
+  const unsubscribe = client.getQueryCache().subscribe(listener)
 
-  watchEffect(callback, {
+  watchEffect(listener, {
     flush: 'sync',
   })
 


### PR DESCRIPTION
In the current beta version, `useIsFetching` will internally run `cloneDeepUnref` in `computed` for deep clone the parameter of `fetchingFilters` and unwrap the `ref`.

https://github.com/TanStack/query/blob/13b17ee45de3299dd3d3a2dfc3d23ad2f024882a/packages/vue-query/src/useIsFetching.ts#L15

Then `isFetching` of `QueryClient` will run `cloneDeepUnref` again.

https://github.com/TanStack/query/blob/13b17ee45de3299dd3d3a2dfc3d23ad2f024882a/packages/vue-query/src/queryClient.ts#L44-L46

Here, We don’t need to repeatedly execute `cloneDeepUnref`, it seems that the `cloneDeepUnref` only need to be triggered when the `listener` of `subscribe` is called.

```ts
const unsubscribe = client.getQueryCache().subscribe(() => {
  isFetching.value = client.isFetching(fetchingFilters)
})
```

In the end, use the `watchSyncEffect` instead of `watch` so, we can remove the `filters` computed property.

```ts
const listener = () => {
  isFetching.value = client.isFetching(fetchingFilters)
}

const unsubscribe = client.getQueryCache().subscribe(listener)

watchSyncEffect(listener)
```