### PR TITLE
Add `queryOptions` to `svelte-query`

### DIFF
--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -6,24 +6,10 @@ import type {
   CreateQueryResult,
   DefinedCreateQueryResult,
 } from './types'
-
-type UndefinedInitialDataOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  initialData?: undefined
-}
-
-type DefinedInitialDataOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  initialData: TQueryFnData | (() => TQueryFnData)
-}
+import type {
+  DefinedInitialDataOptions,
+  UndefinedInitialDataOptions,
+} from './queryOptions'
 
 export function createQuery<
   TQueryFnData = unknown,

--- a/packages/svelte-query/src/index.ts
+++ b/packages/svelte-query/src/index.ts
@@ -6,9 +6,16 @@ export * from '@tanstack/query-core'
 // Svelte Query
 export * from './types'
 export * from './context'
+
 export { createQuery } from './createQuery'
+export type {
+  DefinedInitialDataOptions,
+  UndefinedInitialDataOptions,
+} from './queryOptions'
+export { queryOptions } from './queryOptions'
 export { createQueries } from './createQueries'
 export { createInfiniteQuery } from './createInfiniteQuery'
+export { infiniteQueryOptions } from './infiniteQueryOptions'
 export { createMutation } from './createMutation'
 export { useQueryClient } from './useQueryClient'
 export { useIsFetching } from './useIsFetching'

--- a/packages/svelte-query/src/infiniteQueryOptions.ts
+++ b/packages/svelte-query/src/infiniteQueryOptions.ts
@@ -1,0 +1,29 @@
+import type { InfiniteData } from '@tanstack/query-core'
+import type { CreateInfiniteQueryOptions } from './types'
+import type { DefaultError, QueryKey } from '@tanstack/query-core'
+
+export function infiniteQueryOptions<
+  TQueryFnData,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+>(
+  options: CreateInfiniteQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey,
+    TPageParam
+  >,
+): CreateInfiniteQueryOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryFnData,
+  TQueryKey,
+  TPageParam
+> {
+  return options
+}

--- a/packages/svelte-query/src/queryOptions.ts
+++ b/packages/svelte-query/src/queryOptions.ts
@@ -1,0 +1,50 @@
+import type { DataTag, DefaultError, QueryKey } from '@tanstack/query-core'
+import type { CreateQueryOptions } from './types'
+
+export type UndefinedInitialDataOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  initialData?: undefined
+}
+
+type NonUndefinedGuard<T> = T extends undefined ? never : T
+
+export type DefinedInitialDataOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  initialData:
+    | NonUndefinedGuard<TQueryFnData>
+    | (() => NonUndefinedGuard<TQueryFnData>)
+}
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  queryKey: DataTag<TQueryKey, TData>
+}
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  queryKey: DataTag<TQueryKey, TData>
+}
+
+export function queryOptions(options: unknown) {
+  return options
+}


### PR DESCRIPTION
Fixes #6197 

Not sure whether or not `createInfiniteQuery` needs the overloaded defined/undefined options.