### PR TITLE
fix(core): mutation GC leak when reset, but not unsubscribed

### DIFF
--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -89,6 +89,9 @@ export class MutationObserver<
   }
 
   reset(): void {
+    // reset needs to remove the observer from the mutation because there is no way to "get it back"
+    // another mutate call will yield a new mutation!
+    this.#currentMutation?.removeObserver(this)
     this.#currentMutation = undefined
     this.#updateResult()
     this.#notify()

--- a/packages/query-core/src/tests/mutationObserver.test.tsx
+++ b/packages/query-core/src/tests/mutationObserver.test.tsx
@@ -44,4 +44,54 @@ describe('mutationObserver', () => {
     // Clean-up
     unsubscribe2()
   })
+
+  test('unsubscribe should remove observer to trigger GC', async () => {
+    const mutation = new MutationObserver(queryClient, {
+      mutationFn: async (text: string) => {
+        await sleep(5)
+        return text
+      },
+      gcTime: 10,
+    })
+
+    const subscriptionHandler = vi.fn()
+
+    const unsubscribe = mutation.subscribe(subscriptionHandler)
+
+    await mutation.mutate('input')
+
+    expect(queryClient.getMutationCache().findAll()).toHaveLength(1)
+
+    unsubscribe()
+
+    await waitFor(() =>
+      expect(queryClient.getMutationCache().findAll()).toHaveLength(0),
+    )
+  })
+
+  test('reset should remove observer to trigger GC', async () => {
+    const mutation = new MutationObserver(queryClient, {
+      mutationFn: async (text: string) => {
+        await sleep(5)
+        return text
+      },
+      gcTime: 10,
+    })
+
+    const subscriptionHandler = vi.fn()
+
+    const unsubscribe = mutation.subscribe(subscriptionHandler)
+
+    await mutation.mutate('input')
+
+    expect(queryClient.getMutationCache().findAll()).toHaveLength(1)
+
+    mutation.reset()
+
+    await waitFor(() =>
+      expect(queryClient.getMutationCache().findAll()).toHaveLength(0),
+    )
+
+    unsubscribe()
+  })
 })


### PR DESCRIPTION
mutations were not gc'd correctly when being reset. GC was invoked on unsubscribe, but reset disconnects the observer from the mutation in the cache and must thus also trigger a GC, because the observer is no longer watching the values of that mutation, and another mutate() call will create a new mutation anyway. Thus, the old mutation becomes orphaned when reset is called.