### PR TITLE
remove non-existing menu-item which redirects to react guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -945,10 +945,6 @@
               "to": "angular/guides/filters"
             },
             {
-              "label": "Prefetching & Router Integration",
-              "to": "angular/guides/prefetching"
-            },
-            {
               "label": "Caching",
               "to": "angular/guides/caching"
             },


### PR DESCRIPTION
The menu item is not existing and redirects to a react guide, see attached video


https://github.com/TanStack/query/assets/29756792/89b5ea7f-7dff-439e-9f9f-289352de49dd

