### PR TITLE
fix(query-core): rename Removable to GarbageCollectable

### DIFF
--- a/packages/query-core/src/garbageCollectable.ts
+++ b/packages/query-core/src/garbageCollectable.ts
@@ -1,6 +1,6 @@
 import { isServer, isValidTimeout } from './utils'
 
-export abstract class Removable {
+export abstract class GarbageCollectable {
   gcTime!: number
   #gcTimeout?: ReturnType<typeof setTimeout>
 
@@ -13,7 +13,7 @@ export abstract class Removable {
 
     if (isValidTimeout(this.gcTime)) {
       this.#gcTimeout = setTimeout(() => {
-        this.optionalRemove()
+        this.optionalGc()
       }, this.gcTime)
     }
   }
@@ -33,5 +33,5 @@ export abstract class Removable {
     }
   }
 
-  protected abstract optionalRemove(): void
+  protected abstract optionalGc(): void
 }

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -1,5 +1,5 @@
 import { notifyManager } from './notifyManager'
-import { Removable } from './removable'
+import { GarbageCollectable } from './garbageCollectable'
 import { canFetch, createRetryer } from './retryer'
 import type {
   DefaultError,
@@ -83,7 +83,7 @@ export class Mutation<
   TError = DefaultError,
   TVariables = void,
   TContext = unknown,
-> extends Removable {
+> extends GarbageCollectable {
   state: MutationState<TData, TError, TVariables, TContext>
   options!: MutationOptions<TData, TError, TVariables, TContext>
   readonly mutationId: number
@@ -145,7 +145,7 @@ export class Mutation<
     })
   }
 
-  protected optionalRemove() {
+  protected optionalGc() {
     if (!this.#observers.length) {
       if (this.state.status === 'pending') {
         this.scheduleGc()

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -1,7 +1,7 @@
 import { noop, replaceData, timeUntilStale } from './utils'
 import { notifyManager } from './notifyManager'
 import { canFetch, createRetryer, isCancelledError } from './retryer'
-import { Removable } from './removable'
+import { GarbageCollectable } from './garbageCollectable'
 import type {
   CancelOptions,
   DefaultError,
@@ -148,7 +148,7 @@ export class Query<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends Removable {
+> extends GarbageCollectable {
   queryKey: TQueryKey
   queryHash: string
   options!: QueryOptions<TQueryFnData, TError, TData, TQueryKey>
@@ -190,7 +190,7 @@ export class Query<
     this.updateGcTime(this.options.gcTime)
   }
 
-  protected optionalRemove() {
+  protected optionalGc() {
     if (!this.#observers.length && this.state.fetchStatus === 'idle') {
       this.#cache.remove(this)
     }

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -140,7 +140,7 @@ export interface QueryOptions<
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
   networkMode?: NetworkMode
-   /**
+  /**
    * The time in milliseconds that unused/inactive cache data remains in memory.
    * When a query's cache becomes unused or inactive, that cache data will be garbage collected after this duration.
    * When different garbage collection times are specified, the longest one will be used.


### PR DESCRIPTION
I thought if Class's method name is containing `gc`(garbageCollect), class name should be `GarbageCollectable`. like [`Subscribable`](https://github.com/TanStack/query/blob/main/packages/query-core/src/subscribable.ts) have `subscribe` method. so I renamed `Removable` to `GarbageCollectable`