### PR TITLE
docs(useMutationState): add reference

### DIFF
--- a/docs/vue/reference/useMutationState.md
+++ b/docs/vue/reference/useMutationState.md
@@ -1,0 +1,6 @@
+---
+id: useMutationState
+title: useMutationState
+ref: docs/react/reference/useMutationState.md
+replace: { '@tanstack/react-query': '@tanstack/vue-query' }
+---


### PR DESCRIPTION
I came across the `useMutationState` hook when doing some bug investigation and thought at first that it wasn't implemented for Vue. I later realized it is, but it's not in the API Reference. 

Please let me know if there's anything else that needs to be added in this PR,

Regards
Philip