### PR TITLE
chore(codemods): disable no-unnecessary-condition in test fixtures

### DIFF
--- a/packages/codemods/.eslintrc.cjs
+++ b/packages/codemods/.eslintrc.cjs
@@ -13,6 +13,7 @@ const config = {
         'import/no-unresolved': 'off',
         'sort-imports': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
+        '@typescript-eslint/no-unnecessary-condition': 'off',
       },
     },
   ],


### PR DESCRIPTION
Fixes lint error in test fixtures that appears on some machines.