### PR TITLE
feat(query-devtools): Add btn position relative support

### DIFF
--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -56,9 +56,10 @@ function App() {
 
 - `initialIsOpen: Boolean`
   - Set this `true` if you want the dev tools to default to being open
-- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
+- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`
   - The position of the React Query logo to open and close the devtools panel
+  - If `relative`, the button is placed in the location that you render the devtools.
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`
   - The position of the React Query devtools panel

--- a/packages/query-devtools/src/Context.ts
+++ b/packages/query-devtools/src/Context.ts
@@ -5,7 +5,7 @@ import type { Query, QueryClient, onlineManager } from '@tanstack/query-core'
 type XPosition = 'left' | 'right'
 type YPosition = 'top' | 'bottom'
 export type DevtoolsPosition = XPosition | YPosition
-export type DevtoolsButtonPosition = `${YPosition}-${XPosition}`
+export type DevtoolsButtonPosition = `${YPosition}-${XPosition}` | 'relative'
 
 export interface DevToolsErrorType {
   /**

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -219,15 +219,19 @@ const Devtools: Component<DevtoolsPanelProps> = (props) => {
             transition:
               opacity 0.3s,
               transform 0.3s;
+            opacity: 1;
           }
 
           & .tsqd-button-transition-exit-to,
           & .tsqd-button-transition-enter {
-            transform: ${buttonPosition() === 'top-left'
-              ? `translateX(-72px);`
-              : buttonPosition() === 'top-right'
-                ? `translateX(72px);`
-                : `translateY(72px);`};
+            transform: ${buttonPosition() === 'relative'
+              ? `none;`
+              : buttonPosition() === 'top-left'
+                ? `translateX(-72px);`
+                : buttonPosition() === 'top-right'
+                  ? `translateX(72px);`
+                  : `translateY(72px);`};
+            opacity: 0;
           }
         `,
         'tsqd-transitions-container',
@@ -2268,6 +2272,9 @@ const stylesFactory = (theme: 'light' | 'dark') => {
     'devtoolsBtn-position-top-right': css`
       top: 12px;
       right: 12px;
+    `,
+    'devtoolsBtn-position-relative': css`
+      position: relative;
     `,
     'panel-position-top': css`
       top: 0;


### PR DESCRIPTION
In addition to adding support for relative positioning of the button, I've added in opacity changes for all in/out animations.

This change makes it possible to control the location of the button, in case you have other floating panels, etc., in your app.

The gif below shows a change to the playground example (not committed), that illustrates what is now possible.

![CleanShot 2023-12-22 at 22 29 51](https://github.com/TanStack/query/assets/3663628/e49da532-6b5b-477f-a670-43ef67b46f8e)

My motivation was purely because I have an application with a bunch of devtools in a drawer that I move around the screen as necessary while I develop. The previous version of RQ's devtools allowed me to pass a style directly to the button to control its position so that I could contain it within the drawer. This newer version does not. But allowing the button to just be positioned relatively works just fine for that purpose.

You can **see below (in the lower right of each image)** the best I could do to get v5 to play ball, compared to v4. (And _forget_ moving the panel around!)

|v4 devtools|v5 devtools (without this PR)|
|-|-|
|![CleanShot 2023-12-22 at 23 06 00@2x](https://github.com/TanStack/query/assets/3663628/71793842-681b-46d2-8d28-8da5087d1d39)|![CleanShot 2023-12-22 at 23 03 43@2x](https://github.com/TanStack/query/assets/3663628/4c6ce654-a5eb-4676-95fc-73b9c94a375e)|
