### PR TITLE
feat: add stable-query-client rule

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -306,6 +306,10 @@
             {
               "label": "Prefer object syntax",
               "to": "react/eslint/prefer-query-object-syntax"
+            },
+            {
+              "label": "Stable Query Client",
+              "to": "react/eslint/stable-query-client"
             }
           ]
         },

--- a/docs/react/eslint/eslint-plugin-query.md
+++ b/docs/react/eslint/eslint-plugin-query.md
@@ -33,7 +33,8 @@ Then configure the rules you want to use under the rules section:
 {
   "rules": {
     "@tanstack/query/exhaustive-deps": "error",
-    "@tanstack/query/prefer-query-object-syntax": "error"
+    "@tanstack/query/prefer-query-object-syntax": "error",
+    "@tanstack/query/stable-query-client": "error"
   }
 }
 ```

--- a/docs/react/eslint/stable-query-client.md
+++ b/docs/react/eslint/stable-query-client.md
@@ -1,0 +1,62 @@
+---
+id: stable-query-client
+title: Stable Query Client
+---
+
+The QueryClient contains the QueryCache, so you'd only want to create one instance of the QueryClient for the lifecycle of your application - _not_ a new instance on every render.
+
+> Exception: It's allowed to create a new QueryClient inside an async Server Component, because the async function is only called once on the server.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```tsx
+/* eslint "@tanstack/query/stable-query-client": "error" */
+
+function App() {
+  const queryClient = new QueryClient()
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Home />
+    </QueryClientProvider>
+  )
+}
+```
+
+
+Examples of **correct** code for this rule:
+
+```tsx
+function App() {
+  const [queryClient] = useState(() => new QueryClient())
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Home />
+    </QueryClientProvider>
+  )
+}
+```
+
+```tsx
+const queryClient = new QueryClient()
+function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Home />
+    </QueryClientProvider>
+  )
+}
+```
+
+```
+async function App() {
+  const queryClient = new QueryClient()
+  await queryClient.prefetchQuery(options)
+}
+```
+
+## Attributes
+
+- [x] ✅ Recommended
+- [x] 🔧 Fixable

--- a/packages/eslint-plugin-query/src/configs/index.test.ts
+++ b/packages/eslint-plugin-query/src/configs/index.test.ts
@@ -11,6 +11,7 @@ describe('configs', () => {
           "rules": {
             "@tanstack/query/exhaustive-deps": "error",
             "@tanstack/query/prefer-query-object-syntax": "error",
+            "@tanstack/query/stable-query-client": "error",
           },
         },
       }

--- a/packages/eslint-plugin-query/src/rules/index.ts
+++ b/packages/eslint-plugin-query/src/rules/index.ts
@@ -1,7 +1,9 @@
 import * as exhaustiveDeps from './exhaustive-deps/exhaustive-deps.rule'
 import * as preferObjectSyntax from './prefer-query-object-syntax/prefer-query-object-syntax'
+import * as stableQueryClient from './stable-query-client/stable-query-client.rule'
 
 export const rules = {
   [exhaustiveDeps.name]: exhaustiveDeps.rule,
   [preferObjectSyntax.name]: preferObjectSyntax.rule,
+  [stableQueryClient.name]: stableQueryClient.rule,
 }

--- a/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
@@ -32,6 +32,7 @@ export const rule = createRule({
         if (
           node.callee.type !== AST_NODE_TYPES.Identifier ||
           node.callee.name !== 'QueryClient' ||
+          node.parent?.type !== AST_NODE_TYPES.VariableDeclarator ||
           !helpers.isSpecificTanstackQueryImport(
             node.callee,
             '@tanstack/react-query',
@@ -46,28 +47,13 @@ export const rule = createRule({
           return
         }
 
-        const declarator = ASTUtils.getClosestVariableDeclarator(node)
-
-        if (
-          declarator?.init?.type === AST_NODE_TYPES.CallExpression &&
-          ['useState', 'React.useState'].includes(
-            context.getSourceCode().getText(declarator.init.callee),
-          )
-        ) {
-          return
-        }
-
         context.report({
-          node: node.parent ?? node,
+          node: node.parent,
           messageId: 'unstable',
           fix: (() => {
             const { parent } = node
 
-            if (
-              parent === undefined ||
-              parent.type !== AST_NODE_TYPES.VariableDeclarator ||
-              parent.id.type !== AST_NODE_TYPES.Identifier
-            ) {
+            if (parent.id.type !== AST_NODE_TYPES.Identifier) {
               return
             }
 

--- a/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
@@ -42,8 +42,12 @@ export const rule = createRule({
         }
 
         const fnAncestor = ASTUtils.getFunctionAncestor(context)
+        const isReactServerComponent = fnAncestor?.async === true
 
-        if (!ASTUtils.isValidReactComponentOrHookName(fnAncestor?.id)) {
+        if (
+          !ASTUtils.isValidReactComponentOrHookName(fnAncestor?.id) ||
+          isReactServerComponent
+        ) {
           return
         }
 

--- a/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
@@ -57,32 +57,30 @@ export const rule = createRule({
           return
         }
 
-        const fixer = (() => {
-          const { parent } = node
-
-          if (
-            parent === undefined ||
-            parent.type !== AST_NODE_TYPES.VariableDeclarator ||
-            parent.id.type !== AST_NODE_TYPES.Identifier
-          ) {
-            return
-          }
-
-          const nodeText = context.getSourceCode().getText(node)
-          const variableName = parent.id.name
-
-          return (fixer: TSESLint.RuleFixer) => {
-            return fixer.replaceTextRange(
-              [parent.range[0], parent.range[1]],
-              `[${variableName}] = React.useState(() => ${nodeText})`,
-            )
-          }
-        })()
-
         context.report({
           node: node.parent ?? node,
           messageId: 'unstable',
-          fix: fixer,
+          fix: (() => {
+            const { parent } = node
+
+            if (
+              parent === undefined ||
+              parent.type !== AST_NODE_TYPES.VariableDeclarator ||
+              parent.id.type !== AST_NODE_TYPES.Identifier
+            ) {
+              return
+            }
+
+            const nodeText = context.getSourceCode().getText(node)
+            const variableName = parent.id.name
+
+            return (fixer: TSESLint.RuleFixer) => {
+              return fixer.replaceTextRange(
+                [parent.range[0], parent.range[1]],
+                `[${variableName}] = React.useState(() => ${nodeText})`,
+              )
+            }
+          })(),
         })
       },
     }

--- a/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.rule.ts
@@ -1,0 +1,90 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { ASTUtils } from '../../utils/ast-utils'
+import { createRule } from '../../utils/create-rule'
+import type { TSESLint } from '@typescript-eslint/utils'
+
+export const name = 'stable-query-client'
+
+export const rule = createRule({
+  name,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Makes sure that QueryClient is stable',
+      recommended: 'error',
+    },
+    messages: {
+      unstable: [
+        'QueryClient is not stable. It should be either extracted from the component or wrapped in React.useState.',
+        'See https://tkdodo.eu/blog/react-query-fa-qs#2-the-queryclient-is-not-stable',
+      ].join('\n'),
+      fixTo: 'Fix to {{result}}',
+    },
+    hasSuggestions: true,
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context, _, helpers) {
+    return {
+      NewExpression(node) {
+        if (
+          node.callee.type !== AST_NODE_TYPES.Identifier ||
+          node.callee.name !== 'QueryClient' ||
+          !helpers.isSpecificTanstackQueryImport(
+            node.callee,
+            '@tanstack/react-query',
+          )
+        ) {
+          return
+        }
+
+        const fnAncestor = ASTUtils.getFunctionAncestor(context)
+
+        if (!ASTUtils.isValidReactComponentOrHookName(fnAncestor?.id)) {
+          return
+        }
+
+        const declarator = ASTUtils.getClosestVariableDeclarator(node)
+
+        if (
+          declarator?.init?.type === AST_NODE_TYPES.CallExpression &&
+          ['useState', 'React.useState'].includes(
+            context.getSourceCode().getText(declarator.init.callee),
+          )
+        ) {
+          return
+        }
+
+        const fixer = (() => {
+          const { parent } = node
+
+          if (
+            parent === undefined ||
+            parent.type !== AST_NODE_TYPES.VariableDeclarator ||
+            parent.id.type !== AST_NODE_TYPES.Identifier
+          ) {
+            return
+          }
+
+          const nodeText = context.getSourceCode().getText(node)
+          const variableName = parent.id.name
+
+          return (fixer: TSESLint.RuleFixer) => {
+            return fixer.replaceTextRange(
+              [parent.range[0], parent.range[1]],
+              `[${variableName}] = React.useState(() => ${nodeText})`,
+            )
+          }
+        })()
+
+        context.report({
+          node: node.parent ?? node,
+          messageId: 'unstable',
+          fix: fixer,
+        })
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.test.ts
+++ b/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.test.ts
@@ -32,6 +32,28 @@ ruleTester.run('stable-query-client', rule, {
       `,
     },
     {
+      name: 'QueryClient is stable when wrapped in React.useMemo',
+      code: normalizeIndent`
+          import { QueryClient } from "@tanstack/react-query";
+  
+          function Component() {
+            const [queryClient] = React.useMemo(() => new QueryClient(), []);
+            return;
+          }
+        `,
+    },
+    {
+      name: 'QueryClient is stable when wrapped in useAnything',
+      code: normalizeIndent`
+          import { QueryClient } from "@tanstack/react-query";
+  
+          function Component() {
+            const [queryClient] = useAnything(() => new QueryClient());
+            return;
+          }
+        `,
+    },
+    {
       name: 'QueryClient is imported from a non-tanstack package',
       code: normalizeIndent`
         import { QueryClient } from "other-library";

--- a/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.test.ts
+++ b/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.test.ts
@@ -1,0 +1,162 @@
+import { ESLintUtils } from '@typescript-eslint/utils'
+import { normalizeIndent } from '../../utils/test-utils'
+import { rule } from './stable-query-client.rule'
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+  settings: {},
+})
+
+ruleTester.run('stable-query-client', rule, {
+  valid: [
+    {
+      name: 'QueryClient is stable when wrapped in React.useState',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const [queryClient] = React.useState(() => new QueryClient());
+          return;
+        }
+      `,
+    },
+    {
+      name: 'QueryClient is stable when wrapped in useState',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const [queryClient] = useState(() => new QueryClient());
+          return;
+        }
+      `,
+    },
+    {
+      name: 'QueryClient is imported from a non-tanstack package',
+      code: normalizeIndent`
+        import { QueryClient } from "other-library";
+
+        function Component() {
+          const queryClient = new QueryClient();
+          return;
+        }
+      `,
+    },
+    {
+      name: 'QueryClient is not imported from @tanstack/react-query',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/solid-query";
+
+        function Component() {
+          const queryClient = new QueryClient();
+          return;
+        }
+      `,
+    },
+    {
+      name: 'QueryClient is invoked outside of a function',
+      code: normalizeIndent`
+        import { QueryClient } from "other-library";
+
+        const queryClient = new QueryClient();
+
+        function Component() {
+          return;
+        }
+      `,
+    },
+    {
+      name: 'QueryClient is invoked in a non-component function',
+      code: normalizeIndent`
+        import { QueryClient } from "other-library";
+
+        function someFn() {
+          const queryClient = new QueryClient();
+          return;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'QueryClient is not stable when it is not wrapped in React.useState in component',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const queryClient = new QueryClient();
+          return;
+        }
+      `,
+      output: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const [queryClient] = React.useState(() => new QueryClient());
+          return;
+        }
+      `,
+      errors: [{ messageId: 'unstable' }],
+    },
+    {
+      name: 'QueryClient is not stable when it is not wrapped in React.useState in custom hook',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function useHook() {
+          const queryClient = new QueryClient();
+          return;
+        }
+      `,
+      output: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function useHook() {
+          const [queryClient] = React.useState(() => new QueryClient());
+          return;
+        }
+      `,
+      errors: [{ messageId: 'unstable' }],
+    },
+    {
+      name: 'preserve QueryClient options',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const queryClient = new QueryClient({ defaultOptions: { /* */ } });
+          return;
+        }
+      `,
+      output: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const [queryClient] = React.useState(() => new QueryClient({ defaultOptions: { /* */ } }));
+          return;
+        }
+      `,
+      errors: [{ messageId: 'unstable' }],
+    },
+    {
+      name: 'preserve QueryClient variable declarator name',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const customName = new QueryClient();
+          return;
+        }
+      `,
+      output: normalizeIndent`
+        import { QueryClient } from "@tanstack/react-query";
+
+        function Component() {
+          const [customName] = React.useState(() => new QueryClient());
+          return;
+        }
+      `,
+      errors: [{ messageId: 'unstable' }],
+    },
+  ],
+})

--- a/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.test.ts
+++ b/packages/eslint-plugin-query/src/rules/stable-query-client/stable-query-client.test.ts
@@ -78,7 +78,7 @@ ruleTester.run('stable-query-client', rule, {
     {
       name: 'QueryClient is invoked outside of a function',
       code: normalizeIndent`
-        import { QueryClient } from "other-library";
+        import { QueryClient } from "@tanstack/solid-query";
 
         const queryClient = new QueryClient();
 
@@ -90,9 +90,20 @@ ruleTester.run('stable-query-client', rule, {
     {
       name: 'QueryClient is invoked in a non-component function',
       code: normalizeIndent`
-        import { QueryClient } from "other-library";
+        import { QueryClient } from "@tanstack/solid-query";
 
         function someFn() {
+          const queryClient = new QueryClient();
+          return;
+        }
+      `,
+    },
+    {
+      name: 'QueryClient is invoked in an async (react server) component',
+      code: normalizeIndent`
+        import { QueryClient } from "@tanstack/solid-query";
+
+        async function AsyncComponent() {
           const queryClient = new QueryClient();
           return;
         }

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -203,27 +203,37 @@ export const ASTUtils = {
       ]),
     )
   },
-  isValidReactComponentOrHookName(identifier: TSESTree.Identifier | null) {
-    return identifier !== null && /^(use|[A-Z])/.test(identifier.name)
+  isValidReactComponentOrHookName(
+    identifier: TSESTree.Identifier | null | undefined,
+  ) {
+    return (
+      identifier !== null &&
+      identifier !== undefined &&
+      /^(use|[A-Z])/.test(identifier.name)
+    )
   },
   getFunctionAncestor(
     context: Readonly<RuleContext<string, readonly unknown[]>>,
   ) {
-    return context.getAncestors().find((x) => {
-      if (x.type === AST_NODE_TYPES.FunctionDeclaration) {
-        return true
+    for (const ancestor of context.getAncestors()) {
+      if (ancestor.type === AST_NODE_TYPES.FunctionDeclaration) {
+        return ancestor
       }
 
-      return (
-        x.parent?.type === AST_NODE_TYPES.VariableDeclarator &&
-        x.parent.id.type === AST_NODE_TYPES.Identifier &&
-        ASTUtils.isNodeOfOneOf(x, [
+      if (
+        ancestor.parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+        ancestor.parent.id.type === AST_NODE_TYPES.Identifier &&
+        ASTUtils.isNodeOfOneOf(ancestor, [
           AST_NODE_TYPES.FunctionDeclaration,
           AST_NODE_TYPES.FunctionExpression,
           AST_NODE_TYPES.ArrowFunctionExpression,
         ])
-      )
-    })
+      ) {
+        return ancestor
+      }
+    }
+
+    return undefined
   },
   getReferencedExpressionByIdentifier(params: {
     node: TSESTree.Node
@@ -241,6 +251,19 @@ export const ASTUtils = {
     }
 
     return resolvedNode.init
+  },
+  getClosestVariableDeclarator(node: TSESTree.Node) {
+    let currentNode: TSESTree.Node | undefined = node
+
+    while (currentNode !== undefined && currentNode !== null) {
+      if (currentNode.type === AST_NODE_TYPES.VariableDeclarator) {
+        return currentNode
+      }
+
+      currentNode = currentNode.parent
+    }
+
+    return undefined
   },
   getNestedReturnStatements(node: TSESTree.Node): TSESTree.ReturnStatement[] {
     const returnStatements: TSESTree.ReturnStatement[] = []

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -255,7 +255,10 @@ export const ASTUtils = {
   getClosestVariableDeclarator(node: TSESTree.Node) {
     let currentNode: TSESTree.Node | undefined = node
 
-    while (currentNode !== undefined && currentNode !== null) {
+    while (
+      currentNode !== undefined &&
+      currentNode.type !== AST_NODE_TYPES.Program
+    ) {
       if (currentNode.type === AST_NODE_TYPES.VariableDeclarator) {
         return currentNode
       }

--- a/packages/eslint-plugin-query/src/utils/detect-react-query-imports.ts
+++ b/packages/eslint-plugin-query/src/utils/detect-react-query-imports.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils'
+import { TSESTree } from '@typescript-eslint/utils'
+import type { ESLintUtils, TSESLint } from '@typescript-eslint/utils'
 
 type Create = Parameters<
   ReturnType<typeof ESLintUtils.RuleCreator>

--- a/packages/eslint-plugin-query/src/utils/detect-react-query-imports.ts
+++ b/packages/eslint-plugin-query/src/utils/detect-react-query-imports.ts
@@ -1,4 +1,4 @@
-import type { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils'
+import { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils'
 
 type Create = Parameters<
   ReturnType<typeof ESLintUtils.RuleCreator>
@@ -7,6 +7,10 @@ type Create = Parameters<
 type Context = Parameters<Create>[0]
 type Options = Parameters<Create>[1]
 type Helpers = {
+  isSpecificTanstackQueryImport: (
+    node: TSESTree.Identifier,
+    source: string,
+  ) => boolean
   isTanstackQueryImport: (node: TSESTree.Identifier) => boolean
 }
 
@@ -21,9 +25,23 @@ export function detectTanstackQueryImports(create: EnhancedCreate): Create {
     const tanstackQueryImportSpecifiers: TSESTree.ImportClause[] = []
 
     const helpers: Helpers = {
+      isSpecificTanstackQueryImport(node, source) {
+        return !!tanstackQueryImportSpecifiers.find((specifier) => {
+          if (
+            specifier.type === TSESTree.AST_NODE_TYPES.ImportSpecifier &&
+            specifier.parent?.type ===
+              TSESTree.AST_NODE_TYPES.ImportDeclaration &&
+            specifier.parent.source.value === source
+          ) {
+            return node.name === specifier.local.name
+          }
+
+          return false
+        })
+      },
       isTanstackQueryImport(node) {
         return !!tanstackQueryImportSpecifiers.find((specifier) => {
-          if (specifier.type === 'ImportSpecifier') {
+          if (specifier.type === TSESTree.AST_NODE_TYPES.ImportSpecifier) {
             return node.name === specifier.local.name
           }
 


### PR DESCRIPTION
This PR introduces a new rule named `stable-query-client`. It ensures that the QueryClient is stable. It checks if the QueryClient is either extracted from the component or wrapped in React.useState. If not, it suggests a fix to wrap the QueryClient instantiation in a React.useState call. This rule is recommended to be set as an error.
