### PR TITLE
fix(core): make sure queries initialize correctly

### DIFF
--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -33,7 +33,7 @@ export class QueriesObserver<
 > extends Subscribable<QueriesObserverListener> {
   #client: QueryClient
   #result!: Array<QueryObserverResult>
-  #queries: Array<QueryObserverOptions>
+  #queries!: Array<QueryObserverOptions>
   #observers: Array<QueryObserver>
   #options?: QueriesObserverOptions<TCombinedResult>
   #combinedResult!: TCombinedResult
@@ -46,11 +46,10 @@ export class QueriesObserver<
     super()
 
     this.#client = client
-    this.#queries = []
     this.#observers = []
 
-    this.#setResult([])
     this.setQueries(queries, options)
+    this.#setResult([])
   }
 
   #setResult(value: Array<QueryObserverResult>) {

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -33,7 +33,7 @@ export class QueriesObserver<
 > extends Subscribable<QueriesObserverListener> {
   #client: QueryClient
   #result!: Array<QueryObserverResult>
-  #queries!: Array<QueryObserverOptions>
+  #queries: Array<QueryObserverOptions>
   #observers: Array<QueryObserver>
   #options?: QueriesObserverOptions<TCombinedResult>
   #combinedResult!: TCombinedResult
@@ -46,10 +46,12 @@ export class QueriesObserver<
     super()
 
     this.#client = client
+    this.#queries = queries
+    this.#options = options
     this.#observers = []
 
-    this.setQueries(queries, options)
     this.#setResult([])
+    this.setQueries(queries, options)
   }
 
   #setResult(value: Array<QueryObserverResult>) {


### PR DESCRIPTION
setQueries sets them, so it needs to be set before setResult, where we already access `this.queries`

closes #6369 