### PR TITLE
refactor(vue-query): reduce unnecessary type flexibility

### DIFF
--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -29,12 +29,11 @@ import type {
 } from '@tanstack/query-core'
 
 export class QueryClient extends QC {
-  constructor(config: MaybeRefDeep<QueryClientConfig> = {}) {
-    const unreffedConfig = cloneDeepUnref(config)
-    const vueQueryConfig: QueryClientConfig = {
-      defaultOptions: unreffedConfig.defaultOptions,
-      queryCache: unreffedConfig.queryCache || new QueryCache(),
-      mutationCache: unreffedConfig.mutationCache || new MutationCache(),
+  constructor(config: QueryClientConfig = {}) {
+    const vueQueryConfig = {
+      defaultOptions: config.defaultOptions,
+      queryCache: config.queryCache || new QueryCache(),
+      mutationCache: config.mutationCache || new MutationCache(),
     }
     super(vueQueryConfig)
   }

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -5,7 +5,6 @@ import { QueryClient } from './queryClient'
 import { getClientKey } from './utils'
 import { setupDevtools } from './devtools/devtools'
 import type { QueryClientConfig } from '@tanstack/query-core'
-import type { MaybeRefDeep } from './types'
 
 type ClientPersister = (client: QueryClient) => [() => void, Promise<void>]
 
@@ -16,7 +15,7 @@ interface CommonOptions {
 }
 
 interface ConfigOptions extends CommonOptions {
-  queryClientConfig?: MaybeRefDeep<QueryClientConfig>
+  queryClientConfig?: QueryClientConfig
 }
 
 interface ClientOptions extends CommonOptions {


### PR DESCRIPTION
In the current version (both v5 and v4), vue-query allows users to pass `queryClientConfig` in the options of `VueQueryPlugin`, which is of type `MaybeRefDeep<QueryClientConfig>`.

```ts
const app = createApp(App)

app.use(VueQueryPlugin, {
  // The current version of vue-query, here can be an object 
  // of type `QueryClientConfig`  or `MaybeRefDeep<QueryClientConfig>`
  queryClientConfig: {
  
  }
})
```

However, in the extended QueryClient, the `queryClientConfig` will be deep cloned and deep unwrapped, even though there is no need to track reactive data here.

Perhaps in the next version (v5), we can consider eliminating the flexible typing of `queryClientConfig` and exclusively use the `QueryClientConfig` type. This adjustment could reduce the unnecessary overhead of deep cloning and deep unwrapping `ref` objects.