### PR TITLE
chore: Disable vitest globals

### DIFF
--- a/packages/codemods/vitest.config.ts
+++ b/packages/codemods/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     name: 'codemods',
     dir: './src',
     watch: false,
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/codemods/vitest.config.ts
+++ b/packages/codemods/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     name: 'codemods',
     dir: './src',
     watch: false,
+    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/eslint-plugin-query/src/__tests__/configs.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/configs.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { configs } from '../configs'
 
 describe('configs', () => {

--- a/packages/eslint-plugin-query/tsconfig.json
+++ b/packages/eslint-plugin-query/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "types": ["vitest/globals"]
-  },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/eslint-plugin-query/tsconfig.json
+++ b/packages/eslint-plugin-query/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/eslint-plugin-query/tsconfig.json
+++ b/packages/eslint-plugin-query/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/eslint-plugin-query/vitest.config.ts
+++ b/packages/eslint-plugin-query/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     name: 'eslint-plugin-query',
     dir: './src',
     watch: false,
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/eslint-plugin-query/vitest.config.ts
+++ b/packages/eslint-plugin-query/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     name: 'eslint-plugin-query',
     dir: './src',
     watch: false,
+    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
+++ b/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { asyncThrottle } from '../asyncThrottle'
 import { sleep as delay } from './utils'
 

--- a/packages/query-async-storage-persister/tsconfig.json
+++ b/packages/query-async-storage-persister/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "types": ["vitest/globals"]
-  },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-async-storage-persister/tsconfig.json
+++ b/packages/query-async-storage-persister/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/query-async-storage-persister/tsconfig.json
+++ b/packages/query-async-storage-persister/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/query-async-storage-persister/vitest.config.ts
+++ b/packages/query-async-storage-persister/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     name: 'query-async-storage-persister',
     dir: './src',
     watch: false,
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/query-core/src/tests/focusManager.test.tsx
+++ b/packages/query-core/src/tests/focusManager.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { sleep } from '../utils'
 import { FocusManager } from '../focusManager'
 import { setIsServer } from './utils'

--- a/packages/query-core/src/tests/hydration.test.tsx
+++ b/packages/query-core/src/tests/hydration.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { QueryCache } from '../queryCache'
 import { dehydrate, hydrate } from '../hydration'
 import { MutationCache } from '../mutationCache'

--- a/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryBehavior.test.tsx
@@ -1,5 +1,5 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import { vi } from 'vitest'
 import { CancelledError, InfiniteQueryObserver } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { InfiniteQueryObserverResult, QueryCache, QueryClient } from '..'

--- a/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { InfiniteQueryObserver } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryClient } from '..'

--- a/packages/query-core/src/tests/mutationCache.test.tsx
+++ b/packages/query-core/src/tests/mutationCache.test.tsx
@@ -1,5 +1,5 @@
+import { describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import { vi } from 'vitest'
 import { MutationCache, MutationObserver } from '..'
 import { createQueryClient, executeMutation, queryKey, sleep } from './utils'
 

--- a/packages/query-core/src/tests/mutationObserver.test.tsx
+++ b/packages/query-core/src/tests/mutationObserver.test.tsx
@@ -1,5 +1,5 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import { vi } from 'vitest'
 import { MutationObserver } from '..'
 import { createQueryClient, sleep } from './utils'
 import type { QueryClient } from '..'

--- a/packages/query-core/src/tests/mutations.test.tsx
+++ b/packages/query-core/src/tests/mutations.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
 import { MutationObserver } from '../mutationObserver'
 import { createQueryClient, executeMutation, queryKey, sleep } from './utils'

--- a/packages/query-core/src/tests/notifyManager.test.tsx
+++ b/packages/query-core/src/tests/notifyManager.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createNotifyManager } from '../notifyManager'
 import { sleep } from './utils'
 

--- a/packages/query-core/src/tests/onlineManager.test.tsx
+++ b/packages/query-core/src/tests/onlineManager.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { OnlineManager } from '../onlineManager'
 import { setIsServer, sleep } from './utils'
 

--- a/packages/query-core/src/tests/queriesObserver.test.tsx
+++ b/packages/query-core/src/tests/queriesObserver.test.tsx
@@ -1,5 +1,5 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import { vi } from 'vitest'
 import { QueriesObserver } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryClient, QueryObserverResult } from '..'

--- a/packages/query-core/src/tests/query.test.tsx
+++ b/packages/query-core/src/tests/query.test.tsx
@@ -1,5 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import { vi } from 'vitest'
 import { QueryObserver, isCancelledError, onlineManager } from '..'
 import {
   createQueryClient,

--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -1,5 +1,5 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import { vi } from 'vitest'
 import { QueryCache, QueryClient, QueryObserver } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import '@testing-library/jest-dom/vitest'
 
 import {
   MutationObserver,

--- a/packages/query-core/src/tests/queryClient.types.test.tsx
+++ b/packages/query-core/src/tests/queryClient.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { QueryClient } from '../queryClient'
 import { doNotExecute } from './utils'
 import type { Equal, Expect } from './utils'

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
 import { QueryObserver, focusManager } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryClient, QueryObserverResult } from '..'

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+  vi,
+} from 'vitest'
 import { QueryObserver, focusManager } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryClient, QueryObserverResult } from '..'

--- a/packages/query-core/src/tests/utils.test.tsx
+++ b/packages/query-core/src/tests/utils.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   addToEnd,
   addToStart,

--- a/packages/query-core/src/tests/utils.ts
+++ b/packages/query-core/src/tests/utils.ts
@@ -1,5 +1,5 @@
-import { act } from '@testing-library/react'
 import { vi } from 'vitest'
+import { act } from '@testing-library/react'
 import { QueryClient, onlineManager } from '..'
 import * as utils from '../utils'
 import type { SpyInstance } from 'vitest'

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "types": ["vitest/globals"]
-  },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/query-core/vitest.config.ts
+++ b/packages/query-core/vitest.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
     dir: './src',
     watch: false,
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/devtools.test.tsx
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 describe('ReactQueryDevtools', () => {
   it('should be able to open and close devtools', async () => {
     expect(1).toBe(1)

--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { deleteNestedDataByPath, updateNestedDataByPath } from '../utils'
 
 describe('Utils tests', () => {

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -4,5 +4,5 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
+    "jsxImportSource": "solid-js"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/query-devtools/vitest.config.ts
+++ b/packages/query-devtools/vitest.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
     name: 'query-devtools',
     dir: './src',
     watch: false,
-    setupFiles: [],
     environment: 'jsdom',
     coverage: { provider: 'istanbul' },
   },

--- a/packages/query-devtools/vitest.config.ts
+++ b/packages/query-devtools/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     watch: false,
     setupFiles: [],
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
   plugins: [solid()],

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, test, vi } from 'vitest'
 import { Query, QueryCache, hashKey } from '@tanstack/query-core'
-import { vi } from 'vitest'
 import {
   PERSISTER_KEY_PREFIX,
   experimental_createPersister,

--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, test, vi } from 'vitest'
 import { QueriesObserver } from '@tanstack/query-core'
-import { vi } from 'vitest'
 import { persistQueryClientSubscribe } from '../persist'
 import {
   createMockPersister,

--- a/packages/query-persist-client-core/src/__tests__/utils.ts
+++ b/packages/query-persist-client-core/src/__tests__/utils.ts
@@ -1,5 +1,5 @@
-import { QueryClient } from '@tanstack/query-core'
 import { vi } from 'vitest'
+import { QueryClient } from '@tanstack/query-core'
 import type { QueryClientConfig } from '@tanstack/query-core'
 import type { PersistedClient, Persister } from '../persist'
 

--- a/packages/query-persist-client-core/tsconfig.json
+++ b/packages/query-persist-client-core/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "types": ["vitest/globals"]
-  },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-persist-client-core/tsconfig.json
+++ b/packages/query-persist-client-core/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/query-persist-client-core/tsconfig.json
+++ b/packages/query-persist-client-core/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/query-persist-client-core/vitest.config.ts
+++ b/packages/query-persist-client-core/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     name: 'query-persist-client-core',
     dir: './src',
     watch: false,
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
+++ b/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'vitest'
 import {
   MutationCache,
   QueryCache,

--- a/packages/query-sync-storage-persister/tsconfig.json
+++ b/packages/query-sync-storage-persister/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "types": ["vitest/globals"]
-  },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/query-sync-storage-persister/tsconfig.json
+++ b/packages/query-sync-storage-persister/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/query-sync-storage-persister/tsconfig.json
+++ b/packages/query-sync-storage-persister/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/query-sync-storage-persister/vitest.config.ts
+++ b/packages/query-sync-storage-persister/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     name: 'query-sync-storage-persister',
     dir: './src',
     watch: false,
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 describe('ReactQueryDevtools', () => {
   it('should be able to open and close devtools', async () => {
     expect(1).toBe(1)

--- a/packages/react-query-devtools/test-setup.ts
+++ b/packages/react-query-devtools/test-setup.ts
@@ -1,5 +1,10 @@
-import { act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
 import { notifyManager } from '@tanstack/react-query'
+
+// https://testing-library.com/docs/react-testing-library/api#cleanup
+afterEach(() => cleanup())
 
 // Wrap notifications with act to make sure React knows about React Query updates
 notifyManager.setNotifyFunction((fn) => {

--- a/packages/react-query-devtools/tsconfig.json
+++ b/packages/react-query-devtools/tsconfig.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/react-query-devtools/tsconfig.json
+++ b/packages/react-query-devtools/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-devtools/tsconfig.json
+++ b/packages/react-query-devtools/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-devtools/tsconfig.json
+++ b/packages/react-query-devtools/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/react-query-devtools/vitest.config.ts
+++ b/packages/react-query-devtools/vitest.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     watch: false,
     setupFiles: ['test-setup.ts'],
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/react-query-next-experimental/test-setup.ts
+++ b/packages/react-query-next-experimental/test-setup.ts
@@ -1,5 +1,10 @@
-import { act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
 import { notifyManager } from '@tanstack/react-query'
+
+// https://testing-library.com/docs/react-testing-library/api#cleanup
+afterEach(() => cleanup())
 
 // Wrap notifications with act to make sure React knows about React Query updates
 notifyManager.setNotifyFunction((fn) => {

--- a/packages/react-query-next-experimental/tsconfig.json
+++ b/packages/react-query-next-experimental/tsconfig.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/react-query-next-experimental/tsconfig.json
+++ b/packages/react-query-next-experimental/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-next-experimental/tsconfig.json
+++ b/packages/react-query-next-experimental/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-next-experimental/tsconfig.json
+++ b/packages/react-query-next-experimental/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/react-query-next-experimental/vitest.config.ts
+++ b/packages/react-query-next-experimental/vitest.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     watch: false,
     setupFiles: ['test-setup.ts'],
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,7 +1,6 @@
+import { describe, expect, test, vi } from 'vitest'
 import * as React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { vi } from 'vitest'
-
 import { QueryClient, useQueries, useQuery } from '@tanstack/react-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
 

--- a/packages/react-query-persist-client/src/__tests__/utils.ts
+++ b/packages/react-query-persist-client/src/__tests__/utils.ts
@@ -1,5 +1,4 @@
 import { act } from '@testing-library/react'
-
 import { QueryClient } from '@tanstack/react-query'
 import type { QueryClientConfig } from '@tanstack/react-query'
 

--- a/packages/react-query-persist-client/test-setup.ts
+++ b/packages/react-query-persist-client/test-setup.ts
@@ -1,5 +1,10 @@
-import { act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
 import { notifyManager } from '@tanstack/react-query'
+
+// https://testing-library.com/docs/react-testing-library/api#cleanup
+afterEach(() => cleanup())
 
 // Wrap notifications with act to make sure React knows about React Query updates
 notifyManager.setNotifyFunction((fn) => {

--- a/packages/react-query-persist-client/tsconfig.json
+++ b/packages/react-query-persist-client/tsconfig.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/react-query-persist-client/tsconfig.json
+++ b/packages/react-query-persist-client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-persist-client/tsconfig.json
+++ b/packages/react-query-persist-client/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query-persist-client/tsconfig.json
+++ b/packages/react-query-persist-client/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/react-query-persist-client/vitest.config.ts
+++ b/packages/react-query-persist-client/vitest.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     watch: false,
     setupFiles: ['test-setup.ts'],
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -1,3 +1,4 @@
+import { beforeAll, describe, expect, test } from 'vitest'
 import * as React from 'react'
 import { render } from '@testing-library/react'
 

--- a/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'vitest'
 import * as React from 'react'
 import { render, waitFor } from '@testing-library/react'
 

--- a/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { fireEvent, waitFor } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary'
 import * as React from 'react'

--- a/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
+++ b/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
@@ -1,8 +1,7 @@
+import { describe, expect, it, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import '@testing-library/jest-dom/vitest'
 import * as React from 'react'
 import { QueryCache, hashKey } from '@tanstack/query-core'
-import { vi } from 'vitest'
 import { useQuery } from '..'
 import {
   PERSISTER_KEY_PREFIX,

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.types.test.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
 import { useInfiniteQuery } from '../useInfiniteQuery'

--- a/packages/react-query/src/__tests__/queryOptions.types.test.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { queryOptions } from '../queryOptions'
 import { useQuery } from '../useQuery'

--- a/packages/react-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/react-query/src/__tests__/ssr-hydration.test.tsx
@@ -1,8 +1,8 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
 import ReactDOM from 'react-dom'
 import * as ReactDOMTestUtils from 'react-dom/test-utils'
 import * as ReactDOMServer from 'react-dom/server'
-import { vi } from 'vitest'
 
 import {
   QueryCache,

--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -1,8 +1,7 @@
+import { describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
 // @ts-ignore
 import { renderToString } from 'react-dom/server'
-
-import { vi } from 'vitest'
 import { QueryCache, QueryClientProvider, useInfiniteQuery, useQuery } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 

--- a/packages/react-query/src/__tests__/suspense.test.tsx
+++ b/packages/react-query/src/__tests__/suspense.test.tsx
@@ -1,7 +1,7 @@
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import { vi } from 'vitest'
 import {
   QueryCache,
   QueryErrorResetBoundary,
@@ -816,7 +816,7 @@ describe('useSuspenseQueries', () => {
       })
       return (
         <div>
-          <h1>data: {result.map((it) => it.data ?? 'null').join(',')}</h1>
+          <h1>data: {result.map((item) => item.data ?? 'null').join(',')}</h1>
         </div>
       )
     }
@@ -871,7 +871,7 @@ describe('useSuspenseQueries', () => {
       })
       return (
         <div>
-          <h1>data: {result.map((it) => it.data ?? 'null').join(',')}</h1>
+          <h1>data: {result.map((item) => item.data ?? 'null').join(',')}</h1>
         </div>
       )
     }

--- a/packages/react-query/src/__tests__/suspense.types.test.tsx
+++ b/packages/react-query/src/__tests__/suspense.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { useSuspenseQuery } from '../useSuspenseQuery'
 import { useSuspenseInfiniteQuery } from '../useSuspenseInfiniteQuery'
 import { doNotExecute } from './utils'

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1,7 +1,6 @@
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
-
-import { vi } from 'vitest'
 import { QueryCache, keepPreviousData, useInfiniteQuery } from '..'
 import {
   createQueryClient,

--- a/packages/react-query/src/__tests__/useInfiniteQuery.type.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { useQuery } from '../useQuery'

--- a/packages/react-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/react-query/src/__tests__/useIsFetching.test.tsx
@@ -1,6 +1,6 @@
+import { describe, expect, it } from 'vitest'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
-
 import { QueryCache, useIsFetching, useQuery } from '..'
 import {
   createQueryClient,

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1,9 +1,7 @@
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import '@testing-library/jest-dom/vitest'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-
-import { vi } from 'vitest'
 import { MutationCache, QueryCache, useMutation } from '..'
 import {
   createQueryClient,

--- a/packages/react-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/react-query/src/__tests__/useMutationState.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { useIsMutating, useMutationState } from '../useMutationState'

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -1,8 +1,7 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-
-import { vi } from 'vitest'
 import { QueryCache, useQueries } from '..'
 import {
   createQueryClient,

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -1,8 +1,7 @@
+import { describe, expect, expectTypeOf, it, test, vi } from 'vitest'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
-import '@testing-library/jest-dom/vitest'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import { vi } from 'vitest'
 import { QueryCache, keepPreviousData, useQuery } from '..'
 import {
   Blink,
@@ -154,8 +153,8 @@ describe('useQuery', () => {
           queryFn: () => fetcher(qk[1], 'token'),
           ...options,
         })
-      const test = useWrappedQuery([''], async () => '1')
-      expectTypeOf<string | undefined>(test.data)
+      const testQuery = useWrappedQuery([''], async () => '1')
+      expectTypeOf<string | undefined>(testQuery.data)
 
       // handles wrapped queries with custom fetcher passed directly to useQuery
       const useWrappedFuncStyleQuery = <

--- a/packages/react-query/src/__tests__/useQuery.types.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { useQuery } from '../useQuery'
 import { queryOptions } from '../queryOptions'
 import { doNotExecute } from './utils'

--- a/packages/react-query/src/__tests__/utils.tsx
+++ b/packages/react-query/src/__tests__/utils.tsx
@@ -1,8 +1,7 @@
+import { vi } from 'vitest'
 import * as React from 'react'
 import { act, render } from '@testing-library/react'
-
 import * as utils from '@tanstack/query-core'
-import { vi } from 'vitest'
 import { QueryClient, QueryClientProvider, onlineManager } from '..'
 import type { QueryClientConfig } from '..'
 import type { SpyInstance } from 'vitest'

--- a/packages/react-query/test-setup.ts
+++ b/packages/react-query/test-setup.ts
@@ -1,5 +1,10 @@
-import { act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
 import { notifyManager } from '@tanstack/query-core'
+
+// https://testing-library.com/docs/react-testing-library/api#cleanup
+afterEach(() => cleanup())
 
 // Wrap notifications with act to make sure React knows about React Query updates
 notifyManager.setNotifyFunction((fn) => {

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "jsx": "react",
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "jsx": "react",
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js"]
 }

--- a/packages/react-query/vitest.config.ts
+++ b/packages/react-query/vitest.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     watch: false,
     environment: 'jsdom',
     setupFiles: ['test-setup.ts'],
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
 })

--- a/packages/solid-query-devtools/test-setup.ts
+++ b/packages/solid-query-devtools/test-setup.ts
@@ -1,0 +1,6 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@solidjs/testing-library'
+import { afterEach } from 'vitest'
+
+// https://github.com/solidjs/solid-testing-library
+afterEach(() => cleanup())

--- a/packages/solid-query-devtools/tsconfig.json
+++ b/packages/solid-query-devtools/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/solid-query-devtools/tsconfig.json
+++ b/packages/solid-query-devtools/tsconfig.json
@@ -4,5 +4,12 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/solid-query-devtools/tsconfig.json
+++ b/packages/solid-query-devtools/tsconfig.json
@@ -4,5 +4,5 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/solid-query-devtools/tsconfig.json
+++ b/packages/solid-query-devtools/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
+    "jsxImportSource": "solid-js"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/solid-query-devtools/vitest.config.ts
+++ b/packages/solid-query-devtools/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     watch: false,
     setupFiles: [],
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
   plugins: [solid()],

--- a/packages/solid-query-devtools/vitest.config.ts
+++ b/packages/solid-query-devtools/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     name: 'solid-query-devtools',
     dir: './src',
     watch: false,
-    setupFiles: [],
+    setupFiles: ['test-setup.ts'],
     environment: 'jsdom',
     coverage: { provider: 'istanbul' },
   },

--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom/vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { render, screen, waitFor } from '@solidjs/testing-library'
 import { QueryClient, createQueries, createQuery } from '@tanstack/solid-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'

--- a/packages/solid-query-persist-client/test-setup.ts
+++ b/packages/solid-query-persist-client/test-setup.ts
@@ -1,0 +1,6 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@solidjs/testing-library'
+import { afterEach } from 'vitest'
+
+// https://github.com/solidjs/solid-testing-library
+afterEach(() => cleanup())

--- a/packages/solid-query-persist-client/tsconfig.json
+++ b/packages/solid-query-persist-client/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/solid-query-persist-client/tsconfig.json
+++ b/packages/solid-query-persist-client/tsconfig.json
@@ -4,5 +4,12 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/solid-query-persist-client/tsconfig.json
+++ b/packages/solid-query-persist-client/tsconfig.json
@@ -4,5 +4,5 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/solid-query-persist-client/tsconfig.json
+++ b/packages/solid-query-persist-client/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
+    "jsxImportSource": "solid-js"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/solid-query-persist-client/vitest.config.ts
+++ b/packages/solid-query-persist-client/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     watch: false,
     setupFiles: [],
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
   plugins: [solid()],

--- a/packages/solid-query-persist-client/vitest.config.ts
+++ b/packages/solid-query-persist-client/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     name: 'solid-query-persist-client',
     dir: './src',
     watch: false,
-    setupFiles: [],
+    setupFiles: ['test-setup.ts'],
     environment: 'jsdom',
     coverage: { provider: 'istanbul' },
   },

--- a/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,7 +1,6 @@
+import { describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '@solidjs/testing-library'
-
 import { QueryCache } from '@tanstack/query-core'
-import { vi } from 'vitest'
 import { QueryClientProvider, createQuery, useQueryClient } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 

--- a/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 
 import {
@@ -10,7 +11,6 @@ import {
   createSignal,
   on,
 } from 'solid-js'
-import { vi } from 'vitest'
 import {
   QueryCache,
   QueryClientProvider,

--- a/packages/solid-query/src/__tests__/createMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/createMutation.test.tsx
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom/vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   ErrorBoundary,
   createEffect,
@@ -6,7 +6,6 @@ import {
   createSignal,
 } from 'solid-js'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
-import { vi } from 'vitest'
 import {
   MutationCache,
   QueryCache,

--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -1,8 +1,8 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 import * as QueryCore from '@tanstack/query-core'
 
 import { createRenderEffect, createSignal } from 'solid-js'
-import { vi } from 'vitest'
 import {
   QueriesObserver,
   QueryCache,

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom/vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import {
   ErrorBoundary,
   Match,
@@ -10,7 +10,6 @@ import {
   on,
 } from 'solid-js'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
-import { vi } from 'vitest'
 import { reconcile } from 'solid-js/store'
 import {
   QueryCache,

--- a/packages/solid-query/src/__tests__/createQuery.types.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { createQuery, queryOptions } from '../index'
 
 export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 
 import {
@@ -8,7 +9,6 @@ import {
   createSignal,
   on,
 } from 'solid-js'
-import { vi } from 'vitest'
 import {
   QueryCache,
   QueryClientProvider,

--- a/packages/solid-query/src/__tests__/transition.test.tsx
+++ b/packages/solid-query/src/__tests__/transition.test.tsx
@@ -1,5 +1,5 @@
+import { describe, it } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
-
 import { Show, Suspense, createSignal, startTransition } from 'solid-js'
 import { QueryCache, QueryClientProvider, createQuery } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -1,5 +1,5 @@
+import { describe, expect, it } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
-
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
 import { QueryCache, QueryClientProvider, createQuery, useIsFetching } from '..'
 import { createQueryClient, queryKey, setActTimeout, sleep } from './utils'

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -1,8 +1,7 @@
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
-
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
 import * as QueryCore from '@tanstack/query-core'
-import { vi } from 'vitest'
 import { QueryClientProvider, createMutation, useIsMutating } from '..'
 import { createQueryClient, setActTimeout, sleep } from './utils'
 

--- a/packages/solid-query/src/__tests__/utils.tsx
+++ b/packages/solid-query/src/__tests__/utils.tsx
@@ -1,5 +1,5 @@
-import { Show, createEffect, createSignal, onCleanup } from 'solid-js'
 import { vi } from 'vitest'
+import { Show, createEffect, createSignal, onCleanup } from 'solid-js'
 import { onlineManager } from '@tanstack/query-core'
 import { QueryClient } from '../QueryClient'
 import type { QueryClientConfig } from '@tanstack/query-core'

--- a/packages/solid-query/test-setup.ts
+++ b/packages/solid-query/test-setup.ts
@@ -1,0 +1,6 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@solidjs/testing-library'
+import { afterEach } from 'vitest'
+
+// https://github.com/solidjs/solid-testing-library
+afterEach(() => cleanup())

--- a/packages/solid-query/tsconfig.json
+++ b/packages/solid-query/tsconfig.json
@@ -4,5 +4,12 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/solid-query/tsconfig.json
+++ b/packages/solid-query/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/solid-query/tsconfig.json
+++ b/packages/solid-query/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
+    "jsxImportSource": "solid-js"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/solid-query/vitest.config.ts
+++ b/packages/solid-query/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     watch: false,
     setupFiles: [],
     environment: 'jsdom',
-    globals: true,
     coverage: { provider: 'istanbul' },
   },
   plugins: [solid()],

--- a/packages/solid-query/vitest.config.ts
+++ b/packages/solid-query/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     name: 'solid-query',
     dir: './src',
     watch: false,
-    setupFiles: [],
+    setupFiles: ['test-setup.ts'],
     environment: 'jsdom',
     coverage: { provider: 'istanbul' },
   },

--- a/packages/svelte-query-persist-client/test-setup.ts
+++ b/packages/svelte-query-persist-client/test-setup.ts
@@ -2,4 +2,5 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/svelte'
 import { afterEach } from 'vitest'
 
+// https://testing-library.com/docs/svelte-testing-library/api/#cleanup
 afterEach(() => cleanup())

--- a/packages/svelte-query-persist-client/tsconfig.json
+++ b/packages/svelte-query-persist-client/tsconfig.json
@@ -5,7 +5,7 @@
     "src/**/*.ts",
     "src/**/*.svelte",
     ".eslintrc.cjs",
-    "vite.config.ts",
-    "vitest-setup.ts"
+    "test-setup.ts",
+    "vite.config.ts"
   ]
 }

--- a/packages/svelte-query-persist-client/vite.config.ts
+++ b/packages/svelte-query-persist-client/vite.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     coverage: { provider: 'istanbul' },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,ts}'],
-    setupFiles: ['vitest-setup.ts'],
+    setupFiles: ['test-setup.ts'],
   },
 })

--- a/packages/svelte-query/test-setup.ts
+++ b/packages/svelte-query/test-setup.ts
@@ -2,4 +2,5 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/svelte'
 import { afterEach } from 'vitest'
 
+// https://testing-library.com/docs/svelte-testing-library/api/#cleanup
 afterEach(() => cleanup())

--- a/packages/svelte-query/tsconfig.json
+++ b/packages/svelte-query/tsconfig.json
@@ -5,7 +5,7 @@
     "src/**/*.ts",
     "src/**/*.svelte",
     ".eslintrc.cjs",
-    "vite.config.ts",
-    "vitest-setup.ts"
+    "test-setup.ts",
+    "vite.config.ts"
   ]
 }

--- a/packages/svelte-query/vite.config.ts
+++ b/packages/svelte-query/vite.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     coverage: { provider: 'istanbul' },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,ts}'],
-    setupFiles: ['vitest-setup.ts'],
+    setupFiles: ['test-setup.ts'],
   },
 })

--- a/packages/vue-query/src/__tests__/mutationCache.test.ts
+++ b/packages/vue-query/src/__tests__/mutationCache.test.ts
@@ -1,7 +1,6 @@
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 import { ref } from 'vue-demi'
 import { MutationCache as MutationCacheOrigin } from '@tanstack/query-core'
-
-import { vi } from 'vitest'
 import { MutationCache } from '../mutationCache'
 
 describe('MutationCache', () => {

--- a/packages/vue-query/src/__tests__/queryCache.test.ts
+++ b/packages/vue-query/src/__tests__/queryCache.test.ts
@@ -1,7 +1,6 @@
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 import { ref } from 'vue-demi'
 import { QueryCache as QueryCacheOrigin } from '@tanstack/query-core'
-
-import { vi } from 'vitest'
 import { QueryCache } from '../queryCache'
 
 describe('QueryCache', () => {

--- a/packages/vue-query/src/__tests__/queryClient.test.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test.ts
@@ -1,7 +1,6 @@
+import { describe, expect, test, vi } from 'vitest'
 import { ref } from 'vue-demi'
 import { QueryClient as QueryClientOrigin } from '@tanstack/query-core'
-
-import { vi } from 'vitest'
 import { QueryClient } from '../queryClient'
 
 vi.mock('@tanstack/query-core')

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { flushPromises, infiniteFetcher } from './test-utils'
 

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.types.test.tsx
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { reactive } from 'vue'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { doNotExecute, simpleFetcher } from './test-utils'

--- a/packages/vue-query/src/__tests__/useIsFetching.test.ts
+++ b/packages/vue-query/src/__tests__/useIsFetching.test.ts
@@ -1,6 +1,5 @@
+import { describe, expect, test, vi } from 'vitest'
 import { onScopeDispose, reactive } from 'vue-demi'
-
-import { vi } from 'vitest'
 import { useQuery } from '../useQuery'
 import { useIsFetching } from '../useIsFetching'
 import { flushPromises, simpleFetcher } from './test-utils'

--- a/packages/vue-query/src/__tests__/useIsMutating.test.ts
+++ b/packages/vue-query/src/__tests__/useIsMutating.test.ts
@@ -1,6 +1,5 @@
+import { describe, expect, it, test, vi } from 'vitest'
 import { onScopeDispose, reactive } from 'vue-demi'
-
-import { vi } from 'vitest'
 import { useMutation } from '../useMutation'
 import { useIsMutating, useMutationState } from '../useMutationState'
 import { useQueryClient } from '../useQueryClient'

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -1,5 +1,5 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { reactive, ref } from 'vue-demi'
-import { vi } from 'vitest'
 import { useMutation } from '../useMutation'
 import { useQueryClient } from '../useQueryClient'
 import { errorMutator, flushPromises, successMutator } from './test-utils'

--- a/packages/vue-query/src/__tests__/useMutation.types.test.tsx
+++ b/packages/vue-query/src/__tests__/useMutation.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { reactive } from 'vue'
 import { useMutation } from '../useMutation'
 import { doNotExecute, successMutator } from './test-utils'

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -1,6 +1,5 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { onScopeDispose, ref } from 'vue-demi'
-
-import { vi } from 'vitest'
 import { useQueries } from '../useQueries'
 import { useQueryClient } from '../useQueryClient'
 import { QueryClient } from '../queryClient'

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test, vi } from 'vitest'
 import {
   computed,
   getCurrentInstance,
@@ -6,8 +7,6 @@ import {
   ref,
 } from 'vue-demi'
 import { QueryObserver } from '@tanstack/query-core'
-
-import { vi } from 'vitest'
 import { useQuery } from '../useQuery'
 import { useBaseQuery } from '../useBaseQuery'
 import {

--- a/packages/vue-query/src/__tests__/useQuery.types.test.tsx
+++ b/packages/vue-query/src/__tests__/useQuery.types.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it } from 'vitest'
 import { reactive } from 'vue'
 import { useQuery } from '../useQuery'
 import { doNotExecute, simpleFetcher } from './test-utils'

--- a/packages/vue-query/src/__tests__/useQueryClient.test.ts
+++ b/packages/vue-query/src/__tests__/useQueryClient.test.ts
@@ -1,5 +1,5 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { hasInjectionContext, inject } from 'vue-demi'
-import { vi } from 'vitest'
 import { useQueryClient } from '../useQueryClient'
 import { VUE_QUERY_CLIENT } from '../utils'
 import type { Mock } from 'vitest'

--- a/packages/vue-query/src/__tests__/utils.test.ts
+++ b/packages/vue-query/src/__tests__/utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'vitest'
 import { reactive, ref } from 'vue-demi'
 import { cloneDeep, cloneDeepUnref, updateState } from '../utils'
 

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -1,6 +1,5 @@
+import { describe, expect, test, vi } from 'vitest'
 import { isVue2, isVue3, ref } from 'vue-demi'
-
-import { vi } from 'vitest'
 import { QueryClient } from '../queryClient'
 import { VueQueryPlugin } from '../vueQueryPlugin'
 import { VUE_QUERY_CLIENT } from '../utils'

--- a/packages/vue-query/tsconfig.json
+++ b/packages/vue-query/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "types": ["vitest/globals"]
-  },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
 }

--- a/packages/vue-query/tsconfig.json
+++ b/packages/vue-query/tsconfig.json
@@ -5,7 +5,6 @@
     "src/**/*.tsx",
     ".eslintrc.cjs",
     "test-setup.ts",
-    "tsup.config.js",
-    "vitest.config.ts"
+    "tsup.config.js"
   ]
 }

--- a/packages/vue-query/tsconfig.json
+++ b/packages/vue-query/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "test-setup.ts",
+    "tsup.config.js",
+    "vitest.config.ts"
+  ]
 }

--- a/packages/vue-query/tsconfig.json
+++ b/packages/vue-query/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "test-setup.ts", "tsup.config.js", "vitest.config.ts"]
 }

--- a/packages/vue-query/vitest.config.ts
+++ b/packages/vue-query/vitest.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
     dir: './src',
     watch: false,
     environment: 'jsdom',
-    globals: true,
     setupFiles: ['test-setup.ts'],
     coverage: { provider: 'istanbul' },
     onConsoleLog: function (log) {


### PR DESCRIPTION
Test globals are a remnant from the [jest to vitest migration](https://vitest.dev/guide/migration.html#globals-as-a-default) - globals are disabled by default in vitest. Removing them should hopefully increase test performance and reduce unpredictable testing errors. Where relevant, I've moved the testing-library import and cleanup (necessary when globals are disabled) into a `test-setup.ts` file.