### PR TITLE
docs(ssr): Fix `prefetchQuery()` function calls

### DIFF
--- a/docs/react/guides/ssr.md
+++ b/docs/react/guides/ssr.md
@@ -93,7 +93,7 @@ import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query'
 export async function getStaticProps() {
   const queryClient = new QueryClient()
 
-  await queryClient.prefetchQuery(['posts'], getPosts)
+  await queryClient.prefetchQuery({ queryKey: ['posts'], queryFn: getPosts })
 
   return {
     props: {
@@ -214,7 +214,7 @@ import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query'
 export async function loader() {
   const queryClient = new QueryClient()
 
-  await queryClient.prefetchQuery(['posts'], getPosts)
+  await queryClient.prefetchQuery({ queryKey: ['posts'], queryFn: getPosts })
 
   return json({ dehydratedState: dehydrate(queryClient) })
 }
@@ -264,7 +264,7 @@ import {
 
 async function handleRequest(req, res) {
   const queryClient = new QueryClient()
-  await queryClient.prefetchQuery(['key'], fn)
+  await queryClient.prefetchQuery({ queryKey: ['key'], queryFn: fn })
   const dehydratedState = dehydrate(queryClient)
 
   const html = ReactDOM.renderToString(
@@ -426,7 +426,7 @@ import getQueryClient from './getQueryClient'
 
 export default async function HydratedPosts() {
   const queryClient = getQueryClient()
-  await queryClient.prefetchQuery(['posts'], getPosts)
+  await queryClient.prefetchQuery({ queryKey: ['posts'], queryFn: getPosts })
   const dehydratedState = dehydrate(queryClient)
 
   return (


### PR DESCRIPTION
This is the correct signature for [prefetchQuery](https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientprefetchquery): 

```js
await queryClient.prefetchQuery({ queryKey, queryFn })
```

I noticed the docs were using a slightly stale signature.

Thank you for building an amazing library. :)