### PR TITLE
switching retry strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,7 @@ jobs:
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter query --prefer-offline install
       - name: Run Tests
-        uses: nick-fields/retry@v2.8.3
-        with:
-          command: pnpm run test:ci
-          timeout_minutes: 10
-          max_attempts: 3
+        run: pnpm run test:ci
       - name: Publish
         run: |
           git config --global user.name 'Tanner Linsley'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,11 +48,7 @@ jobs:
       - name: Start CI Orchestrator
         run: npx nx-cloud start-ci-run
       - name: Run Tests
-        uses: nick-fields/retry@v2.8.3
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: npx nx affected --targets=test:eslint,test:lib,test:types,test:build,test:bundle
+        run: npx nx affected --targets=test:eslint,test:lib,test:types,test:build,test:bundle
       - name: Stop Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest run --coverage --retry=3",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "tsup"

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest run --coverage --retry=3",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "pnpm build:tsup && pnpm build:codemods",

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -46,7 +46,7 @@
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest run --coverage --retry=3",
     "test:lib:dev": "vitest watch --coverage",
     "test:build": "publint --strict",
     "build": "tsup"


### PR DESCRIPTION
We were seeing issues running Nx Cloud with the retry github action - this PR changes the retry strategy to instead retry at the vitest cmd line argument level. (This is slightly more efficient as well, because vitest will retry at the individual test level, whereas the previous strategy would retry the entire command again).

Note that only the flaky tests have been adjusted:
+ react-query
+ solid-query
+ react-query-persist-client