### PR TITLE
chore: Add Sherif to CI to lint monorepo config

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: npx nx affected --targets=test:eslint,test:lib,test:types,test:build,test:bundle
+          command: npx nx affected --targets=test:sherif,test:eslint,test:lib,test:types,test:build,test:bundle
       - name: Stop Agents
         run: npx nx-cloud stop-all-agents
       - name: Upload coverage to Codecov

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: npx nx affected --targets=test:sherif,test:eslint,test:lib,test:types,test:build,test:bundle
+          command: npx nx affected --targets=test:eslint,test:lib,test:types,test:build,test:bundle
       - name: Stop Agents
         run: npx nx-cloud stop-all-agents
       - name: Upload coverage to Codecov

--- a/examples/react/algolia/package.json
+++ b/examples/react/algolia/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
     "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   },
   "browserslist": {

--- a/examples/react/algolia/package.json
+++ b/examples/react/algolia/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
     "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   },
   "browserslist": {

--- a/examples/react/basic-typescript/package.json
+++ b/examples/react/basic-typescript/package.json
@@ -23,7 +23,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.8.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   },
   "browserslist": {

--- a/examples/react/basic-typescript/package.json
+++ b/examples/react/basic-typescript/package.json
@@ -23,7 +23,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.8.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   },
   "browserslist": {

--- a/examples/react/nextjs-suspense-streaming/package.json
+++ b/examples/react/nextjs-suspense-streaming/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
-    "typescript": "^5.1.3"
+    "typescript": "^5.2.2"
   }
 }

--- a/examples/react/nextjs-suspense-streaming/package.json
+++ b/examples/react/nextjs-suspense-streaming/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }

--- a/examples/react/optimistic-updates-cache/package.json
+++ b/examples/react/optimistic-updates-cache/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "scripts": {
     "dev": "next",

--- a/examples/react/optimistic-updates-cache/package.json
+++ b/examples/react/optimistic-updates-cache/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
-    "typescript": "^5.0.4"
+    "typescript": "^5.2.2"
   },
   "scripts": {
     "dev": "next",

--- a/examples/react/optimistic-updates-ui/package.json
+++ b/examples/react/optimistic-updates-ui/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "scripts": {
     "dev": "next",

--- a/examples/react/optimistic-updates-ui/package.json
+++ b/examples/react/optimistic-updates-ui/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
-    "typescript": "^5.0.4"
+    "typescript": "^5.2.2"
   },
   "scripts": {
     "dev": "next",

--- a/examples/react/react-native/package.json
+++ b/examples/react/react-native/package.json
@@ -44,6 +44,6 @@
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.8.8",
-    "typescript": "^5.0.4"
+    "typescript": "^5.2.2"
   }
 }

--- a/examples/react/react-native/package.json
+++ b/examples/react/react-native/package.json
@@ -44,6 +44,6 @@
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.8.8",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }

--- a/examples/solid/basic-graphql-request/package.json
+++ b/examples/solid/basic-graphql-request/package.json
@@ -16,7 +16,7 @@
     "solid-js": "^1.8.1"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11",
     "vite-plugin-solid": "^2.7.2"
   }

--- a/examples/solid/basic-typescript/package.json
+++ b/examples/solid/basic-typescript/package.json
@@ -14,7 +14,7 @@
     "solid-js": "^1.8.1"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11",
     "vite-plugin-solid": "^2.7.2"
   }

--- a/examples/solid/default-query-function/package.json
+++ b/examples/solid/default-query-function/package.json
@@ -14,7 +14,7 @@
     "solid-js": "^1.8.1"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11",
     "vite-plugin-solid": "^2.7.2"
   }

--- a/examples/solid/simple/package.json
+++ b/examples/solid/simple/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.0.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11",
     "vite-plugin-solid": "^2.7.2"
   }

--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -21,7 +21,7 @@
     "esbuild": "^0.19.5",
     "postcss": "^8.4.31",
     "solid-start-node": "^0.3.7",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   },
   "engines": {

--- a/examples/svelte/auto-refetching/package.json
+++ b/examples/svelte/auto-refetching/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/auto-refetching/package.json
+++ b/examples/svelte/auto-refetching/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/load-more-infinite-scroll/package.json
+++ b/examples/svelte/load-more-infinite-scroll/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/load-more-infinite-scroll/package.json
+++ b/examples/svelte/load-more-infinite-scroll/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/optimistic-updates-typescript/package.json
+++ b/examples/svelte/optimistic-updates-typescript/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/optimistic-updates-typescript/package.json
+++ b/examples/svelte/optimistic-updates-typescript/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/playground/package.json
+++ b/examples/svelte/playground/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/playground/package.json
+++ b/examples/svelte/playground/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/simple/package.json
+++ b/examples/svelte/simple/package.json
@@ -17,7 +17,7 @@
     "@tsconfig/svelte": "^5.0.2",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/simple/package.json
+++ b/examples/svelte/simple/package.json
@@ -17,7 +17,7 @@
     "@tsconfig/svelte": "^5.0.2",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/ssr/package.json
+++ b/examples/svelte/ssr/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/ssr/package.json
+++ b/examples/svelte/ssr/package.json
@@ -17,7 +17,7 @@
     "@sveltejs/kit": "^1.26.0",
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/star-wars/package.json
+++ b/examples/svelte/star-wars/package.json
@@ -20,7 +20,7 @@
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
     "tailwindcss": "^3.3.2",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/svelte/star-wars/package.json
+++ b/examples/svelte/star-wars/package.json
@@ -20,7 +20,7 @@
     "svelte": "^4.0.0",
     "svelte-check": "^3.4.4",
     "tailwindcss": "^3.3.2",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/vue/2.6-basic/package.json
+++ b/examples/vue/2.6-basic/package.json
@@ -14,7 +14,7 @@
     "vue-template-compiler": "2.6.14"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11",
     "vite-plugin-vue2": "2.0.2"
   }

--- a/examples/vue/2.6-basic/package.json
+++ b/examples/vue/2.6-basic/package.json
@@ -14,7 +14,7 @@
     "vue-template-compiler": "2.6.14"
   },
   "devDependencies": {
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11",
     "vite-plugin-vue2": "2.0.2"
   }

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/vue/dependent-queries/package.json
+++ b/examples/vue/dependent-queries/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/examples/vue/dependent-queries/package.json
+++ b/examples/vue/dependent-queries/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/vue/persister/package.json
+++ b/examples/vue/persister/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11"
   }
 }

--- a/examples/vue/persister/package.json
+++ b/examples/vue/persister/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11"
   }
 }

--- a/integrations/react-next/package.json
+++ b/integrations/react-next/package.json
@@ -15,6 +15,6 @@
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   }
 }

--- a/integrations/react-next/package.json
+++ b/integrations/react-next/package.json
@@ -15,6 +15,6 @@
     "@types/node": "^18.18.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "preinstall": "node -e \"if(process.env.CI == 'true') {console.log('Skipping preinstall...'); process.exit(1)}\" || npx -y only-allow pnpm",
     "install:csb": "corepack enable && pnpm install --frozen-lockfile",
     "test": "pnpm run test:ci",
-    "test:ci": "nx run-many --exclude=examples/** --targets=test:format,test:eslint,test:lib,test:types,test:build,test:bundle,build",
+    "test:ci": "nx run-many --exclude=examples/** --targets=test:format,test:sherif,test:eslint,test:lib,test:types,test:build,test:bundle,build",
     "test:eslint": "nx affected --target=test:eslint",
     "test:format": "pnpm run prettier --check",
+    "test:sherif": "sherif -i react-scripts",
     "test:lib": "nx affected --target=test:lib",
     "test:lib:dev": "pnpm --filter \"./packages/**\" run test:lib:dev",
     "test:build": "nx affected --target=test:build",
@@ -30,7 +31,8 @@
   },
   "nx": {
     "includedScripts": [
-      "test:format"
+      "test:format",
+      "test:sherif"
     ]
   },
   "namespace": "@tanstack",
@@ -81,14 +83,22 @@
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
     "semver": "^7.5.4",
+    "sherif": "^0.5.0",
     "solid-js": "^1.8.1",
     "stream-to-array": "^2.3.0",
     "ts-node": "^10.7.0",
     "tsup": "^7.2.0",
     "type-fest": "^4.5.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.11",
     "vitest": "^0.33.0",
     "vue": "^3.3.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@typescript-eslint/eslint-plugin": "$@typescript-eslint/eslint-plugin",
+      "@typescript-eslint/parser": "$@typescript-eslint/parser",
+      "eslint": "$eslint"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "ts-node": "^10.7.0",
     "tsup": "^7.2.0",
     "type-fest": "^4.5.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11",
     "vitest": "^0.33.0",
     "vue": "^3.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@typescript-eslint/eslint-plugin': ^5.54.0
+  '@typescript-eslint/parser': ^5.54.0
+  eslint: ^8.34.0
+
 importers:
 
   .:
@@ -58,10 +63,10 @@ importers:
         version: 2.3.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.54.0
-        version: 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
+        version: 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.54.0
-        version: 5.54.0(eslint@8.34.0)(typescript@5.2.2)
+        version: 5.54.0(eslint@8.53.0)(typescript@5.1.6)
       '@vitest/coverage-istanbul':
         specifier: ^0.33.0
         version: 0.33.0(vitest@0.33.0)
@@ -91,22 +96,22 @@ importers:
         version: 1.0.0
       eslint:
         specifier: ^8.34.0
-        version: 8.34.0
+        version: 8.53.0
       eslint-config-prettier:
         specifier: ^8.8.0
-        version: 8.8.0(eslint@8.34.0)
+        version: 8.8.0(eslint@8.53.0)
       eslint-import-resolver-typescript:
         specifier: ^3.5.5
-        version: 3.5.5(@typescript-eslint/parser@5.54.0)(eslint-plugin-import@2.27.5)(eslint@8.34.0)
+        version: 3.5.5(@typescript-eslint/parser@5.54.0)(eslint-plugin-import@2.27.5)(eslint@8.53.0)
       eslint-plugin-import:
         specifier: ^2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
+        version: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
       eslint-plugin-react:
         specifier: ^7.32.2
-        version: 7.32.2(eslint@8.34.0)
+        version: 7.32.2(eslint@8.53.0)
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
-        version: 4.6.0(eslint@8.34.0)
+        version: 4.6.0(eslint@8.53.0)
       git-log-parser:
         specifier: ^1.2.0
         version: 1.2.0
@@ -146,6 +151,9 @@ importers:
       semver:
         specifier: ^7.5.4
         version: 7.5.4
+      sherif:
+        specifier: ^0.5.0
+        version: 0.5.0
       solid-js:
         specifier: ^1.8.1
         version: 1.8.1
@@ -154,16 +162,16 @@ importers:
         version: 2.3.0
       ts-node:
         specifier: ^10.7.0
-        version: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
+        version: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(ts-node@10.7.0)(typescript@5.2.2)
+        version: 7.2.0(ts-node@10.7.0)(typescript@5.1.6)
       type-fest:
         specifier: ^4.5.0
         version: 4.5.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -211,8 +219,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(vite@4.4.11)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -335,13 +343,13 @@ importers:
         version: 4.0.0(vite@4.4.11)
       eslint:
         specifier: ^8.34.0
-        version: 8.34.0
+        version: 8.53.0
       eslint-config-prettier:
         specifier: ^8.8.0
-        version: 8.8.0(eslint@8.34.0)
+        version: 8.8.0(eslint@8.53.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -486,8 +494,8 @@ importers:
         specifier: ^18.2.31
         version: 18.2.31
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
 
   examples/react/offline:
     dependencies:
@@ -563,8 +571,8 @@ importers:
         specifier: ^18.2.14
         version: 18.2.14
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
 
   examples/react/optimistic-updates-ui:
     dependencies:
@@ -600,8 +608,8 @@ importers:
         specifier: ^18.2.14
         version: 18.2.14
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
 
   examples/react/pagination:
     dependencies:
@@ -729,7 +737,7 @@ importers:
         version: 7.21.8
       '@callstack/eslint-config':
         specifier: ^13.0.2
-        version: 13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(typescript@5.2.2)
+        version: 13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(typescript@5.1.6)
       '@expo/config':
         specifier: ^8.0.2
         version: 8.0.2
@@ -738,22 +746,22 @@ importers:
         version: 0.71.0
       eslint:
         specifier: ^8.34.0
-        version: 8.34.0
+        version: 8.53.0
       eslint-import-resolver-alias:
         specifier: ^1.1.2
         version: 1.1.2(eslint-plugin-import@2.27.5)
       eslint-plugin-flowtype:
         specifier: ^8.0.3
-        version: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.34.0)
+        version: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.53.0)
       eslint-plugin-prettier:
         specifier: ^4.0.0
-        version: 4.0.0(eslint-config-prettier@8.8.0)(eslint@8.34.0)(prettier@2.8.8)
+        version: 4.0.0(eslint-config-prettier@8.8.0)(eslint@8.53.0)(prettier@2.8.8)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
 
   examples/react/react-router:
     dependencies:
@@ -950,8 +958,8 @@ importers:
         version: 1.8.1
     devDependencies:
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -972,8 +980,8 @@ importers:
         version: 1.8.1
     devDependencies:
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -994,8 +1002,8 @@ importers:
         version: 1.8.1
     devDependencies:
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1019,8 +1027,8 @@ importers:
         specifier: ^5.0.0
         version: link:../../../packages/eslint-plugin-query
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1065,8 +1073,8 @@ importers:
         specifier: ^0.3.7
         version: 0.3.7(solid-start@0.3.7)(vite@4.4.11)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1093,8 +1101,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1121,8 +1129,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1149,8 +1157,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1177,8 +1185,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1205,8 +1213,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1233,8 +1241,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1261,8 +1269,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1298,8 +1306,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2(ts-node@10.7.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1320,8 +1328,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0(vite@4.4.11)(vue@3.3.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1339,8 +1347,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0(vite@4.4.11)(vue@3.3.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1370,8 +1378,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0(vite@4.4.11)(vue@3.3.0)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1392,7 +1400,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-scripts:
         specifier: ^4.0.3
-        version: 4.0.3(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.2.2)
+        version: 4.0.3(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.1.6)
 
   integrations/react-cra5:
     dependencies:
@@ -1410,7 +1418,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-scripts:
         specifier: ^5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.2.2)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.1.6)
 
   integrations/react-next:
     dependencies:
@@ -1440,8 +1448,8 @@ importers:
         specifier: ^18.2.14
         version: 18.2.14
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: 5.1.6
+        version: 5.1.6
 
   integrations/react-vite:
     dependencies:
@@ -1528,11 +1536,11 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^5.54.0
-        version: 5.54.0(eslint@8.34.0)(typescript@5.2.2)
+        version: 5.54.0(eslint@8.53.0)(typescript@5.1.6)
     devDependencies:
       eslint:
         specifier: ^8.34.0
-        version: 8.34.0
+        version: 8.53.0
 
   packages/query-async-storage-persister:
     dependencies:
@@ -1766,7 +1774,7 @@ importers:
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.2.2
-        version: 2.2.2(svelte@4.0.0)(typescript@5.2.2)
+        version: 2.2.2(svelte@4.0.0)(typescript@5.1.6)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.4.6
         version: 2.4.6(svelte@4.0.0)(vite@4.4.11)
@@ -1775,7 +1783,7 @@ importers:
         version: 4.0.4(svelte@4.0.0)
       eslint-plugin-svelte:
         specifier: ^2.32.0
-        version: 2.32.0(eslint@8.34.0)(svelte@4.0.0)(ts-node@10.7.0)
+        version: 2.32.0(eslint@8.53.0)(svelte@4.0.0)(ts-node@10.7.0)
       svelte:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1794,7 +1802,7 @@ importers:
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.2.2
-        version: 2.2.2(svelte@4.0.0)(typescript@5.2.2)
+        version: 2.2.2(svelte@4.0.0)(typescript@5.1.6)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.4.6
         version: 2.4.6(svelte@4.0.0)(vite@4.4.11)
@@ -1803,7 +1811,7 @@ importers:
         version: link:../svelte-query
       eslint-plugin-svelte:
         specifier: ^2.32.0
-        version: 2.32.0(eslint@8.34.0)(svelte@4.0.0)(ts-node@10.7.0)
+        version: 2.32.0(eslint@8.53.0)(svelte@4.0.0)(ts-node@10.7.0)
       svelte:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1819,7 +1827,7 @@ importers:
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.2.2
-        version: 2.2.2(svelte@4.0.0)(typescript@5.2.2)
+        version: 2.2.2(svelte@4.0.0)(typescript@5.1.6)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.4.6
         version: 2.4.6(svelte@4.0.0)(vite@4.4.11)
@@ -1831,7 +1839,7 @@ importers:
         version: 4.0.4(svelte@4.0.0)
       eslint-plugin-svelte:
         specifier: ^2.32.0
-        version: 2.32.0(eslint@8.34.0)(svelte@4.0.0)(ts-node@10.7.0)
+        version: 2.32.0(eslint@8.53.0)(svelte@4.0.0)(ts-node@10.7.0)
       svelte:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1887,7 +1895,7 @@ importers:
         version: 3.3.0
       vue-tsc:
         specifier: ^1.8.21
-        version: 1.8.21(typescript@5.2.2)
+        version: 1.8.21(typescript@5.1.6)
 
 packages:
 
@@ -2020,12 +2028,6 @@ packages:
     dependencies:
       '@babel/highlight': 7.22.20
 
-  /@babel/code-frame@7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
-    dependencies:
-      '@babel/highlight': 7.22.20
-    dev: false
-
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
@@ -2105,30 +2107,30 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/eslint-parser@7.22.15(@babel/core@7.21.8)(eslint@8.34.0):
+  /@babel/eslint-parser@7.22.15(@babel/core@7.21.8)(eslint@8.53.0):
     resolution: {integrity: sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
-      eslint: ^7.5.0 || ^8.0.0
+      eslint: ^8.34.0
     dependencies:
       '@babel/core': 7.21.8
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.34.0
+      eslint: 8.53.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: true
 
-  /@babel/eslint-parser@7.22.15(@babel/core@7.23.2)(eslint@8.34.0):
+  /@babel/eslint-parser@7.22.15(@babel/core@7.23.2)(eslint@8.53.0):
     resolution: {integrity: sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
-      eslint: ^7.5.0 || ^8.0.0
+      eslint: ^8.34.0
     dependencies:
       '@babel/core': 7.23.2
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.34.0
+      eslint: 8.53.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: false
@@ -4844,29 +4846,29 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: false
 
-  /@callstack/eslint-config@13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(typescript@5.2.2):
+  /@callstack/eslint-config@13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-EYd00hKeKZ6B5lBYz0nWyfVnYACRqdw6s/65sKoEcNP4fkrBIhxLyQbd2pNfg+QauuNqK7XRR3P3zVh7p5IimQ==}
     engines: {node: ^12.22.0 || ^13.14.0 || ^14.17.0 || ^15.3.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=8.1.0'
+      eslint: ^8.34.0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/eslint-parser': 7.22.15(@babel/core@7.21.8)(eslint@8.34.0)
+      '@babel/eslint-parser': 7.22.15(@babel/core@7.21.8)(eslint@8.53.0)
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.21.8)
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
-      eslint: 8.34.0
-      eslint-config-prettier: 8.8.0(eslint@8.34.0)
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.34.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
-      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
-      eslint-plugin-prettier: 4.0.0(eslint-config-prettier@8.8.0)(eslint@8.34.0)(prettier@2.8.8)
-      eslint-plugin-promise: 6.1.1(eslint@8.34.0)
-      eslint-plugin-react: 7.32.2(eslint@8.34.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.34.0)
-      eslint-plugin-react-native: 4.1.0(eslint@8.34.0)
-      eslint-plugin-react-native-a11y: 3.3.0(eslint@8.34.0)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
+      eslint: 8.53.0
+      eslint-config-prettier: 8.8.0(eslint@8.53.0)
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.53.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
+      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      eslint-plugin-prettier: 4.0.0(eslint-config-prettier@8.8.0)(eslint@8.53.0)(prettier@2.8.8)
+      eslint-plugin-promise: 6.1.1(eslint@8.53.0)
+      eslint-plugin-react: 7.32.2(eslint@8.53.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
+      eslint-plugin-react-native: 4.1.0(eslint@8.53.0)
+      eslint-plugin-react-native-a11y: 3.3.0(eslint@8.53.0)
       eslint-restricted-globals: 0.2.0
       prettier: 2.8.8
     transitivePeerDependencies:
@@ -5761,34 +5763,21 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.34.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.53.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+      eslint: ^8.34.0
     dependencies:
-      eslint: 8.34.0
+      eslint: 8.53.0
       eslint-visitor-keys: 3.4.3
 
-  /@eslint/eslintrc@0.4.3:
-    resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4(supports-color@6.1.0)
-      espree: 7.3.1
-      globals: 13.23.0
-      ignore: 4.0.6
-      import-fresh: 3.3.0
-      js-yaml: 3.14.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+  /@eslint-community/regexpp@4.10.0:
+    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  /@eslint/eslintrc@1.4.1:
-    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
+  /@eslint/eslintrc@2.1.3:
+    resolution: {integrity: sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
@@ -5802,6 +5791,10 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /@eslint/js@8.53.0:
+    resolution: {integrity: sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /@expo/bunyan@4.0.0:
     resolution: {integrity: sha512-Ydf4LidRB/EBI+YrB+cVLqIseiRfjUI/AeHBgjGMtq3GroraDu81OV7zqophRgupngoL3iS3JUMDMnxO7g39qA==}
@@ -6224,37 +6217,22 @@ packages:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  /@humanwhocodes/config-array@0.11.12:
-    resolution: {integrity: sha512-NlGesA1usRNn6ctHCZ21M4/dKPgW9Nn1FypRdIKKgZOKzkVV4T1FlK5mBiLhHBCDmEbdQG0idrcXlbZfksJ+RA==}
+  /@humanwhocodes/config-array@0.11.13:
+    resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.0
+      '@humanwhocodes/object-schema': 2.0.1
       debug: 4.3.4(supports-color@6.1.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
-
-  /@humanwhocodes/config-array@0.5.0:
-    resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@6.1.0)
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
 
-  /@humanwhocodes/object-schema@1.2.1:
-    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
-    dev: false
-
-  /@humanwhocodes/object-schema@2.0.0:
-    resolution: {integrity: sha512-9S9QrXY2K0L4AGDcSgTi9vgiCcG8VcBv4Mp7/1hDPYoswIy6Z6KO5blYto82BT8M0MZNRWmCFLpCs3HlpYGGdw==}
+  /@humanwhocodes/object-schema@2.0.1:
+    resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
 
   /@internationalized/date@3.5.0:
     resolution: {integrity: sha512-nw0Q+oRkizBWMioseI8+2TeUPEyopJVz5YxoYVzR0W1v+2YytiYah7s/ot35F149q/xAg4F1gT/6eTd+tsUpFQ==}
@@ -8144,7 +8122,7 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/package@2.2.2(svelte@4.0.0)(typescript@5.2.2):
+  /@sveltejs/package@2.2.2(svelte@4.0.0)(typescript@5.1.6):
     resolution: {integrity: sha512-rP3sVv6cAntcdcG4r4KspLU6nZYYUrHJBAX3Arrw0KJFdgxtlsi2iDwN0Jwr/vIkgjcU0ZPWM8kkT5kpZDlWAw==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -8156,7 +8134,7 @@ packages:
       sade: 1.8.1
       semver: 7.5.4
       svelte: 4.0.0
-      svelte2tsx: 0.6.23(svelte@4.0.0)(typescript@5.2.2)
+      svelte2tsx: 0.6.23(svelte@4.0.0)(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -8900,69 +8878,43 @@ packages:
       '@types/yargs-parser': 21.0.2
     dev: false
 
-  /@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.2.2)
-      '@typescript-eslint/scope-manager': 4.33.0
-      debug: 4.3.4(supports-color@6.1.0)
-      eslint: 7.32.0
-      functional-red-black-tree: 1.0.1
-      ignore: 5.2.4
-      regexpp: 3.2.0
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@typescript-eslint/parser': ^5.54.0
+      eslint: ^8.34.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/type-utils': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@6.1.0)
-      eslint: 8.34.0
+      eslint: 8.53.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/experimental-utils@3.10.1(eslint@7.32.0)(typescript@5.2.2):
+  /@typescript-eslint/experimental-utils@3.10.1(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^8.34.0
     dependencies:
       '@types/json-schema': 7.0.14
       '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/typescript-estree': 3.10.1(typescript@5.2.2)
-      eslint: 7.32.0
+      '@typescript-eslint/typescript-estree': 3.10.1(typescript@5.1.6)
+      eslint: 8.53.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     transitivePeerDependencies:
@@ -8970,62 +8922,42 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@5.2.2):
+  /@typescript-eslint/experimental-utils@4.33.0(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^8.34.0
     dependencies:
       '@types/json-schema': 7.0.14
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.2.2)
-      eslint: 7.32.0
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.1.6)
+      eslint: 8.53.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@7.32.0)
+      eslint-utils: 3.0.0(eslint@8.53.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.34.0)(typescript@5.2.2):
+  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^8.34.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.34.0)(typescript@5.2.2)
-      eslint: 8.34.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.53.0)(typescript@5.1.6)
+      eslint: 8.53.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.33.0
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.2.2)
-      debug: 4.3.4(supports-color@6.1.0)
-      eslint: 7.32.0
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/parser@5.54.0(eslint@8.34.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@5.54.0(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^8.34.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -9033,10 +8965,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
       debug: 4.3.4(supports-color@6.1.0)
-      eslint: 8.34.0
-      typescript: 5.2.2
+      eslint: 8.53.0
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9063,22 +8995,22 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.54.0(eslint@8.34.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@5.54.0(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-WI+WMJ8+oS+LyflqsD4nlXMsVdzTMYTxl16myXPaCXnSgc7LWwMsjxQFZCK/rVmTZ3FN71Ct78ehO9bRC7erYQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^8.34.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@6.1.0)
-      eslint: 8.34.0
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      eslint: 8.53.0
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9101,7 +9033,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree@3.10.1(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@3.10.1(typescript@5.1.6):
     resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -9117,13 +9049,13 @@ packages:
       is-glob: 4.0.3
       lodash: 4.17.21
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@4.33.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@4.33.0(typescript@5.1.6):
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -9138,13 +9070,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.54.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@5.54.0(typescript@5.1.6):
     resolution: {integrity: sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9159,12 +9091,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9179,44 +9111,44 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.54.0(eslint@8.34.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.54.0(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-cuwm8D/Z/7AuyAeJ+T0r4WZmlnlxQ8wt7C7fLpFlKMR+dY6QO79Cq1WpJhvZbMA4ZeZGHiRWnht7ZJ8qkdAunw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^8.34.0
     dependencies:
       '@types/json-schema': 7.0.14
       '@types/semver': 7.5.4
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.2.2)
-      eslint: 8.34.0
+      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
+      eslint: 8.53.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.34.0)
+      eslint-utils: 3.0.0(eslint@8.53.0)
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.34.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.62.0(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^8.34.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.34.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
       '@types/json-schema': 7.0.14
       '@types/semver': 7.5.4
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
-      eslint: 8.34.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
+      eslint: 8.53.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -9253,6 +9185,9 @@ packages:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
     dev: false
+
+  /@ungap/structured-clone@1.2.0:
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
   /@urql/core@2.3.6(graphql@15.8.0):
     resolution: {integrity: sha512-PUxhtBh7/8167HJK6WqBv6Z0piuiaZHQGYbhwpNL9aIQmLROPEdaUYkY4wh45wPQXcTpnd11l0q3Pw+TI11pdw==}
@@ -9424,7 +9359,7 @@ packages:
     resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
     dev: false
 
-  /@vue/language-core@1.8.21(typescript@5.2.2):
+  /@vue/language-core@1.8.21(typescript@5.1.6):
     resolution: {integrity: sha512-dKQJc1xfWIZfv6BeXyxz3SSNrC7npJpDIN/VOb1rodAm4o247TElrXOHYAJdV9x1KilaEUo3YbnQE+WA3vQwMw==}
     peerDependencies:
       typescript: '*'
@@ -9439,7 +9374,7 @@ packages:
       computeds: 0.0.1
       minimatch: 9.0.3
       muggle-string: 0.3.1
-      typescript: 5.2.2
+      typescript: 5.1.6
       vue-template-compiler: 2.7.15
     dev: true
 
@@ -9794,14 +9729,6 @@ packages:
       acorn: 8.10.0
     dev: false
 
-  /acorn-jsx@5.3.2(acorn@7.4.1):
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 7.4.1
-    dev: false
-
   /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -9973,6 +9900,7 @@ packages:
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+    dev: true
 
   /ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -10305,11 +10233,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
-    dev: false
-
   /async-each@1.0.6:
     resolution: {integrity: sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==}
     dev: false
@@ -10426,18 +10349,18 @@ packages:
       '@babel/core': 7.23.2
     dev: false
 
-  /babel-eslint@10.1.0(eslint@7.32.0):
+  /babel-eslint@10.1.0(eslint@8.53.0):
     resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
     engines: {node: '>=6'}
     deprecated: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
     peerDependencies:
-      eslint: '>= 4.12.1'
+      eslint: ^8.34.0
     dependencies:
       '@babel/code-frame': 7.22.13
       '@babel/parser': 7.23.0
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
-      eslint: 7.32.0
+      eslint: 8.53.0
       eslint-visitor-keys: 1.3.0
       resolve: 1.18.1
     transitivePeerDependencies:
@@ -13394,6 +13317,7 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.3
+    dev: true
 
   /entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
@@ -13735,23 +13659,23 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-prettier@8.8.0(eslint@8.34.0):
+  /eslint-config-prettier@8.8.0(eslint@8.53.0):
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
     peerDependencies:
-      eslint: '>=7.0.0'
+      eslint: ^8.34.0
     dependencies:
-      eslint: 8.34.0
+      eslint: 8.53.0
     dev: true
 
-  /eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@4.33.0)(@typescript-eslint/parser@4.33.0)(babel-eslint@10.1.0)(eslint-plugin-flowtype@5.10.0)(eslint-plugin-import@2.27.5)(eslint-plugin-jest@24.7.0)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint-plugin-testing-library@3.10.2)(eslint@7.32.0)(typescript@5.2.2):
+  /eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.54.0)(@typescript-eslint/parser@5.54.0)(babel-eslint@10.1.0)(eslint-plugin-flowtype@5.10.0)(eslint-plugin-import@2.27.5)(eslint-plugin-jest@24.7.0)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint-plugin-testing-library@3.10.2)(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^4.0.0
-      '@typescript-eslint/parser': ^4.0.0
+      '@typescript-eslint/eslint-plugin': ^5.54.0
+      '@typescript-eslint/parser': ^5.54.0
       babel-eslint: ^10.0.0
-      eslint: ^7.5.0
+      eslint: ^8.34.0
       eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jest: ^24.0.0
@@ -13768,47 +13692,47 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.2.2)
-      babel-eslint: 10.1.0(eslint@7.32.0)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
+      babel-eslint: 10.1.0(eslint@8.53.0)
       confusing-browser-globals: 1.0.11
-      eslint: 7.32.0
-      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@4.33.0)(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)
-      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@4.33.0)(eslint@7.32.0)(typescript@5.2.2)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@7.32.0)
-      eslint-plugin-react: 7.32.2(eslint@7.32.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
-      eslint-plugin-testing-library: 3.10.2(eslint@7.32.0)(typescript@5.2.2)
-      typescript: 5.2.2
+      eslint: 8.53.0
+      eslint-plugin-flowtype: 5.10.0(eslint@8.53.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
+      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.53.0)
+      eslint-plugin-react: 7.32.2(eslint@8.53.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
+      eslint-plugin-testing-library: 3.10.2(eslint@8.53.0)(typescript@5.1.6)
+      typescript: 5.1.6
     dev: false
 
-  /eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(jest@27.5.1)(typescript@5.2.2):
+  /eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(jest@27.5.1)(typescript@5.1.6):
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      eslint: ^8.0.0
+      eslint: ^8.34.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/eslint-parser': 7.22.15(@babel/core@7.23.2)(eslint@8.34.0)
+      '@babel/eslint-parser': 7.22.15(@babel/core@7.23.2)(eslint@8.53.0)
       '@rushstack/eslint-patch': 1.5.1
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 8.34.0
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.34.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(jest@27.5.1)(typescript@5.2.2)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.34.0)
-      eslint-plugin-react: 7.32.2(eslint@8.34.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.34.0)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.34.0)(typescript@5.2.2)
-      typescript: 5.2.2
+      eslint: 8.53.0
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.53.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.53.0)(jest@27.5.1)(typescript@5.1.6)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.53.0)
+      eslint-plugin-react: 7.32.2(eslint@8.53.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
+      eslint-plugin-testing-library: 5.11.1(eslint@8.53.0)(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
       - '@babel/plugin-transform-react-jsx'
@@ -13824,7 +13748,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -13836,18 +13760,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.54.0)(eslint-plugin-import@2.27.5)(eslint@8.34.0):
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.54.0)(eslint-plugin-import@2.27.5)(eslint@8.53.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^8.34.0
       eslint-plugin-import: '*'
     dependencies:
       debug: 4.3.4(supports-color@6.1.0)
       enhanced-resolve: 5.15.0
-      eslint: 8.34.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
+      eslint: 8.53.0
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
       get-tsconfig: 4.7.2
       globby: 13.2.2
       is-core-module: 2.13.0
@@ -13859,7 +13783,7 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@4.33.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13880,121 +13804,58 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
       debug: 3.2.7(supports-color@6.1.0)
-      eslint: 7.32.0
+      eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.54.0)(eslint-plugin-import@2.27.5)(eslint@8.34.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
-      debug: 3.2.7(supports-color@6.1.0)
-      eslint: 8.34.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.54.0)(eslint-plugin-import@2.27.5)(eslint@8.34.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.54.0)(eslint-plugin-import@2.27.5)(eslint@8.53.0)
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-plugin-flowtype@5.10.0(eslint@7.32.0):
+  /eslint-plugin-flowtype@5.10.0(eslint@8.53.0):
     resolution: {integrity: sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: ^7.1.0
+      eslint: ^8.34.0
     dependencies:
-      eslint: 7.32.0
+      eslint: 8.53.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
     dev: false
 
-  /eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.34.0):
+  /eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.53.0):
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@babel/plugin-syntax-flow': ^7.14.5
       '@babel/plugin-transform-react-jsx': ^7.14.9
-      eslint: ^8.1.0
+      eslint: ^8.34.0
     dependencies:
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.21.8)
-      eslint: 8.34.0
+      eslint: 8.53.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@4.33.0)(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: ^8.34.0
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
       array-includes: 3.1.7
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7(supports-color@6.1.0)
       doctrine: 2.1.0
-      eslint: 7.32.0
+      eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@4.33.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)
-      has: 1.0.4
-      is-core-module: 2.13.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.7
-      resolve: 1.22.8
-      semver: 6.3.1
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: false
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
-      array-includes: 3.1.7
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@6.1.0)
-      doctrine: 2.1.0
-      eslint: 8.34.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
       has: 1.0.4
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -14008,30 +13869,30 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@4.33.0)(eslint@7.32.0)(typescript@5.2.2):
+  /eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': '>= 4'
-      eslint: '>=5'
+      '@typescript-eslint/eslint-plugin': ^5.54.0
+      eslint: ^8.34.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.2.2)
-      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.2.2)
-      eslint: 7.32.0
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/experimental-utils': 4.33.0(eslint@8.53.0)(typescript@5.1.6)
+      eslint: 8.53.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(jest@27.5.1)(typescript@5.2.2):
+  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.53.0)(jest@27.5.1)(typescript@5.1.6):
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@typescript-eslint/eslint-plugin': ^5.54.0
+      eslint: ^8.34.0
       jest: '*'
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
@@ -14039,21 +13900,21 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.34.0)(typescript@5.2.2)
-      eslint: 8.34.0
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.53.0)(typescript@5.1.6)
+      eslint: 8.53.0
       jest: 27.5.1(ts-node@10.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /eslint-plugin-jest@27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(typescript@5.2.2):
+  /eslint-plugin-jest@27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-3Nfvv3wbq2+PZlRTf2oaAWXWwbdBejFRBR2O8tAO67o+P8zno+QGbcDYaAXODlreXVg+9gvWhKKmG2rgfb8GEg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0 || ^6.0.0
-      eslint: ^7.0.0 || ^8.0.0
+      '@typescript-eslint/eslint-plugin': ^5.54.0
+      eslint: ^8.34.0
       jest: '*'
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
@@ -14061,19 +13922,19 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
-      eslint: 8.34.0
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
+      eslint: 8.53.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.7.1(eslint@7.32.0):
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.53.0):
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^8.34.0
     dependencies:
       '@babel/runtime': 7.23.2
       aria-query: 5.3.0
@@ -14084,7 +13945,7 @@ packages:
       axobject-query: 3.2.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 7.32.0
+      eslint: 8.53.0
       has: 1.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.5
@@ -14094,83 +13955,49 @@ packages:
       semver: 6.3.1
     dev: false
 
-  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.34.0):
-    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      '@babel/runtime': 7.23.2
-      aria-query: 5.3.0
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      ast-types-flow: 0.0.7
-      axe-core: 4.8.2
-      axobject-query: 3.2.1
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 8.34.0
-      has: 1.0.4
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      semver: 6.3.1
-    dev: false
-
-  /eslint-plugin-prettier@4.0.0(eslint-config-prettier@8.8.0)(eslint@8.34.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@4.0.0(eslint-config-prettier@8.8.0)(eslint@8.53.0)(prettier@2.8.8):
     resolution: {integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
-      eslint: '>=7.28.0'
+      eslint: ^8.34.0
       eslint-config-prettier: '*'
       prettier: '>=2.0.0'
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 8.34.0
-      eslint-config-prettier: 8.8.0(eslint@8.34.0)
+      eslint: 8.53.0
+      eslint-config-prettier: 8.8.0(eslint@8.53.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
     dev: true
 
-  /eslint-plugin-promise@6.1.1(eslint@8.34.0):
+  /eslint-plugin-promise@6.1.1(eslint@8.53.0):
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^8.34.0
     dependencies:
-      eslint: 8.34.0
+      eslint: 8.53.0
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@7.32.0):
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.53.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: ^8.34.0
     dependencies:
-      eslint: 7.32.0
-    dev: false
+      eslint: 8.53.0
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.34.0):
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.34.0
-
-  /eslint-plugin-react-native-a11y@3.3.0(eslint@8.34.0):
+  /eslint-plugin-react-native-a11y@3.3.0(eslint@8.53.0):
     resolution: {integrity: sha512-21bIs/0yROcMq7KtAG+OVNDWAh8M+6scII0iXcO3i9NYHe2xZ443yPs5KSUMSvQJeRLLjuKB7V5saqNjoMWDHA==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^8.34.0
     dependencies:
       '@babel/runtime': 7.23.2
       ast-types-flow: 0.0.7
-      eslint: 8.34.0
+      eslint: 8.53.0
       jsx-ast-utils: 3.3.5
     dev: true
 
@@ -14178,50 +14005,26 @@ packages:
     resolution: {integrity: sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==}
     dev: true
 
-  /eslint-plugin-react-native@4.1.0(eslint@8.34.0):
+  /eslint-plugin-react-native@4.1.0(eslint@8.53.0):
     resolution: {integrity: sha512-QLo7rzTBOl43FvVqDdq5Ql9IoElIuTdjrz9SKAXCvULvBoRZ44JGSkx9z4999ZusCsb4rK3gjS8gOGyeYqZv2Q==}
     peerDependencies:
-      eslint: ^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^8.34.0
     dependencies:
-      eslint: 8.34.0
+      eslint: 8.53.0
       eslint-plugin-react-native-globals: 0.1.2
     dev: true
 
-  /eslint-plugin-react@7.32.2(eslint@7.32.0):
+  /eslint-plugin-react@7.32.2(eslint@8.53.0):
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^8.34.0
     dependencies:
       array-includes: 3.1.7
       array.prototype.flatmap: 1.3.2
       array.prototype.tosorted: 1.1.2
       doctrine: 2.1.0
-      eslint: 7.32.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      object.hasown: 1.1.3
-      object.values: 1.1.7
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.10
-    dev: false
-
-  /eslint-plugin-react@7.32.2(eslint@8.34.0):
-    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      array.prototype.tosorted: 1.1.2
-      doctrine: 2.1.0
-      eslint: 8.34.0
+      eslint: 8.53.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
@@ -14234,20 +14037,20 @@ packages:
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
 
-  /eslint-plugin-svelte@2.32.0(eslint@8.34.0)(svelte@4.0.0)(ts-node@10.7.0):
+  /eslint-plugin-svelte@2.32.0(eslint@8.53.0)(svelte@4.0.0)(ts-node@10.7.0):
     resolution: {integrity: sha512-q8uxR4wFmAkb+RX2qIJIO+xAjecInZuGYXbXOvpxMwv7Y5oQrq5WOkiYwLqPZk6p1L5UmSr54duloKiBucDL7A==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0-0
+      eslint: ^8.34.0
       svelte: ^3.37.0 || ^4.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.34.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
       '@jridgewell/sourcemap-codec': 1.4.15
       debug: 4.3.4(supports-color@6.1.0)
-      eslint: 8.34.0
+      eslint: 8.53.0
       esutils: 2.0.3
       known-css-properties: 0.27.0
       postcss: 8.4.31
@@ -14262,27 +14065,27 @@ packages:
       - ts-node
     dev: true
 
-  /eslint-plugin-testing-library@3.10.2(eslint@7.32.0)(typescript@5.2.2):
+  /eslint-plugin-testing-library@3.10.2(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==}
     engines: {node: ^10.12.0 || >=12.0.0, npm: '>=6'}
     peerDependencies:
-      eslint: ^5 || ^6 || ^7
+      eslint: ^8.34.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1(eslint@7.32.0)(typescript@5.2.2)
-      eslint: 7.32.0
+      '@typescript-eslint/experimental-utils': 3.10.1(eslint@8.53.0)(typescript@5.1.6)
+      eslint: 8.53.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /eslint-plugin-testing-library@5.11.1(eslint@8.34.0)(typescript@5.2.2):
+  /eslint-plugin-testing-library@5.11.1(eslint@8.53.0)(typescript@5.1.6):
     resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
+      eslint: ^8.34.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.34.0)(typescript@5.2.2)
-      eslint: 8.34.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.53.0)(typescript@5.1.6)
+      eslint: 8.53.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14321,23 +14124,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: false
 
-  /eslint-utils@3.0.0(eslint@7.32.0):
+  /eslint-utils@3.0.0(eslint@8.53.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
-      eslint: '>=5'
+      eslint: ^8.34.0
     dependencies:
-      eslint: 7.32.0
-      eslint-visitor-keys: 2.1.0
-    dev: false
-
-  /eslint-utils@3.0.0(eslint@8.34.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.34.0
+      eslint: 8.53.0
       eslint-visitor-keys: 2.1.0
 
   /eslint-visitor-keys@1.3.0:
@@ -14353,16 +14146,16 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /eslint-webpack-plugin@2.7.0(eslint@7.32.0)(webpack@4.44.2):
+  /eslint-webpack-plugin@2.7.0(eslint@8.53.0)(webpack@4.44.2):
     resolution: {integrity: sha512-bNaVVUvU4srexGhVcayn/F4pJAz19CWBkKoMx7aSQ4wtTbZQCnG5O9LHCE42mM+JSKOUp7n6vd5CIwzj7lOVGA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^8.34.0
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       '@types/eslint': 7.29.0
       arrify: 2.0.1
-      eslint: 7.32.0
+      eslint: 8.53.0
       jest-worker: 27.5.1
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -14370,15 +14163,15 @@ packages:
       webpack: 4.44.2
     dev: false
 
-  /eslint-webpack-plugin@3.2.0(eslint@8.34.0)(webpack@5.89.0):
+  /eslint-webpack-plugin@3.2.0(eslint@8.53.0)(webpack@5.89.0):
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^8.34.0
       webpack: ^5.0.0
     dependencies:
       '@types/eslint': 8.44.0
-      eslint: 8.34.0
+      eslint: 8.53.0
       jest-worker: 28.1.3
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -14386,64 +14179,19 @@ packages:
       webpack: 5.89.0(esbuild@0.18.20)
     dev: false
 
-  /eslint@7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    hasBin: true
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3
-      '@humanwhocodes/config-array': 0.5.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@6.1.0)
-      doctrine: 3.0.0
-      enquirer: 2.3.6
-      escape-string-regexp: 4.0.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-      eslint-visitor-keys: 2.1.0
-      espree: 7.3.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.2
-      globals: 13.23.0
-      ignore: 4.0.6
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      js-yaml: 3.14.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.3
-      progress: 2.0.3
-      regexpp: 3.2.0
-      semver: 7.5.4
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      table: 6.8.1
-      text-table: 0.2.0
-      v8-compile-cache: 2.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint@8.34.0:
-    resolution: {integrity: sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==}
+  /eslint@8.53.0:
+    resolution: {integrity: sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.4.1
-      '@humanwhocodes/config-array': 0.11.12
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
+      '@eslint-community/regexpp': 4.10.0
+      '@eslint/eslintrc': 2.1.3
+      '@eslint/js': 8.53.0
+      '@humanwhocodes/config-array': 0.11.13
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
@@ -14451,7 +14199,6 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
-      eslint-utils: 3.0.0(eslint@8.34.0)
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.5.0
@@ -14461,13 +14208,11 @@ packages:
       find-up: 5.0.0
       glob-parent: 6.0.2
       globals: 13.23.0
-      grapheme-splitter: 1.0.4
+      graphemer: 1.4.0
       ignore: 5.2.4
-      import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-sdsl: 4.4.2
       js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
@@ -14475,24 +14220,13 @@ packages:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.3
-      regexpp: 3.2.0
       strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
 
   /esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
-
-  /espree@7.3.1:
-    resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2(acorn@7.4.1)
-      eslint-visitor-keys: 1.3.0
-    dev: false
 
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -15270,11 +15004,11 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin@4.1.6(eslint@7.32.0)(typescript@5.2.2)(webpack@4.44.2):
+  /fork-ts-checker-webpack-plugin@4.1.6(eslint@8.53.0)(typescript@5.1.6)(webpack@4.44.2):
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
-      eslint: '>= 6'
+      eslint: ^8.34.0
       typescript: '>= 2.7'
       vue-template-compiler: '*'
       webpack: '>= 4'
@@ -15286,23 +15020,23 @@ packages:
     dependencies:
       '@babel/code-frame': 7.22.13
       chalk: 2.4.2
-      eslint: 7.32.0
+      eslint: 8.53.0
       micromatch: 3.1.10(supports-color@6.1.0)
       minimatch: 3.1.2
       semver: 5.7.2
       tapable: 1.1.3
-      typescript: 5.2.2
+      typescript: 5.1.6
       webpack: 4.44.2
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.34.0)(typescript@5.2.2)(webpack@5.89.0):
+  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.53.0)(typescript@5.1.6)(webpack@5.89.0):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
-      eslint: '>= 6'
+      eslint: ^8.34.0
       typescript: '>= 2.7'
       vue-template-compiler: '*'
       webpack: '>= 4'
@@ -15318,7 +15052,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 8.34.0
+      eslint: 8.53.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.5.3
@@ -15326,7 +15060,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.5.4
       tapable: 1.1.3
-      typescript: 5.2.2
+      typescript: 5.1.6
       webpack: 5.89.0(esbuild@0.18.20)
     dev: false
 
@@ -15497,10 +15231,6 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.22.2
       functions-have-names: 1.2.3
-
-  /functional-red-black-tree@1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
-    dev: false
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -15786,6 +15516,9 @@ packages:
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   /graphql-request@6.1.0(graphql@16.8.1):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
@@ -16302,11 +16035,6 @@ packages:
     dependencies:
       minimatch: 5.1.6
     dev: true
-
-  /ignore@4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
-    engines: {node: '>= 4'}
-    dev: false
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -17230,7 +16958,7 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.5
       pretty-format: 26.6.2
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -17271,7 +16999,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -18204,9 +17932,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /js-sdsl@4.4.2:
-    resolution: {integrity: sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==}
-
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -18798,10 +18523,6 @@ packages:
 
   /lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
-    dev: false
-
-  /lodash.truncate@4.4.2:
-    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
     dev: false
 
   /lodash.uniq@4.5.0:
@@ -21095,11 +20816,11 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: false
 
-  /pnp-webpack-plugin@1.6.4(typescript@5.2.2):
+  /pnp-webpack-plugin@1.6.4(typescript@5.1.6):
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0(typescript@5.2.2)
+      ts-pnp: 1.2.0(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -21652,7 +21373,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
       yaml: 1.10.2
     dev: true
 
@@ -21670,7 +21391,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
       yaml: 2.3.3
 
   /postcss-loader@3.0.0:
@@ -22927,7 +22648,7 @@ packages:
       whatwg-fetch: 3.6.19
     dev: false
 
-  /react-dev-utils@11.0.4(eslint@7.32.0)(typescript@5.2.2)(webpack@4.44.2):
+  /react-dev-utils@11.0.4(eslint@8.53.0)(typescript@5.1.6)(webpack@4.44.2):
     resolution: {integrity: sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -22946,7 +22667,7 @@ packages:
       escape-string-regexp: 2.0.0
       filesize: 6.1.0
       find-up: 4.1.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@7.32.0)(typescript@5.2.2)(webpack@4.44.2)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@8.53.0)(typescript@5.1.6)(webpack@4.44.2)
       global-modules: 2.0.0
       globby: 11.0.1
       gzip-size: 5.1.1
@@ -22961,7 +22682,7 @@ packages:
       shell-quote: 1.7.2
       strip-ansi: 6.0.0
       text-table: 0.2.0
-      typescript: 5.2.2
+      typescript: 5.1.6
       webpack: 4.44.2
     transitivePeerDependencies:
       - eslint
@@ -22969,7 +22690,7 @@ packages:
       - vue-template-compiler
     dev: false
 
-  /react-dev-utils@12.0.1(eslint@8.34.0)(typescript@5.2.2)(webpack@5.89.0):
+  /react-dev-utils@12.0.1(eslint@8.53.0)(typescript@5.1.6)(webpack@5.89.0):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -22988,7 +22709,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.34.0)(typescript@5.2.2)(webpack@5.89.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.53.0)(typescript@5.1.6)(webpack@5.89.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -23003,7 +22724,7 @@ packages:
       shell-quote: 1.8.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.2.2
+      typescript: 5.1.6
       webpack: 5.89.0(esbuild@0.18.20)
     transitivePeerDependencies:
       - eslint
@@ -23343,12 +23064,12 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-scripts@4.0.3(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.2.2):
+  /react-scripts@4.0.3(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.1.6):
     resolution: {integrity: sha512-S5eO4vjUzUisvkIPB7jVsKtuH2HhWcASREYWHAQ1FP5HyCv3xgn+wpILAEWkmy+A+tTNbSZClhxjT3qz6g4L1A==}
     engines: {node: ^10.12.0 || >=12.0.0}
     hasBin: true
     peerDependencies:
-      eslint: '*'
+      eslint: ^8.34.0
       react: '>= 16'
       typescript: ^3.2.1 || ^4
     peerDependenciesMeta:
@@ -23358,9 +23079,9 @@ packages:
       '@babel/core': 7.12.3
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.3(react-refresh@0.8.3)(type-fest@4.5.0)(webpack-dev-server@3.11.1)(webpack@4.44.2)
       '@svgr/webpack': 5.5.0
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.2.2)
-      babel-eslint: 10.1.0(eslint@7.32.0)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.53.0)(typescript@5.1.6)
+      babel-eslint: 10.1.0(eslint@8.53.0)
       babel-jest: 26.6.3(@babel/core@7.12.3)
       babel-loader: 8.1.0(@babel/core@7.12.3)(webpack@4.44.2)
       babel-plugin-named-asset-import: 0.3.8(@babel/core@7.12.3)
@@ -23371,16 +23092,16 @@ packages:
       css-loader: 4.3.0(webpack@4.44.2)
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@4.33.0)(@typescript-eslint/parser@4.33.0)(babel-eslint@10.1.0)(eslint-plugin-flowtype@5.10.0)(eslint-plugin-import@2.27.5)(eslint-plugin-jest@24.7.0)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint-plugin-testing-library@3.10.2)(eslint@7.32.0)(typescript@5.2.2)
-      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@4.33.0)(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)
-      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@4.33.0)(eslint@7.32.0)(typescript@5.2.2)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@7.32.0)
-      eslint-plugin-react: 7.32.2(eslint@7.32.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
-      eslint-plugin-testing-library: 3.10.2(eslint@7.32.0)(typescript@5.2.2)
-      eslint-webpack-plugin: 2.7.0(eslint@7.32.0)(webpack@4.44.2)
+      eslint: 8.53.0
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.54.0)(@typescript-eslint/parser@5.54.0)(babel-eslint@10.1.0)(eslint-plugin-flowtype@5.10.0)(eslint-plugin-import@2.27.5)(eslint-plugin-jest@24.7.0)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint-plugin-testing-library@3.10.2)(eslint@8.53.0)(typescript@5.1.6)
+      eslint-plugin-flowtype: 5.10.0(eslint@8.53.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)
+      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.53.0)(typescript@5.1.6)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.53.0)
+      eslint-plugin-react: 7.32.2(eslint@8.53.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
+      eslint-plugin-testing-library: 3.10.2(eslint@8.53.0)(typescript@5.1.6)
+      eslint-webpack-plugin: 2.7.0(eslint@8.53.0)(webpack@4.44.2)
       file-loader: 6.1.1(webpack@4.44.2)
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.0(webpack@4.44.2)
@@ -23391,7 +23112,7 @@ packages:
       jest-watch-typeahead: 0.6.1(jest@26.6.0)
       mini-css-extract-plugin: 0.11.3(webpack@4.44.2)
       optimize-css-assets-webpack-plugin: 5.0.4(webpack@4.44.2)
-      pnp-webpack-plugin: 1.6.4(typescript@5.2.2)
+      pnp-webpack-plugin: 1.6.4(typescript@5.1.6)
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 3.0.0
       postcss-normalize: 8.0.1
@@ -23400,7 +23121,7 @@ packages:
       prompts: 2.4.0
       react: 18.2.0
       react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@5.2.2)(webpack@4.44.2)
+      react-dev-utils: 11.0.4(eslint@8.53.0)(typescript@5.1.6)(webpack@4.44.2)
       react-refresh: 0.8.3
       resolve: 1.18.1
       resolve-url-loader: 3.1.5
@@ -23408,8 +23129,8 @@ packages:
       semver: 7.3.2
       style-loader: 1.3.0(webpack@4.44.2)
       terser-webpack-plugin: 4.2.3(webpack@4.44.2)
-      ts-pnp: 1.2.0(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-pnp: 1.2.0(typescript@5.1.6)
+      typescript: 5.1.6
       url-loader: 4.1.1(file-loader@6.1.1)(webpack@4.44.2)
       webpack: 4.44.2
       webpack-dev-server: 3.11.1(webpack@4.44.2)
@@ -23439,12 +23160,12 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /react-scripts@5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.2.2):
+  /react-scripts@5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(react@18.2.0)(ts-node@10.7.0)(type-fest@4.5.0)(typescript@5.1.6):
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     peerDependencies:
-      eslint: '*'
+      eslint: ^8.34.0
       react: '>= 16'
       typescript: ^3.2.1 || ^4
     peerDependenciesMeta:
@@ -23466,9 +23187,9 @@ packages:
       css-minimizer-webpack-plugin: 3.4.1(esbuild@0.18.20)(webpack@5.89.0)
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.34.0
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(jest@27.5.1)(typescript@5.2.2)
-      eslint-webpack-plugin: 3.2.0(eslint@8.34.0)(webpack@5.89.0)
+      eslint: 8.53.0
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint-import-resolver-typescript@3.5.5)(eslint@8.53.0)(jest@27.5.1)(typescript@5.1.6)
+      eslint-webpack-plugin: 3.2.0(eslint@8.53.0)(webpack@5.89.0)
       file-loader: 6.2.0(webpack@5.89.0)
       fs-extra: 10.1.0
       html-webpack-plugin: 5.5.3(webpack@5.89.0)
@@ -23485,7 +23206,7 @@ packages:
       prompts: 2.4.2
       react: 18.2.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.34.0)(typescript@5.2.2)(webpack@5.89.0)
+      react-dev-utils: 12.0.1(eslint@8.53.0)(typescript@5.1.6)(webpack@5.89.0)
       react-refresh: 0.11.0
       resolve: 1.22.8
       resolve-url-loader: 4.0.0
@@ -23495,7 +23216,7 @@ packages:
       style-loader: 3.3.3(webpack@5.89.0)
       tailwindcss: 3.3.2(ts-node@10.7.0)
       terser-webpack-plugin: 5.3.9(esbuild@0.18.20)(webpack@5.89.0)
-      typescript: 5.2.2
+      typescript: 5.1.6
       webpack: 5.89.0(esbuild@0.18.20)
       webpack-dev-server: 4.15.1(webpack@5.89.0)
       webpack-manifest-plugin: 4.1.1(webpack@5.89.0)
@@ -24587,6 +24308,66 @@ packages:
     dev: false
     optional: true
 
+  /sherif-darwin-arm64@0.5.0:
+    resolution: {integrity: sha512-FnuTing71i8l8FPBiKSXRG1FgmA9W0UsCXYz1nua/ImDdf/KfA+r3C+8jETmPY9teHIwi0rA4LdvlL4JxPeMzw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /sherif-darwin-x64@0.5.0:
+    resolution: {integrity: sha512-Nmt8YTFNlWYCVabae9iMHZ1HMXDTwPLSOm/UB/SN3pAiN8QFTVinsaeOZIefnRNuPrV4piUQrXSd1o9KSrFtBQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /sherif-linux-arm64@0.5.0:
+    resolution: {integrity: sha512-erM3X3xcJ54X5p1e5w8/FYMt0Yn53ulL3RDIS4Ffm6Rv2bpA5JpEu5FLRdPIKShYOidCe8PNFhRoCx6yhsqWLA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /sherif-linux-x64@0.5.0:
+    resolution: {integrity: sha512-0XW9tv9X3spSdy/q0kb/M6KCCAatuWhnayEQoKB0hhqiIDAXmzRApFCyVGXZQ+xLbP/ZJ+gD0e8bow1kUi2e8w==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /sherif-windows-arm64@0.5.0:
+    resolution: {integrity: sha512-mZSa99XyilYwc29OlBkiz8vlL7IvWv3vu3Oe1oSwbw6C+OeZx/B0h/XAAHVzJiLzB3CX0H3kBGEBf2ou/3iaXg==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /sherif-windows-x64@0.5.0:
+    resolution: {integrity: sha512-rx6b7hRE+fI1siGN107P/69eJ56mrHcznMNfoad5LT+H54SKpw+eTuK1h+vFBMYT4fnrVNW4OLCjdE+0oh3Iwg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /sherif@0.5.0:
+    resolution: {integrity: sha512-VjK3nq+GbSbbGTKc0DloWOmzNi8RN5fy27W38sIW1IzocdOKqbNgNNlnHNMBpEmFP7RxTHl7mc4/FM2R9pcErA==}
+    hasBin: true
+    optionalDependencies:
+      sherif-darwin-arm64: 0.5.0
+      sherif-darwin-x64: 0.5.0
+      sherif-linux-arm64: 0.5.0
+      sherif-linux-x64: 0.5.0
+      sherif-windows-arm64: 0.5.0
+      sherif-windows-x64: 0.5.0
+    dev: true
+
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -24646,15 +24427,6 @@ packages:
       ansi-styles: 3.2.1
       astral-regex: 1.0.0
       is-fullwidth-code-point: 2.0.0
-    dev: false
-
-  /slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
     dev: false
 
   /slugify@1.6.6:
@@ -25503,8 +25275,8 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.0.0
-      svelte-preprocess: 5.0.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)(typescript@5.2.2)
-      typescript: 5.2.2
+      svelte-preprocess: 5.0.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -25543,7 +25315,7 @@ packages:
       svelte: 4.0.0
     dev: true
 
-  /svelte-preprocess@5.0.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)(typescript@5.2.2):
+  /svelte-preprocess@5.0.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)(typescript@5.1.6):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -25589,10 +25361,10 @@ packages:
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 4.0.0
-      typescript: 5.2.2
+      typescript: 5.1.6
     dev: true
 
-  /svelte2tsx@0.6.23(svelte@4.0.0)(typescript@5.2.2):
+  /svelte2tsx@0.6.23(svelte@4.0.0)(typescript@5.1.6):
     resolution: {integrity: sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
@@ -25601,7 +25373,7 @@ packages:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
       svelte: 4.0.0
-      typescript: 5.2.2
+      typescript: 5.1.6
     dev: true
 
   /svelte@4.0.0:
@@ -25671,17 +25443,6 @@ packages:
     dependencies:
       '@pkgr/utils': 2.4.2
       tslib: 2.6.2
-
-  /table@6.8.1:
-    resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      ajv: 8.12.0
-      lodash.truncate: 4.4.2
-      slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-    dev: false
 
   /tailwindcss@3.3.2(ts-node@10.7.0):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
@@ -26122,7 +25883,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-node@10.7.0(@types/node@18.18.0)(typescript@5.2.2):
+  /ts-node@10.7.0(@types/node@18.18.0)(typescript@5.1.6):
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
     peerDependencies:
@@ -26148,11 +25909,11 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.2.2
+      typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /ts-pnp@1.2.0(typescript@5.2.2):
+  /ts-pnp@1.2.0(typescript@5.1.6):
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -26161,7 +25922,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.1.6
     dev: false
 
   /tsconfig-paths@3.14.2:
@@ -26197,14 +25958,14 @@ packages:
       tsup: ^7.0.0
     dependencies:
       esbuild-plugin-solid: 0.5.0(esbuild@0.19.5)(solid-js@1.8.1)
-      tsup: 7.2.0(ts-node@10.7.0)(typescript@5.2.2)
+      tsup: 7.2.0(ts-node@10.7.0)(typescript@5.1.6)
     transitivePeerDependencies:
       - esbuild
       - solid-js
       - supports-color
     dev: true
 
-  /tsup@7.2.0(ts-node@10.7.0)(typescript@5.2.2):
+  /tsup@7.2.0(ts-node@10.7.0)(typescript@5.1.6):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -26234,20 +25995,20 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.2.2
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils@3.21.0(typescript@5.2.2):
+  /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.2.2
+      typescript: 5.1.6
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -26381,8 +26142,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -26680,6 +26441,7 @@ packages:
 
   /v8-compile-cache@2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
+    dev: true
 
   /v8-to-istanbul@7.1.2:
     resolution: {integrity: sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==}
@@ -26931,16 +26693,16 @@ packages:
       he: 1.2.0
     dev: true
 
-  /vue-tsc@1.8.21(typescript@5.2.2):
+  /vue-tsc@1.8.21(typescript@5.1.6):
     resolution: {integrity: sha512-gc9e+opdeF0zKixaadXT5v2s+x+77oqpuza/vwqDhdDyEeLZUOmZaVeb9noZpkdhFaLq7t7ils/7lFU8E/Hgew==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
       '@volar/typescript': 1.10.10
-      '@vue/language-core': 1.8.21(typescript@5.2.2)
+      '@vue/language-core': 1.8.21(typescript@5.1.6)
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.1.6
     dev: true
 
   /vue@2.6.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,10 +58,10 @@ importers:
         version: 2.3.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.54.0
-        version: 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.1.6)
+        version: 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: ^5.54.0
-        version: 5.54.0(eslint@8.34.0)(typescript@5.1.6)
+        version: 5.54.0(eslint@8.34.0)(typescript@5.2.2)
       '@vitest/coverage-istanbul':
         specifier: ^0.33.0
         version: 0.33.0(vitest@0.33.0)
@@ -154,16 +154,16 @@ importers:
         version: 2.3.0
       ts-node:
         specifier: ^10.7.0
-        version: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
+        version: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(ts-node@10.7.0)(typescript@5.1.6)
+        version: 7.2.0(ts-node@10.7.0)(typescript@5.2.2)
       type-fest:
         specifier: ^4.5.0
         version: 4.5.0
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -211,8 +211,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(vite@4.4.11)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -340,8 +340,8 @@ importers:
         specifier: ^8.8.0
         version: 8.8.0(eslint@8.34.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -486,8 +486,8 @@ importers:
         specifier: ^18.2.31
         version: 18.2.31
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
   examples/react/offline:
     dependencies:
@@ -563,8 +563,8 @@ importers:
         specifier: ^18.2.14
         version: 18.2.14
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
   examples/react/optimistic-updates-ui:
     dependencies:
@@ -600,8 +600,8 @@ importers:
         specifier: ^18.2.14
         version: 18.2.14
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
   examples/react/pagination:
     dependencies:
@@ -729,7 +729,7 @@ importers:
         version: 7.21.8
       '@callstack/eslint-config':
         specifier: ^13.0.2
-        version: 13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(typescript@5.1.6)
+        version: 13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(typescript@5.2.2)
       '@expo/config':
         specifier: ^8.0.2
         version: 8.0.2
@@ -752,8 +752,8 @@ importers:
         specifier: ^2.8.8
         version: 2.8.8
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
 
   examples/react/react-router:
     dependencies:
@@ -1093,8 +1093,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1121,8 +1121,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1149,8 +1149,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1177,8 +1177,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1205,8 +1205,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1233,8 +1233,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1261,8 +1261,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4(@babel/core@7.23.2)(postcss@8.4.31)(svelte@4.0.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1298,8 +1298,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2(ts-node@10.7.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1320,8 +1320,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0(vite@4.4.11)(vue@3.3.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1339,8 +1339,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0(vite@4.4.11)(vue@3.3.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1370,8 +1370,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0(vite@4.4.11)(vue@3.3.0)
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@18.18.0)
@@ -1440,7 +1440,7 @@ importers:
         specifier: ^18.2.14
         version: 18.2.14
       typescript:
-        specifier: ^5.1.6
+        specifier: ^5.2.2
         version: 5.2.2
 
   integrations/react-vite:
@@ -4844,7 +4844,7 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: false
 
-  /@callstack/eslint-config@13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(typescript@5.1.6):
+  /@callstack/eslint-config@13.0.2(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)(typescript@5.2.2):
     resolution: {integrity: sha512-EYd00hKeKZ6B5lBYz0nWyfVnYACRqdw6s/65sKoEcNP4fkrBIhxLyQbd2pNfg+QauuNqK7XRR3P3zVh7p5IimQ==}
     engines: {node: ^12.22.0 || ^13.14.0 || ^14.17.0 || ^15.3.0 || >=16.0.0}
     peerDependencies:
@@ -4854,13 +4854,13 @@ packages:
       '@babel/eslint-parser': 7.22.15(@babel/core@7.21.8)(eslint@8.34.0)
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.21.8)
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.21.8)
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
       eslint: 8.34.0
       eslint-config-prettier: 8.8.0(eslint@8.34.0)
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.34.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.34.0)
-      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(typescript@5.1.6)
+      eslint-plugin-jest: 27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
       eslint-plugin-prettier: 4.0.0(eslint-config-prettier@8.8.0)(eslint@8.34.0)(prettier@2.8.8)
       eslint-plugin-promise: 6.1.1(eslint@8.34.0)
       eslint-plugin-react: 7.32.2(eslint@8.34.0)
@@ -8926,34 +8926,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
-      '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/type-utils': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@6.1.0)
-      eslint: 8.34.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      regexpp: 3.2.0
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2):
     resolution: {integrity: sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8980,7 +8952,6 @@ packages:
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/experimental-utils@3.10.1(eslint@7.32.0)(typescript@5.2.2):
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
@@ -9050,25 +9021,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.54.0(eslint@8.34.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@6.1.0)
-      eslint: 8.34.0
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-
   /@typescript-eslint/parser@5.54.0(eslint@8.34.0)(typescript@5.2.2):
     resolution: {integrity: sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9087,7 +9039,6 @@ packages:
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/scope-manager@4.33.0:
     resolution: {integrity: sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==}
@@ -9112,26 +9063,6 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.54.0(eslint@8.34.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-WI+WMJ8+oS+LyflqsD4nlXMsVdzTMYTxl16myXPaCXnSgc7LWwMsjxQFZCK/rVmTZ3FN71Ct78ehO9bRC7erYQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@6.1.0)
-      eslint: 8.34.0
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/type-utils@5.54.0(eslint@8.34.0)(typescript@5.2.2):
     resolution: {integrity: sha512-WI+WMJ8+oS+LyflqsD4nlXMsVdzTMYTxl16myXPaCXnSgc7LWwMsjxQFZCK/rVmTZ3FN71Ct78ehO9bRC7erYQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9150,7 +9081,6 @@ packages:
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/types@3.10.1:
     resolution: {integrity: sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==}
@@ -9214,26 +9144,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.54.0(typescript@5.1.6):
-    resolution: {integrity: sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/visitor-keys': 5.54.0
-      debug: 4.3.4(supports-color@6.1.0)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-
   /@typescript-eslint/typescript-estree@5.54.0(typescript@5.2.2):
     resolution: {integrity: sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9253,7 +9163,6 @@ packages:
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -9276,26 +9185,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.54.0(eslint@8.34.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-cuwm8D/Z/7AuyAeJ+T0r4WZmlnlxQ8wt7C7fLpFlKMR+dY6QO79Cq1WpJhvZbMA4ZeZGHiRWnht7ZJ8qkdAunw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.14
-      '@types/semver': 7.5.4
-      '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
-      eslint: 8.34.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.34.0)
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/utils@5.54.0(eslint@8.34.0)(typescript@5.2.2):
     resolution: {integrity: sha512-cuwm8D/Z/7AuyAeJ+T0r4WZmlnlxQ8wt7C7fLpFlKMR+dY6QO79Cq1WpJhvZbMA4ZeZGHiRWnht7ZJ8qkdAunw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9314,7 +9203,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
 
   /@typescript-eslint/utils@5.62.0(eslint@8.34.0)(typescript@5.2.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -14022,7 +13910,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
       debug: 3.2.7(supports-color@6.1.0)
       eslint: 8.34.0
       eslint-import-resolver-node: 0.3.9
@@ -14098,7 +13986,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
       array-includes: 3.1.7
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
@@ -14160,7 +14048,7 @@ packages:
       - typescript
     dev: false
 
-  /eslint-plugin-jest@27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(typescript@5.1.6):
+  /eslint-plugin-jest@27.4.2(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.34.0)(typescript@5.2.2):
     resolution: {integrity: sha512-3Nfvv3wbq2+PZlRTf2oaAWXWwbdBejFRBR2O8tAO67o+P8zno+QGbcDYaAXODlreXVg+9gvWhKKmG2rgfb8GEg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -14173,8 +14061,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.34.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.34.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.54.0(eslint@8.34.0)(typescript@5.2.2)
       eslint: 8.34.0
     transitivePeerDependencies:
       - supports-color
@@ -17342,7 +17230,7 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.5
       pretty-format: 26.6.2
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -17383,7 +17271,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -21764,7 +21652,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
       yaml: 1.10.2
     dev: true
 
@@ -21782,7 +21670,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
-      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.1.6)
+      ts-node: 10.7.0(@types/node@18.18.0)(typescript@5.2.2)
       yaml: 2.3.3
 
   /postcss-loader@3.0.0:
@@ -26234,7 +26122,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-node@10.7.0(@types/node@18.18.0)(typescript@5.1.6):
+  /ts-node@10.7.0(@types/node@18.18.0)(typescript@5.2.2):
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
     peerDependencies:
@@ -26260,7 +26148,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.1.6
+      typescript: 5.2.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -26309,14 +26197,14 @@ packages:
       tsup: ^7.0.0
     dependencies:
       esbuild-plugin-solid: 0.5.0(esbuild@0.19.5)(solid-js@1.8.1)
-      tsup: 7.2.0(ts-node@10.7.0)(typescript@5.1.6)
+      tsup: 7.2.0(ts-node@10.7.0)(typescript@5.2.2)
     transitivePeerDependencies:
       - esbuild
       - solid-js
       - supports-color
     dev: true
 
-  /tsup@7.2.0(ts-node@10.7.0)(typescript@5.1.6):
+  /tsup@7.2.0(ts-node@10.7.0)(typescript@5.2.2):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -26346,20 +26234,11 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.1.6
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
-
-  /tsutils@3.21.0(typescript@5.1.6):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.6
 
   /tsutils@3.21.0(typescript@5.2.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -26369,7 +26248,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.2.2
-    dev: false
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -26502,11 +26380,6 @@ packages:
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
-
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}


### PR DESCRIPTION
Following on from #6354

We cannot currently upgrade to TS 5.2+ since typescript-eslint v5 is incompatible (see [this StackOverflow post](https://stackoverflow.com/questions/76996326/parsing-error-deprecationerror-originalkeywordkind-has-been-deprecated-since)). I've added pnpm overrides to remove the extremely old eslint/typescript-eslint versions added by CRA v4.