### PR TITLE
docs: add documentation for gcTime error for react-query

### DIFF
--- a/docs/react/guides/important-defaults.md
+++ b/docs/react/guides/important-defaults.md
@@ -20,7 +20,7 @@ Out of the box, TanStack Query is configured with **aggressive but sane** defaul
 - Query results that have no more active instances of `useQuery`, `useInfiniteQuery` or query observers are labeled as "inactive" and remain in the cache in case they are used again at a later time.
 - By default, "inactive" queries are garbage collected after **5 minutes**.
 
-  > To change this, you can alter the default `gcTime` for queries to something other than `1000 * 60 * 5` milliseconds.
+  > To change this, you can alter the default `gcTime` for queries to something other than `1000 * 60 * 5` milliseconds. Avoid setting `gcTime` to `0` as that will cause a hydration error.
 
 - Queries that fail are **silently retried 3 times, with exponential backoff delay** before capturing and displaying an error to the UI.
 

--- a/docs/react/guides/important-defaults.md
+++ b/docs/react/guides/important-defaults.md
@@ -20,7 +20,7 @@ Out of the box, TanStack Query is configured with **aggressive but sane** defaul
 - Query results that have no more active instances of `useQuery`, `useInfiniteQuery` or query observers are labeled as "inactive" and remain in the cache in case they are used again at a later time.
 - By default, "inactive" queries are garbage collected after **5 minutes**.
 
-  > To change this, you can alter the default `gcTime` for queries to something other than `1000 * 60 * 5` milliseconds. Avoid setting `gcTime` to `0` as that can cause a hydration error.
+  > To change this, you can alter the default `gcTime` for queries to something other than `1000 * 60 * 5` milliseconds.
 
 - Queries that fail are **silently retried 3 times, with exponential backoff delay** before capturing and displaying an error to the UI.
 

--- a/docs/react/guides/important-defaults.md
+++ b/docs/react/guides/important-defaults.md
@@ -20,7 +20,7 @@ Out of the box, TanStack Query is configured with **aggressive but sane** defaul
 - Query results that have no more active instances of `useQuery`, `useInfiniteQuery` or query observers are labeled as "inactive" and remain in the cache in case they are used again at a later time.
 - By default, "inactive" queries are garbage collected after **5 minutes**.
 
-  > To change this, you can alter the default `gcTime` for queries to something other than `1000 * 60 * 5` milliseconds. Avoid setting `gcTime` to `0` as that will cause a hydration error.
+  > To change this, you can alter the default `gcTime` for queries to something other than `1000 * 60 * 5` milliseconds. Avoid setting `gcTime` to `0` as that can cause a hydration error.
 
 - Queries that fail are **silently retried 3 times, with exponential backoff delay** before capturing and displaying an error to the UI.
 

--- a/docs/react/guides/ssr.md
+++ b/docs/react/guides/ssr.md
@@ -541,9 +541,11 @@ In case you are creating the `QueryClient` for every request, React Query create
 
 On the server, `gcTime` defaults to `Infinity` which disables manual garbage collection and will automatically clear memory once a request has finished. If you are explicitly setting a non-Infinity `gcTime` then you will be responsible for clearing the cache early.
 
+Avoid setting `gcTime` to `0` as it may result in a hydration error. This occurs because the [Hydration Boundary](../reference/hydration#hydrationboundary) places necessary data into the cache for rendering, but if the garbage collector removes the data before the rendering completes, issues may arise. If you require a shorter `gcTime`, we recommend setting it to `2 * 1000` to allow sufficient time for the app to reference the data. 
+
 To clear the cache after it is not needed and to lower memory consumption, you can add a call to [`queryClient.clear()`](../reference/QueryClient#queryclientclear) after the request is handled and dehydrated state has been sent to the client.
 
-Alternatively, you can set a smaller `gcTime`. Avoid setting `gcTime` to `0`, as doing so may lead to a hydration error.
+Alternatively, you can set a smaller `gcTime`.
 
 ### Caveat for Next.js rewrites
 

--- a/docs/react/guides/ssr.md
+++ b/docs/react/guides/ssr.md
@@ -543,7 +543,7 @@ On the server, `gcTime` defaults to `Infinity` which disables manual garbage col
 
 To clear the cache after it is not needed and to lower memory consumption, you can add a call to [`queryClient.clear()`](../reference/QueryClient#queryclientclear) after the request is handled and dehydrated state has been sent to the client.
 
-Alternatively, you can set a smaller `gcTime`.
+Alternatively, you can set a smaller `gcTime`. Avoid setting `gcTime` to `0`, as doing so may lead to a hydration error.
 
 ### Caveat for Next.js rewrites
 


### PR DESCRIPTION
Currently, the documentation doesn't warn developers about an error caused when `gcTime` is `0`: 
https://github.com/TanStack/query/blob/60cbd75e4010a47ceba63ef8b7b6a69f384a9817/docs/react/guides/important-defaults.md?plain=1#L23

This change updates the docs to include this sentence: **Avoid setting `gcTime` to `0` as that can cause a hydration error.**

Issue reference: #6427