### PR TITLE
fix(react-query-persist-client): decouple subscribe and unsubscribe

### DIFF
--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -1,7 +1,10 @@
 'use client'
 import * as React from 'react'
 
-import { persistQueryClient } from '@tanstack/query-persist-client-core'
+import {
+  persistQueryClientRestore,
+  persistQueryClientSubscribe,
+} from '@tanstack/query-persist-client-core'
 import { IsRestoringProvider, QueryClientProvider } from '@tanstack/react-query'
 import type { PersistQueryClientOptions } from '@tanstack/query-persist-client-core'
 import type { QueryClientProviderProps } from '@tanstack/react-query'
@@ -27,24 +30,24 @@ export const PersistQueryClientProvider = ({
   })
 
   React.useEffect(() => {
+    const options = {
+      ...refs.current.persistOptions,
+      queryClient: client,
+    }
+    let unsubscribe: (() => void) | undefined
     if (!didRestore.current) {
       didRestore.current = true
       setIsRestoring(true)
-      const [unsubscribe, promise] = persistQueryClient({
-        ...refs.current.persistOptions,
-        queryClient: client,
+      persistQueryClientRestore(options).then(async () => {
+        try {
+          await refs.current.onSuccess?.()
+          unsubscribe = persistQueryClientSubscribe(options)
+        } finally {
+          setIsRestoring(false)
+        }
       })
-
-      promise.then(() => {
-        refs.current.onSuccess?.()
-        setIsRestoring(false)
-      })
-
-      return () => {
-        unsubscribe()
-      }
     }
-    return undefined
+    return unsubscribe?.()
   }, [client])
 
   return (

--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -34,21 +34,19 @@ export const PersistQueryClientProvider = ({
       ...refs.current.persistOptions,
       queryClient: client,
     }
-    let unsubscribe: (() => void) | undefined
     if (!didRestore.current) {
       didRestore.current = true
       setIsRestoring(true)
       persistQueryClientRestore(options).then(async () => {
         try {
           await refs.current.onSuccess?.()
-          unsubscribe = persistQueryClientSubscribe(options)
         } finally {
           setIsRestoring(false)
         }
       })
     }
-    return unsubscribe?.()
-  }, [client])
+    return isRestoring ? undefined : persistQueryClientSubscribe(options)
+  }, [client, isRestoring])
 
   return (
     <QueryClientProvider client={client} {...props}>

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 
 import { QueryClient, useQueries, useQuery } from '@tanstack/react-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
@@ -119,6 +119,70 @@ describe('PersistQueryClientProvider', () => {
       fetchStatus: 'idle',
       data: 'fetched',
     })
+  })
+
+  test('should subscribe correctly in StrictMode', async () => {
+    const key = queryKey()
+
+    const queryClient = createQueryClient()
+    await queryClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => Promise.resolve('hydrated'),
+    })
+
+    const persister = createMockPersister()
+
+    await persistQueryClientSave({ queryClient, persister })
+
+    queryClient.clear()
+
+    function Page() {
+      const state = useQuery({
+        queryKey: key,
+        queryFn: async () => {
+          await sleep(10)
+          return 'fetched'
+        },
+      })
+
+      return (
+        <div>
+          <h1>{state.data}</h1>
+          <h2>fetchStatus: {state.fetchStatus}</h2>
+          <button
+            onClick={() => {
+              queryClient.setQueryData(key, 'updated')
+            }}
+          >
+            update
+          </button>
+        </div>
+      )
+    }
+
+    const rendered = render(
+      <React.StrictMode>
+        <PersistQueryClientProvider
+          client={queryClient}
+          persistOptions={{ persister }}
+        >
+          <Page />
+        </PersistQueryClientProvider>
+        ,
+      </React.StrictMode>,
+    )
+
+    await waitFor(() => rendered.getByText('fetchStatus: idle'))
+    await waitFor(() => rendered.getByText('hydrated'))
+    await waitFor(() => rendered.getByText('fetched'))
+
+    fireEvent.click(rendered.getByRole('button', { name: /update/i }))
+
+    await waitFor(() => rendered.getByText('updated'))
+
+    const state = await persister.restoreClient()
+
+    expect(state.clientState.queries[0].state.data).toBe('updated')
   })
 
   test('should also put useQueries into idle state', async () => {

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -182,7 +182,7 @@ describe('PersistQueryClientProvider', () => {
 
     const state = await persister.restoreClient()
 
-    expect(state.clientState.queries[0].state.data).toBe('updated')
+    expect(state?.clientState.queries[0]?.state.data).toBe('updated')
   })
 
   test('should also put useQueries into idle state', async () => {


### PR DESCRIPTION
to make sure subscriptions are always done at the end, even if we unsubscribe while we're restoring