### PR TITLE
fix(tests): add type tests for useQueries

### DIFF
--- a/packages/react-query/src/__tests__/useQueries.types.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.types.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it } from 'vitest'
+import { queryOptions, useQueries } from '..'
+import { doNotExecute } from './utils'
+import type { UseQueryOptions } from '..'
+import type { Equal, Expect } from './utils'
+
+describe('UseQueries config object overload', () => {
+  it('TData should always be defined when initialData is provided as an object', () => {
+    const query1 = {
+      queryKey: ['key1'],
+      queryFn: () => {
+        return {
+          wow: true,
+        }
+      },
+      initialData: {
+        wow: false,
+      },
+    }
+
+    const query2 = {
+      queryKey: ['key2'],
+      queryFn: () => 'Query Data',
+      initialData: 'initial data',
+    }
+
+    const query3 = {
+      queryKey: ['key2'],
+      queryFn: () => 'Query Data',
+    }
+
+    doNotExecute(() => {
+      const queryResults = useQueries({ queries: [query1, query2, query3] })
+
+      const query1Data = queryResults[0].data
+      const query2Data = queryResults[1].data
+      const query3Data = queryResults[2].data
+
+      const result1: Expect<Equal<{ wow: boolean }, typeof query1Data>> = true
+
+      const result2: Expect<Equal<string, typeof query2Data>> = true
+
+      const result3: Expect<Equal<string | undefined, typeof query3Data>> = true
+
+      return result1 && result2 && result3
+    })
+  })
+
+  it('TData should be defined when passed through queryOptions', () => {
+    doNotExecute(() => {
+      const options = queryOptions({
+        queryKey: ['key'],
+        queryFn: () => {
+          return {
+            wow: true,
+          }
+        },
+        initialData: {
+          wow: true,
+        },
+      })
+      const queryResults = useQueries({ queries: [options] })
+
+      const data = queryResults[0].data
+
+      const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+      return result
+    })
+  })
+
+  it('it should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQuery', () => {
+    doNotExecute(() => {
+      const query1 = queryOptions({
+        queryKey: ['key'],
+        queryFn: () => Promise.resolve(1),
+        select: (data) => data > 1,
+      })
+
+      const query2 = {
+        queryKey: ['key'],
+        queryFn: () => Promise.resolve(1),
+        select: (data: number) => data > 1,
+      }
+
+      const queryResults = useQueries({ queries: [query1, query2] })
+      const query1Data = queryResults[0].data
+      const query2Data = queryResults[1].data
+
+      const result1: Expect<Equal<boolean | undefined, typeof query1Data>> =
+        true
+      const result2: Expect<Equal<boolean | undefined, typeof query2Data>> =
+        true
+      return result1 && result2
+    })
+  })
+
+  it('TData should have undefined in the union when initialData is provided as a function which can return undefined', () => {
+    doNotExecute(() => {
+      const queryResults = useQueries({
+        queries: [
+          {
+            queryKey: ['key'],
+            queryFn: () => {
+              return {
+                wow: true,
+              }
+            },
+            initialData: () => undefined as { wow: boolean } | undefined,
+          },
+        ],
+      })
+
+      const data = queryResults[0].data
+
+      const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+        true
+      return result
+    })
+  })
+
+  describe('custom hook', () => {
+    it('should allow custom hooks using UseQueryOptions', () => {
+      doNotExecute(() => {
+        type Data = string
+
+        const useCustomQueries = (
+          options?: Omit<UseQueryOptions<Data>, 'queryKey' | 'queryFn'>,
+        ) => {
+          return useQueries({
+            queries: [
+              {
+                ...options,
+                queryKey: ['todos-key'],
+                queryFn: () => Promise.resolve('data'),
+              },
+            ],
+          })
+        }
+
+        const queryResults = useCustomQueries()
+        const data = queryResults[0].data
+
+        const result: Expect<Equal<Data | undefined, typeof data>> = true
+        return result
+      })
+    })
+  })
+})

--- a/packages/vue-query/src/__tests__/useQueries.types.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.types.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from 'vitest'
+import { reactive } from 'vue'
+import { useQueries } from '..'
+import { queryOptions } from '../queryOptions'
+import { doNotExecute } from './test-utils'
+import type { UseQueryOptions } from '../useQuery'
+import type { Equal, Expect } from './test-utils'
+
+describe('UseQueries config object overload', () => {
+  it('TData should always be defined when initialData is provided as an object', () => {
+    const query1 = {
+      queryKey: ['key1'],
+      queryFn: () => {
+        return {
+          wow: true,
+        }
+      },
+      initialData: {
+        wow: false,
+      },
+    }
+
+    const query2 = queryOptions({
+      queryKey: ['key2'],
+      queryFn: () => 'Query Data',
+      initialData: 'initial data',
+    })
+
+    const query3 = {
+      queryKey: ['key2'],
+      queryFn: () => 'Query Data',
+    }
+
+    doNotExecute(() => {
+      const { value: queriesState } = useQueries({
+        queries: [query1, query2, query3],
+      })
+
+      const query1Data = queriesState[0].data
+      const query2Data = queriesState[1].data
+      const query3Data = queriesState[2].data
+
+      const result1: Expect<Equal<{ wow: boolean }, typeof query1Data>> = true
+
+      const result2: Expect<Equal<string, typeof query2Data>> = true
+
+      const result3: Expect<Equal<string | undefined, typeof query3Data>> = true
+
+      return result1 && result2 && result3
+    })
+  })
+
+  it('TData should be defined when passed through queryOptions', () => {
+    doNotExecute(() => {
+      const options = queryOptions({
+        queryKey: ['key'],
+        queryFn: () => {
+          return {
+            wow: true,
+          }
+        },
+        initialData: {
+          wow: true,
+        },
+      })
+
+      const { value: queriesState } = useQueries({ queries: [options] })
+
+      const data = queriesState[0].data
+
+      const result: Expect<Equal<{ wow: boolean }, typeof data>> = true
+      return result
+    })
+  })
+
+  it('it should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQueries', () => {
+    doNotExecute(() => {
+      const query1 = queryOptions({
+        queryKey: ['key'],
+        queryFn: () => Promise.resolve(1),
+        select: (data) => data > 1,
+      })
+
+      const query2 = {
+        queryKey: ['key'],
+        queryFn: () => Promise.resolve(1),
+        select: (data: any) => data > 1,
+      }
+
+      const queriesState = reactive(useQueries({ queries: [query1, query2] }))
+      const query1Data = queriesState.value[0].data
+      const query2Data = queriesState.value[1].data
+
+      const result1: Expect<Equal<boolean | undefined, typeof query1Data>> =
+        true
+      const result2: Expect<Equal<boolean | undefined, typeof query2Data>> =
+        true
+      return result1 && result2
+    })
+  })
+
+  it('TData should have undefined in the union when initialData is provided as a function which can return undefined', () => {
+    doNotExecute(() => {
+      const { value: queriesState } = useQueries({
+        queries: [
+          {
+            queryKey: ['key'],
+            queryFn: () => {
+              return {
+                wow: true,
+              }
+            },
+            initialData: () => undefined as { wow: boolean } | undefined,
+          },
+        ],
+      })
+
+      const data = queriesState[0].data
+
+      const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
+        true
+      return result
+    })
+  })
+
+  describe('custom hook', () => {
+    it('should allow custom hooks using UseQueryOptions', () => {
+      doNotExecute(() => {
+        type Data = string
+
+        const useCustomQueries = (
+          options?: Omit<UseQueryOptions<Data>, 'queryKey' | 'queryFn'>,
+        ) => {
+          return useQueries({
+            queries: [
+              {
+                ...options,
+                queryKey: ['todos-key'],
+                queryFn: () => Promise.resolve('data'),
+              },
+            ],
+          })
+        }
+
+        const { value: queriesState } = useCustomQueries()
+        const data = queriesState[0].data
+
+        const result: Expect<Equal<Data | undefined, typeof data>> = true
+        return result
+      })
+    })
+  })
+})

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -14,6 +14,7 @@ import { cloneDeepUnref } from './utils'
 import type { Ref } from 'vue-demi'
 import type {
   DefaultError,
+  DefinedQueryObserverResult,
   QueriesObserverOptions,
   QueriesPlaceholderDataFunction,
   QueryFunction,
@@ -23,7 +24,7 @@ import type {
 } from '@tanstack/query-core'
 import type { UseQueryOptions } from './useQuery'
 import type { QueryClient } from './queryClient'
-import type { DistributiveOmit, MaybeRefDeep } from './types'
+import type { DeepUnwrapRef, DistributiveOmit, MaybeRefDeep } from './types'
 
 // This defines the `UseQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
 // `placeholderData` function does not have a parameter
@@ -33,7 +34,7 @@ type UseQueryOptionsForUseQueries<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = DistributiveOmit<
-  UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  UseQueryOptions<TQueryFnData, TError, TData, unknown, TQueryKey>,
   'placeholderData'
 > & {
   placeholderData?: TQueryFnData | QueriesPlaceholderDataFunction<TQueryFnData>
@@ -43,87 +44,125 @@ type UseQueryOptionsForUseQueries<
 type MAXIMUM_DEPTH = 20
 
 type GetOptions<T> =
-  // Part 1: responsible for applying explicit type parameter to function arguments, if object { queryFnData: TQueryFnData, error: TError, data: TData }
-  T extends {
-    queryFnData: infer TQueryFnData
-    error?: infer TError
-    data: infer TData
-  }
-    ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
-    : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-      ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
-      : T extends { data: infer TData; error?: infer TError }
-        ? UseQueryOptionsForUseQueries<unknown, TError, TData>
-        : // Part 2: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
-          T extends [infer TQueryFnData, infer TError, infer TData]
-          ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
-          : T extends [infer TQueryFnData, infer TError]
-            ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
-            : T extends [infer TQueryFnData]
-              ? UseQueryOptionsForUseQueries<TQueryFnData>
-              : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
-                T extends {
-                    queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    select?: (data: any) => infer TData
-                    throwOnError?: ThrowOnError<any, infer TError, any, any>
-                  }
-                ? UseQueryOptionsForUseQueries<
-                    TQueryFnData,
-                    TError,
-                    TData,
-                    TQueryKey
-                  >
-                : T extends {
+  // Part 1: if UseQueryOptions are already being sent through, then just return T
+  T extends UseQueryOptions
+    ? DeepUnwrapRef<T>
+    : // Part 2: responsible for applying explicit type parameter to function arguments, if object { queryFnData: TQueryFnData, error: TError, data: TData }
+      T extends {
+          queryFnData: infer TQueryFnData
+          error?: infer TError
+          data: infer TData
+        }
+      ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
+      : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
+        ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
+        : T extends { data: infer TData; error?: infer TError }
+          ? UseQueryOptionsForUseQueries<unknown, TError, TData>
+          : // Part 3: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
+            T extends [infer TQueryFnData, infer TError, infer TData]
+            ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
+            : T extends [infer TQueryFnData, infer TError]
+              ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
+              : T extends [infer TQueryFnData]
+                ? UseQueryOptionsForUseQueries<TQueryFnData>
+                : // Part 4: responsible for inferring and enforcing type if no explicit parameter was provided
+                  T extends {
                       queryFn?: QueryFunction<
                         infer TQueryFnData,
                         infer TQueryKey
                       >
+                      select?: (data: any) => infer TData
                       throwOnError?: ThrowOnError<any, infer TError, any, any>
                     }
                   ? UseQueryOptionsForUseQueries<
                       TQueryFnData,
                       TError,
-                      TQueryFnData,
+                      TData,
                       TQueryKey
                     >
-                  : // Fallback
-                    UseQueryOptionsForUseQueries
+                  : T extends {
+                        queryFn?: QueryFunction<
+                          infer TQueryFnData,
+                          infer TQueryKey
+                        >
+                        throwOnError?: ThrowOnError<any, infer TError, any, any>
+                      }
+                    ? UseQueryOptionsForUseQueries<
+                        TQueryFnData,
+                        TError,
+                        TQueryFnData,
+                        TQueryKey
+                      >
+                    : // Fallback
+                      UseQueryOptionsForUseQueries
+
+// A defined initialData setting should return a DefinedQueryObserverResult rather than QueryObserverResult
+type GetDefinedOrUndefinedQueryResult<T, TData, TError = unknown> = T extends {
+  initialData?: infer TInitialData
+}
+  ? unknown extends TInitialData
+    ? QueryObserverResult<TData, TError>
+    : TInitialData extends TData
+      ? DefinedQueryObserverResult<TData, TError>
+      : TInitialData extends () => infer TInitialDataResult
+        ? unknown extends TInitialDataResult
+          ? QueryObserverResult<TData, TError>
+          : TInitialDataResult extends TData
+            ? DefinedQueryObserverResult<TData, TError>
+            : QueryObserverResult<TData, TError>
+        : QueryObserverResult<TData, TError>
+  : QueryObserverResult<TData, TError>
 
 type GetResults<T> =
-  // Part 1: responsible for mapping explicit type parameter to function result, if object
-  T extends { queryFnData: any; error?: infer TError; data: infer TData }
-    ? QueryObserverResult<TData, TError>
-    : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-      ? QueryObserverResult<TQueryFnData, TError>
-      : T extends { data: infer TData; error?: infer TError }
-        ? QueryObserverResult<TData, TError>
-        : // Part 2: responsible for mapping explicit type parameter to function result, if tuple
-          T extends [any, infer TError, infer TData]
-          ? QueryObserverResult<TData, TError>
-          : T extends [infer TQueryFnData, infer TError]
-            ? QueryObserverResult<TQueryFnData, TError>
-            : T extends [infer TQueryFnData]
-              ? QueryObserverResult<TQueryFnData>
-              : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
-                T extends {
-                    queryFn?: QueryFunction<infer TQueryFnData, any>
-                    select?: (data: any) => infer TData
-                    throwOnError?: ThrowOnError<any, infer TError, any, any>
-                  }
-                ? QueryObserverResult<
-                    unknown extends TData ? TQueryFnData : TData,
-                    unknown extends TError ? DefaultError : TError
-                  >
-                : T extends {
+  // Part 1: if using UseQueryOptions then the types are already set
+  T extends UseQueryOptions<
+    infer TQueryFnData,
+    infer TError,
+    infer TData,
+    any,
+    any
+  >
+    ? GetDefinedOrUndefinedQueryResult<
+        T,
+        undefined extends TData ? TQueryFnData : TData,
+        TError
+      >
+    : // Part 2: responsible for mapping explicit type parameter to function result, if object
+      T extends { queryFnData: any; error?: infer TError; data: infer TData }
+      ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+      : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
+        ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
+        : T extends { data: infer TData; error?: infer TError }
+          ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+          : // Part 3: responsible for mapping explicit type parameter to function result, if tuple
+            T extends [any, infer TError, infer TData]
+            ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+            : T extends [infer TQueryFnData, infer TError]
+              ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
+              : T extends [infer TQueryFnData]
+                ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData>
+                : // Part 4: responsible for mapping inferred type to results, if no explicit parameter was provided
+                  T extends {
                       queryFn?: QueryFunction<infer TQueryFnData, any>
+                      select?: (data: any) => infer TData
                       throwOnError?: ThrowOnError<any, infer TError, any, any>
                     }
-                  ? QueryObserverResult<
-                      TQueryFnData,
+                  ? GetDefinedOrUndefinedQueryResult<
+                      T,
+                      unknown extends TData ? TQueryFnData : TData,
                       unknown extends TError ? DefaultError : TError
                     >
-                  : // Fallback
-                    QueryObserverResult
+                  : T extends {
+                        queryFn?: QueryFunction<infer TQueryFnData, any>
+                        throwOnError?: ThrowOnError<any, infer TError, any, any>
+                      }
+                    ? GetDefinedOrUndefinedQueryResult<
+                        T,
+                        TQueryFnData,
+                        unknown extends TError ? DefaultError : TError
+                      >
+                    : // Fallback
+                      QueryObserverResult
 
 /**
  * UseQueriesOptions reducer recursively unwraps function arguments to infer/enforce type param


### PR DESCRIPTION
Creating new useQueries type tests in react-query and vue-query and fixing a couple of type bugs.

discussed in https://github.com/TanStack/query/issues/6442