### PR TITLE
perf(vue-query): avoid unnecessary deep watch

### DIFF
--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -136,7 +136,7 @@ export function useBaseQuery<
 
         run()
 
-        stopWatch = watch(defaultedOptions, run, { deep: true })
+        stopWatch = watch(defaultedOptions, run)
       },
     )
   }


### PR DESCRIPTION
The reason for this PR is the same as RP https://github.com/TanStack/query/pull/5764,