### PR TITLE
Use latest version of jscodeshift

### DIFF
--- a/docs/react/guides/migrating-to-v5.md
+++ b/docs/react/guides/migrating-to-v5.md
@@ -106,7 +106,7 @@ To make the remove overloads migration easier, v5 comes with a codemod.
 If you want to run it against `.js` or `.jsx` files, please use the command below:
 
 ```
-npx jscodeshift ./path/to/src/ \
+npx jscodeshift@lastest ./path/to/src/ \
   --extensions=js,jsx \
   --transform=./node_modules/@tanstack/react-query/build/codemods/src/v5/remove-overloads/remove-overloads.js
 ```
@@ -114,7 +114,7 @@ npx jscodeshift ./path/to/src/ \
 If you want to run it against `.ts` or `.tsx` files, please use the command below:
 
 ```
-npx jscodeshift ./path/to/src/ \
+npx jscodeshift@lastest ./path/to/src/ \
   --extensions=ts,tsx \
   --parser=tsx \
   --transform=./node_modules/@tanstack/react-query/build/codemods/src/v5/remove-overloads/remove-overloads.js


### PR DESCRIPTION
Unfortunately `npx` takes whatever version it can get when you run it with no version.

This was causing me problems when trying to update, as it just crashed. Adding `@latest` makes sure it's a recent version of the dependency.