### PR TITLE
refactor(queryClient): accept generics on setQueryDefaults and setMutationDefaults

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -372,10 +372,18 @@ export class QueryClient {
     this.#defaultOptions = options
   }
 
-  setQueryDefaults(
+  setQueryDefaults<
+    TData = unknown,
+    TError = DefaultError,
+    TVariables = void,
+    TContext = unknown,
+  >(
     queryKey: QueryKey,
     options: Partial<
-      Omit<QueryObserverOptions<unknown, any, any, any>, 'queryKey'>
+      Omit<
+        QueryObserverOptions<TData, TError, TVariables, TContext>,
+        'queryKey'
+      >
     >,
   ): void {
     this.#queryDefaults.set(hashKey(queryKey), {
@@ -399,9 +407,17 @@ export class QueryClient {
     return result
   }
 
-  setMutationDefaults(
+  setMutationDefaults<
+    TData = unknown,
+    TError = DefaultError,
+    TVariables = void,
+    TContext = unknown,
+  >(
     mutationKey: MutationKey,
-    options: Omit<MutationObserverOptions<any, any, any, any>, 'mutationKey'>,
+    options: Omit<
+      MutationObserverOptions<TData, TError, TVariables, TContext>,
+      'mutationKey'
+    >,
   ): void {
     this.#mutationDefaults.set(hashKey(mutationKey), {
       mutationKey,


### PR DESCRIPTION
This change improves type inferring and improves DX.

As an example, before this PR, variables accepted by onSettled and onError would not be typed. After this PR, and thanks to v5's default Error, the whole thing is now typed after you specify mutationFn and create a context. This means developer doesn't have to manually type cast anymore if he is working with data, context, error or response variables inside setMutationDefaults or setQueryDefaults methods.

```ts
queryClient.setMutationDefaults(key, {
  mutationFn: async (text: string) => text,
  onMutate: () => {
    return 1
  },
  onSettled: (data, error, context) => {

  },
  onError(error, variables, context) {

  },
})
```