### PR TITLE
docs: update usage examples for nuxt 3

### DIFF
--- a/docs/vue/guides/ssr.md
+++ b/docs/vue/guides/ssr.md
@@ -35,9 +35,7 @@ export default defineNuxtPlugin((nuxt) => {
   }
 
   if (process.client) {
-    nuxt.hooks.hook('app:created', () => {
-      hydrate(queryClient, vueQueryState.value)
-    })
+    hydrate(queryClient, vueQueryState.value)
   }
 })
 ```


### PR DESCRIPTION
Currently, the document suggests setting up vue-query in a Nuxt plugin as follows:

https://github.com/TanStack/query/blob/b484fe5adb8833507e5e3112a7750cee0145fba2/docs/vue/guides/ssr.md#L37-L41

However, after `v5`, we can use `useQuery` in Nuxt middleware. This means that if we still wait until `app:created` to execute `hydrate` in the Nuxt plugin, even though `useQuery` in the Nuxt middleware has already been executed on the server side, it will run again on the client side.

So I adjusted the example to look like this:

```ts
if (process.client) {
  hydrate(queryClient, vueQueryState.value)
}
```

After changing to this, if `useQuery` in middleware has already been executed on the server side, it will not be executed again on the client side.