### PR TITLE
fix(query-devtools): Improve Perf for queries table

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -2060,15 +2060,12 @@ const setupQueryCacheSubscription = () => {
   })
 
   const unsub = queryCache().subscribe((q) => {
-    let count = 0
     batch(() => {
       for (const [callback, value] of queryCacheMap.entries()) {
         if (!value.shouldUpdate(q)) continue
-        count++
         value.setter(callback(queryCache))
       }
     })
-    console.log('batched', count)
   })
 
   onCleanup(() => {

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -63,7 +63,8 @@
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "tsup"
+    "build": "tsup",
+    "build:dev": "tsup --watch"
   },
   "dependencies": {
     "@tanstack/query-devtools": "workspace:*"


### PR DESCRIPTION
This change dramatically improves the performance of the queries table. The issue was that each Query Row would update on every queryCache update. Now, each QueryRow only updates when its particular query is updated.

I want to make the same change for the MutationRow component too but currently `MutationCacheNotifyEvent` type is not exported. I will make a separate PR for that and then add the perf improvements on it when that change is merged.