### PR TITLE
style(utils): fix typo in comment

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -272,7 +272,7 @@ export function isPlainObject(o: any): o is Object {
     return false
   }
 
-  // If has modified constructor
+  // If has no constructor
   const ctor = o.constructor
   if (typeof ctor === 'undefined') {
     return true


### PR DESCRIPTION
This is a *very minor fix*, but I do copy/paste this piece of code from time to time (the entire `replaceEqualDeep`) and I noticed this comment was wrong. This is probably just the result of a copy/paste from the section below:

```ts
  // If has modified prototype
  const prot = ctor.prototype
  if (!hasObjectPrototype(prot)) {
    return false
  }
```