### PR TITLE
fix(vue-query): ensure built-in types are not being unwrapped

### DIFF
--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -9,6 +9,7 @@ import type { Ref, UnwrapRef } from 'vue-demi'
 import type { QueryClient } from './queryClient'
 
 type Primitive = string | number | boolean | bigint | symbol | undefined | null
+type Builtin = Primitive | Function | Date | Error | RegExp;
 
 export type MaybeRefDeep<T> = MaybeRef<
   T extends Function
@@ -22,7 +23,7 @@ export type MaybeRefDeep<T> = MaybeRef<
 
 export type MaybeRef<T> = Ref<T> | T
 
-export type DeepUnwrapRef<T> = T extends Primitive
+export type DeepUnwrapRef<T> = T extends Builtin
   ? T
   : T extends Ref<infer U>
   ? DeepUnwrapRef<U>

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -9,7 +9,7 @@ import type { Ref, UnwrapRef } from 'vue-demi'
 import type { QueryClient } from './queryClient'
 
 type Primitive = string | number | boolean | bigint | symbol | undefined | null
-type Builtin = Primitive | Function | Date | Error | RegExp;
+type Builtin = Primitive | Function | Date | Error | RegExp
 
 export type MaybeRefDeep<T> = MaybeRef<
   T extends Function

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -9,7 +9,16 @@ import type { Ref, UnwrapRef } from 'vue-demi'
 import type { QueryClient } from './queryClient'
 
 type Primitive = string | number | boolean | bigint | symbol | undefined | null
-type Builtin = Primitive | Function | Date | Error | RegExp
+type UnwrapLeaf =
+  | Primitive
+  | Function
+  | Date
+  | Error
+  | RegExp
+  | Map<any, any>
+  | WeakMap<any, any>
+  | Set<any>
+  | WeakSet<any>
 
 export type MaybeRefDeep<T> = MaybeRef<
   T extends Function
@@ -23,7 +32,7 @@ export type MaybeRefDeep<T> = MaybeRef<
 
 export type MaybeRef<T> = Ref<T> | T
 
-export type DeepUnwrapRef<T> = T extends Builtin
+export type DeepUnwrapRef<T> = T extends UnwrapLeaf
   ? T
   : T extends Ref<infer U>
   ? DeepUnwrapRef<U>


### PR DESCRIPTION
## Resolve the following error

This error was mentioned in PR  https://github.com/TanStack/query/pull/5935#issuecomment-1705020256

```ts
import { useQuery, UseQueryOptions } from https://github.com/TanStack/query/tree/master/packages/vue-query;
import { Ref, toRef } from https://github.com/vuejs/core;

type MaybeRef<T> = T | Ref<T>;
type MaybeRefOrGetter<T> = MaybeRef<T> | (() => T);

const fetchUser = (userId: Date) =>
  fetch(`/api/user/${userId.toISOString()}`).then(res => res.json());

type User = any;
export function useUser(
  userId: MaybeRefOrGetter<Date>,
  options?: UseQueryOptions<User, any, User, readonly [string, Ref<Date>]>
) {
  return useQuery({
    queryKey: ['user', toRef(userId)],
    queryFn({ queryKey }) {
      return fetchUser(queryKey[1]);
    },
    ...options,
  } satisfies typeof options);
}
```

```
example.ts:185:24 - error TS2345: Argument of type '{ toString: {}; toDateString: {}; toTimeString: {}; toLocaleString: {}; toLocaleDateString: {}; toLocaleTimeString: {}; valueOf: {}; getTime: {}; getFullYear: {}; getUTCFullYear: {}; getMonth: {}; ... 32 more ...; [Symbol.toPrimitive]: {}; }' is not assignable to parameter of type 'Date'.
  Types of property 'toString' are incompatible.
    Type '{}' is not assignable to type '() => string'.
      Type '{}' provides no match for the signature '(): string'.
```

In that PR, not avoiding unwrapping **built-in types** resulted in errors, such as Ref<Date>, occurring.

## Before
<img width="800" alt="截圖 2023-09-04 下午7 35 04" src="https://github.com/TanStack/query/assets/39984251/690e6ac8-7ba1-47eb-a1c2-e0b08599b9d1">

## After

<img width="900" alt="截圖 2023-09-04 下午7 36 39" src="https://github.com/TanStack/query/assets/39984251/ee8fd364-01bf-48f3-ac0d-397b8ed43ce0">
