### PR TITLE
docs: fix isPending boolean about dependent queries

### DIFF
--- a/docs/react/guides/dependent-queries.md
+++ b/docs/react/guides/dependent-queries.md
@@ -37,7 +37,7 @@ The `projects` query will start in:
 
 ```tsx
 status: 'pending'
-isPending: false
+isPending: true
 fetchStatus: 'idle'
 ```
 


### PR DESCRIPTION
I noticed the mistake: if `status === "pending"`, `isPending` should be true.