### PR TITLE
doc(react-query): useInifiniteQuery fetching state and fetchNextPage …

### DIFF
--- a/docs/react/guides/infinite-queries.md
+++ b/docs/react/guides/infinite-queries.md
@@ -101,7 +101,7 @@ function Projects() {
 
 It's essential to understand that calling `fetchNextPage` while an ongoing fetch is in progress runs the risk of overwriting data refreshes happening in the background. This situation becomes particularly critical when rendering a list and triggering `fetchNextPage` simultaneously.
 
-Remember, there can only be a single ongoing fetch for an InfiniteQuery. Despite having a single cache entry spread across multiple pages, attempting to fetch two pages simultaneously might lead to data overwrites.
+Remember, there can only be a single ongoing fetch for an InfiniteQuery. A single cache entry is shared for all pages, attempting to fetch twice simultaneously might lead to data overwrites.
 
 If you intend to enable simultaneous fetching, you can utilize the `{ cancelRefetch: false }` option (default: true) within `fetchNextPage`.
 

--- a/docs/react/guides/infinite-queries.md
+++ b/docs/react/guides/infinite-queries.md
@@ -99,6 +99,24 @@ function Projects() {
 
 [//]: # 'Example'
 
+It's essential to understand that calling `fetchNextPage` while an ongoing fetch is in progress runs the risk of overwriting data refreshes happening in the background. This situation becomes particularly critical when rendering a list and triggering `fetchNextPage` simultaneously.
+
+Remember, there can only be a single ongoing fetch for an InfiniteQuery. Despite having a single cache entry spread across multiple pages, attempting to fetch two pages simultaneously might lead to data overwrites.
+
+If you intend to enable simultaneous fetching, you can utilize the `{ cancelRefetch: false }` option (default: true) within `fetchNextPage`.
+
+To ensure a seamless querying process without conflicts, it's highly recommended to verify that the query is not in an `isFetching` state, especially if the user won't directly control that call.
+
+[//]: # 'Example1'
+
+```jsx
+<List
+  onEndReached={() => !isFetching && fetchNextPage()}
+/>
+```
+
+[//]: # 'Example1'
+
 ## What happens when an infinite query needs to be refetched?
 
 When an infinite query becomes `stale` and needs to be refetched, each group is fetched `sequentially`, starting from the first one. This ensures that even if the underlying data is mutated, we're not using stale cursors and potentially getting duplicates or skipping records. If an infinite query's results are ever removed from the queryCache, the pagination restarts at the initial state with only the initial group being requested.


### PR DESCRIPTION
**Issue Addressed**

Especially when utilizing react.production, a potentially perplexing behavior can arise when employing `useInfiniteQuery` for a list with infinite scrolling. 
This behavior stems from a concurrency concern, wherein a query fetch and a subsequent page request might conflict. Due to react-query sharing a singular cache entry, the initial fetch could be canceled while the second one proceeds.

**Solution Proposed**

To circumvent this peculiar behavior, it's advised to abstain from triggering the fetching of the next page while a fetch operation is already in progress.

This pull request addresses the aforementioned issue, enhancing the infinite scrolling behavior's stability when using `useInfiniteQuery` in conjunction with React.

**Related Issue**

For further context, please refer to the discussion in #5583. 

Your insights and feedback are greatly appreciated as we work towards a robust solution.