### PR TITLE
fix: update types field to make packages cjs default in esm

### DIFF
--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "main": "./build/index.cjs",
   "module": "./build/index.js",
-  "types": "./build/index.d.ts",
+  "types": "./build/index.d.cts",
   "browser": {},
   "exports": {
     "solid": {

--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/react-query-next-experimental/package.json
+++ b/packages/react-query-next-experimental/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {

--- a/packages/solid-query-devtools/package.json
+++ b/packages/solid-query-devtools/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "main": "./build/index.cjs",
   "module": "./build/index.js",
-  "types": "./build/index.d.ts",
+  "types": "./build/index.d.cts",
   "browser": {},
   "exports": {
     "solid": {

--- a/packages/solid-query-persist-client/package.json
+++ b/packages/solid-query-persist-client/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "./build/index.d.ts",
+  "types": "./build/index.d.cts",
   "main": "./build/index.cjs",
   "module": "./build/index.js",
   "exports": {

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "main": "./build/index.cjs",
   "module": "./build/index.js",
-  "types": "./build/index.d.ts",
+  "types": "./build/index.d.cts",
   "browser": {},
   "exports": {
     "development": {

--- a/packages/svelte-query-devtools/package.json
+++ b/packages/svelte-query-devtools/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "dist/index.d.cts",
   "module": "dist/index.js",
   "svelte": "./dist/index.js",
   "exports": {

--- a/packages/svelte-query-persist-client/package.json
+++ b/packages/svelte-query-persist-client/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "dist/index.d.cts",
   "module": "dist/index.js",
   "svelte": "./dist/index.js",
   "exports": {

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "dist/index.d.cts",
   "module": "dist/index.js",
   "svelte": "./dist/index.js",
   "exports": {

--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
+  "types": "build/legacy/index.d.cts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
   "exports": {


### PR DESCRIPTION
I updated all packages' `types` field of package.json to make package using cjs default following `main` field after trying using `exports` field and failing using it

I'm not sure but isn't this right? I'm so confused even after read this doc https://www.typescriptlang.org/docs/handbook/modules/reference.html

@ahejlsberg Could you help this case and updating doc to setup package.json like this case