### PR TITLE
Add openapi-fetch to Community Projects

### DIFF
--- a/docs/react/community/community-projects.md
+++ b/docs/react/community/community-projects.md
@@ -67,6 +67,12 @@ Generate a zodios client from an OpenAPI specification
 
 Link: https://github.com/astahmer/openapi-zod-client
 
+## openapi-fetch
+
+A 2KB min, typesafe fetch wrapper that uses static TypeScript type inference and no runtime checks.
+
+Link: https://openapi-ts.pages.dev/openapi-fetch/
+
 ## Orval
 
 Generate TypeScript client from OpenAPI specifications


### PR DESCRIPTION
Hello, I’m the maintainer of openapi-fetch, and use it primarily with TanStack Query. Though it’s a vanillaJS project, it works perfectly with TanStack Query and there are even dedicated docs to using the two together.

Happy to accept any change requests in the description, etc.