### PR TITLE
Docs: add typescript meta docs

### DIFF
--- a/docs/react/guides/query-functions.md
+++ b/docs/react/guides/query-functions.md
@@ -104,7 +104,7 @@ The `QueryFunctionContext` is the object passed to each query function. It consi
   - [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) instance provided by TanStack Query
   - Can be used for [Query Cancellation](../guides/query-cancellation)
 - `meta: Record<string, unknown> | undefined`
-  - an optional field you can fill with additional information about your query#
+  - an optional field you can fill with additional information about your query
 
 Additionally, [Infinite Queries](../guides/infinite-queries) get the following options passed:
 

--- a/docs/react/typescript.md
+++ b/docs/react/typescript.md
@@ -148,6 +148,28 @@ const { error } = useQuery({ queryKey: ['groups'], queryFn: fetchGroups })
 ```
 
 [//]: # 'RegisterErrorType'
+
+[//]: # 'TypingMeta'
+
+## Typing meta
+
+[//]: # 'RegisterMetaType'
+
+### Registering global Meta
+
+Similarly to registering a [global error type](#registering-a-global-error) you can also register a global `Meta` type. This ensures the optional `meta` field on [queries](./reference/useQuery.md) and [mutations](./reference/useMutation.md) stays consistent and is type-safe.
+
+```ts
+declare module '@tanstack/react-query' {
+  interface Register {
+    queryMeta: MyMeta,
+    mutationMeta: MyMeta
+  }
+}
+```
+[//]: # 'RegisterMetaType'
+[//]: # 'TypingMeta'
+
 [//]: # 'TypingQueryOptions'
 
 ## Typing Query Options


### PR DESCRIPTION
This adds documentation about registering a global meta type for queries and mutations