### PR TITLE
fix: changed import path in react prefetching example

### DIFF
--- a/examples/react/prefetching/src/pages/[user]/[repo].js
+++ b/examples/react/prefetching/src/pages/[user]/[repo].js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import fetch from '../../libs/fetch'
+import fetch from '../../../libs/fetch'
 
 import { useQuery } from '@tanstack/react-query'
 


### PR DESCRIPTION
The `fetch.js` path was incorrect, so I corrected the import path of the `fetch.js`

![image](https://github.com/TanStack/query/assets/76807107/a9545778-f2d8-44d0-ba6f-99c650810538)
