### PR TITLE
feat(query-devtools): Add clear cache and remove btns

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -1108,7 +1108,7 @@ const QueryDetails = () => {
                 color: ${tokens.colors.pink[400]};
               `,
               'tsqd-query-details-actions-btn',
-              'tsqd-query-details-action-refetch',
+              'tsqd-query-details-action-remove',
             )}
             onClick={() => {
               queryClient.removeQueries(activeQuery())

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -33,6 +33,7 @@ import {
   Search,
   Settings,
   TanstackLogo,
+  Trash,
   Wifi,
 } from './icons'
 import Explorer from './Explorer'
@@ -519,6 +520,19 @@ export const DevtoolsPanel: Component<DevtoolsPanelProps> = (props) => {
           </div>
 
           <div class={cx(styles.actionsContainer, 'tsqd-actions-container')}>
+            <button
+              onClick={() => {
+                cache().clear()
+              }}
+              class={cx(
+                styles.actionsBtn,
+                'tsqd-actions-btn',
+                'tsqd-action-clear-cache',
+              )}
+              aria-label="Clear query cache"
+            >
+              <Trash />
+            </button>
             <button
               onClick={() => {
                 if (offline()) {
@@ -1091,6 +1105,27 @@ const QueryDetails = () => {
           <button
             class={cx(
               css`
+                color: ${tokens.colors.pink[400]};
+              `,
+              'tsqd-query-details-actions-btn',
+              'tsqd-query-details-action-refetch',
+            )}
+            onClick={() => {
+              queryClient.removeQueries(activeQuery())
+              setSelectedQueryHash(null)
+            }}
+            disabled={statusLabel() === 'fetching'}
+          >
+            <span
+              class={css`
+                background-color: ${tokens.colors.pink[400]};
+              `}
+            ></span>
+            Remove
+          </button>
+          <button
+            class={cx(
+              css`
                 color: ${tokens.colors.cyan[400]};
               `,
               'tsqd-query-details-actions-btn',
@@ -1613,9 +1648,6 @@ const getStyles = () => {
       &:focus-visible {
         outline-offset: 2px;
         outline: 2px solid ${colors.blue[800]};
-      }
-      & span:nth-child(2) {
-        color: ${colors.gray[300]}${alpha[80]};
       }
     `,
     statusTooltip: css`

--- a/packages/query-devtools/src/icons/index.tsx
+++ b/packages/query-devtools/src/icons/index.tsx
@@ -20,6 +20,26 @@ export function Search() {
   )
 }
 
+export function Trash() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 3H15M3 6H21M19 6L18.2987 16.5193C18.1935 18.0975 18.1409 18.8867 17.8 19.485C17.4999 20.0118 17.0472 20.4353 16.5017 20.6997C15.882 21 15.0911 21 13.5093 21H10.4907C8.90891 21 8.11803 21 7.49834 20.6997C6.95276 20.4353 6.50009 20.0118 6.19998 19.485C5.85911 18.8867 5.8065 18.0975 5.70129 16.5193L5 6M10 10.5V15.5M14 10.5V15.5"
+        stroke="#98A2B3"
+        stroke-width="1.66667"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
 export function ChevronDown() {
   return (
     <svg


### PR DESCRIPTION
This change adds two new buttons existing in v4 devtools but missing from v5 version

1. Clear cache button

https://github.com/TanStack/query/assets/45807386/18ef590d-8947-4515-b0c2-0b208354cc79

2. Remove query from cache in query details view

https://github.com/TanStack/query/assets/45807386/03f5f27b-3621-4a7f-9771-7d8dee0b3de8

