### PR TITLE
docs(useMutationState): Clarify `mutationKey` usage

### DIFF
--- a/docs/react/reference/useMutationState.md
+++ b/docs/react/reference/useMutationState.md
@@ -5,17 +5,35 @@ title: useMutationState
 
 `useMutationState` is a hook that gives you access to all mutations in the `MutationCache`. You can pass `filters` to it to narrow down your mutations, and `select` to transform the mutation state.
 
+**Example 1: Get all variables of all running mutations**
+
 ```tsx
 import { useMutationState } from '@tanstack/react-query'
-// Get all variables of all running mutations
+
 const variables = useMutationState({
   filters: { status: 'pending' },
   select: (mutation) => mutation.state.variables,
 })
+```
 
-// Get all data of all "post" mutations
+**Example 2: Get all data for specific mutations via the `mutationKey`**
+
+```tsx
+import { useMutation, useMutationState } from '@tanstack/react-query'
+
+const mutationKey = ['posts']
+
+// Some mutation that we want to get the state for
+const mutation = useMutation({
+  mutationKey,
+  mutationFn: (newPost) => {
+    return axios.post('/posts', newPost)
+  },
+})
+
 const data = useMutationState({
-  filters: { mutationKey: ['posts'] },
+  // this mutation key needs to match the mutation key of the given mutation (see above)
+  filters: { mutationKey },
   select: (mutation) => mutation.state.data,
 })
 ```


### PR DESCRIPTION
This adds a mutation to the examples to (hopefully) clarify how to use the `mutationKey` for referencing the mutation state.

Fun fact: I created the [original issue two years ago](https://github.com/TanStack/query/issues/2304), very happy to add **this** example now 😁