### PR TITLE
fix(svelte-query): Support v5 alpha

### DIFF
--- a/packages/svelte-query-devtools/package.json
+++ b/packages/svelte-query-devtools/package.json
@@ -48,6 +48,6 @@
   },
   "peerDependencies": {
     "@tanstack/svelte-query": "workspace:^",
-    "svelte": ">=3 <5"
+    "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0"
   }
 }

--- a/packages/svelte-query-persist-client/package.json
+++ b/packages/svelte-query-persist-client/package.json
@@ -50,6 +50,6 @@
   },
   "peerDependencies": {
     "@tanstack/svelte-query": "workspace:^",
-    "svelte": ">=3 <5"
+    "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0"
   }
 }

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -54,6 +54,6 @@
     "svelte-eslint-parser": "^0.32.2"
   },
   "peerDependencies": {
-    "svelte": ">=3 <5"
+    "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0"
   }
 }


### PR DESCRIPTION
Uses the same peerDeps range as SvelteKit.