### PR TITLE
perf(vue-query): reuse parsing utility functions from `query-core`

### DIFF
--- a/packages/vue-query/src/__tests__/useIsFetching.test.ts
+++ b/packages/vue-query/src/__tests__/useIsFetching.test.ts
@@ -1,7 +1,7 @@
-import { onScopeDispose, reactive, ref } from 'vue-demi'
+import { onScopeDispose, reactive } from 'vue-demi'
 
 import { useQuery } from '../useQuery'
-import { parseFilterArgs, useIsFetching } from '../useIsFetching'
+import { useIsFetching } from '../useIsFetching'
 import { flushPromises, simpleFetcher } from './test-utils'
 
 jest.mock('../useQueryClient')
@@ -70,32 +70,5 @@ describe('useIsFetching', () => {
     expect(isFetching.value).toStrictEqual(1)
 
     await flushPromises(100)
-  })
-
-  describe('parseFilterArgs', () => {
-    test('should default to empty filters', () => {
-      const result = parseFilterArgs(undefined)
-
-      expect(result).toEqual({})
-    })
-
-    test('should merge query key with filters', () => {
-      const filters = { stale: true }
-
-      const result = parseFilterArgs(['key'], filters)
-      const expected = { ...filters, queryKey: ['key'] }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs arguments', () => {
-      const key = ref(['key'])
-      const filters = ref({ stale: ref(true) })
-
-      const result = parseFilterArgs(key, filters)
-      const expected = { queryKey: ['key'], stale: true }
-
-      expect(result).toEqual(expected)
-    })
   })
 })

--- a/packages/vue-query/src/__tests__/useIsMutating.test.ts
+++ b/packages/vue-query/src/__tests__/useIsMutating.test.ts
@@ -1,7 +1,7 @@
-import { onScopeDispose, reactive, ref } from 'vue-demi'
+import { onScopeDispose, reactive } from 'vue-demi'
 
 import { useMutation } from '../useMutation'
-import { parseFilterArgs, useIsMutating } from '../useIsMutating'
+import { useIsMutating } from '../useIsMutating'
 import { useQueryClient } from '../useQueryClient'
 import { flushPromises, successMutator } from './test-utils'
 
@@ -76,32 +76,5 @@ describe('useIsMutating', () => {
     await flushPromises()
 
     expect(isMutating.value).toStrictEqual(1)
-  })
-
-  describe('parseMutationFilterArgs', () => {
-    test('should default to empty filters', () => {
-      const result = parseFilterArgs(undefined)
-
-      expect(result).toEqual({})
-    })
-
-    test('should merge mutation key with filters', () => {
-      const filters = { fetching: true }
-
-      const result = parseFilterArgs(['key'], filters)
-      const expected = { ...filters, mutationKey: ['key'] }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs arguments', () => {
-      const key = ref(['key'])
-      const filters = ref({ fetching: ref(true) })
-
-      const result = parseFilterArgs(key, filters)
-      const expected = { mutationKey: ['key'], fetching: true }
-
-      expect(result).toEqual(expected)
-    })
   })
 })

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -1,5 +1,5 @@
 import { reactive, ref } from 'vue-demi'
-import { parseMutationArgs, useMutation } from '../useMutation'
+import { useMutation } from '../useMutation'
 import { useQueryClient } from '../useQueryClient'
 import { errorMutator, flushPromises, successMutator } from './test-utils'
 
@@ -328,58 +328,6 @@ describe('useMutation', () => {
 
       expect(boundaryFn).toHaveBeenCalledTimes(1)
       expect(boundaryFn).toHaveBeenCalledWith(err)
-    })
-  })
-
-  describe('parseMutationArgs', () => {
-    test('should return the same instance of options', () => {
-      const options = { retry: false }
-      const result = parseMutationArgs(options)
-
-      expect(result).toEqual(options)
-    })
-
-    test('should merge query key with options', () => {
-      const options = { retry: false }
-      const result = parseMutationArgs(['key'], options)
-      const expected = { ...options, mutationKey: ['key'] }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should merge query fn with options', () => {
-      const options = { retry: false }
-      const result = parseMutationArgs(successMutator, options)
-      const expected = { ...options, mutationFn: successMutator }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should merge query key and fn with options', () => {
-      const options = { retry: false }
-      const result = parseMutationArgs(['key'], successMutator, options)
-      const expected = {
-        ...options,
-        mutationKey: ['key'],
-        mutationFn: successMutator,
-      }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs arguments', () => {
-      const key = ref(['key'])
-      const mutationFn = ref(successMutator)
-      const options = ref({ retry: ref(12) })
-
-      const result = parseMutationArgs(key, mutationFn, options)
-      const expected = {
-        mutationKey: ['key'],
-        mutationFn: successMutator,
-        retry: 12,
-      }
-
-      expect(result).toEqual(expected)
     })
   })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -8,7 +8,7 @@ import {
 import { QueryObserver } from '@tanstack/query-core'
 
 import { useQuery } from '../useQuery'
-import { parseQueryArgs, useBaseQuery } from '../useBaseQuery'
+import { useBaseQuery } from '../useBaseQuery'
 import {
   flushPromises,
   getSimpleFetcherWithReturnData,
@@ -279,53 +279,6 @@ describe('useQuery', () => {
           state: expect.objectContaining({ status: 'error' }),
         }),
       )
-    })
-  })
-
-  describe('parseQueryArgs', () => {
-    test('should unwrap refs arguments', () => {
-      const key = ref(['key'])
-      const fn = ref(simpleFetcher)
-      const options = ref({ enabled: ref(true) })
-
-      const result = parseQueryArgs(key, fn, options)
-      const expected = {
-        queryKey: ['key'],
-        queryFn: simpleFetcher,
-        enabled: true,
-      }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs with fn in options', () => {
-      const key = ref(['key'])
-      const fn = ref(simpleFetcher)
-      const options = ref({ queryFn: fn, enabled: ref(true) })
-
-      const result = parseQueryArgs(key, options)
-      const expected = {
-        queryKey: ['key'],
-        queryFn: simpleFetcher,
-        enabled: true,
-      }
-
-      expect(result).toEqual(expected)
-    })
-
-    test('should unwrap refs in options', () => {
-      const key = ref(['key'])
-      const fn = ref(simpleFetcher)
-      const options = ref({ queryKey: key, queryFn: fn, enabled: ref(true) })
-
-      const result = parseQueryArgs(options)
-      const expected = {
-        queryKey: ['key'],
-        queryFn: simpleFetcher,
-        enabled: true,
-      }
-
-      expect(result).toEqual(expected)
     })
   })
 

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -62,22 +62,3 @@ export function useIsFetching(
 
   return isFetching
 }
-
-// export function parseFilterArgs(
-//   arg1?: MaybeRef<QueryKey> | QueryFilters,
-//   arg2: QueryFilters = {},
-// ) {
-//   const plainArg1 = unref(arg1)
-//   const plainArg2 = unref(arg2)
-
-//   let options = plainArg1
-
-//   if (isQueryKey(plainArg1)) {
-//     options = { ...plainArg2, queryKey: plainArg1 }
-//   } else {
-//     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-//     options = plainArg1 || {}
-//   }
-
-//   return cloneDeepUnref(options) as WithQueryClientKey<QF>
-// }

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -6,8 +6,9 @@ import {
   unref,
   watchSyncEffect,
 } from 'vue-demi'
+import { parseFilterArgs } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient'
-import { cloneDeepUnref, isQueryKey } from './utils'
+import { cloneDeepUnref } from './utils'
 import type { Ref } from 'vue-demi'
 import type { QueryFilters as QF, QueryKey } from '@tanstack/query-core'
 
@@ -32,7 +33,16 @@ export function useIsFetching(
     }
   }
 
-  const filters = computed(() => parseFilterArgs(arg1, arg2))
+  const filters = computed(
+    () =>
+      cloneDeepUnref(
+        parseFilterArgs(
+          // @ts-expect-error this is fine
+          unref(arg1),
+          unref(arg2),
+        )[0],
+      ) as WithQueryClientKey<QF>,
+  )
   const queryClient =
     filters.value.queryClient ?? useQueryClient(filters.value.queryClientKey)
 
@@ -53,21 +63,21 @@ export function useIsFetching(
   return isFetching
 }
 
-export function parseFilterArgs(
-  arg1?: MaybeRef<QueryKey> | QueryFilters,
-  arg2: QueryFilters = {},
-) {
-  const plainArg1 = unref(arg1)
-  const plainArg2 = unref(arg2)
+// export function parseFilterArgs(
+//   arg1?: MaybeRef<QueryKey> | QueryFilters,
+//   arg2: QueryFilters = {},
+// ) {
+//   const plainArg1 = unref(arg1)
+//   const plainArg2 = unref(arg2)
 
-  let options = plainArg1
+//   let options = plainArg1
 
-  if (isQueryKey(plainArg1)) {
-    options = { ...plainArg2, queryKey: plainArg1 }
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    options = plainArg1 || {}
-  }
+//   if (isQueryKey(plainArg1)) {
+//     options = { ...plainArg2, queryKey: plainArg1 }
+//   } else {
+//     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+//     options = plainArg1 || {}
+//   }
 
-  return cloneDeepUnref(options) as WithQueryClientKey<QF>
-}
+//   return cloneDeepUnref(options) as WithQueryClientKey<QF>
+// }

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -62,22 +62,3 @@ export function useIsMutating(
 
   return isMutating
 }
-
-// export function parseFilterArgs(
-//   arg1?: MaybeRef<MutationKey> | MutationFilters,
-//   arg2: MutationFilters = {},
-// ) {
-//   const plainArg1 = unref(arg1)
-//   const plainArg2 = unref(arg2)
-
-//   let options = plainArg1
-
-//   if (isQueryKey(plainArg1)) {
-//     options = { ...plainArg2, mutationKey: plainArg1 }
-//   } else {
-//     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-//     options = plainArg1 || {}
-//   }
-
-//   return cloneDeepUnref(options) as WithQueryClientKey<MF>
-// }

--- a/packages/vue-query/src/useIsMutating.ts
+++ b/packages/vue-query/src/useIsMutating.ts
@@ -6,8 +6,9 @@ import {
   unref,
   watchSyncEffect,
 } from 'vue-demi'
+import { parseMutationFilterArgs } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient'
-import { cloneDeepUnref, isQueryKey } from './utils'
+import { cloneDeepUnref } from './utils'
 import type { Ref } from 'vue-demi'
 import type { MutationFilters as MF, MutationKey } from '@tanstack/query-core'
 
@@ -32,7 +33,16 @@ export function useIsMutating(
     }
   }
 
-  const filters = computed(() => parseFilterArgs(arg1, arg2))
+  const filters = computed(
+    () =>
+      cloneDeepUnref(
+        parseMutationFilterArgs(
+          // @ts-expect-error this is fine
+          unref(arg1),
+          unref(arg2),
+        )[0],
+      ) as WithQueryClientKey<MF>,
+  )
   const queryClient =
     filters.value.queryClient ?? useQueryClient(filters.value.queryClientKey)
 
@@ -53,21 +63,21 @@ export function useIsMutating(
   return isMutating
 }
 
-export function parseFilterArgs(
-  arg1?: MaybeRef<MutationKey> | MutationFilters,
-  arg2: MutationFilters = {},
-) {
-  const plainArg1 = unref(arg1)
-  const plainArg2 = unref(arg2)
+// export function parseFilterArgs(
+//   arg1?: MaybeRef<MutationKey> | MutationFilters,
+//   arg2: MutationFilters = {},
+// ) {
+//   const plainArg1 = unref(arg1)
+//   const plainArg2 = unref(arg2)
 
-  let options = plainArg1
+//   let options = plainArg1
 
-  if (isQueryKey(plainArg1)) {
-    options = { ...plainArg2, mutationKey: plainArg1 }
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    options = plainArg1 || {}
-  }
+//   if (isQueryKey(plainArg1)) {
+//     options = { ...plainArg2, mutationKey: plainArg1 }
+//   } else {
+//     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+//     options = plainArg1 || {}
+//   }
 
-  return cloneDeepUnref(options) as WithQueryClientKey<MF>
-}
+//   return cloneDeepUnref(options) as WithQueryClientKey<MF>
+// }


### PR DESCRIPTION
In query-core, there are several utility functions provided, such as `parseQueryArgs`, `parseMutationArgs`, `parseFilterArgs`, and `parseMutationFilterArgs`. These can be reused in vue-query, and all we need to do is unwrap  `ref` and perform deep cloning to track nested reactive data.

This PR can reduce the bundle size a little bit 

```` 
index.product.js ⏤ 12.6 kB (-156 B) ≈ -1.24%
````