### PR TITLE
fix(query-core): rename sleep param as ms

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -297,9 +297,9 @@ function hasObjectPrototype(o: any): boolean {
   return Object.prototype.toString.call(o) === '[object Object]'
 }
 
-export function sleep(timeout: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
-    setTimeout(resolve, timeout)
+    setTimeout(resolve, ms)
   })
 }
 


### PR DESCRIPTION
I changed the name of the sleep parameter to `ms` because I thought it was more appropriate than `timeout`. I thought that `timeout` could be mistaken for `Node.Timeout`, so I unified it to `ms`, the same as the parameter name of `setTimeout`.

<img width="498" alt="image" src="https://github.com/TanStack/query/assets/61593290/dd05a6d0-ed70-415a-a9c6-af55e799fbe7">
