### PR TITLE
fix(examples-react-suspense): add font-awesome dependency to display …

### DIFF
--- a/examples/react/suspense/package.json
+++ b/examples/react/suspense/package.json
@@ -6,6 +6,7 @@
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-query-devtools": "^5.0.0",
     "axios": "^1.5.1",
+    "font-awesome": "^4.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4"

--- a/examples/react/suspense/src/index.jsx
+++ b/examples/react/suspense/src/index.jsx
@@ -1,3 +1,4 @@
+import 'font-awesome/css/font-awesome.min.css'
 import React, { lazy } from 'react'
 import ReactDOM from 'react-dom/client'
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -911,6 +911,9 @@ importers:
       axios:
         specifier: ^1.5.1
         version: 1.5.1
+      font-awesome:
+        specifier: ^4.7.0
+        version: 4.7.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -15360,6 +15363,11 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@6.1.0)
+
+  /font-awesome@4.7.0:
+    resolution: {integrity: sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==}
+    engines: {node: '>=0.10.3'}
+    dev: false
 
   /fontfaceobserver@2.3.0:
     resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}


### PR DESCRIPTION
…Spinner correctly

Spinner is not visible in the Suspense example due to missing font-awesome dependency.