### PR TITLE
fix(types): Fix types when using select with the queryOptions helper

### DIFF
--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import { QueryCache, useQueries } from '..'
+import { QueryCache, queryOptions, useQueries } from '..'
 import {
   createQueryClient,
   expectTypeNotAny,
@@ -368,6 +368,40 @@ describe('useQueries', () => {
           },
         ],
       })
+    }
+  })
+
+  it('correctly returns types when passing through queryOptions ', () => {
+    // @ts-expect-error (Page component is not rendered)
+    // eslint-disable-next-line
+    function Page() {
+      // data and results types are correct when using queryOptions
+      const result4 = useQueries({
+        queries: [
+          queryOptions({
+            queryKey: ['key1'],
+            queryFn: () => 'string',
+            select: (a) => {
+              expectTypeOf<string>(a)
+              expectTypeNotAny(a)
+              return a.toLowerCase()
+            },
+          }),
+          queryOptions({
+            queryKey: ['key2'],
+            queryFn: () => 'string',
+            select: (a) => {
+              expectTypeOf<string>(a)
+              expectTypeNotAny(a)
+              return parseInt(a)
+            },
+          }),
+        ],
+      })
+      expectTypeOf<QueryObserverResult<string, unknown>>(result4[0])
+      expectTypeOf<QueryObserverResult<number, unknown>>(result4[1])
+      expectTypeOf<string | undefined>(result4[0].data)
+      expectTypeOf<number | undefined>(result4[1].data)
     }
   })
 

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -70,7 +70,7 @@ type GetOptions<T> =
               : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
                 T extends {
                     queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    select: (data: any) => infer TData
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? UseQueryOptionsForUseQueries<
@@ -112,12 +112,12 @@ type GetResults<T> =
               ? UseQueryResult<TQueryFnData>
               : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
                 T extends {
-                    queryFn?: QueryFunction<unknown, any>
-                    select: (data: any) => infer TData
+                    queryFn?: QueryFunction<infer TQueryFnData, any>
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? UseQueryResult<
-                    TData,
+                    unknown extends TData ? TQueryFnData : TData,
                     unknown extends TError ? DefaultError : TError
                   >
                 : T extends {

--- a/packages/react-query/src/useSuspenseQueries.ts
+++ b/packages/react-query/src/useSuspenseQueries.ts
@@ -34,7 +34,7 @@ type GetSuspenseOptions<T> =
               : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
                 T extends {
                     queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    select: (data: any) => infer TData
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? UseSuspenseQueryOptions<
@@ -76,12 +76,12 @@ type GetSuspenseResults<T> =
               ? UseSuspenseQueryResult<TQueryFnData>
               : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
                 T extends {
-                    queryFn?: QueryFunction<unknown, any>
-                    select: (data: any) => infer TData
+                    queryFn?: QueryFunction<infer TQueryFnData, any>
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? UseSuspenseQueryResult<
-                    TData,
+                    unknown extends TData ? TQueryFnData : TData,
                     unknown extends TError ? DefaultError : TError
                   >
                 : T extends {

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -65,7 +65,7 @@ type GetOptions<T> =
               : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
                 T extends {
                     queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    select: (data: any) => infer TData
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? CreateQueryOptionsForCreateQueries<
@@ -107,12 +107,12 @@ type GetResults<T> =
               ? CreateQueryResult<TQueryFnData>
               : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
                 T extends {
-                    queryFn?: QueryFunction<unknown, any>
-                    select: (data: any) => infer TData
+                    queryFn?: QueryFunction<infer TQueryFnData, any>
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? CreateQueryResult<
-                    TData,
+                    unknown extends TData ? TQueryFnData : TData,
                     unknown extends TError ? DefaultError : TError
                   >
                 : T extends {

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -56,7 +56,7 @@ type GetOptions<T> =
               : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
                 T extends {
                     queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    select: (data: any) => infer TData
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? QueryObserverOptionsForCreateQueries<
@@ -98,12 +98,12 @@ type GetResults<T> =
               ? QueryObserverResult<TQueryFnData>
               : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
                 T extends {
-                    queryFn?: QueryFunction<unknown, any>
-                    select: (data: any) => infer TData
+                    queryFn?: QueryFunction<infer TQueryFnData, any>
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? QueryObserverResult<
-                    TData,
+                    unknown extends TData ? TQueryFnData : TData,
                     unknown extends TError ? DefaultError : TError
                   >
                 : T extends {

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -64,7 +64,7 @@ type GetOptions<T> =
               : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
                 T extends {
                     queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    select: (data: any) => infer TData
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? UseQueryOptionsForUseQueries<
@@ -106,12 +106,12 @@ type GetResults<T> =
               ? QueryObserverResult<TQueryFnData>
               : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
                 T extends {
-                    queryFn?: QueryFunction<unknown, any>
-                    select: (data: any) => infer TData
+                    queryFn?: QueryFunction<infer TQueryFnData, any>
+                    select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
                 ? QueryObserverResult<
-                    TData,
+                    unknown extends TData ? TQueryFnData : TData,
                     unknown extends TError ? DefaultError : TError
                   >
                 : T extends {


### PR DESCRIPTION
useQueries, createQueries and useSuspenseQueries now return the correct data type if using the queryOptions helper with the select option.

fixes #6442