### PR TITLE
feat: Allow returning undefined from initialData

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -3237,6 +3237,38 @@ describe('useQuery', () => {
     })
   })
 
+  it('should fetch if initial data is a function returning undefined', async () => {
+    const key = queryKey()
+    const states: Array<DefinedUseQueryResult<string>> = []
+
+    function Page() {
+      const state = useQuery({
+        queryKey: key,
+        queryFn: () => 'data',
+        initialData: () => undefined,
+      })
+      states.push(state)
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await sleep(50)
+
+    expect(states.length).toBe(2)
+
+    expect(states[0]).toMatchObject({
+      data: undefined,
+      isStale: true,
+      isFetching: true,
+    })
+    expect(states[1]).toMatchObject({
+      data: 'data',
+      isStale: true,
+      isFetching: false,
+    })
+  })
+
   it('should not fetch if initial data is set with a stale time', async () => {
     const key = queryKey()
     const states: Array<DefinedUseQueryResult<string>> = []

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -10,17 +10,13 @@ export type UndefinedInitialDataOptions<
   initialData?: undefined
 }
 
-type NonUndefinedGuard<T> = T extends undefined ? never : T
-
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  initialData:
-    | NonUndefinedGuard<TQueryFnData>
-    | (() => NonUndefinedGuard<TQueryFnData>)
+  initialData: TQueryFnData | (() => TQueryFnData | undefined)
 }
 
 type ValidateQueryOptions<T> = {

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -2947,6 +2947,44 @@ describe('createQuery', () => {
     })
   })
 
+  it('should fetch if initial data is a function returning undefined', async () => {
+    const key = queryKey()
+    const states: Array<DefinedCreateQueryResult<string>> = []
+
+    function Page() {
+      const state = createQuery(() => ({
+        queryKey: key,
+        queryFn: () => 'data',
+        initialData: () => undefined,
+      }))
+      createRenderEffect(() => {
+        states.push({ ...state })
+      })
+      return null
+    }
+
+    render(() => (
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    await sleep(50)
+
+    expect(states.length).toBe(2)
+
+    expect(states[0]).toMatchObject({
+      data: undefined,
+      isStale: true,
+      isFetching: true,
+    })
+    expect(states[1]).toMatchObject({
+      data: 'data',
+      isStale: true,
+      isFetching: false,
+    })
+  })
+
   it('should keep initial data when the query key changes', async () => {
     const key = queryKey()
     const states: Array<Partial<DefinedCreateQueryResult<{ count: number }>>> =

--- a/packages/solid-query/src/createQuery.ts
+++ b/packages/solid-query/src/createQuery.ts
@@ -30,7 +30,7 @@ type DefinedInitialDataOptions<
   TQueryKey extends QueryKey = QueryKey,
 > = FunctionedParams<
   SolidQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-    initialData: TQueryFnData | (() => TQueryFnData)
+    initialData: TQueryFnData | (() => TQueryFnData | undefined)
   }
 >
 


### PR DESCRIPTION
This pull request changes `react-query` and `solid-query` to allow the function form of `initialData` to return `undefined`, allowing it to work better with:
- [`queryClient.getQueryData`](https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientgetquerydata) which Returns `TQueryFnData | undefined`
- [`queryClient.getQueriesData`](https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientgetqueriesdata) which Returns `[queryKey: QueryKey, data: TQueryFnData | undefined][]`

Tests were added for both packages for this situation where `initialData` is a function returning `undefined`.

For example before this change I had to cast the return value of the [Initial Data from Cache](https://tanstack.com/query/v5/docs/react/guides/initial-query-data#initial-data-from-cache) example in TypeScript:
```js
const result = useQuery({
  queryKey: ['todo', todoId],
  queryFn: () => fetch('/todos'),
  initialData: () => {
    // This might also return undefined.
    return queryClient.getQueryData(['todos'])?.find((d) => d.id === todoId)
  },
})
```