### PR TITLE
docs(QueryClient.md): fix typo immuatable → immutable

### DIFF
--- a/docs/react/reference/QueryClient.md
+++ b/docs/react/reference/QueryClient.md
@@ -252,7 +252,7 @@ If the updater function returns `undefined`, the query data will not be updated.
 
 **Immutability**
 
-Updates via `setQueryData` must be performed in an _immuatable_ way. **DO NOT** attempt to write directly to the cache by mutating `oldData` or data that you retrieved via `getQueryData` in place.
+Updates via `setQueryData` must be performed in an _immutable_ way. **DO NOT** attempt to write directly to the cache by mutating `oldData` or data that you retrieved via `getQueryData` in place.
 
 ## `queryClient.getQueryState`
 


### PR DESCRIPTION
I made a [PR for this before](https://github.com/TanStack/query/pull/6328) but turns out that change was for v4 only. This is for latest