### PR TITLE
fix(eslint-plugin-query): provide missing peerDependencies

### DIFF
--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/eslint-plugin-query",
-  "version": "4.32.5",
+  "version": "4.32.6",
   "description": "ESLint plugin for TanStack Query",
   "author": "Eliya Cohen",
   "license": "MIT",
@@ -51,5 +51,8 @@
     "@typescript-eslint/utils": "^5.41.0",
     "eslint": "^8.26.0",
     "tsup": "^6.3.0"
+  },
+  "peerDependencies": {
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
Exposing eslint as peerDependency This is needed for package managers that don't rely on hoisting heuristic to determine dependencies.

Addressing: [issue](https://github.com/TanStack/query/issues/5909#issue-1865041635)