### PR TITLE
fix(query-devtools): remove automatic inclusion of font cdn link

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -57,7 +57,6 @@ import {
   useQueryDevtoolsContext,
   useTheme,
 } from './Context'
-import { loadFonts } from './fonts'
 import type {
   DevToolsErrorType,
   DevtoolsButtonPosition,
@@ -138,8 +137,6 @@ const DevtoolsComponent: DevtoolsComponentType = (props) => {
 export default DevtoolsComponent
 
 const Devtools: Component<DevtoolsPanelProps> = (props) => {
-  loadFonts()
-
   const theme = useTheme()
   const styles = createMemo(() => {
     return theme() === 'dark' ? darkStyles : lightStyles

--- a/packages/query-devtools/src/fonts.ts
+++ b/packages/query-devtools/src/fonts.ts
@@ -1,7 +1,0 @@
-export const loadFonts = () => {
-  const link = document.createElement('link')
-  link.href =
-    'https://fonts.googleapis.com/css2?family=Fira+Code&family=Inter:wght@100;200;300;400;500;600;700;800;900&family=Roboto&display=swap'
-  link.rel = 'stylesheet'
-  document.head.appendChild(link)
-}


### PR DESCRIPTION
Related Discussion: https://github.com/TanStack/query/discussions/6535

# Description

The v5 Query DevTools automatically appends a link to download fonts from a CDN. This is not compatible with offline/air-gapped uses. This _may_ also be problematic in some countries due to law around use of Google Fonts.

This pull request removes the code that auto-inserts the link.

# Testing

Start the DevTools (see CONTRIBUTING.md) and confirm that fonts use specific CSS or fall-back to those specified by the application HTML body CSS or browser defaults.
