### PR TITLE
Fix example hook cleanup if window is undefined

### DIFF
--- a/docs/react/guides/window-focus-refetching.md
+++ b/docs/react/guides/window-focus-refetching.md
@@ -51,11 +51,10 @@ focusManager.setEventListener((handleFocus) => {
   // Listen to visibilitychange
   if (typeof window !== 'undefined' && window.addEventListener) {
     window.addEventListener('visibilitychange', handleFocus, false)
-  }
-
-  return () => {
-    // Be sure to unsubscribe if a new handler is set
-    window.removeEventListener('visibilitychange', handleFocus)
+    return () => {
+      // Be sure to unsubscribe if a new handler is set
+      window.removeEventListener('visibilitychange', handleFocus)
+    }
   }
 })
 ```


### PR DESCRIPTION
If window is undefined, we'd skip initialization of the event, but window.removeEventListener would still be attempted to be called upon cleanup and fail with error due to undefined window.