### PR TITLE
types(query-core): ensureQueryData TError default type

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -115,7 +115,7 @@ export class QueryClient {
 
   ensureQueryData<
     TQueryFnData,
-    TError,
+    TError = DefaultError,
     TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
   >(


### PR DESCRIPTION
I couldn't figure out the reason for this omission nor find any reason in a brief search of the repo for `ensureQueryData`, so I assume this is just an oversight.