### PR TITLE
fix(solid-query): Default `reconcile` to false

### DIFF
--- a/packages/solid-query/src/QueryClient.ts
+++ b/packages/solid-query/src/QueryClient.ts
@@ -30,7 +30,7 @@ export interface QueryObserverOptions<
    * Set this to a reconciliation key to enable reconciliation between query results.
    * Set this to `false` to disable reconciliation between query results.
    * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom reconciliation logic.
-   * Defaults reconciliation key to `id`.
+   * Defaults reconciliation to false.
    */
   reconcile?:
     | string
@@ -60,7 +60,7 @@ export interface InfiniteQueryObserverOptions<
    * Set this to a reconciliation key to enable reconciliation between query results.
    * Set this to `false` to disable reconciliation between query results.
    * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom reconciliation logic.
-   * Defaults reconciliation key to `id`.
+   * Defaults reconciliation to false.
    */
   reconcile?:
     | string

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1046,6 +1046,7 @@ describe('createQuery', () => {
           count++
           return count === 1 ? result1 : result2
         },
+        reconcile: 'id',
       }))
 
       createRenderEffect(() => {

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -111,7 +111,7 @@ export function createBaseQuery<
   const isRestoring = useIsRestoring()
 
   const defaultedOptions = createMemo(() =>
-    mergeProps(client().defaultQueryOptions(options()), {
+    mergeProps(client()?.defaultQueryOptions(options()) || {}, {
       get _optimisticResults() {
         return isRestoring() ? 'isRestoring' : 'optimistic'
       },
@@ -167,7 +167,7 @@ export function createBaseQuery<
           return reconcileFn(
             store,
             result,
-            reconcileOptions === undefined ? 'id' : reconcileOptions,
+            reconcileOptions === undefined ? false : reconcileOptions,
           )
         })
         // If the query has data we dont suspend but instead mutate the resource


### PR DESCRIPTION
Fixes #5738
Fixes #5994
Fixes #6102 

There seems to be a bug in how reconcile works with previously reconciled objects. Potentially a solid-js issue. Either way, The `reconcile` option needs to be used carefully and is not suitable for most cases. So I am making this opt-in. It wasn't documented yet so it's safe to default it to false.