### PR TITLE
fix(svelte-query-devtools): make styleNonce prop optional

### DIFF
--- a/packages/svelte-query-devtools/src/Devtools.svelte
+++ b/packages/svelte-query-devtools/src/Devtools.svelte
@@ -15,7 +15,7 @@
   export let position: DevtoolsPosition = 'bottom'
   export let client: QueryClient = useQueryClient()
   export let errorTypes: Array<DevToolsErrorType> = []
-  export let styleNonce: string | undefined
+  export let styleNonce: string | undefined = undefined
 
   let ref: HTMLDivElement
   let devtools: TanstackQueryDevtools | undefined


### PR DESCRIPTION
Fixes #6416 

- Set default value to `styleNonce` prop to make `styleNonce` prop optional.

```ts
import { SvelteComponentTyped } from "svelte";
declare const __propDef: {
    props: {
        initialIsOpen?: boolean | undefined;
        buttonPosition?: any;
        position?: any;
        client?: any;
        errorTypes?: DevToolsErrorType[] | undefined;
        styleNonce?: string | undefined;
    };
    events: {
        [evt: string]: CustomEvent<any>;
    };
    slots: {};
};
...
//# sourceMappingURL=Devtools.svelte.d.ts.map
```