### PR TITLE
refactor(query-core): Updates the Return Type of the isFetching and isMutating methods from Number to Boolean

### DIFF
--- a/packages/angular-query-experimental/src/injectIsFetching.ts
+++ b/packages/angular-query-experimental/src/injectIsFetching.ts
@@ -7,7 +7,7 @@ import type { Injector, Signal } from '@angular/core'
 export function injectIsFetching(
   filters?: QueryFilters,
   injector?: Injector,
-): Signal<number> {
+): Signal<boolean> {
   return assertInjector(injectIsFetching, injector, () => {
     const queryClient = injectQueryClient()
     const destroyRef = inject(DestroyRef)

--- a/packages/angular-query-experimental/src/injectIsMutating.ts
+++ b/packages/angular-query-experimental/src/injectIsMutating.ts
@@ -7,7 +7,7 @@ import type { Injector, Signal } from '@angular/core'
 export function injectIsMutating(
   filters?: MutationFilters,
   injector?: Injector,
-): Signal<number> {
+): Signal<boolean> {
   return assertInjector(injectIsMutating, injector, () => {
     const queryClient = injectQueryClient()
     const destroyRef = inject(DestroyRef)

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -99,13 +99,16 @@ export class QueryClient {
     this.#unsubscribeOnline = undefined
   }
 
-  isFetching(filters?: QueryFilters): number {
-    return this.#queryCache.findAll({ ...filters, fetchStatus: 'fetching' })
-      .length
+  isFetching(filters?: QueryFilters): boolean {
+    return this.#queryCache
+      .findAll({ ...filters, fetchStatus: 'fetching' })
+      .some(Boolean)
   }
 
-  isMutating(filters?: MutationFilters): number {
-    return this.#mutationCache.findAll({ ...filters, status: 'pending' }).length
+  isMutating(filters?: MutationFilters): boolean {
+    return this.#mutationCache
+      .findAll({ ...filters, status: 'pending' })
+      .some(Boolean)
   }
 
   getQueryData<

--- a/packages/react-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/react-query/src/__tests__/useIsFetching.test.tsx
@@ -61,7 +61,7 @@ describe('useIsFetching', () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
-    const isFetchings: Array<number> = []
+    const isFetchings: Array<boolean> = []
 
     function IsFetching() {
       const isFetching = useIsFetching()
@@ -118,7 +118,7 @@ describe('useIsFetching', () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
-    const isFetchings: Array<number> = []
+    const isFetchings: Array<boolean> = []
 
     function One() {
       useQuery({

--- a/packages/react-query/src/useIsFetching.ts
+++ b/packages/react-query/src/useIsFetching.ts
@@ -8,7 +8,7 @@ import type { QueryClient, QueryFilters } from '@tanstack/query-core'
 export function useIsFetching(
   filters?: QueryFilters,
   queryClient?: QueryClient,
-): number {
+): boolean {
   const client = useQueryClient(queryClient)
   const queryCache = client.getQueryCache()
 

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -59,7 +59,7 @@ describe('useIsFetching', () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
-    const isFetchings: Array<number> = []
+    const isFetchings: Array<boolean> = []
 
     function IsFetching() {
       const isFetching = useIsFetching()
@@ -125,7 +125,7 @@ describe('useIsFetching', () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
-    const isFetchings: Array<number> = []
+    const isFetchings: Array<boolean> = []
 
     function One() {
       createQuery(() => ({

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -7,7 +7,7 @@ import { createQueryClient, setActTimeout, sleep } from './utils'
 
 describe('useIsMutating', () => {
   it('should return the number of fetching mutations', async () => {
-    const isMutatings: Array<number> = []
+    const isMutatings: Array<boolean> = []
     const queryClient = createQueryClient()
 
     function IsMutating() {
@@ -62,7 +62,7 @@ describe('useIsMutating', () => {
   })
 
   it('should filter correctly by mutationKey', async () => {
-    const isMutatings: Array<number> = []
+    const isMutatings: Array<boolean> = []
     const queryClient = createQueryClient()
 
     function IsMutating() {
@@ -107,7 +107,7 @@ describe('useIsMutating', () => {
   })
 
   it('should filter correctly by predicate', async () => {
-    const isMutatings: Array<number> = []
+    const isMutatings: Array<boolean> = []
     const queryClient = createQueryClient()
 
     function IsMutating() {

--- a/packages/solid-query/src/useIsFetching.ts
+++ b/packages/solid-query/src/useIsFetching.ts
@@ -7,7 +7,7 @@ import type { Accessor } from 'solid-js'
 export function useIsFetching(
   filters?: Accessor<QueryFilters>,
   queryClient?: Accessor<QueryClient>,
-): Accessor<number> {
+): Accessor<boolean> {
   const client = createMemo(() => useQueryClient(queryClient?.()))
   const queryCache = createMemo(() => client().getQueryCache())
 

--- a/packages/solid-query/src/useIsMutating.ts
+++ b/packages/solid-query/src/useIsMutating.ts
@@ -7,7 +7,7 @@ import type { Accessor } from 'solid-js'
 export function useIsMutating(
   filters?: Accessor<MutationFilters>,
   queryClient?: Accessor<QueryClient>,
-): Accessor<number> {
+): Accessor<boolean> {
   const client = createMemo(() => useQueryClient(queryClient?.()))
   const mutationCache = createMemo(() => client().getMutationCache())
 

--- a/packages/svelte-query/src/useIsFetching.ts
+++ b/packages/svelte-query/src/useIsFetching.ts
@@ -10,7 +10,7 @@ import type { Readable } from 'svelte/store'
 export function useIsFetching(
   filters?: QueryFilters,
   queryClient?: QueryClient,
-): Readable<number> {
+): Readable<boolean> {
   const client = useQueryClient(queryClient)
   const cache = client.getQueryCache()
   // isFetching is the prev value initialized on mount *

--- a/packages/svelte-query/src/useIsMutating.ts
+++ b/packages/svelte-query/src/useIsMutating.ts
@@ -10,7 +10,7 @@ import type { Readable } from 'svelte/store'
 export function useIsMutating(
   filters?: MutationFilters,
   queryClient?: QueryClient,
-): Readable<number> {
+): Readable<boolean> {
   const client = useQueryClient(queryClient)
   const cache = client.getMutationCache()
   // isMutating is the prev value initialized on mount *

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -40,11 +40,11 @@ export class QueryClient extends QC {
 
   isRestoring = ref(false)
 
-  isFetching(filters: MaybeRefDeep<QueryFilters> = {}): number {
+  isFetching(filters: MaybeRefDeep<QueryFilters> = {}): boolean {
     return super.isFetching(cloneDeepUnref(filters))
   }
 
-  isMutating(filters: MaybeRefDeep<MutationFilters> = {}): number {
+  isMutating(filters: MaybeRefDeep<MutationFilters> = {}): boolean {
     return super.isMutating(cloneDeepUnref(filters))
   }
 

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -10,7 +10,7 @@ export type QueryFilters = MaybeRefDeep<QF>
 export function useIsFetching(
   fetchingFilters: MaybeRefDeep<QF> = {},
   queryClient?: QueryClient,
-): Ref<number> {
+): Ref<boolean> {
   if (process.env.NODE_ENV === 'development') {
     if (!getCurrentScope()) {
       console.warn(


### PR DESCRIPTION
## Changes Made

I proceeded with updating the return type to boolean, in line with the is-prefix for improved readability.

### Changes Overview

- **query-core**
  - Modified internal logic in `queryClient.ts` to handle return values of `isFetching` and `isMutating` as boolean.
- **react-query** 
  - Change the return type of `useIsFetching.ts` to `boolean` from `number`.
- **angular-query-experimental**
  - Change the return type of `injectIsFetching.ts` and `injectIsMutating.ts` to `boolean` from `number`.
- **solid-query and svelte-query** 
  - Change the return type of `useIsFetching.ts` and `useIsMutating.ts` to `boolean` from `number`.
- **vue-query** 
  - Change the return type of `isFetching` and `isMutating` from number to boolean within the `queryClient.ts` file.
  - Change the return type of `useIsFetching.ts` to `boolean` from `number`.

### Test

- ‼️ There may be a need for tests related to the number of queries, so if you guys agree with my opinion, I'll modify the test code accordingly and commit it together.
