### PR TITLE
test(asyncThrottle): migrated to useFakeTimers

### DIFF
--- a/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
+++ b/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { asyncThrottle } from '../asyncThrottle'
 import { sleep as delay } from './utils'
 
 describe('asyncThrottle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   test('basic', async () => {
     const interval = 10
     const execTimeStamps: Array<number> = []
@@ -18,10 +26,15 @@ describe('asyncThrottle', () => {
     const testFunc = asyncThrottle(mockFunc, { interval })
 
     testFunc(1)
-    await delay(1)
+    await vi.advanceTimersByTimeAsync(1)
+
     testFunc(2)
-    await delay(1)
-    await new Promise((resolve) => testFunc(3, resolve))
+    await vi.advanceTimersByTimeAsync(1)
+
+    new Promise((resolve) => testFunc(3, resolve))
+
+    await vi.advanceTimersToNextTimerAsync()
+    await vi.advanceTimersByTimeAsync(interval)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(3)
@@ -47,10 +60,13 @@ describe('asyncThrottle', () => {
 
     testFunc(1)
     testFunc(2)
-    await delay(35)
+    await vi.advanceTimersByTimeAsync(35)
     testFunc(3)
-    await delay(35)
-    await new Promise((resolve) => testFunc(4, resolve))
+    await vi.advanceTimersByTimeAsync(35)
+    new Promise((resolve) => testFunc(4, resolve))
+
+    await vi.advanceTimersToNextTimerAsync()
+    await vi.advanceTimersByTimeAsync(interval)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(4)
@@ -76,7 +92,11 @@ describe('asyncThrottle', () => {
 
     testFunc(1)
     testFunc(2)
-    await new Promise((resolve) => testFunc(3, resolve))
+    new Promise((resolve) => testFunc(3, resolve))
+
+    await vi.advanceTimersToNextTimerAsync()
+    await vi.advanceTimersByTimeAsync(interval + 10)
+    await vi.advanceTimersByTimeAsync(interval + 10)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(3)
@@ -87,6 +107,8 @@ describe('asyncThrottle', () => {
   })
 
   test('"func" throw error not break next invoke', async () => {
+    const interval = 10
+
     const mockFunc = vi.fn(
       async (id: number, complete?: (value?: unknown) => void) => {
         if (id === 1) throw new Error('error')
@@ -96,11 +118,13 @@ describe('asyncThrottle', () => {
         }
       },
     )
-    const testFunc = asyncThrottle(mockFunc, { interval: 10 })
+    const testFunc = asyncThrottle(mockFunc, { interval })
 
     testFunc(1)
-    await delay(1)
-    await new Promise((resolve) => testFunc(2, resolve))
+    await vi.advanceTimersByTimeAsync(1)
+
+    new Promise((resolve) => testFunc(2, resolve))
+    await vi.advanceTimersByTimeAsync(interval)
 
     expect(mockFunc).toBeCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(2)


### PR DESCRIPTION
I made a mistake and recreated my pr, previos
https://github.com/TanStack/query/pull/6308

I moved beforeEach, afterEach into the top describe block. 

If at the top level (beforeEach,afterEach), it is applied to the entire file. Inside a describe block - only to that describe block