### PR TITLE
chore(query-core): add deprecated hint for `isDataEqual`

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -76,6 +76,9 @@ export interface QueryOptions<
   retryDelay?: RetryDelayValue<TError>
   networkMode?: NetworkMode
   cacheTime?: number
+  /**
+   * @deprecated This callback will be removed in the next major version. You can achieve the same functionality by passing a function to `structuralSharing` instead.
+   */
   isDataEqual?: (oldData: TData | undefined, newData: TData) => boolean
   queryFn?: QueryFunction<TQueryFnData, TQueryKey>
   queryHash?: string


### PR DESCRIPTION
The `isDataEqual` function in `QueryObserver` has been deprecated, and it is recommended to use `structuralSharing` instead. Currently, it will only be displayed through the console during development execution. Adding this TSDoc annotation can enable ESLint to help us check whether it is being used. These are deprecated APIs.