### PR TITLE
fix(vue-query): update observer's options to latest value during suspense

### DIFF
--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -141,6 +141,8 @@ export function useBaseQuery<
         }
         const run = () => {
           if (defaultedOptions.value.enabled !== false) {
+            // fix #6133
+            observer.setOptions(defaultedOptions.value)
             const optimisticResult = observer.getOptimisticResult(
               defaultedOptions.value,
             )


### PR DESCRIPTION
Closes #6133 

A solution I came up with is to just manually set the observer's options during suspense to ensure we have the most up to date values.