### PR TITLE
refactor(query-core): remove `queryKey` check in production environment

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -354,8 +354,8 @@ export class Query<
       }
     }
 
-    if (!Array.isArray(this.options.queryKey)) {
-      if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production') {
+      if (!Array.isArray(this.options.queryKey)) {
         this.logger.error(
           `As of v4, queryKey needs to be an Array. If you are using a string like 'repoData', please change it to an Array, e.g. ['repoData']`,
         )


### PR DESCRIPTION
## Before

This is production code(to see clearly, I turned off minify), and `if (!Array.isArray(this.options.queryKey))` is in there

<img width="510" alt="截圖 2023-09-07 上午7 00 08" src="https://github.com/TanStack/query/assets/39984251/0be78592-938b-4361-88cb-421fd6bdc8b5">

## After

`if (!Array.isArray(this.options.queryKey))` be removed in production.

<img width="510" alt="截圖 2023-09-07 上午7 05 03" src="https://github.com/TanStack/query/assets/39984251/3bd71761-ba0a-4199-953c-9bc6811fbb8b">
