### PR TITLE
fix(query-broadcast-client): allow passing in type for the channel

### DIFF
--- a/docs/react/plugins/broadcastQueryClient.md
+++ b/docs/react/plugins/broadcastQueryClient.md
@@ -47,6 +47,8 @@ interface broadcastQueryClient {
   /** This is the unique channel name that will be used
    * to communicate between tabs and windows */
   broadcastChannel?: string
+  /** Options for the BroadcastChannel API */
+  options?: BroadcastChannelOptions
 }
 ```
 

--- a/packages/query-broadcast-client-experimental/src/index.ts
+++ b/packages/query-broadcast-client-experimental/src/index.ts
@@ -1,14 +1,17 @@
 import { BroadcastChannel } from 'broadcast-channel'
+import type { BroadcastChannelOptions } from 'broadcast-channel'
 import type { QueryClient } from '@tanstack/query-core'
 
 interface BroadcastQueryClientOptions {
   queryClient: QueryClient
   broadcastChannel?: string
+  type?: BroadcastChannelOptions['type']
 }
 
 export function broadcastQueryClient({
   queryClient,
   broadcastChannel = 'tanstack-query',
+  type,
 }: BroadcastQueryClientOptions) {
   let transaction = false
   const tx = (cb: () => void) => {
@@ -18,6 +21,7 @@ export function broadcastQueryClient({
   }
 
   const channel = new BroadcastChannel(broadcastChannel, {
+    type,
     webWorkerSupport: false,
   })
 

--- a/packages/query-broadcast-client-experimental/src/index.ts
+++ b/packages/query-broadcast-client-experimental/src/index.ts
@@ -5,13 +5,13 @@ import type { QueryClient } from '@tanstack/query-core'
 interface BroadcastQueryClientOptions {
   queryClient: QueryClient
   broadcastChannel?: string
-  type?: BroadcastChannelOptions['type']
+  options?: BroadcastChannelOptions
 }
 
 export function broadcastQueryClient({
   queryClient,
   broadcastChannel = 'tanstack-query',
-  type,
+  options,
 }: BroadcastQueryClientOptions) {
   let transaction = false
   const tx = (cb: () => void) => {
@@ -21,8 +21,8 @@ export function broadcastQueryClient({
   }
 
   const channel = new BroadcastChannel(broadcastChannel, {
-    type,
     webWorkerSupport: false,
+    ...options,
   })
 
   const queryCache = queryClient.getQueryCache()


### PR DESCRIPTION
allowed values are: 'native', 'idb', 'localstorage', 'node'

closes #5535 