### PR TITLE
fix: pass TError, TQueryData and TQueryKey to PlaceholderDataFunction

### DIFF
--- a/packages/query-core/src/tests/queryObserver.types.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.types.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it } from 'vitest'
+import { QueryObserver } from '..'
+import { createQueryClient, doNotExecute } from './utils'
+import type { Equal, Expect } from './utils'
+
+describe('placeholderData', () => {
+  describe('placeholderData function', () => {
+    it('previousQuery should have typed queryKey', () => {
+      doNotExecute(() => {
+        const queryKey = ['SomeQuery', 42, { foo: 'bar' }] as const
+        type QueryKey = typeof queryKey
+
+        new QueryObserver(createQueryClient(), {
+          queryKey,
+          placeholderData: (_, previousQuery) => {
+            const previousQueryKey = previousQuery?.queryKey
+
+            const result: Expect<
+              Equal<typeof previousQueryKey, QueryKey | undefined>
+            > = true
+            return result
+          },
+        })
+      })
+    })
+
+    it('previousQuery should have typed error', () => {
+      doNotExecute(() => {
+        class CustomError extends Error {
+          name = 'CustomError' as const
+        }
+
+        new QueryObserver<boolean, CustomError>(createQueryClient(), {
+          placeholderData: (_, previousQuery) => {
+            const error = previousQuery?.state.error
+
+            const result: Expect<
+              Equal<typeof error, CustomError | null | undefined>
+            > = true
+            return result
+          },
+        })
+      })
+    })
+
+    it('previousData should have the same type as query data', () => {
+      doNotExecute(() => {
+        const queryData = { foo: 'bar' } as const
+        type QueryData = typeof queryData
+
+        new QueryObserver(createQueryClient(), {
+          queryFn: () => queryData,
+          select: (data) => data.foo,
+          placeholderData: (previousData) => {
+            const result: Expect<
+              Equal<typeof previousData, QueryData | undefined>
+            > = true
+            return result ? previousData : undefined
+          },
+        })
+      })
+    })
+  })
+})

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -140,7 +140,7 @@ export interface QueryOptions<
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
   networkMode?: NetworkMode
-   /**
+  /**
    * The time in milliseconds that unused/inactive cache data remains in memory.
    * When a query's cache becomes unused or inactive, that cache data will be garbage collected after this duration.
    * When different garbage collection times are specified, the longest one will be used.

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -319,7 +319,12 @@ export interface QueryObserverOptions<
    */
   placeholderData?:
     | NonFunctionGuard<TQueryData>
-    | PlaceholderDataFunction<NonFunctionGuard<TQueryData>>
+    | PlaceholderDataFunction<
+        NonFunctionGuard<TQueryData>,
+        TError,
+        NonFunctionGuard<TQueryData>,
+        TQueryKey
+      >
 
   _optimisticResults?: 'optimistic' | 'isRestoring'
 }


### PR DESCRIPTION
The `previousData` and `previousQuery` parameters of the placeholder function seem to not be properly types. I think this should fix it. I tested it like this:
```typescript
const observer = new QueryObserver(
  {} as any,
  {
    queryKey: ['A', 'B'] as const,
    queryFn: () => 'Foo',
    placeholderData: (prev, prevQuery) => {
      // typeof key is now ['A', 'B'] instead of QueryKey
      const key = prevQuery?.queryKey
      return prev
    },
  },
)
```
Please let me know if I missed something.