### PR TITLE
docs: add information about error while retry attempts

### DIFF
--- a/docs/react/guides/query-retries.md
+++ b/docs/react/guides/query-retries.md
@@ -29,6 +29,8 @@ const result = useQuery({
 
 [//]: # 'Example'
 
+> Info: Contents of the `error` property will be part of `failureReason` response property of `useQuery` until the last retry attempt. So in above example any error contents will be part of `failureReason` property for first 9 retry attempts (Overall 10 attempts) and finally they will be part of `error` after last attempt if error persists after all retry attempts.
+
 ## Retry Delay
 
 By default, retries in TanStack Query do not happen immediately after a request fails. As is standard, a back-off delay is gradually applied to each retry attempt.


### PR DESCRIPTION
I noticed this while I was trying to use useQuery and trying to capture the error property. I think this is something which can be added as extra information for those who will be using it for first time.

Reference Discussion: https://github.com/TanStack/query/discussions/6271