### PR TITLE
fix(query-core): ensureQueryData call fetchQuery when the query actually does not exist

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -132,7 +132,9 @@ export class QueryClient {
   ): Promise<TData> {
     const cachedData = this.getQueryData<TData>(options.queryKey)
 
-    return cachedData ? Promise.resolve(cachedData) : this.fetchQuery(options)
+    return cachedData !== undefined
+      ? Promise.resolve(cachedData)
+      : this.fetchQuery(options)
   }
 
   getQueriesData<TQueryFnData = unknown>(

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -435,13 +435,13 @@ describe('queryClient', () => {
 
     test('should return the cached query data if the query is found and cached query data is falsey', async () => {
       const key = queryKey()
-      const queryFn = () => Promise.resolve('data')
+      const queryFn = () => Promise.resolve(0)
 
-      queryClient.setQueryData([key, 'id'], '')
+      queryClient.setQueryData([key, 'id'], null)
 
       await expect(
         queryClient.ensureQueryData({ queryKey: [key, 'id'], queryFn }),
-      ).resolves.toEqual('')
+      ).resolves.toEqual(null)
     })
 
     test('should call fetchQuery and return its results if the query is not found', async () => {

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -433,6 +433,17 @@ describe('queryClient', () => {
       ).resolves.toEqual('bar')
     })
 
+    test('should return the cached query data if the query is found and cached query data is falsey', async () => {
+      const key = queryKey()
+      const queryFn = () => Promise.resolve('data')
+
+      queryClient.setQueryData([key, 'id'], '')
+
+      await expect(
+        queryClient.ensureQueryData({ queryKey: [key, 'id'], queryFn }),
+      ).resolves.toEqual('')
+    })
+
     test('should call fetchQuery and return its results if the query is not found', async () => {
       const key = queryKey()
       const queryFn = () => Promise.resolve('data')


### PR DESCRIPTION
# `queryClient.ensureQueryData` 

Bug:
```typescript
  const queryClient = useQueryClient();

  const { data: count } = useQuery({
    queryKey: ['cacheKey'],
    queryFn: async () => {
      // return falsy data. ex) 0 / null / '' / false ...
     return 0
    },
  });

  const handleClick = async () => {
    const data = await queryClient.ensureQueryData({ queryKey: ['cacheKey'] });
    // queryFn runs every time click
  };
```

If the cached data for the existing query is falsey data ( 0, null, "", false ... ) , `queryClient.fetchQuery` will be called when using `queryClient.ensureQueryData`. This leads to unintentional queryFn (API) calls.

So ensure a clear check for the existence of the query's cached data.

