### PR TITLE
fix: update devtools installation version to beta for compatibility

### DIFF
--- a/docs/react/devtools.md
+++ b/docs/react/devtools.md
@@ -16,11 +16,11 @@ When you begin your React Query journey, you'll want these devtools by your side
 The devtools are a separate package that you need to install:
 
 ```bash
-$ npm i @tanstack/react-query-devtools
+$ npm i @tanstack/react-query-devtools@beta
 # or
-$ pnpm add @tanstack/react-query-devtools
+$ pnpm add @tanstack/react-query-devtools@beta
 # or
-$ yarn add @tanstack/react-query-devtools
+$ yarn add @tanstack/react-query-devtools@beta
 ```
 
 You can import the devtools like this:


### PR DESCRIPTION
Update documentation to specify the 'beta' version instead of directing users to install the latest version of devtools.

This change is made to resolve the peer dependency problem I have encountered.