### PR TITLE
chore: Enable `prefer-workspace-packages`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+prefer-workspace-packages=true


### PR DESCRIPTION
I was running into a problem where running `pnpm install` would download the NPM version of packages, overriding linked monorepo packages. It turns out this was because my fork was not synced and a new version had been released. By enabling [prefer-workspace-packages](https://pnpm.io/npmrc#prefer-workspace-packages), it always uses the locally linked packages, which is the expected behaviour during development.