### PR TITLE
Update dependent-queries.md

### DIFF
--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -58,7 +58,7 @@ fetchStatus: 'idle'
 
 Dynamic parallel query - `useQueries` can depend on a previous query also, here's how to achieve this:
 
-[//]: # 'Example'
+[//]: # 'Example2'
 
 ```tsx
 // Get the users ids
@@ -80,5 +80,7 @@ const usersMessages = useQueries({
   : [], // if users is undefined, an empty array will be returned
 })
 ```
+
+[//]: # 'Example2'
 
 **Note** that `useQueries` return an **array of query results**

--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -78,7 +78,7 @@ const usersMessages = useQueries({
           queryFn: () => getMessagesByUsers(id),
         };
       })
-  : [], // if users is underfined an empty array will be returned
+  : [], // if users is undefined, an empty array will be returned
 })
 ```
 

--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -61,13 +61,12 @@ Dynamic parallel query - `useQueries` can depend on a previous query also, here'
 [//]: # 'Example'
 
 ```tsx
-// Get the users Data
-const { data: users } = useQuery({
+// Get the users ids
+const { data: userIds } = useQuery({
   queryKey: ['users'],
   queryFn: getUsersData,
+  select: users => users.map(user => user.id),
 })
-
-const usersId = users?.filter(user => user?.id)
 
 // Then get the users messages
 const usersMessages = useQueries({

--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -3,6 +3,8 @@ id: dependent-queries
 title: Dependent Queries
 ---
 
+## useQuery dependent Query
+
 Dependent (or serial) queries depend on previous ones to finish before they can execute. To achieve this, it's as easy as using the `enabled` option to tell a query when it is ready to run:
 
 [//]: # 'Example'
@@ -51,3 +53,33 @@ Once we have the projects, it will go to:
 status: 'success'
 fetchStatus: 'idle'
 ```
+
+## useQueries dependent Query
+
+Dynamic parallel query - `useQueries` can depend on a previous query also, here's how to achieve this:
+
+[//]: # 'Example'
+
+```tsx
+// Get the users Data
+const { data: users } = useQuery({
+  queryKey: ['users'],
+  queryFn: getUsersData,
+})
+
+const usersId = users?.filter(user => user?.id)
+
+// Then get the user's messages
+const usersMessages = useQueries({
+  queries: users
+    ? usersId.map(id => {
+        return {
+          queryKey: ['messages', id],
+          queryFn: () => getMessagesByUsers(id),
+        };
+      })
+  : [], // if users is underfined and empty array will be returned
+})
+```
+
+**Note** that `useQueries` return an **array of query results**

--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -69,7 +69,7 @@ const { data: users } = useQuery({
 
 const usersId = users?.filter(user => user?.id)
 
-// Then get the user's messages
+// Then get the users messages
 const usersMessages = useQueries({
   queries: users
     ? usersId.map(id => {

--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -78,7 +78,7 @@ const usersMessages = useQueries({
           queryFn: () => getMessagesByUsers(id),
         };
       })
-  : [], // if users is underfined and empty array will be returned
+  : [], // if users is underfined an empty array will be returned
 })
 ```
 


### PR DESCRIPTION
This is to show how the useQueries hook can also be dependent on a query.

---

## useQueries dependent Query

Dynamic parallel query - useQueries can depend on a previous query also, here's how to achieve this:

```tsx
// Get the users Data
const { data: users } = useQuery({
  queryKey: ['users'],
  queryFn: getUsersData,
})

const usersId = users?.filter(user => user?.id)

// Then get the user's messages
const usersMessages = useQueries({
  queries: users
    ? usersId.map(id => {
        return {
          queryKey: ['messages', id],
          queryFn: () => getMessagesByUsers(id),
        };
      })
  : [], // if users is underfined an empty array will be returned
})
```

**Note** that useQueries return an array of query results