### PR TITLE
docs(useInfiniteQuery): add warning about fetchNextPage disrupting default refetch behaviour

### DIFF
--- a/docs/react/reference/useInfiniteQuery.md
+++ b/docs/react/reference/useInfiniteQuery.md
@@ -69,3 +69,5 @@ The returned properties for `useInfiniteQuery` are identical to the [`useQuery` 
 - `isRefetching: boolean`
   - Is `true` whenever a background refetch is in-flight, which _does not_ include initial `loading` or fetching of next or previous page
   - Is the same as `isFetching && !isLoading && !isFetchingNextPage && !isFetchingPreviousPage`
+
+Keep in mind that imperative fetch calls, such as `fetchNextPage`, may interfere with the default refetch behaviour, resulting in outdated data. Make sure to call these functions only in response to user actions, or add conditions like `hasNextPage && !isFetching`.


### PR DESCRIPTION
PR includes a brief warning. 

For context, see https://github.com/TanStack/query/issues/5972.
TL;DR: Invoking `fetchNextPage` prevents automatic refetching of invalidated or stale cache data. This may occur when `fetchNextPage` is called immediately after mounting, such as in the [`onEndReached`](https://reactnative.dev/docs/virtualizedlist#onendreached) callback.