### PR TITLE
Update updates-from-mutation-responses.md

### DIFF
--- a/docs/react/guides/updates-from-mutation-responses.md
+++ b/docs/react/guides/updates-from-mutation-responses.md
@@ -51,7 +51,7 @@ const useMutateTodo = () => {
 
 ## Immutability
 
-Updates via `setQueryData` must be performed in an _immutable_ way. **DO NOT** attempt to write directly to the cache by mutating data (that you retrieved via from the cache) in place. It might work at first but can lead to subtle bugs along the way.
+Updates via `setQueryData` must be performed in an _immutable_ way. **DO NOT** attempt to write directly to the cache by mutating data (that you retrieved from the cache) in place. It might work at first but can lead to subtle bugs along the way.
 
 [//]: # 'Example3'
 ```tsx


### PR DESCRIPTION
Removed an unnecessary word "via", which was grammatically incorrect.