### PR TITLE
fix some false positive for prefer-query-object-syntax rule

### DIFF
--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -46,11 +46,12 @@
     "outDir": "build/lib"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.41.0",
-    "@typescript-eslint/parser": "^5.41.0",
-    "@typescript-eslint/utils": "^5.41.0",
+    "@typescript-eslint/eslint-plugin": "^5.45.0",
+    "@typescript-eslint/parser": "^5.45.0",
+    "@typescript-eslint/utils": "^5.45.0",
     "eslint": "^8.26.0",
-    "tsup": "^6.3.0"
+    "tsup": "^6.3.0",
+    "typescript": "^4.9"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
@@ -55,6 +55,13 @@ ruleTester.run(name, rule, {
     {
       code: normalizeIndent`
         import { useQuery } from "@tanstack/react-query";
+        import { postsQuery } from "somewhere-else";
+        const usePosts = useQuery(postsQuery);
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
         const getQuery = () => ({ queryKey: ['foo'], queryFn: () => Promise.resolve(5) })
         useQuery(getQuery())
       `,
@@ -91,6 +98,13 @@ ruleTester.run(name, rule, {
             return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };
           }
         }
+        useQuery(getQuery())
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        import { getQuery } from "somewhere-else";
         useQuery(getQuery())
       `,
     },
@@ -149,17 +163,6 @@ ruleTester.run(name, rule, {
       output: normalizeIndent`
         import { useQuery } from "@tanstack/react-query";
         useQuery({ queryKey: ['data'] });
-      `,
-    },
-    {
-      code: normalizeIndent`
-        import { useQuery } from "@tanstack/react-query";
-        useQuery(queryKey);
-      `,
-      errors: [{ messageId: 'preferObjectSyntax' }],
-      output: normalizeIndent`
-        import { useQuery } from "@tanstack/react-query";
-        useQuery({ queryKey });
       `,
     },
     {

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
@@ -158,6 +158,16 @@ ruleTester.run(name, rule, {
         const usePosts = () => useMutation(postsQuery);
       `,
     },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        const queryOptions = {
+          queryKey: ["queryKey"],
+          queryFn: () => Promise.resolve([]),
+        } as const satisfies QueryOptions;
+        useQuery(queryOptions);
+      `,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
@@ -3,7 +3,14 @@ import { normalizeIndent } from '../../utils/test-utils'
 import { name, rule } from './prefer-query-object-syntax'
 
 const ruleTester = new ESLintUtils.RuleTester({
-  parser: '@typescript-eslint/parser',
+  /** HACK
+   * We are using a newer version of typescript than the one at the repository root,
+   * to be able to test code that uses newer typescript features.
+   * To prevent RuleTester from using the typescript version at the root
+   * we resolve '@typescript-eslint/parser' here instead of letting it do it internally.
+   * Once the version at the root is updated to >=4.9 this can be replaced by just "@typescript-eslint/parser"
+   */
+  parser: require.resolve('@typescript-eslint/parser') as any,
   settings: {},
 })
 

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.test.ts
@@ -100,7 +100,7 @@ ruleTester.run(name, rule, {
         import { useQuery } from "@tanstack/react-query";
         const getQuery = () => {
           try {
-            return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };  
+            return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };
           } finally {
             return { queryKey: ['foo'], queryFn: () => Promise.resolve(5) };
           }
@@ -165,6 +165,26 @@ ruleTester.run(name, rule, {
           queryKey: ["queryKey"],
           queryFn: () => Promise.resolve([]),
         } as const satisfies QueryOptions;
+        useQuery(queryOptions);
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        const queryOptions = {
+          queryKey: ["queryKey"],
+          queryFn: () => Promise.resolve([]),
+        } as const;
+        useQuery(queryOptions);
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { useQuery } from "@tanstack/react-query";
+        const queryOptions = {
+          queryKey: ["queryKey"],
+          queryFn: () => Promise.resolve([]),
+        } satisfies QueryOptions;
         useQuery(queryOptions);
       `,
     },

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
@@ -126,6 +126,10 @@ export const rule: TSESLint.RuleModule<MessageKey, readonly unknown[]> =
               },
             )
 
+            if (referencedNode == null && node.arguments.length === 1) {
+              return
+            }
+
             if (referencedNode?.type === AST_NODE_TYPES.ObjectExpression) {
               return runCheckOnNode({
                 context: context,

--- a/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
+++ b/packages/eslint-plugin-query/src/rules/prefer-query-object-syntax/prefer-query-object-syntax.ts
@@ -119,15 +119,22 @@ export const rule: TSESLint.RuleModule<MessageKey, readonly unknown[]> =
           }
 
           if (firstArgument.type === AST_NODE_TYPES.Identifier) {
-            const referencedNode = ASTUtils.getReferencedExpressionByIdentifier(
-              {
-                context,
-                node: firstArgument,
-              },
-            )
+            let referencedNode = ASTUtils.getReferencedExpressionByIdentifier({
+              context,
+              node: firstArgument,
+            })
 
             if (referencedNode == null && node.arguments.length === 1) {
               return
+            }
+
+            // unwrap typescript nodes
+            while (
+              referencedNode != null &&
+              (referencedNode.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+                referencedNode.type === AST_NODE_TYPES.TSAsExpression)
+            ) {
+              referencedNode = referencedNode.expression
             }
 
             if (referencedNode?.type === AST_NODE_TYPES.ObjectExpression) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1225,20 +1225,23 @@ importers:
   packages/eslint-plugin-query:
     devDependencies:
       '@typescript-eslint/eslint-plugin':
-        specifier: ^5.41.0
-        version: 5.41.0(@typescript-eslint/parser@5.41.0)(eslint@8.26.0)(typescript@4.8.4)
+        specifier: ^5.45.0
+        version: 5.45.0(@typescript-eslint/parser@5.45.0)(eslint@8.26.0)(typescript@4.9.3)
       '@typescript-eslint/parser':
-        specifier: ^5.41.0
-        version: 5.41.0(eslint@8.26.0)(typescript@4.8.4)
+        specifier: ^5.45.0
+        version: 5.45.0(eslint@8.26.0)(typescript@4.9.3)
       '@typescript-eslint/utils':
-        specifier: ^5.41.0
-        version: 5.41.0(eslint@8.26.0)(typescript@4.8.4)
+        specifier: ^5.45.0
+        version: 5.45.0(eslint@8.26.0)(typescript@4.9.3)
       eslint:
         specifier: ^8.26.0
         version: 8.26.0
       tsup:
         specifier: ^6.3.0
-        version: 6.3.0(ts-node@10.8.2)(typescript@4.8.4)
+        version: 6.3.0(ts-node@10.8.2)(typescript@4.9.3)
+      typescript:
+        specifier: ^4.9
+        version: 4.9.3
 
   packages/query-async-storage-persister:
     dependencies:
@@ -1379,15 +1382,6 @@ importers:
       react-dom-17:
         specifier: npm:react-dom@^17.0.2
         version: /react-dom@17.0.2(react@18.2.0)
-
-  packages/react-query/build/codemods:
-    devDependencies:
-      '@types/jscodeshift':
-        specifier: 0.11.6
-        version: 0.11.6
-      jscodeshift:
-        specifier: 0.15.0
-        version: 0.15.0(@babel/preset-env@7.18.6)
 
   packages/solid-query:
     dependencies:
@@ -2072,7 +2066,7 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.18.6(@babel/core@7.9.0)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.9.0)
     transitivePeerDependencies:
@@ -2761,7 +2755,7 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.18.6(@babel/core@7.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -3212,7 +3206,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-replace-supers': 7.18.6
     transitivePeerDependencies:
       - supports-color
@@ -6226,13 +6220,6 @@ packages:
       recast: 0.20.5
     dev: true
 
-  /@types/jscodeshift@0.11.6:
-    resolution: {integrity: sha512-3lJ4DajWkk4MZ1F7q+1C7jE0z0xOtbu0VU/Kg3wdPq2DUvJjySSlu3B5Q/bICrTxugLhONBO7inRUWsymOID/A==}
-    dependencies:
-      ast-types: 0.14.2
-      recast: 0.20.5
-    dev: true
-
   /@types/json-schema@7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
@@ -6369,32 +6356,6 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.41.0(@typescript-eslint/parser@5.41.0)(eslint@8.26.0)(typescript@4.8.4):
-    resolution: {integrity: sha512-DXUS22Y57/LAFSg3x7Vi6RNAuLpTXwxB9S2nIA7msBb/Zt8p7XqMwdpdc1IU7CkOQUPgAqR5fWvxuKCbneKGmA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.41.0(eslint@8.26.0)(typescript@4.8.4)
-      '@typescript-eslint/scope-manager': 5.41.0
-      '@typescript-eslint/type-utils': 5.41.0(eslint@8.26.0)(typescript@4.8.4)
-      '@typescript-eslint/utils': 5.41.0(eslint@8.26.0)(typescript@4.8.4)
-      debug: 4.3.4
-      eslint: 8.26.0
-      ignore: 5.2.0
-      regexpp: 3.2.0
-      semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin@5.41.0(@typescript-eslint/parser@5.41.0)(eslint@8.34.0)(typescript@4.4.4):
     resolution: {integrity: sha512-DXUS22Y57/LAFSg3x7Vi6RNAuLpTXwxB9S2nIA7msBb/Zt8p7XqMwdpdc1IU7CkOQUPgAqR5fWvxuKCbneKGmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6414,7 +6375,7 @@ packages:
       eslint: 8.34.0
       ignore: 5.2.0
       regexpp: 3.2.0
-      semver: 7.5.3
+      semver: 7.3.8
       tsutils: 3.21.0(typescript@4.4.4)
       typescript: 4.4.4
     transitivePeerDependencies:
@@ -6447,22 +6408,29 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.41.0(eslint@8.26.0)(typescript@4.8.4):
-    resolution: {integrity: sha512-HQVfix4+RL5YRWZboMD1pUfFN8MpRH4laziWkkAzyO1fvNOY/uinZcvo3QiFJVS/siNHupV8E5+xSwQZrl6PZA==}
+  /@typescript-eslint/eslint-plugin@5.45.0(@typescript-eslint/parser@5.45.0)(eslint@8.26.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.41.0
-      '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/typescript-estree': 5.41.0(typescript@4.8.4)
+      '@typescript-eslint/parser': 5.45.0(eslint@8.26.0)(typescript@4.9.3)
+      '@typescript-eslint/scope-manager': 5.45.0
+      '@typescript-eslint/type-utils': 5.45.0(eslint@8.26.0)(typescript@4.9.3)
+      '@typescript-eslint/utils': 5.45.0(eslint@8.26.0)(typescript@4.9.3)
       debug: 4.3.4
       eslint: 8.26.0
-      typescript: 4.8.4
+      ignore: 5.2.0
+      natural-compare-lite: 1.4.0
+      regexpp: 3.2.0
+      semver: 7.5.3
+      tsutils: 3.21.0(typescript@4.9.3)
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6507,6 +6475,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser@5.45.0(eslint@8.26.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.45.0
+      '@typescript-eslint/types': 5.45.0
+      '@typescript-eslint/typescript-estree': 5.45.0(typescript@4.9.3)
+      debug: 4.3.4
+      eslint: 8.26.0
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager@5.41.0:
     resolution: {integrity: sha512-xOxPJCnuktUkY2xoEZBKXO5DBCugFzjrVndKdUnyQr3+9aDWZReKq9MhaoVnbL+maVwWJu/N0SEtrtEUNb62QQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6515,24 +6503,12 @@ packages:
       '@typescript-eslint/visitor-keys': 5.41.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.41.0(eslint@8.26.0)(typescript@4.8.4):
-    resolution: {integrity: sha512-L30HNvIG6A1Q0R58e4hu4h+fZqaO909UcnnPbwKiN6Rc3BUEx6ez2wgN7aC0cBfcAjZfwkzE+E2PQQ9nEuoqfA==}
+  /@typescript-eslint/scope-manager@5.45.0:
+    resolution: {integrity: sha512-noDMjr87Arp/PuVrtvN3dXiJstQR1+XlQ4R1EvzG+NMgXi8CuMCXpb8JqNtFHKceVSQ985BZhfRdowJzbv4yKw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.41.0(typescript@4.8.4)
-      '@typescript-eslint/utils': 5.41.0(eslint@8.26.0)(typescript@4.8.4)
-      debug: 4.3.4
-      eslint: 8.26.0
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
-    transitivePeerDependencies:
-      - supports-color
+      '@typescript-eslint/types': 5.45.0
+      '@typescript-eslint/visitor-keys': 5.45.0
     dev: true
 
   /@typescript-eslint/type-utils@5.41.0(eslint@8.34.0)(typescript@4.4.4):
@@ -6575,8 +6551,33 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils@5.45.0(eslint@8.26.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-DY7BXVFSIGRGFZ574hTEyLPRiQIvI/9oGcN8t1A7f6zIs6ftbrU0nhyV26ZW//6f85avkwrLag424n+fkuoJ1Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.45.0(typescript@4.9.3)
+      '@typescript-eslint/utils': 5.45.0(eslint@8.26.0)(typescript@4.9.3)
+      debug: 4.3.4
+      eslint: 8.26.0
+      tsutils: 3.21.0(typescript@4.9.3)
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types@5.41.0:
     resolution: {integrity: sha512-5BejraMXMC+2UjefDvrH0Fo/eLwZRV6859SXRg+FgbhA0R0l6lDqDGAQYhKbXhPN2ofk2kY5sgGyLNL907UXpA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types@5.45.0:
+    resolution: {integrity: sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -6622,8 +6623,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.41.0(typescript@4.8.4):
-    resolution: {integrity: sha512-SlzFYRwFSvswzDSQ/zPkIWcHv8O5y42YUskko9c4ki+fV6HATsTODUPbRbcGDFYP86gaJL5xohUEytvyNNcXWg==}
+  /@typescript-eslint/typescript-estree@5.45.0(typescript@4.4.4):
+    resolution: {integrity: sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -6631,36 +6632,37 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/visitor-keys': 5.41.0
+      '@typescript-eslint/types': 5.45.0
+      '@typescript-eslint/visitor-keys': 5.45.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.8.4)
-      typescript: 4.8.4
+      tsutils: 3.21.0(typescript@4.4.4)
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.41.0(eslint@8.26.0)(typescript@4.8.4):
-    resolution: {integrity: sha512-QlvfwaN9jaMga9EBazQ+5DDx/4sAdqDkcs05AsQHMaopluVCUyu1bTRUVKzXbgjDlrRAQrYVoi/sXJ9fmG+KLQ==}
+  /@typescript-eslint/typescript-estree@5.45.0(typescript@4.9.3):
+    resolution: {integrity: sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.41.0
-      '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/typescript-estree': 5.41.0(typescript@4.8.4)
-      eslint: 8.26.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.26.0)
+      '@typescript-eslint/types': 5.45.0
+      '@typescript-eslint/visitor-keys': 5.45.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
       semver: 7.5.3
+      tsutils: 3.21.0(typescript@4.9.3)
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils@5.41.0(eslint@8.34.0)(typescript@4.4.4):
@@ -6703,11 +6705,59 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils@5.45.0(eslint@8.26.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.45.0
+      '@typescript-eslint/types': 5.45.0
+      '@typescript-eslint/typescript-estree': 5.45.0(typescript@4.9.3)
+      eslint: 8.26.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0(eslint@8.26.0)
+      semver: 7.5.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils@5.45.0(eslint@8.34.0)(typescript@4.4.4):
+    resolution: {integrity: sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.45.0
+      '@typescript-eslint/types': 5.45.0
+      '@typescript-eslint/typescript-estree': 5.45.0(typescript@4.4.4)
+      eslint: 8.34.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0(eslint@8.34.0)
+      semver: 7.5.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys@5.41.0:
     resolution: {integrity: sha512-vilqeHj267v8uzzakbm13HkPMl7cbYpKVjgFWZPIOHIJHZtinvypUhJ5xBXfWYg4eFKqztbMMpOgFpT9Gfx4fw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.41.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys@5.45.0:
+    resolution: {integrity: sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.45.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -7524,15 +7574,6 @@ packages:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
     dev: false
 
-  /assert@2.0.0:
-    resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
-    dependencies:
-      es6-object-assign: 1.1.0
-      is-nan: 1.3.2
-      object-is: 1.1.5
-      util: 0.12.5
-    dev: true
-
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
@@ -7556,13 +7597,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       tslib: 2.6.0
-
-  /ast-types@0.16.1:
-    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
-    engines: {node: '>=4'}
-    dependencies:
-      tslib: 2.6.0
-    dev: true
 
   /astral-regex@1.0.0:
     resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==}
@@ -9251,10 +9285,6 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /es6-object-assign@1.1.0:
-    resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
-    dev: true
-
   /es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
     dev: true
@@ -9694,7 +9724,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.41.0(@typescript-eslint/parser@5.41.0)(eslint@8.34.0)(typescript@4.4.4)
-      '@typescript-eslint/utils': 5.41.0(eslint@8.34.0)(typescript@4.4.4)
+      '@typescript-eslint/utils': 5.45.0(eslint@8.34.0)(typescript@4.4.4)
       eslint: 8.34.0
       jest: 27.5.1(ts-node@10.8.2)
     transitivePeerDependencies:
@@ -11248,14 +11278,6 @@ packages:
     dependencies:
       kind-of: 6.0.3
 
-  /is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      has-tostringtag: 1.0.0
-    dev: true
-
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
     dependencies:
@@ -11407,13 +11429,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.0
-    dev: true
-
   /is-git-repository@1.1.1:
     resolution: {integrity: sha512-hxLpJytJnIZ5Og5QsxSkzmb8Qx8rGau9bio1JN/QtXcGEFuSsQYau0IiqlsCwftsfVYjF1mOq6uLdmwNSspgpA==}
     dependencies:
@@ -11446,14 +11461,6 @@ packages:
 
   /is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-    dev: true
-
-  /is-nan@1.3.2:
-    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.4
     dev: true
 
   /is-negative-zero@2.0.2:
@@ -12357,39 +12364,6 @@ packages:
       neo-async: 2.6.2
       node-dir: 0.1.17
       recast: 0.20.5
-      temp: 0.8.4
-      write-file-atomic: 2.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /jscodeshift@0.15.0(@babel/preset-env@7.18.6):
-    resolution: {integrity: sha512-t337Wx7Vy1ffhas7E1KZUHaR9YPdeCfxPvxz9k6DKwYW88pcs1piR1eR9d+7GQZGSQIZd6a+cfIM3XpMe9rFKQ==}
-    hasBin: true
-    peerDependencies:
-      '@babel/preset-env': ^7.1.6
-    peerDependenciesMeta:
-      '@babel/preset-env':
-        optional: true
-    dependencies:
-      '@babel/core': 7.19.1
-      '@babel/parser': 7.19.1
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.19.1)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.19.1)
-      '@babel/plugin-proposal-optional-chaining': 7.18.6(@babel/core@7.19.1)
-      '@babel/plugin-transform-modules-commonjs': 7.18.6(@babel/core@7.19.1)
-      '@babel/preset-env': 7.18.6(@babel/core@7.19.1)
-      '@babel/preset-flow': 7.18.6(@babel/core@7.19.1)
-      '@babel/preset-typescript': 7.18.6(@babel/core@7.19.1)
-      '@babel/register': 7.18.6(@babel/core@7.19.1)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.19.1)
-      chalk: 4.1.2
-      flow-parser: 0.121.0
-      graceful-fs: 4.2.10
-      micromatch: 4.0.5
-      neo-async: 2.6.2
-      node-dir: 0.1.17
-      recast: 0.23.3
       temp: 0.8.4
       write-file-atomic: 2.4.3
     transitivePeerDependencies:
@@ -13672,6 +13646,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /natural-compare-lite@1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
+    dev: true
+
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -13988,14 +13966,6 @@ packages:
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
-    dev: true
-
-  /object-is@1.1.5:
-    resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.4
     dev: true
 
   /object-keys@1.1.1:
@@ -15230,17 +15200,6 @@ packages:
       source-map: 0.6.1
       tslib: 2.6.0
 
-  /recast@0.23.3:
-    resolution: {integrity: sha512-HbCVFh2ANP6a09nzD4lx7XthsxMOJWKX5pIcUwtLrmeEIl3I0DwjCoVXDE0Aobk+7k/mS3H50FK4iuYArpcT6Q==}
-    engines: {node: '>= 4'}
-    dependencies:
-      assert: 2.0.0
-      ast-types: 0.16.1
-      esprima: 4.0.1
-      source-map: 0.6.1
-      tslib: 2.6.0
-    dev: true
-
   /rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
@@ -16376,8 +16335,8 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.55.0
-      svelte-preprocess: 4.10.7(@babel/core@7.19.1)(postcss@8.4.21)(svelte@3.55.0)(typescript@4.8.4)
-      typescript: 4.8.4
+      svelte-preprocess: 4.10.7(@babel/core@7.19.1)(postcss@8.4.21)(svelte@3.55.0)(typescript@4.9.3)
+      typescript: 4.9.3
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -16412,7 +16371,7 @@ packages:
       svelte: 3.55.0
     dev: true
 
-  /svelte-preprocess@4.10.7(@babel/core@7.19.1)(postcss@8.4.21)(svelte@3.55.0)(typescript@4.8.4):
+  /svelte-preprocess@4.10.7(@babel/core@7.19.1)(postcss@8.4.21)(svelte@3.55.0)(typescript@4.9.3):
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -16462,7 +16421,7 @@ packages:
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.55.0
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /svelte2tsx@0.6.0(svelte@3.55.0)(typescript@4.8.4):
@@ -16911,7 +16870,7 @@ packages:
   /tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
 
-  /tsup@6.3.0(ts-node@10.8.2)(typescript@4.8.4):
+  /tsup@6.3.0(ts-node@10.8.2)(typescript@4.9.3):
     resolution: {integrity: sha512-IaNQO/o1rFgadLhNonVKNCT2cks+vvnWX3DnL8sB87lBDqRvJXHENr5lSPJlqwplUlDxSwZK8dSg87rgBu6Emw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -16941,7 +16900,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.23.0
       tree-kill: 1.2.2
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -16967,14 +16926,14 @@ packages:
       typescript: 4.8.3
     dev: true
 
-  /tsutils@3.21.0(typescript@4.8.4):
+  /tsutils@3.21.0(typescript@4.9.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /type-check@0.3.2:
@@ -17063,6 +17022,12 @@ packages:
 
   /typescript@4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript@4.9.3:
+    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -17272,16 +17237,6 @@ packages:
     dependencies:
       define-properties: 1.1.4
       object.getownpropertydescriptors: 2.1.4
-    dev: true
-
-  /util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.1.1
-      is-generator-function: 1.0.10
-      is-typed-array: 1.1.10
-      which-typed-array: 1.1.9
     dev: true
 
   /utils-merge@1.0.1:


### PR DESCRIPTION
Fixes #5028, and cases where the query options object is not defined in the same file as the `useQuery` call.

To be able to test the issue with `satisfies` I had to update `typescript` and `@typescript-eslint` packages, but I have only updated `devDependencies` in `eslint-plugin-query`.

I have removed a test case for invalid code:
```
import { useQuery } from "@tanstack/react-query";
useQuery(queryKey);
```
Because I think in most cases for `useQuery(some_variable)` when `some_variable` is not defined in the current file, it will be a query options object.
