### PR TITLE
test(asyncThrottle): migrated to useFakeTimers

### DIFF
--- a/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
+++ b/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { asyncThrottle } from '../asyncThrottle'
 import { sleep as delay } from './utils'
 
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 describe('asyncThrottle', () => {
   test('basic', async () => {
+    vi.useFakeTimers()
+
     const interval = 10
+
     const execTimeStamps: Array<number> = []
     const mockFunc = vi.fn(
       async (id: number, complete?: (value?: unknown) => void) => {
@@ -18,10 +25,15 @@ describe('asyncThrottle', () => {
     const testFunc = asyncThrottle(mockFunc, { interval })
 
     testFunc(1)
-    await delay(1)
+    await vi.advanceTimersByTimeAsync(1)
+
     testFunc(2)
-    await delay(1)
-    await new Promise((resolve) => testFunc(3, resolve))
+    await vi.advanceTimersByTimeAsync(1)
+
+    new Promise((resolve) => testFunc(3, resolve))
+
+    await vi.advanceTimersToNextTimerAsync()
+    await vi.advanceTimersByTimeAsync(interval)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(3)
@@ -32,6 +44,8 @@ describe('asyncThrottle', () => {
   })
 
   test('Bug #3331 case 1: Special timing', async () => {
+    vi.useFakeTimers()
+
     const interval = 1000
     const execTimeStamps: Array<number> = []
     const mockFunc = vi.fn(
@@ -47,10 +61,13 @@ describe('asyncThrottle', () => {
 
     testFunc(1)
     testFunc(2)
-    await delay(35)
+    await vi.advanceTimersByTimeAsync(35)
     testFunc(3)
-    await delay(35)
-    await new Promise((resolve) => testFunc(4, resolve))
+    await vi.advanceTimersByTimeAsync(35)
+    new Promise((resolve) => testFunc(4, resolve))
+
+    await vi.advanceTimersToNextTimerAsync()
+    await vi.advanceTimersByTimeAsync(interval)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(4)
@@ -61,6 +78,8 @@ describe('asyncThrottle', () => {
   })
 
   test('Bug #3331 case 2: "func" execution time is greater than the interval.', async () => {
+    vi.useFakeTimers()
+
     const interval = 1000
     const execTimeStamps: Array<number> = []
     const mockFunc = vi.fn(
@@ -76,7 +95,11 @@ describe('asyncThrottle', () => {
 
     testFunc(1)
     testFunc(2)
-    await new Promise((resolve) => testFunc(3, resolve))
+    new Promise((resolve) => testFunc(3, resolve))
+
+    await vi.advanceTimersToNextTimerAsync()
+    await vi.advanceTimersByTimeAsync(interval + 10)
+    await vi.advanceTimersByTimeAsync(interval + 10)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(3)
@@ -87,6 +110,10 @@ describe('asyncThrottle', () => {
   })
 
   test('"func" throw error not break next invoke', async () => {
+    vi.useFakeTimers()
+
+    const interval = 10
+
     const mockFunc = vi.fn(
       async (id: number, complete?: (value?: unknown) => void) => {
         if (id === 1) throw new Error('error')
@@ -96,11 +123,13 @@ describe('asyncThrottle', () => {
         }
       },
     )
-    const testFunc = asyncThrottle(mockFunc, { interval: 10 })
+    const testFunc = asyncThrottle(mockFunc, { interval })
 
     testFunc(1)
-    await delay(1)
-    await new Promise((resolve) => testFunc(2, resolve))
+    await vi.advanceTimersByTimeAsync(1)
+
+    new Promise((resolve) => testFunc(2, resolve))
+    await vi.advanceTimersByTimeAsync(interval)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(2)


### PR DESCRIPTION
Hi @TkDodo,  I was on the twitch stream and asked about using fake timers in tests. This is my first example, on a small codebase.

The test time has noticeably decreased, 4.56 s => 468 ms.

What do you think about it ? I can also migrate other packages gradually.