### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/docs/vue/guides/ssr.md
+++ b/docs/vue/guides/ssr.md
@@ -15,7 +15,7 @@ First create `vue-query.ts` file in your `plugins` directory with the following 
 import type { DehydratedState, VueQueryPluginOptions } from '@tanstack/vue-query'
 import { VueQueryPlugin, QueryClient, hydrate, dehydrate } from '@tanstack/vue-query'
 // Nuxt 3 app aliases
-import { useState } from '#app'
+import { useState } from '#imports'
 
 export default defineNuxtPlugin((nuxt) => {
   const vueQueryState = useState<DehydratedState | null>('vue-query')

--- a/docs/vue/guides/ssr.md
+++ b/docs/vue/guides/ssr.md
@@ -15,7 +15,7 @@ First create `vue-query.ts` file in your `plugins` directory with the following 
 import type { DehydratedState, VueQueryPluginOptions } from '@tanstack/vue-query'
 import { VueQueryPlugin, QueryClient, hydrate, dehydrate } from '@tanstack/vue-query'
 // Nuxt 3 app aliases
-import { useState } from '#imports'
+import { defineNuxtPlugin, useState } from '#imports'
 
 export default defineNuxtPlugin((nuxt) => {
   const vueQueryState = useState<DehydratedState | null>('vue-query')

--- a/examples/vue/nuxt3/plugins/vue-query.ts
+++ b/examples/vue/nuxt3/plugins/vue-query.ts
@@ -9,7 +9,7 @@ import {
   dehydrate,
 } from '@tanstack/vue-query'
 // Nuxt 3 app aliases
-import { useState } from '#imports'
+import { defineNuxtPlugin, useState } from '#imports'
 
 export default defineNuxtPlugin((nuxt) => {
   const vueQueryState = useState<DehydratedState | null>('vue-query')

--- a/examples/vue/nuxt3/plugins/vue-query.ts
+++ b/examples/vue/nuxt3/plugins/vue-query.ts
@@ -9,7 +9,7 @@ import {
   dehydrate,
 } from '@tanstack/vue-query'
 // Nuxt 3 app aliases
-import { useState } from '#app'
+import { useState } from '#imports'
 
 export default defineNuxtPlugin((nuxt) => {
   const vueQueryState = useState<DehydratedState | null>('vue-query')


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.