### PR TITLE
fix(query-devtools): do not wrap words on labels

### DIFF
--- a/packages/query-devtools/src/Explorer.tsx
+++ b/packages/query-devtools/src/Explorer.tsx
@@ -554,6 +554,7 @@ const stylesFactory = (theme: 'light' | 'dark') => {
     `,
     label: css`
       color: ${t(colors.gray[700], colors.gray[300])};
+      white-space: nowrap;
     `,
     value: css`
       color: ${t(colors.purple[600], colors.purple[400])};


### PR DESCRIPTION
Do not wrap words on labels when values are long

Current:
<img width="749" alt="image" src="https://github.com/TanStack/query/assets/1697714/bda6ccc5-b586-4033-ab23-48863bd4fd85">


Expected:
<img width="745" alt="image" src="https://github.com/TanStack/query/assets/1697714/ef52ab51-058e-4b3a-9024-bd045223fb49">
