### PR TITLE
docs(paginated-queries): Add import statements

### DIFF
--- a/docs/react/guides/paginated-queries.md
+++ b/docs/react/guides/paginated-queries.md
@@ -30,6 +30,9 @@ Consider the following example where we would ideally want to increment a pageIn
 
 [//]: # 'Example2'
 ```tsx
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import React from "react";
+
 function Todos() {
   const [page, setPage] = React.useState(0)
 


### PR DESCRIPTION
It could be a bit confusing how to use `keepPreviousData`, so this PR adds import statements for the example.