### PR TITLE
perf(vue-query): clean up the type definition about query composables

### DIFF
--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -11,7 +11,6 @@ import type { UseQueryReturnType } from './useBaseQuery'
 
 import type {
   DeepUnwrapRef,
-  DistributiveOmit,
   VueInfiniteQueryObserverOptions,
   WithQueryClientKey,
 } from './types'
@@ -31,23 +30,11 @@ export type UseInfiniteQueryOptions<
   >
 >
 
-type InfiniteQueryReturnType<TData, TError> = UseQueryReturnType<
+export type UseInfiniteQueryReturnType<TData, TError> = UseQueryReturnType<
   TData,
   TError,
   InfiniteQueryObserverResult<TData, TError>
 >
-export type UseInfiniteQueryReturnType<TData, TError> = DistributiveOmit<
-  InfiniteQueryReturnType<TData, TError>,
-  'fetchNextPage' | 'fetchPreviousPage' | 'refetch' | 'remove'
-> & {
-  fetchNextPage: InfiniteQueryObserverResult<TData, TError>['fetchNextPage']
-  fetchPreviousPage: InfiniteQueryObserverResult<
-    TData,
-    TError
-  >['fetchPreviousPage']
-  refetch: InfiniteQueryObserverResult<TData, TError>['refetch']
-  remove: InfiniteQueryObserverResult<TData, TError>['remove']
-}
 
 export function useInfiniteQuery<
   TQueryFnData = unknown,
@@ -104,7 +91,7 @@ export function useInfiniteQuery<
     arg1,
     arg2,
     arg3,
-  ) as InfiniteQueryReturnType<TData, TError>
+  ) as UseInfiniteQueryReturnType<TData, TError>
 
   return result
 }

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -1,37 +1,25 @@
 import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type { ToRefs } from 'vue-demi'
 import type {
   DefinedQueryObserverResult,
   QueryFunction,
   QueryKey,
-  QueryObserverResult,
 } from '@tanstack/query-core'
 import type { UseQueryReturnType as UQRT } from './useBaseQuery'
 import type {
   DeepUnwrapRef,
-  DistributiveOmit,
   MaybeRef,
   VueQueryObserverOptions,
   WithQueryClientKey,
 } from './types'
 
-export type UseQueryReturnType<TData, TError> = DistributiveOmit<
-  UQRT<TData, TError>,
-  'refetch' | 'remove'
-> & {
-  refetch: QueryObserverResult<TData, TError>['refetch']
-  remove: QueryObserverResult<TData, TError>['remove']
-}
+export type UseQueryReturnType<TData, TError> = UQRT<TData, TError>
 
-export type UseQueryDefinedReturnType<TData, TError> = DistributiveOmit<
-  ToRefs<Readonly<DefinedQueryObserverResult<TData, TError>>>,
-  'refetch' | 'remove'
-> & {
-  suspense: () => Promise<QueryObserverResult<TData, TError>>
-  refetch: QueryObserverResult<TData, TError>['refetch']
-  remove: QueryObserverResult<TData, TError>['remove']
-}
+export type UseQueryDefinedReturnType<TData, TError> = UQRT<
+  TData,
+  TError,
+  DefinedQueryObserverResult<TData, TError>
+>
 
 export type UseQueryOptions<
   TQueryFnData = unknown,


### PR DESCRIPTION
### Description

After PR #6043, there is no longer a need to override the `UseQueryReturnType` type returned by `useBaseQuery`, so this PR cleans up the type definition, making it appear cleaner and improving type resolution performance.

I cloned the repository mentioned in issue #4556 and tried running it, and nothing broke after this PR.