### PR TITLE
Fix generic type passed to structural sharing function

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -158,7 +158,7 @@ export interface QueryOptions<
    * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
    * Defaults to `true`.
    */
-  structuralSharing?: boolean | (<T>(oldData: T | undefined, newData: T) => T)
+  structuralSharing?: boolean | ((oldData: TData | undefined, newData: TData) => TData)
   _defaulted?: boolean
   /**
    * Additional payload to be stored on each query.

--- a/packages/react-query/src/__tests__/useQuery.types.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.types.test.tsx
@@ -169,7 +169,7 @@ describe('initialData', () => {
         useQuery({
           queryKey: ['key'],
           queryFn: () => 5,
-          structuralSharing: (_oldData, newData) => {
+          structuralSharing: (_oldData: number | undefined, newData: number) => {
             return newData
           },
         })


### PR DESCRIPTION
I noticed when upgrading that our code, that is using structural sharing, could no longer properly infer the type of the oldData and newData from the query. 

It looks like structural sharing was expanded before v5 to take the type of T instead of TData. I could not find a way to make it work so I thought it must be a bug and decided to open up a PR to fix it. 

If there is a way to fix it without the changes let me know but I did confirm that the type of oldData and newData in the test was not being inferred properly so I added explicit typing to the test that was added when the change went in