### PR TITLE
  Fix #6344: useSuspenseQuery() returns undefined as data when network is offline 

### DIFF
--- a/packages/react-query/src/suspense.ts
+++ b/packages/react-query/src/suspense.ts
@@ -40,13 +40,7 @@ export const shouldSuspend = (
     | DefaultedQueryObserverOptions<any, any, any, any, any>
     | undefined,
   result: QueryObserverResult<any, any>,
-  isRestoring: boolean,
-) => {
-  if (defaultedOptions?.suspense && result.isPending && !isRestoring) {
-    return true
-  }
-  return defaultedOptions?.suspense && willFetch(result, isRestoring)
-}
+) => defaultedOptions?.suspense && result.isPending
 
 export const fetchOptimistic = <
   TQueryFnData,

--- a/packages/react-query/src/suspense.ts
+++ b/packages/react-query/src/suspense.ts
@@ -41,7 +41,12 @@ export const shouldSuspend = (
     | undefined,
   result: QueryObserverResult<any, any>,
   isRestoring: boolean,
-) => defaultedOptions?.suspense && willFetch(result, isRestoring)
+) => {
+  if (defaultedOptions?.suspense && result.isPaused && !isRestoring) {
+    return true;
+  }
+  return defaultedOptions?.suspense && willFetch(result, isRestoring);
+}
 
 export const fetchOptimistic = <
   TQueryFnData,

--- a/packages/react-query/src/suspense.ts
+++ b/packages/react-query/src/suspense.ts
@@ -42,10 +42,10 @@ export const shouldSuspend = (
   result: QueryObserverResult<any, any>,
   isRestoring: boolean,
 ) => {
-  if (defaultedOptions?.suspense && result.isPaused && !isRestoring) {
-    return true;
+  if (defaultedOptions?.suspense && result.isPending && !isRestoring) {
+    return true
   }
-  return defaultedOptions?.suspense && willFetch(result, isRestoring);
+  return defaultedOptions?.suspense && willFetch(result, isRestoring)
 }
 
 export const fetchOptimistic = <

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -90,7 +90,7 @@ export function useBaseQuery<
   }, [defaultedOptions, observer])
 
   // Handle suspense
-  if (shouldSuspend(defaultedOptions, result, isRestoring)) {
+  if (shouldSuspend(defaultedOptions, result)) {
     throw fetchOptimistic(defaultedOptions, observer, errorResetBoundary)
   }
 

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -286,7 +286,7 @@ export function useQueries<
   }, [defaultedQueries, options, observer])
 
   const shouldAtLeastOneSuspend = optimisticResult.some((result, index) =>
-    shouldSuspend(defaultedQueries[index], result, isRestoring),
+    shouldSuspend(defaultedQueries[index], result),
   )
 
   const suspensePromises = shouldAtLeastOneSuspend
@@ -295,7 +295,7 @@ export function useQueries<
 
         if (opts) {
           const queryObserver = new QueryObserver(client, opts)
-          if (shouldSuspend(opts, result, isRestoring)) {
+          if (shouldSuspend(opts, result)) {
             return fetchOptimistic(opts, queryObserver, errorResetBoundary)
           } else if (willFetch(result, isRestoring)) {
             void fetchOptimistic(opts, queryObserver, errorResetBoundary)


### PR DESCRIPTION
This is a reproduction for #6344.

I suggest not merging it yet to main since it prints some errors in the console.