### PR TITLE
chore(solid-query): Replace `screen` with `rendered` in tests

### DIFF
--- a/examples/solid/basic-graphql-request/package.json
+++ b/examples/solid/basic-graphql-request/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-query-devtools": "^5.0.0",
     "graphql": "^16.8.1",
     "graphql-request": "^6.1.0",
-    "solid-js": "^1.8.1"
+    "solid-js": "^1.8.7"
   },
   "devDependencies": {
     "typescript": "5.2.2",

--- a/examples/solid/basic-typescript/package.json
+++ b/examples/solid/basic-typescript/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@tanstack/solid-query": "^5.0.0",
     "@tanstack/solid-query-devtools": "^5.0.0",
-    "solid-js": "^1.8.1"
+    "solid-js": "^1.8.7"
   },
   "devDependencies": {
     "typescript": "5.2.2",

--- a/examples/solid/default-query-function/package.json
+++ b/examples/solid/default-query-function/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@tanstack/solid-query": "^5.0.0",
     "@tanstack/solid-query-devtools": "^5.0.0",
-    "solid-js": "^1.8.1"
+    "solid-js": "^1.8.7"
   },
   "devDependencies": {
     "typescript": "5.2.2",

--- a/examples/solid/simple/package.json
+++ b/examples/solid/simple/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@tanstack/solid-query": "^5.0.0",
     "@tanstack/solid-query-devtools": "^5.0.0",
-    "solid-js": "^1.8.1"
+    "solid-js": "^1.8.7"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.0.0",

--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -12,7 +12,7 @@
     "@solidjs/router": "^0.8.3",
     "@tanstack/solid-query": "^5.0.0",
     "@tanstack/solid-query-devtools": "^5.0.0",
-    "solid-js": "^1.8.1",
+    "solid-js": "^1.8.7",
     "solid-start": "^0.3.7",
     "undici": "^5.28.2"
   },

--- a/integrations/solid-vite/package.json
+++ b/integrations/solid-vite/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@tanstack/solid-query": "workspace:*",
     "@tanstack/solid-query-devtools": "workspace:*",
-    "solid-js": "^1.8.1",
+    "solid-js": "^1.8.7",
     "vite": "^4.5.1",
     "vite-plugin-solid": "^2.7.2"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "namespace": "@tanstack",
   "devDependencies": {
     "@commitlint/parse": "^18.4.3",
-    "@solidjs/testing-library": "^0.7.1",
+    "@solidjs/testing-library": "^0.8.5",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@types/current-git-branch": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "rimraf": "^5.0.5",
     "semver": "^7.5.4",
     "sherif": "^0.7.0",
-    "solid-js": "^1.8.1",
+    "solid-js": "^1.8.7",
     "stream-to-array": "^2.3.0",
     "tsup": "^8.0.1",
     "type-fest": "^4.8.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "namespace": "@tanstack",
   "devDependencies": {
     "@commitlint/parse": "^18.4.3",
-    "@solidjs/testing-library": "^0.5.1",
+    "@solidjs/testing-library": "^0.7.1",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@types/current-git-branch": "^1.1.6",

--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -56,7 +56,7 @@
     "@tanstack/query-core": "workspace:*",
     "clsx": "^2.0.0",
     "goober": "^2.1.13",
-    "solid-js": "^1.8.1",
+    "solid-js": "^1.8.7",
     "solid-transition-group": "^0.2.3",
     "superjson": "^1.13.3",
     "tsup-preset-solid": "^2.2.0",

--- a/packages/solid-query-devtools/package.json
+++ b/packages/solid-query-devtools/package.json
@@ -49,11 +49,11 @@
     "@tanstack/query-devtools": "workspace:*"
   },
   "peerDependencies": {
-    "solid-js": "^1.8.1",
+    "solid-js": "^1.8.7",
     "@tanstack/solid-query": "workspace:^"
   },
   "devDependencies": {
-    "solid-js": "^1.8.1",
+    "solid-js": "^1.8.7",
     "@tanstack/solid-query": "workspace:^",
     "tsup-preset-solid": "^2.2.0",
     "vite-plugin-solid": "^2.7.2"

--- a/packages/solid-query-persist-client/package.json
+++ b/packages/solid-query-persist-client/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "tsup-preset-solid": "^2.2.0",
     "vite-plugin-solid": "^2.7.2",
-    "solid-js": "^1.8.1"
+    "solid-js": "^1.8.7"
   },
   "peerDependencies": {
     "@tanstack/solid-query": "workspace:*",

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@tanstack/query-core": "workspace:*",
-    "solid-js": "^1.8.1"
+    "solid-js": "^1.8.7"
   },
   "devDependencies": {
     "tsup-preset-solid": "^2.2.0",

--- a/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@solidjs/testing-library'
+import { render, waitFor } from '@solidjs/testing-library'
 import { QueryCache } from '@tanstack/query-core'
 import { QueryClientProvider, createQuery, useQueryClient } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
@@ -27,14 +27,14 @@ describe('QueryClientProvider', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
     await waitFor(() => {
-      return screen.getByText('test')
+      return rendered.getByText('test')
     })
 
     expect(queryCache.find({ queryKey: key })).toBeDefined()
@@ -81,7 +81,7 @@ describe('QueryClientProvider', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <>
         <QueryClientProvider client={queryClient1}>
           <Page1 />
@@ -92,8 +92,8 @@ describe('QueryClientProvider', () => {
       </>
     ))
 
-    await waitFor(() => screen.getByText('test1'))
-    await waitFor(() => screen.getByText('test2'))
+    await waitFor(() => rendered.getByText('test1'))
+    await waitFor(() => rendered.getByText('test2'))
 
     expect(queryCache1.find({ queryKey: key1 })).toBeDefined()
     expect(queryCache1.find({ queryKey: key2 })).not.toBeDefined()
@@ -130,13 +130,13 @@ describe('QueryClientProvider', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('test'))
+    await waitFor(() => rendered.getByText('test'))
 
     expect(queryCache.find({ queryKey: key })).toBeDefined()
     expect(queryCache.find({ queryKey: key })?.options.gcTime).toBe(Infinity)

--- a/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createInfiniteQuery.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 
 import {
   For,
@@ -242,20 +242,20 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 0-desc'))
-    fireEvent.click(screen.getByRole('button', { name: /fetchNextPage/i }))
+    await waitFor(() => rendered.getByText('data: 0-desc'))
+    fireEvent.click(rendered.getByRole('button', { name: /fetchNextPage/i }))
 
-    await waitFor(() => screen.getByText('data: 0-desc,1-desc'))
-    fireEvent.click(screen.getByRole('button', { name: /order/i }))
+    await waitFor(() => rendered.getByText('data: 0-desc,1-desc'))
+    fireEvent.click(rendered.getByRole('button', { name: /order/i }))
 
-    await waitFor(() => screen.getByText('data: 0-asc'))
-    await waitFor(() => screen.getByText('isFetching: false'))
+    await waitFor(() => rendered.getByText('data: 0-asc'))
+    await waitFor(() => rendered.getByText('isFetching: false'))
     await waitFor(() => expect(states.length).toBe(6))
 
     expect(states[0]).toMatchObject({
@@ -436,16 +436,16 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 0'))
-    fireEvent.click(screen.getByRole('button', { name: /fetchNextPage/i }))
+    await waitFor(() => rendered.getByText('data: 0'))
+    fireEvent.click(rendered.getByRole('button', { name: /fetchNextPage/i }))
 
-    await waitFor(() => screen.getByText('data: 1,0'))
+    await waitFor(() => rendered.getByText('data: 1,0'))
 
     await waitFor(() => expect(states.length).toBe(4))
     expect(states[0]).toMatchObject({
@@ -598,21 +598,23 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 10'))
-    fireEvent.click(screen.getByRole('button', { name: /fetchNextPage/i }))
+    await waitFor(() => rendered.getByText('data: 10'))
+    fireEvent.click(rendered.getByRole('button', { name: /fetchNextPage/i }))
 
-    await waitFor(() => screen.getByText('data: 10,11'))
-    fireEvent.click(screen.getByRole('button', { name: /fetchPreviousPage/i }))
-    await waitFor(() => screen.getByText('data: 9,10,11'))
-    fireEvent.click(screen.getByRole('button', { name: /refetch/i }))
+    await waitFor(() => rendered.getByText('data: 10,11'))
+    fireEvent.click(
+      rendered.getByRole('button', { name: /fetchPreviousPage/i }),
+    )
+    await waitFor(() => rendered.getByText('data: 9,10,11'))
+    fireEvent.click(rendered.getByRole('button', { name: /refetch/i }))
 
-    await waitFor(() => screen.getByText('isFetching: false'))
+    await waitFor(() => rendered.getByText('isFetching: false'))
     await waitFor(() => expect(states.length).toBe(8))
 
     // Initial fetch
@@ -1476,55 +1478,55 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    screen.getByText('Loading...')
+    rendered.getByText('Loading...')
 
-    await waitFor(() => screen.getByText('Item: 2'))
-    await waitFor(() => screen.getByText('Page 0: 0'))
+    await waitFor(() => rendered.getByText('Item: 2'))
+    await waitFor(() => rendered.getByText('Page 0: 0'))
 
-    fireEvent.click(screen.getByText('Load More'))
+    fireEvent.click(rendered.getByText('Load More'))
 
-    await waitFor(() => screen.getByText('Loading more...'))
-    await waitFor(() => screen.getByText('Item: 5'))
-    await waitFor(() => screen.getByText('Page 0: 0'))
-    await waitFor(() => screen.getByText('Page 1: 1'))
+    await waitFor(() => rendered.getByText('Loading more...'))
+    await waitFor(() => rendered.getByText('Item: 5'))
+    await waitFor(() => rendered.getByText('Page 0: 0'))
+    await waitFor(() => rendered.getByText('Page 1: 1'))
 
-    fireEvent.click(screen.getByText('Load More'))
+    fireEvent.click(rendered.getByText('Load More'))
 
-    await waitFor(() => screen.getByText('Loading more...'))
-    await waitFor(() => screen.getByText('Item: 8'))
-    await waitFor(() => screen.getByText('Page 0: 0'))
-    await waitFor(() => screen.getByText('Page 1: 1'))
-    await waitFor(() => screen.getByText('Page 2: 2'))
+    await waitFor(() => rendered.getByText('Loading more...'))
+    await waitFor(() => rendered.getByText('Item: 8'))
+    await waitFor(() => rendered.getByText('Page 0: 0'))
+    await waitFor(() => rendered.getByText('Page 1: 1'))
+    await waitFor(() => rendered.getByText('Page 2: 2'))
 
-    fireEvent.click(screen.getByText('Refetch'))
+    fireEvent.click(rendered.getByText('Refetch'))
 
-    await waitFor(() => screen.getByText('Background Updating...'))
-    await waitFor(() => screen.getByText('Item: 8'))
-    await waitFor(() => screen.getByText('Page 0: 3'))
-    await waitFor(() => screen.getByText('Page 1: 4'))
-    await waitFor(() => screen.getByText('Page 2: 5'))
+    await waitFor(() => rendered.getByText('Background Updating...'))
+    await waitFor(() => rendered.getByText('Item: 8'))
+    await waitFor(() => rendered.getByText('Page 0: 3'))
+    await waitFor(() => rendered.getByText('Page 1: 4'))
+    await waitFor(() => rendered.getByText('Page 2: 5'))
 
     // ensure that Item: 4 is rendered before removing it
-    expect(screen.queryAllByText('Item: 4')).toHaveLength(1)
+    expect(rendered.queryAllByText('Item: 4')).toHaveLength(1)
 
     // remove Item: 4
-    fireEvent.click(screen.getByText('Remove item'))
+    fireEvent.click(rendered.getByText('Remove item'))
 
-    await waitFor(() => screen.getByText('Background Updating...'))
+    await waitFor(() => rendered.getByText('Background Updating...'))
     // ensure that an additional item is rendered (it means that cursors were properly rebuilt)
-    await waitFor(() => screen.getByText('Item: 9'))
-    await waitFor(() => screen.getByText('Page 0: 6'))
-    await waitFor(() => screen.getByText('Page 1: 7'))
-    await waitFor(() => screen.getByText('Page 2: 8'))
+    await waitFor(() => rendered.getByText('Item: 9'))
+    await waitFor(() => rendered.getByText('Page 0: 6'))
+    await waitFor(() => rendered.getByText('Page 1: 7'))
+    await waitFor(() => rendered.getByText('Page 2: 8'))
 
     // ensure that Item: 4 is no longer rendered
-    expect(screen.queryAllByText('Item: 4')).toHaveLength(0)
+    expect(rendered.queryAllByText('Item: 4')).toHaveLength(0)
   })
 
   it('should compute hasNextPage correctly for falsy getFetchMore return value on refetching', async () => {
@@ -1603,59 +1605,59 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    screen.getByText('Loading...')
+    rendered.getByText('Loading...')
 
     await waitFor(() => {
-      screen.getByText('Item: 9')
-      screen.getByText('Page 0: 0')
+      rendered.getByText('Item: 9')
+      rendered.getByText('Page 0: 0')
     })
 
-    fireEvent.click(screen.getByText('Load More'))
+    fireEvent.click(rendered.getByText('Load More'))
 
-    await waitFor(() => screen.getByText('Loading more...'))
+    await waitFor(() => rendered.getByText('Loading more...'))
 
     await waitFor(() => {
-      screen.getByText('Item: 19')
-      screen.getByText('Page 0: 0')
-      screen.getByText('Page 1: 1')
+      rendered.getByText('Item: 19')
+      rendered.getByText('Page 0: 0')
+      rendered.getByText('Page 1: 1')
     })
 
-    fireEvent.click(screen.getByText('Load More'))
+    fireEvent.click(rendered.getByText('Load More'))
 
-    await waitFor(() => screen.getByText('Loading more...'))
+    await waitFor(() => rendered.getByText('Loading more...'))
 
     await waitFor(() => {
-      screen.getByText('Item: 29')
-      screen.getByText('Page 0: 0')
-      screen.getByText('Page 1: 1')
-      screen.getByText('Page 2: 2')
+      rendered.getByText('Item: 29')
+      rendered.getByText('Page 0: 0')
+      rendered.getByText('Page 1: 1')
+      rendered.getByText('Page 2: 2')
     })
 
-    screen.getByText('Nothing more to load')
+    rendered.getByText('Nothing more to load')
 
-    fireEvent.click(screen.getByText('Remove Last Page'))
+    fireEvent.click(rendered.getByText('Remove Last Page'))
 
     await sleep(10)
 
-    fireEvent.click(screen.getByText('Refetch'))
+    fireEvent.click(rendered.getByText('Refetch'))
 
-    await waitFor(() => screen.getByText('Background Updating...'))
+    await waitFor(() => rendered.getByText('Background Updating...'))
 
     await waitFor(() => {
-      screen.getByText('Page 0: 3')
-      screen.getByText('Page 1: 4')
+      rendered.getByText('Page 0: 3')
+      rendered.getByText('Page 1: 4')
     })
 
-    expect(screen.queryByText('Item: 29')).toBeNull()
-    expect(screen.queryByText('Page 2: 5')).toBeNull()
+    expect(rendered.queryByText('Item: 29')).toBeNull()
+    expect(rendered.queryByText('Page 2: 5')).toBeNull()
 
-    screen.getByText('Nothing more to load')
+    rendered.getByText('Nothing more to load')
   })
 
   it('should cancel the query function when there are no more subscriptions', async () => {
@@ -1686,7 +1688,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Blink duration={5}>
           <Page />
@@ -1694,7 +1696,7 @@ describe('useInfiniteQuery', () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('off'))
+    await waitFor(() => rendered.getByText('off'))
 
     expect(cancelFn).toHaveBeenCalled()
   })
@@ -1722,8 +1724,8 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    render(() => <Page />)
+    const rendered = render(() => <Page />)
 
-    await waitFor(() => screen.getByText('Status: custom client'))
+    await waitFor(() => rendered.getByText('Status: custom client'))
   })
 })

--- a/packages/solid-query/src/__tests__/createMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/createMutation.test.tsx
@@ -5,7 +5,7 @@ import {
   createRenderEffect,
   createSignal,
 } from 'solid-js'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import {
   MutationCache,
   QueryCache,
@@ -41,24 +41,24 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    expect(screen.getByRole('heading').textContent).toBe('empty')
+    expect(rendered.getByRole('heading').textContent).toBe('empty')
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('heading').textContent).toBe('mutation')
+      expect(rendered.getByRole('heading').textContent).toBe('mutation')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /reset/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('heading').textContent).toBe('empty')
+      expect(rendered.getByRole('heading').textContent).toBe('empty')
     })
   })
 
@@ -85,28 +85,28 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
     await waitFor(() => {
-      expect(screen.queryByRole('heading')).toBeNull()
+      expect(rendered.queryByRole('heading')).toBeNull()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('heading').textContent).toBe(
+      expect(rendered.getByRole('heading').textContent).toBe(
         'Expected mock error. All is well!',
       )
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /reset/i }))
 
     await waitFor(() => {
-      expect(screen.queryByRole('heading')).toBeNull()
+      expect(rendered.queryByRole('heading')).toBeNull()
     })
 
     consoleMock.mockRestore()
@@ -143,20 +143,20 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    expect(screen.getByRole('heading').textContent).toBe('0')
+    expect(rendered.getByRole('heading').textContent).toBe('0')
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('heading').textContent).toBe('3')
+      expect(rendered.getByRole('heading').textContent).toBe('3')
     })
 
     await waitFor(() => {
@@ -214,26 +214,26 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Data'))
+    await waitFor(() => rendered.getByText('Data'))
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    await waitFor(() => screen.getByText('Data'))
-    await waitFor(() => screen.getByText('Status error'))
-    await waitFor(() => screen.getByText('Failed 1 times'))
-    await waitFor(() => screen.getByText('Failed because Error test Jonas'))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await waitFor(() => rendered.getByText('Data'))
+    await waitFor(() => rendered.getByText('Status error'))
+    await waitFor(() => rendered.getByText('Failed 1 times'))
+    await waitFor(() => rendered.getByText('Failed because Error test Jonas'))
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    await waitFor(() => screen.getByText('Status pending'))
-    await waitFor(() => screen.getByText('Status success'))
-    await waitFor(() => screen.getByText('Data 2'))
-    await waitFor(() => screen.getByText('Failed 0 times'))
-    await waitFor(() => screen.getByText('Failed because null'))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await waitFor(() => rendered.getByText('Status pending'))
+    await waitFor(() => rendered.getByText('Status success'))
+    await waitFor(() => rendered.getByText('Data 2'))
+    await waitFor(() => rendered.getByText('Failed 0 times'))
+    await waitFor(() => rendered.getByText('Failed because null'))
   })
 
   it('should be able to call `onError` and `onSettled` after each failed mutate', async () => {
@@ -273,20 +273,20 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    expect(screen.getByRole('heading').textContent).toBe('0')
+    expect(rendered.getByRole('heading').textContent).toBe('0')
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('heading').textContent).toBe('3')
+      expect(rendered.getByRole('heading').textContent).toBe('3')
     })
 
     await waitFor(() => {
@@ -528,7 +528,7 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
@@ -536,17 +536,17 @@ describe('createMutation', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('error: null, status: idle, isPaused: false'),
+        rendered.getByText('error: null, status: idle, isPaused: false'),
       ).toBeInTheDocument()
     })
 
     window.dispatchEvent(new Event('offline'))
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
     await waitFor(() => {
       expect(
-        screen.getByText('error: null, status: pending, isPaused: true'),
+        rendered.getByText('error: null, status: pending, isPaused: true'),
       ).toBeInTheDocument()
     })
 
@@ -559,7 +559,7 @@ describe('createMutation', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('error: oops, status: error, isPaused: false'),
+        rendered.getByText('error: oops, status: error, isPaused: false'),
       ).toBeInTheDocument()
     })
 
@@ -592,19 +592,19 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('data: null, status: idle, isPaused: false')
+    await rendered.findByText('data: null, status: idle, isPaused: false')
 
     window.dispatchEvent(new Event('offline'))
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
-    await screen.findByText('data: null, status: pending, isPaused: true')
+    await rendered.findByText('data: null, status: pending, isPaused: true')
 
     expect(onMutate).toHaveBeenCalledTimes(1)
     expect(onMutate).toHaveBeenCalledWith('todo')
@@ -612,7 +612,7 @@ describe('createMutation', () => {
     onlineMock.mockRestore()
     window.dispatchEvent(new Event('online'))
 
-    await screen.findByText('data: 1, status: success, isPaused: false')
+    await rendered.findByText('data: 1, status: success, isPaused: false')
 
     expect(onMutate).toHaveBeenCalledTimes(1)
     expect(count).toBe(1)
@@ -647,17 +647,17 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('data: null, status: idle, isPaused: false')
+    await rendered.findByText('data: null, status: idle, isPaused: false')
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
-    await screen.findByText('data: null, status: pending, isPaused: true')
+    await rendered.findByText('data: null, status: pending, isPaused: true')
 
     // no intermediate 'pending, false' state is expected because we don't start mutating!
     expect(states[0]).toBe('idle, false')
@@ -666,7 +666,7 @@ describe('createMutation', () => {
     onlineMock.mockReturnValue(true)
     window.dispatchEvent(new Event('online'))
 
-    await screen.findByText('data: 1, status: success, isPaused: false')
+    await rendered.findByText('data: 1, status: success, isPaused: false')
 
     onlineMock.mockRestore()
   })
@@ -776,13 +776,13 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    fireEvent.click(screen.getByText('mutate'))
-    fireEvent.click(screen.getByText('unmount'))
+    fireEvent.click(rendered.getByText('mutate'))
+    fireEvent.click(rendered.getByText('unmount'))
   })
 
   it('should be able to throw an error when throwOnError is set to true', async () => {
@@ -807,7 +807,7 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary
           fallback={() => (
@@ -821,10 +821,10 @@ describe('createMutation', () => {
       </QueryClientProvider>
     ))
 
-    fireEvent.click(screen.getByText('mutate'))
+    fireEvent.click(rendered.getByText('mutate'))
 
     await waitFor(() => {
-      expect(screen.queryByText('error')).not.toBeNull()
+      expect(rendered.queryByText('error')).not.toBeNull()
     })
 
     consoleMock.mockRestore()
@@ -857,7 +857,7 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary
           fallback={() => (
@@ -872,15 +872,15 @@ describe('createMutation', () => {
     ))
 
     // first error goes to component
-    fireEvent.click(screen.getByText('mutate'))
+    fireEvent.click(rendered.getByText('mutate'))
     await waitFor(() => {
-      expect(screen.queryByText('mock error')).not.toBeNull()
+      expect(rendered.queryByText('mock error')).not.toBeNull()
     })
 
     // second error goes to boundary
-    fireEvent.click(screen.getByText('mutate'))
+    fireEvent.click(rendered.getByText('mutate'))
     await waitFor(() => {
-      expect(screen.queryByText('error boundary')).not.toBeNull()
+      expect(rendered.queryByText('error boundary')).not.toBeNull()
     })
 
     consoleMock.mockRestore()
@@ -926,18 +926,18 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClientMutationMeta}>
         <Page />
       </QueryClientProvider>
     ))
 
-    fireEvent.click(screen.getByText('succeed'))
-    fireEvent.click(screen.getByText('error'))
+    fireEvent.click(rendered.getByText('succeed'))
+    fireEvent.click(rendered.getByText('error'))
 
     await waitFor(() => {
-      expect(screen.queryByText('successTest')).not.toBeNull()
-      expect(screen.queryByText('errorTest')).not.toBeNull()
+      expect(rendered.queryByText('successTest')).not.toBeNull()
+      expect(rendered.queryByText('errorTest')).not.toBeNull()
     })
 
     expect(successMock).toHaveBeenCalledTimes(1)
@@ -997,16 +997,16 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('data: null, status: idle, isPaused: false')
+    await rendered.findByText('data: null, status: idle, isPaused: false')
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    fireEvent.click(screen.getByRole('button', { name: /hide/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /hide/i }))
 
     await waitFor(() => {
       expect(
@@ -1059,18 +1059,18 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('data: null, status: idle')
+    await rendered.findByText('data: null, status: idle')
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
-    await screen.findByText('data: result2, status: success')
+    await rendered.findByText('data: result2, status: success')
 
     expect(count).toBe(2)
 
@@ -1109,17 +1109,17 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('status: idle')
+    await rendered.findByText('status: idle')
 
-    screen.getByRole('button', { name: /mutate/i }).click()
+    rendered.getByRole('button', { name: /mutate/i }).click()
 
-    await screen.findByText('status: error')
+    await rendered.findByText('status: error')
 
     expect(onError).toHaveBeenCalledWith(error, 'todo', undefined)
   })
@@ -1149,17 +1149,17 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('error: null, status: idle')
+    await rendered.findByText('error: null, status: idle')
 
-    screen.getByRole('button', { name: /mutate/i }).click()
+    rendered.getByRole('button', { name: /mutate/i }).click()
 
-    await screen.findByText('error: mutateFnError, status: error')
+    await rendered.findByText('error: mutateFnError, status: error')
   })
 
   it('should go to error state if onSettled callback errors', async () => {
@@ -1189,17 +1189,17 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('error: null, status: idle')
+    await rendered.findByText('error: null, status: idle')
 
-    screen.getByRole('button', { name: /mutate/i }).click()
+    rendered.getByRole('button', { name: /mutate/i }).click()
 
-    await screen.findByText('error: mutateFnError, status: error')
+    await rendered.findByText('error: mutateFnError, status: error')
 
     expect(onError).toHaveBeenCalledWith(mutateFnError, 'todo', undefined)
   })
@@ -1227,12 +1227,12 @@ describe('createMutation', () => {
       )
     }
 
-    render(() => <Page></Page>)
+    const rendered = render(() => <Page></Page>)
 
-    await screen.findByText('data: null, status: idle')
+    await rendered.findByText('data: null, status: idle')
 
-    fireEvent.click(screen.getByRole('button', { name: /mutate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
 
-    await screen.findByText('data: custom client, status: success')
+    await rendered.findByText('data: custom client, status: success')
   })
 })

--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import * as QueryCore from '@tanstack/query-core'
 
 import { createRenderEffect, createSignal } from 'solid-js'
@@ -61,13 +61,13 @@ describe('useQueries', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data1: 1, data2: 2'))
+    await waitFor(() => rendered.getByText('data1: 1, data2: 2'))
 
     expect(results.length).toBe(3)
     expect(results[0]).toMatchObject([{ data: undefined }, { data: undefined }])
@@ -701,12 +701,13 @@ describe('useQueries', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    fireEvent.click(screen.getByText('unmount'))
+
+    fireEvent.click(rendered.getByText('unmount'))
 
     // Should not display the console error
     // "Warning: Can't perform a React state update on an unmounted component"

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -9,7 +9,7 @@ import {
   createSignal,
   on,
 } from 'solid-js'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { reconcile } from 'solid-js/store'
 import {
   QueryCache,
@@ -212,15 +212,15 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    screen.getByText('default')
+    rendered.getByText('default')
 
-    await waitFor(() => screen.getByText('test'))
+    await waitFor(() => rendered.getByText('test'))
   })
 
   it('should return the correct states for a successful query', async () => {
@@ -263,13 +263,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('test'))
+    await waitFor(() => rendered.getByText('test'))
 
     expect(states.length).toEqual(2)
 
@@ -354,13 +354,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Status: error'))
+    await waitFor(() => rendered.getByText('Status: error'))
 
     expect(states[0]).toEqual({
       data: undefined,
@@ -669,17 +669,17 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('data: 1')
+    await rendered.findByText('data: 1')
 
-    fireEvent.click(screen.getByRole('button', { name: /toggle/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /toggle/i }))
 
-    await screen.findByText('data: 2')
+    await rendered.findByText('data: 2')
 
     expect(states.length).toBe(4)
     // First load
@@ -881,13 +881,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: test'))
+    await waitFor(() => rendered.getByText('data: test'))
 
     expect(states.length).toBe(2)
     expect(states[0]).toMatchObject({ data: undefined })
@@ -964,13 +964,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('test'))
+    await waitFor(() => rendered.getByText('test'))
 
     expect(states.length).toBe(2)
     expect(states[0]).toMatchObject({ data: undefined })
@@ -1062,16 +1062,16 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: false'))
+    await waitFor(() => rendered.getByText('data: false'))
     await sleep(20)
-    fireEvent.click(screen.getByRole('button', { name: /refetch/i }))
-    await waitFor(() => screen.getByText('data: true'))
+    fireEvent.click(rendered.getByRole('button', { name: /refetch/i }))
+    await waitFor(() => rendered.getByText('data: true'))
 
     await waitFor(() => expect(states.length).toBe(4))
 
@@ -1123,15 +1123,15 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: set'))
-    fireEvent.click(screen.getByRole('button', { name: /refetch/i }))
-    await waitFor(() => screen.getByText('data: fetched'))
+    await waitFor(() => rendered.getByText('data: set'))
+    fireEvent.click(rendered.getByRole('button', { name: /refetch/i }))
+    await waitFor(() => rendered.getByText('data: fetched'))
 
     await waitFor(() => expect(results.length).toBe(3))
 
@@ -1172,15 +1172,15 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 1'))
-    fireEvent.click(screen.getByRole('button', { name: /invalidate/i }))
-    await waitFor(() => screen.getByText('data: 2'))
+    await waitFor(() => rendered.getByText('data: 1'))
+    fireEvent.click(rendered.getByRole('button', { name: /invalidate/i }))
+    await waitFor(() => rendered.getByText('data: 2'))
 
     await waitFor(() => expect(states.length).toBe(4))
 
@@ -1462,20 +1462,20 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
     await waitFor(() =>
-      screen.getByText('data: 0, count: 0, isFetching: false'),
+      rendered.getByText('data: 0, count: 0, isFetching: false'),
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'inc' }))
+    fireEvent.click(rendered.getByRole('button', { name: 'inc' }))
 
     await waitFor(() =>
-      screen.getByText('data: 1, count: 1, isFetching: false'),
+      rendered.getByText('data: 1, count: 1, isFetching: false'),
     )
 
     await waitFor(() => expect(states.length).toBe(4))
@@ -1634,14 +1634,14 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 1'))
-    fireEvent.click(screen.getByRole('button', { name: /refetch/i }))
+    await waitFor(() => rendered.getByText('data: 1'))
+    fireEvent.click(rendered.getByRole('button', { name: /refetch/i }))
 
     await waitFor(() => expect(states.length).toBe(4))
 
@@ -1875,16 +1875,16 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    screen.getByText('First Data: init')
-    screen.getByText('Second Data: init')
-    screen.getByText('First Status: success')
-    screen.getByText('Second Status: success')
+    rendered.getByText('First Data: init')
+    rendered.getByText('Second Data: init')
+    rendered.getByText('First Status: success')
+    rendered.getByText('Second Status: success')
   })
 
   it('should not override query configuration on render', async () => {
@@ -1964,13 +1964,13 @@ describe('createQuery', () => {
       return <div>{state.data}</div>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('new'))
+    await waitFor(() => rendered.getByText('new'))
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/170
@@ -2001,7 +2001,7 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
@@ -2009,9 +2009,9 @@ describe('createQuery', () => {
 
     // use "act" to wait for state update and prevent console warning
 
-    screen.getByText('First Status: pending, idle')
-    await waitFor(() => screen.getByText('Second Status: pending, fetching'))
-    await waitFor(() => screen.getByText('Second Status: success, idle'))
+    rendered.getByText('First Status: pending, idle')
+    await waitFor(() => rendered.getByText('Second Status: pending, fetching'))
+    await waitFor(() => rendered.getByText('Second Status: success, idle'))
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/144
@@ -2030,13 +2030,13 @@ describe('createQuery', () => {
       return <div>status: {status}</div>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    screen.getByText('status: pending')
+    rendered.getByText('status: pending')
   })
 
   it('should not refetch query on focus when `enabled` is set to `false`', async () => {
@@ -2057,13 +2057,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('default'))
+    await waitFor(() => rendered.getByText('default'))
 
     window.dispatchEvent(new Event('visibilitychange'))
 
@@ -2237,13 +2237,13 @@ describe('createQuery', () => {
       return <div>data: {state.data}</div>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('data: 0')
+    await rendered.findByText('data: 0')
 
     expect(states.length).toBe(2)
     expect(states[0]).toMatchObject({ data: undefined, isFetching: true })
@@ -2251,7 +2251,7 @@ describe('createQuery', () => {
 
     window.dispatchEvent(new Event('visibilitychange'))
 
-    await screen.findByText('data: 1')
+    await rendered.findByText('data: 1')
 
     // refetch should happen
     expect(states.length).toBe(4)
@@ -2377,14 +2377,14 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('error'))
-    await waitFor(() => screen.getByText('Error test jaylen'))
+    await waitFor(() => rendered.getByText('error'))
+    await waitFor(() => rendered.getByText('Error test jaylen'))
 
     consoleMock.mockRestore()
   })
@@ -2412,7 +2412,7 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary fallback={() => <div>error boundary</div>}>
           <Page />
@@ -2420,7 +2420,7 @@ describe('createQuery', () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('error boundary'))
 
     consoleMock.mockRestore()
   })
@@ -2474,7 +2474,7 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary fallback={() => <div>error boundary</div>}>
           <Page />
@@ -2482,8 +2482,8 @@ describe('createQuery', () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('error'))
-    await waitFor(() => screen.getByText('Local Error'))
+    await waitFor(() => rendered.getByText('error'))
+    await waitFor(() => rendered.getByText('Local Error'))
   })
 
   it('should throw error instead of setting status when error should be thrown', async () => {
@@ -2505,7 +2505,7 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary
           fallback={(error) => (
@@ -2521,8 +2521,8 @@ describe('createQuery', () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('error boundary'))
-    await waitFor(() => screen.getByText('Remote Error'))
+    await waitFor(() => rendered.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('Remote Error'))
   })
 
   it('should continue retries when observers unmount and remount while waiting for a retry (#3031)', async () => {
@@ -2564,18 +2564,18 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('failureCount: 1'))
-    await waitFor(() => screen.getByText('failureReason: some error'))
-    fireEvent.click(screen.getByRole('button', { name: /hide/i }))
-    await waitFor(() => screen.getByRole('button', { name: /show/i }))
-    fireEvent.click(screen.getByRole('button', { name: /show/i }))
-    await waitFor(() => screen.getByText('error: some error'))
+    await waitFor(() => rendered.getByText('failureCount: 1'))
+    await waitFor(() => rendered.getByText('failureReason: some error'))
+    fireEvent.click(rendered.getByRole('button', { name: /hide/i }))
+    await waitFor(() => rendered.getByRole('button', { name: /show/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /show/i }))
+    await waitFor(() => rendered.getByText('error: some error'))
 
     expect(count).toBe(3)
   })
@@ -2621,19 +2621,19 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('failureCount: 1'))
-    await waitFor(() => screen.getByText('failureReason: some error'))
-    fireEvent.click(screen.getByRole('button', { name: /hide/i }))
-    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
-    await waitFor(() => screen.getByRole('button', { name: /show/i }))
-    fireEvent.click(screen.getByRole('button', { name: /show/i }))
-    await waitFor(() => screen.getByText('error: some error'))
+    await waitFor(() => rendered.getByText('failureCount: 1'))
+    await waitFor(() => rendered.getByText('failureReason: some error'))
+    fireEvent.click(rendered.getByRole('button', { name: /hide/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /cancel/i }))
+    await waitFor(() => rendered.getByRole('button', { name: /show/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /show/i }))
+    await waitFor(() => rendered.getByText('error: some error'))
 
     // initial fetch (1), which will be cancelled, followed by new mount(2) + 2 retries = 4
     expect(count).toBe(4)
@@ -2667,13 +2667,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: data'))
+    await waitFor(() => rendered.getByText('data: data'))
     await waitFor(() => expect(states.length).toBe(3))
 
     expect(states[0]).toMatchObject({
@@ -2921,18 +2921,18 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('pending'))
-    await waitFor(() => screen.getByText('error'))
+    await waitFor(() => rendered.getByText('pending'))
+    await waitFor(() => rendered.getByText('error'))
 
     // query should fail `retry + 1` times, since first time isn't a "retry"
-    await waitFor(() => screen.getByText('Failed 2 times'))
-    await waitFor(() => screen.getByText('Failed because Error test Barrett'))
+    await waitFor(() => rendered.getByText('Failed 2 times'))
+    await waitFor(() => rendered.getByText('Failed because Error test Barrett'))
 
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
@@ -2968,17 +2968,17 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('pending'))
-    await waitFor(() => screen.getByText('error'))
-    await waitFor(() => screen.getByText('Failed 2 times'))
-    await waitFor(() => screen.getByText('Failed because NoRetry'))
-    await waitFor(() => screen.getByText('NoRetry'))
+    await waitFor(() => rendered.getByText('pending'))
+    await waitFor(() => rendered.getByText('error'))
+    await waitFor(() => rendered.getByText('Failed 2 times'))
+    await waitFor(() => rendered.getByText('Failed because NoRetry'))
+    await waitFor(() => rendered.getByText('NoRetry'))
 
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
@@ -3010,7 +3010,7 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
@@ -3020,8 +3020,8 @@ describe('createQuery', () => {
 
     expect(queryFn).toHaveBeenCalledTimes(1)
 
-    await waitFor(() => screen.getByText('Failed because DelayError: 50ms'))
-    await waitFor(() => screen.getByText('Failed 2 times'))
+    await waitFor(() => rendered.getByText('Failed because DelayError: 50ms'))
+    await waitFor(() => rendered.getByText('Failed 2 times'))
 
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
@@ -3056,36 +3056,36 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
     // The query should display the first error result
-    await waitFor(() => screen.getByText('failureCount 1'))
-    await waitFor(() => screen.getByText('failureReason fetching error 1'))
-    await waitFor(() => screen.getByText('status pending'))
-    await waitFor(() => screen.getByText('error null'))
+    await waitFor(() => rendered.getByText('failureCount 1'))
+    await waitFor(() => rendered.getByText('failureReason fetching error 1'))
+    await waitFor(() => rendered.getByText('status pending'))
+    await waitFor(() => rendered.getByText('error null'))
 
     // Check if the query really paused
     await sleep(10)
-    await waitFor(() => screen.getByText('failureCount 1'))
-    await waitFor(() => screen.getByText('failureReason fetching error 1'))
+    await waitFor(() => rendered.getByText('failureCount 1'))
+    await waitFor(() => rendered.getByText('failureReason fetching error 1'))
 
     visibilityMock.mockRestore()
     window.dispatchEvent(new Event('visibilitychange'))
 
     // Wait for the final result
-    await waitFor(() => screen.getByText('failureCount 4'))
-    await waitFor(() => screen.getByText('failureReason fetching error 4'))
-    await waitFor(() => screen.getByText('status error'))
-    await waitFor(() => screen.getByText('error fetching error 4'))
+    await waitFor(() => rendered.getByText('failureCount 4'))
+    await waitFor(() => rendered.getByText('failureReason fetching error 4'))
+    await waitFor(() => rendered.getByText('status error'))
+    await waitFor(() => rendered.getByText('error fetching error 4'))
 
     // Check if the query really stopped
     await sleep(10)
-    await waitFor(() => screen.getByText('failureCount 4'))
-    await waitFor(() => screen.getByText('failureReason fetching error 4'))
+    await waitFor(() => rendered.getByText('failureCount 4'))
+    await waitFor(() => rendered.getByText('failureReason fetching error 4'))
   })
 
   it('should fetch on mount when a query was already created with setQueryData', async () => {
@@ -3298,16 +3298,16 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('failureCount 2'))
-    await waitFor(() => screen.getByText('failureReason error'))
-    await waitFor(() => screen.getByText('failureCount 0'))
-    await waitFor(() => screen.getByText('failureReason null'))
+    await waitFor(() => rendered.getByText('failureCount 2'))
+    await waitFor(() => rendered.getByText('failureReason error'))
+    await waitFor(() => rendered.getByText('failureCount 0'))
+    await waitFor(() => rendered.getByText('failureReason null'))
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/199
@@ -3349,16 +3349,16 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('isPrefetched'))
+    await waitFor(() => rendered.getByText('isPrefetched'))
 
-    fireEvent.click(screen.getByText('setKey'))
-    await waitFor(() => screen.getByText('data: prefetched data'))
-    await waitFor(() => screen.getByText('data: 1'))
+    fireEvent.click(rendered.getByText('setKey'))
+    await waitFor(() => rendered.getByText('data: prefetched data'))
+    await waitFor(() => rendered.getByText('data: 1'))
     expect(count).toBe(1)
   })
 
@@ -3385,21 +3385,21 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    screen.getByText('FetchStatus: idle')
-    screen.getByText('Data: no data')
+    rendered.getByText('FetchStatus: idle')
+    rendered.getByText('Data: no data')
 
-    fireEvent.click(screen.getByText('fetch'))
+    fireEvent.click(rendered.getByText('fetch'))
 
-    await waitFor(() => screen.getByText('FetchStatus: fetching'))
+    await waitFor(() => rendered.getByText('FetchStatus: fetching'))
     await waitFor(() => [
-      screen.getByText('FetchStatus: idle'),
-      screen.getByText('Data: data'),
+      rendered.getByText('FetchStatus: idle'),
+      rendered.getByText('Data: data'),
     ])
   })
 
@@ -3424,14 +3424,14 @@ describe('createQuery', () => {
       return <div>data: {result.data}</div>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: initialData'))
-    await waitFor(() => screen.getByText('data: serverData'))
+    await waitFor(() => rendered.getByText('data: initialData'))
+    await waitFor(() => rendered.getByText('data: serverData'))
 
     expect(results.length).toBe(2)
     expect(results[0]).toMatchObject({ data: 'initialData', isFetching: true })
@@ -3525,7 +3525,7 @@ describe('createQuery', () => {
       return <div>fetchStatus: {fetchStatus}</div>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
@@ -3533,7 +3533,7 @@ describe('createQuery', () => {
 
     expect(queryFn).not.toHaveBeenCalled()
     expect(queryCache.find({ queryKey: key })).not.toBeUndefined()
-    screen.getByText('fetchStatus: idle')
+    rendered.getByText('fetchStatus: idle')
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/360
@@ -3556,13 +3556,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('status: pending, idle'))
+    await waitFor(() => rendered.getByText('status: pending, idle'))
   })
 
   it('should not schedule garbage collection, if gcTimeout is set to `Infinity`', async () => {
@@ -3577,16 +3577,16 @@ describe('createQuery', () => {
       return <div>{query.data}</div>
     }
 
-    const result = render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('fetched data'))
+    await waitFor(() => rendered.getByText('fetched data'))
     const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
 
-    result.unmount()
+    rendered.unmount()
 
     expect(setTimeoutSpy).not.toHaveBeenCalled()
   })
@@ -3603,16 +3603,16 @@ describe('createQuery', () => {
       return <div>{query.data}</div>
     }
 
-    const result = render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('fetched data'))
+    await waitFor(() => rendered.getByText('fetched data'))
     const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
 
-    result.unmount()
+    rendered.unmount()
 
     expect(setTimeoutSpy).toHaveBeenLastCalledWith(
       expect.any(Function),
@@ -3654,17 +3654,17 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('status pending'))
-    await waitFor(() => screen.getByText('status success'))
-    fireEvent.click(screen.getByText('refetch'))
-    await waitFor(() => screen.getByText('isFetching true'))
-    await waitFor(() => screen.getByText('isFetching false'))
+    await waitFor(() => rendered.getByText('status pending'))
+    await waitFor(() => rendered.getByText('status success'))
+    fireEvent.click(rendered.getByText('refetch'))
+    await waitFor(() => rendered.getByText('isFetching true'))
+    await waitFor(() => rendered.getByText('isFetching false'))
     expect(queryFn).toHaveBeenCalledTimes(2)
     expect(memoFn).toHaveBeenCalledTimes(2)
   })
@@ -3690,16 +3690,16 @@ describe('createQuery', () => {
       return <div>count: {state.data}</div>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
     // mount
-    await waitFor(() => screen.getByText('count: 0'))
-    await waitFor(() => screen.getByText('count: 1'))
-    await waitFor(() => screen.getByText('count: 2'))
+    await waitFor(() => rendered.getByText('count: 0'))
+    await waitFor(() => rendered.getByText('count: 1'))
+    await waitFor(() => rendered.getByText('count: 2'))
   })
 
   it('should refetch in an interval depending on function result', async () => {
@@ -3731,13 +3731,13 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('count: 2'))
+    await waitFor(() => rendered.getByText('count: 2'))
 
     expect(states.length).toEqual(6)
 
@@ -3793,13 +3793,13 @@ describe('createQuery', () => {
       return <div>count: {state.data}</div>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('count: 1'))
+    await waitFor(() => rendered.getByText('count: 1'))
 
     await sleep(10) //extra sleep to make sure we're not re-fetching
 
@@ -3828,13 +3828,13 @@ describe('createQuery', () => {
       return <>{JSON.stringify(result.data)}</>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText(''))
+    await waitFor(() => rendered.getByText(''))
   })
 
   it('should accept an object as query key', async () => {
@@ -3846,13 +3846,13 @@ describe('createQuery', () => {
       return <>{JSON.stringify(result.data)}</>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('[{"a":"a"}]'))
+    await waitFor(() => rendered.getByText('[{"a":"a"}]'))
   })
 
   it('should refetch if any query instance becomes enabled', async () => {
@@ -3881,14 +3881,14 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
     expect(queryFn).toHaveBeenCalledTimes(0)
-    fireEvent.click(screen.getByText('enable'))
-    await waitFor(() => screen.getByText('data'))
+    fireEvent.click(rendered.getByText('enable'))
+    await waitFor(() => rendered.getByText('data'))
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
 
@@ -3916,12 +3916,12 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('Data: data'))
+    await waitFor(() => rendered.getByText('Data: data'))
 
     expect(states).toMatchObject([
       {
@@ -3969,12 +3969,12 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('Data: data'))
+    await waitFor(() => rendered.getByText('Data: data'))
 
     expect(states).toMatchObject([
       {
@@ -4029,12 +4029,12 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('Data: 2'))
+    await waitFor(() => rendered.getByText('Data: 2'))
 
     expect(states).toMatchObject([
       {
@@ -4079,12 +4079,12 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('Data: 2'))
+    await waitFor(() => rendered.getByText('Data: 2'))
 
     expect(states).toMatchObject([
       {
@@ -4140,24 +4140,24 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('Data: selected 101')) // 99 + 2
+    await waitFor(() => rendered.getByText('Data: selected 101')) // 99 + 2
 
-    await waitFor(() => screen.getByText('Data: selected 2')) // 0 + 2
+    await waitFor(() => rendered.getByText('Data: selected 2')) // 0 + 2
 
-    fireEvent.click(screen.getByRole('button', { name: /inc/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /inc/i }))
 
-    await waitFor(() => screen.getByText('Data: selected 3')) // 0 + 3
+    await waitFor(() => rendered.getByText('Data: selected 3')) // 0 + 3
 
-    fireEvent.click(screen.getByRole('button', { name: /forceUpdate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /forceUpdate/i }))
 
-    await waitFor(() => screen.getByText('forceValue: 2'))
+    await waitFor(() => rendered.getByText('forceValue: 2'))
     // data should still be 3 after an independent re-render
-    await waitFor(() => screen.getByText('Data: selected 3'))
+    await waitFor(() => rendered.getByText('Data: selected 3'))
   })
 
   it('select should structurally share data', async () => {
@@ -4195,18 +4195,18 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('Data: [2,3]'))
+    await waitFor(() => rendered.getByText('Data: [2,3]'))
     expect(states).toHaveLength(1)
 
-    fireEvent.click(screen.getByRole('button', { name: /forceUpdate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /forceUpdate/i }))
 
-    await waitFor(() => screen.getByText('forceValue: 2'))
-    await waitFor(() => screen.getByText('Data: [2,3]'))
+    await waitFor(() => rendered.getByText('forceValue: 2'))
+    await waitFor(() => rendered.getByText('Data: [2,3]'))
 
     // effect should not be triggered again due to structural sharing
     expect(states).toHaveLength(1)
@@ -4250,18 +4250,18 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    await waitFor(() => screen.getByText('Data: [2,3]'))
+    await waitFor(() => rendered.getByText('Data: [2,3]'))
     expect(states).toHaveLength(1)
 
-    fireEvent.click(screen.getByRole('button', { name: /forceUpdate/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /forceUpdate/i }))
 
-    await waitFor(() => screen.getByText('forceValue: 2'))
-    await waitFor(() => screen.getByText('Data: [2,3]'))
+    await waitFor(() => rendered.getByText('forceValue: 2'))
+    await waitFor(() => rendered.getByText('Data: [2,3]'))
 
     // effect should not be triggered again due to structural sharing
     expect(states).toHaveLength(1)
@@ -4290,7 +4290,7 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Blink duration={5}>
           <Page />
@@ -4298,7 +4298,7 @@ describe('createQuery', () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('off'))
+    await waitFor(() => rendered.getByText('off'))
 
     expect(cancelFn).toHaveBeenCalled()
   })
@@ -4332,7 +4332,7 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Blink duration={5}>
           <Page limit={0} />
@@ -4343,7 +4343,7 @@ describe('createQuery', () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('off'))
+    await waitFor(() => rendered.getByText('off'))
     await sleep(20)
 
     await waitFor(() => expect(states).toHaveLength(4))
@@ -4454,18 +4454,18 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 1'))
-    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    await waitFor(() => rendered.getByText('data: 1'))
+    fireEvent.click(rendered.getByRole('button', { name: /reset/i }))
 
     await waitFor(() => expect(states.length).toBe(4))
 
-    await waitFor(() => screen.getByText('data: 2'))
+    await waitFor(() => rendered.getByText('data: 2'))
 
     expect(count).toBe(2)
 
@@ -4532,19 +4532,19 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: null'))
-    fireEvent.click(screen.getByRole('button', { name: /refetch/i }))
+    await waitFor(() => rendered.getByText('data: null'))
+    fireEvent.click(rendered.getByRole('button', { name: /refetch/i }))
 
-    await waitFor(() => screen.getByText('data: 1'))
-    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    await waitFor(() => rendered.getByText('data: 1'))
+    fireEvent.click(rendered.getByRole('button', { name: /reset/i }))
 
-    await waitFor(() => screen.getByText('data: null'))
+    await waitFor(() => rendered.getByText('data: null'))
     await waitFor(() => expect(states.length).toBe(4))
 
     expect(count).toBe(1)
@@ -4650,26 +4650,26 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
     // initial state check
-    screen.getByText('status: pending')
+    rendered.getByText('status: pending')
 
     // // render error state component
-    await waitFor(() => screen.getByText('error'))
+    await waitFor(() => rendered.getByText('error'))
     expect(queryFn).toBeCalledTimes(1)
 
     // change to enabled to false
-    fireEvent.click(screen.getByLabelText('retry'))
-    await waitFor(() => screen.getByText('error'))
+    fireEvent.click(rendered.getByLabelText('retry'))
+    await waitFor(() => rendered.getByText('error'))
     expect(queryFn).toBeCalledTimes(1)
 
     // // change to enabled to true
-    fireEvent.click(screen.getByLabelText('retry'))
+    fireEvent.click(rendered.getByLabelText('retry'))
     expect(queryFn).toBeCalledTimes(2)
   })
 
@@ -4717,25 +4717,25 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
     // initial state check
-    screen.getByText('status: pending')
+    rendered.getByText('status: pending')
 
     // render error state component
-    await waitFor(() => screen.getByText('error'))
+    await waitFor(() => rendered.getByText('error'))
 
     // change to unmount query
-    fireEvent.click(screen.getByLabelText('change'))
-    await waitFor(() => screen.getByText('rendered'))
+    fireEvent.click(rendered.getByLabelText('change'))
+    await waitFor(() => rendered.getByText('rendered'))
 
     // change to mount new query
-    fireEvent.click(screen.getByLabelText('change'))
-    await waitFor(() => screen.getByText('error'))
+    fireEvent.click(rendered.getByLabelText('change'))
+    await waitFor(() => rendered.getByText('error'))
   })
 
   it('should refetch when query key changed when switching between erroneous queries', async () => {
@@ -4777,27 +4777,27 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
     // initial state check
-    screen.getByText('status: fetching')
+    rendered.getByText('status: fetching')
 
     // render error state component
-    await waitFor(() => screen.getByText('error'))
+    await waitFor(() => rendered.getByText('error'))
 
     // change to mount second query
-    fireEvent.click(screen.getByLabelText('change'))
-    await waitFor(() => screen.getByText('status: fetching'))
-    await waitFor(() => screen.getByText('error'))
+    fireEvent.click(rendered.getByLabelText('change'))
+    await waitFor(() => rendered.getByText('status: fetching'))
+    await waitFor(() => rendered.getByText('error'))
 
     // change to mount first query again
-    fireEvent.click(screen.getByLabelText('change'))
-    await waitFor(() => screen.getByText('status: fetching'))
-    await waitFor(() => screen.getByText('error'))
+    fireEvent.click(rendered.getByLabelText('change'))
+    await waitFor(() => rendered.getByText('status: fetching'))
+    await waitFor(() => rendered.getByText('error'))
   })
 
   it('should have no error in pending state when refetching after error occurred', async () => {
@@ -4840,16 +4840,16 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('error'))
+    await waitFor(() => rendered.getByText('error'))
 
-    fireEvent.click(screen.getByRole('button', { name: 'refetch' }))
-    await waitFor(() => screen.getByText('data: 5'))
+    fireEvent.click(rendered.getByRole('button', { name: 'refetch' }))
+    await waitFor(() => rendered.getByText('data: 5'))
 
     await waitFor(() => expect(states.length).toBe(4))
 
@@ -4908,7 +4908,7 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
@@ -4916,14 +4916,16 @@ describe('createQuery', () => {
 
       window.dispatchEvent(new Event('offline'))
 
-      await waitFor(() => screen.getByText('status: pending, isPaused: true'))
+      await waitFor(() => rendered.getByText('status: pending, isPaused: true'))
 
       onlineMock.mockRestore()
       window.dispatchEvent(new Event('online'))
 
-      await waitFor(() => screen.getByText('status: success, isPaused: false'))
+      await waitFor(() =>
+        rendered.getByText('status: success, isPaused: false'),
+      )
       await waitFor(() => {
-        expect(screen.getByText('data: data')).toBeInTheDocument()
+        expect(rendered.getByText('data: data')).toBeInTheDocument()
       })
 
       expect(states).toEqual(['paused', 'fetching', 'idle'])
@@ -4960,41 +4962,43 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
-      await waitFor(() => screen.getByText('data: data1'))
+      await waitFor(() => rendered.getByText('data: data1'))
 
       const onlineMock = mockOnlineManagerIsOnline(false)
       window.dispatchEvent(new Event('offline'))
-      fireEvent.click(screen.getByRole('button', { name: /invalidate/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /invalidate/i }))
 
       await waitFor(() =>
-        screen.getByText(
+        rendered.getByText(
           'status: success, fetchStatus: paused, failureCount: 0',
         ),
       )
-      await waitFor(() => screen.getByText('failureReason: null'))
+      await waitFor(() => rendered.getByText('failureReason: null'))
 
       onlineMock.mockRestore()
       window.dispatchEvent(new Event('online'))
 
       await waitFor(() =>
-        screen.getByText(
+        rendered.getByText(
           'status: success, fetchStatus: fetching, failureCount: 0',
         ),
       )
-      await waitFor(() => screen.getByText('failureReason: null'))
+      await waitFor(() => rendered.getByText('failureReason: null'))
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: idle, failureCount: 0'),
+        rendered.getByText(
+          'status: success, fetchStatus: idle, failureCount: 0',
+        ),
       )
-      await waitFor(() => screen.getByText('failureReason: null'))
+      await waitFor(() => rendered.getByText('failureReason: null'))
 
       await waitFor(() => {
-        expect(screen.getByText('data: data2')).toBeInTheDocument()
+        expect(rendered.getByText('data: data2')).toBeInTheDocument()
       })
     })
 
@@ -5027,26 +5031,26 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
-      await waitFor(() => screen.getByText('data: data1'))
+      await waitFor(() => rendered.getByText('data: data1'))
 
       const onlineMock = mockOnlineManagerIsOnline(false)
-      fireEvent.click(screen.getByRole('button', { name: /invalidate/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /invalidate/i }))
 
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: paused'),
+        rendered.getByText('status: success, fetchStatus: paused'),
       )
 
       window.dispatchEvent(new Event('visibilitychange'))
       await sleep(15)
 
       await waitFor(() =>
-        expect(screen.queryByText('data: data2')).not.toBeInTheDocument(),
+        expect(rendered.queryByText('data: data2')).not.toBeInTheDocument(),
       )
       expect(count).toBe(1)
       onlineMock.mockRestore()
@@ -5083,23 +5087,23 @@ describe('createQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
       await waitFor(() =>
-        screen.getByText('status: pending, fetchStatus: paused'),
+        rendered.getByText('status: pending, fetchStatus: paused'),
       )
 
-      fireEvent.click(screen.getByRole('button', { name: /invalidate/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /invalidate/i }))
 
       await sleep(15)
 
       // invalidation should not trigger a refetch
       await waitFor(() =>
-        screen.getByText('status: pending, fetchStatus: paused'),
+        rendered.getByText('status: pending, fetchStatus: paused'),
       )
 
       expect(count).toBe(0)
@@ -5138,26 +5142,26 @@ describe('createQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: paused'),
+        rendered.getByText('status: success, fetchStatus: paused'),
       )
       await waitFor(() => {
-        expect(screen.getByText('data: initial')).toBeInTheDocument()
+        expect(rendered.getByText('data: initial')).toBeInTheDocument()
       })
 
-      fireEvent.click(screen.getByRole('button', { name: /invalidate/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /invalidate/i }))
 
       await sleep(15)
 
       // invalidation should not trigger a refetch
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: paused'),
+        rendered.getByText('status: success, fetchStatus: paused'),
       )
 
       expect(count).toBe(0)
@@ -5196,7 +5200,7 @@ describe('createQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
@@ -5205,19 +5209,19 @@ describe('createQuery', () => {
       window.dispatchEvent(new Event('offline'))
 
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: paused'),
+        rendered.getByText('status: success, fetchStatus: paused'),
       )
       await waitFor(() => {
-        expect(screen.getByText('data: initial')).toBeInTheDocument()
+        expect(rendered.getByText('data: initial')).toBeInTheDocument()
       })
 
       // triggers one pause
-      fireEvent.click(screen.getByRole('button', { name: /invalidate/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /invalidate/i }))
 
       await sleep(15)
 
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: paused'),
+        rendered.getByText('status: success, fetchStatus: paused'),
       )
 
       // triggers a second pause
@@ -5227,10 +5231,10 @@ describe('createQuery', () => {
       window.dispatchEvent(new Event('online'))
 
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: idle'),
+        rendered.getByText('status: success, fetchStatus: idle'),
       )
       await waitFor(() => {
-        expect(screen.getByText('data: data1')).toBeInTheDocument()
+        expect(rendered.getByText('data: data1')).toBeInTheDocument()
       })
 
       expect(count).toBe(1)
@@ -5263,18 +5267,18 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
       await waitFor(() =>
-        screen.getByText(
+        rendered.getByText(
           'status: pending, fetchStatus: fetching, failureCount: 1',
         ),
       )
-      await waitFor(() => screen.getByText('failureReason: failed1'))
+      await waitFor(() => rendered.getByText('failureReason: failed1'))
 
       window.dispatchEvent(new Event('offline'))
       const onlineMock = mockOnlineManagerIsOnline(false)
@@ -5282,11 +5286,11 @@ describe('createQuery', () => {
       await sleep(20)
 
       await waitFor(() =>
-        screen.getByText(
+        rendered.getByText(
           'status: pending, fetchStatus: paused, failureCount: 1',
         ),
       )
-      await waitFor(() => screen.getByText('failureReason: failed1'))
+      await waitFor(() => rendered.getByText('failureReason: failed1'))
 
       expect(count).toBe(1)
 
@@ -5294,9 +5298,9 @@ describe('createQuery', () => {
       window.dispatchEvent(new Event('online'))
 
       await waitFor(() =>
-        screen.getByText('status: error, fetchStatus: idle, failureCount: 3'),
+        rendered.getByText('status: error, fetchStatus: idle, failureCount: 3'),
       )
-      await waitFor(() => screen.getByText('failureReason: failed3'))
+      await waitFor(() => rendered.getByText('failureReason: failed3'))
 
       expect(count).toBe(3)
     })
@@ -5338,7 +5342,7 @@ describe('createQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
@@ -5347,10 +5351,10 @@ describe('createQuery', () => {
       window.dispatchEvent(new Event('offline'))
 
       await waitFor(() =>
-        screen.getByText('status: pending, fetchStatus: paused'),
+        rendered.getByText('status: pending, fetchStatus: paused'),
       )
 
-      fireEvent.click(screen.getByRole('button', { name: /hide/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /hide/i }))
 
       onlineMock.mockRestore()
       window.dispatchEvent(new Event('online'))
@@ -5397,20 +5401,20 @@ describe('createQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
       await waitFor(() =>
-        screen.getByText('status: pending, fetchStatus: paused'),
+        rendered.getByText('status: pending, fetchStatus: paused'),
       )
 
-      fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /cancel/i }))
 
       await waitFor(() =>
-        screen.getByText('status: pending, fetchStatus: idle'),
+        rendered.getByText('status: pending, fetchStatus: idle'),
       )
 
       expect(count).toBe(0)
@@ -5421,7 +5425,7 @@ describe('createQuery', () => {
       await sleep(15)
 
       await waitFor(() =>
-        screen.getByText('status: pending, fetchStatus: idle'),
+        rendered.getByText('status: pending, fetchStatus: idle'),
       )
 
       expect(count).toBe(0)
@@ -5469,25 +5473,25 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: idle'),
+        rendered.getByText('status: success, fetchStatus: idle'),
       )
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      fireEvent.click(screen.getByRole('button', { name: /invalidate/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /invalidate/i }))
 
       await waitFor(() =>
-        screen.getByText('status: success, fetchStatus: paused'),
+        rendered.getByText('status: success, fetchStatus: paused'),
       )
 
-      fireEvent.click(screen.getByRole('button', { name: /hide/i }))
+      fireEvent.click(rendered.getByRole('button', { name: /hide/i }))
 
       await sleep(15)
 
@@ -5535,16 +5539,18 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
-      await waitFor(() => screen.getByText('status: success, isPaused: false'))
+      await waitFor(() =>
+        rendered.getByText('status: success, isPaused: false'),
+      )
 
       await waitFor(() => {
-        expect(screen.getByText('data: data 1')).toBeInTheDocument()
+        expect(rendered.getByText('data: data 1')).toBeInTheDocument()
       })
 
       onlineMock.mockRestore()
@@ -5581,16 +5587,16 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
       ))
 
-      await waitFor(() => screen.getByText('status: error, isPaused: false'))
+      await waitFor(() => rendered.getByText('status: error, isPaused: false'))
 
       await waitFor(() => {
-        expect(screen.getByText('error: error 2')).toBeInTheDocument()
+        expect(rendered.getByText('error: error 2')).toBeInTheDocument()
       })
 
       expect(count).toBe(2)
@@ -5630,7 +5636,7 @@ describe('createQuery', () => {
         )
       }
 
-      render(() => (
+      const rendered = render(() => (
         <QueryClientProvider client={queryClient}>
           <Page />
         </QueryClientProvider>
@@ -5639,11 +5645,11 @@ describe('createQuery', () => {
       window.dispatchEvent(new Event('offline'))
 
       await waitFor(() =>
-        screen.getByText(
+        rendered.getByText(
           'status: pending, fetchStatus: paused, failureCount: 1',
         ),
       )
-      await waitFor(() => screen.getByText('failureReason: failed1'))
+      await waitFor(() => rendered.getByText('failureReason: failed1'))
 
       expect(count).toBe(1)
 
@@ -5651,9 +5657,9 @@ describe('createQuery', () => {
       window.dispatchEvent(new Event('online'))
 
       await waitFor(() =>
-        screen.getByText('status: error, fetchStatus: idle, failureCount: 3'),
+        rendered.getByText('status: error, fetchStatus: idle, failureCount: 3'),
       )
-      await waitFor(() => screen.getByText('failureReason: failed3'))
+      await waitFor(() => rendered.getByText('failureReason: failed3'))
 
       expect(count).toBe(3)
     })
@@ -5723,17 +5729,17 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: data'))
-    fireEvent.click(screen.getByRole('button', { name: /setQueryData/i }))
-    await waitFor(() => screen.getByText('data: newData'))
+    await waitFor(() => rendered.getByText('data: data'))
+    fireEvent.click(rendered.getByRole('button', { name: /setQueryData/i }))
+    await waitFor(() => rendered.getByText('data: newData'))
     await waitFor(() => {
-      expect(screen.getByText('dataUpdatedAt: 100')).toBeInTheDocument()
+      expect(rendered.getByText('dataUpdatedAt: 100')).toBeInTheDocument()
     })
   })
 
@@ -5756,17 +5762,19 @@ describe('createQuery', () => {
         </div>
       )
     }
-    render(() => (
+
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    const fetchBtn = screen.getByRole('button', { name: 'refetch' })
-    await waitFor(() => screen.getByText('data: 1'))
+
+    const fetchBtn = rendered.getByRole('button', { name: 'refetch' })
+    await waitFor(() => rendered.getByText('data: 1'))
     fireEvent.click(fetchBtn)
-    await waitFor(() => screen.getByText('data: 2'))
+    await waitFor(() => rendered.getByText('data: 2'))
     fireEvent.click(fetchBtn)
-    await waitFor(() => screen.getByText('data: 3'))
+    await waitFor(() => rendered.getByText('data: 3'))
   })
 
   it('should use provided custom queryClient', async () => {
@@ -5787,8 +5795,8 @@ describe('createQuery', () => {
       )
     }
 
-    render(() => <Page />)
+    const rendered = render(() => <Page />)
 
-    await waitFor(() => screen.getByText('Status: custom client'))
+    await waitFor(() => rendered.getByText('Status: custom client'))
   })
 })

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 
 import {
   ErrorBoundary,
@@ -63,7 +63,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Suspense fallback="loading">
           <Page />
@@ -71,10 +71,10 @@ describe("useQuery's in Suspense mode", () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 1'))
-    fireEvent.click(screen.getByLabelText('toggle'))
+    await waitFor(() => rendered.getByText('data: 1'))
+    fireEvent.click(rendered.getByLabelText('toggle'))
 
-    await waitFor(() => screen.getByText('data: 2'))
+    await waitFor(() => rendered.getByText('data: 2'))
 
     expect(renders).toBe(4)
     expect(states.length).toBe(4)
@@ -111,7 +111,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Suspense fallback="loading">
           <Page />
@@ -119,7 +119,7 @@ describe("useQuery's in Suspense mode", () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('data: 1'))
+    await waitFor(() => rendered.getByText('data: 1'))
 
     // TODO(lukemurray): in react this is 1 in solid this is 2 because suspense
     // occurs on read.
@@ -129,8 +129,8 @@ describe("useQuery's in Suspense mode", () => {
       status: 'success',
     })
 
-    fireEvent.click(screen.getByText('next'))
-    await waitFor(() => screen.getByText('data: 2'))
+    fireEvent.click(rendered.getByText('next'))
+    await waitFor(() => rendered.getByText('data: 2'))
 
     // TODO(lukemurray): in react this is 2 and in solid it is 4
     expect(states.length).toBe(4)
@@ -155,7 +155,7 @@ describe("useQuery's in Suspense mode", () => {
       return <>rendered</>
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Suspense fallback="loading">
           <Page />
@@ -163,7 +163,7 @@ describe("useQuery's in Suspense mode", () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('rendered'))
+    await waitFor(() => rendered.getByText('rendered'))
 
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
@@ -197,23 +197,23 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
-    expect(screen.queryByText('rendered')).toBeNull()
+    expect(rendered.queryByText('rendered')).toBeNull()
     expect(queryCache.find({ queryKey: key })).toBeFalsy()
 
-    fireEvent.click(screen.getByLabelText('toggle'))
-    await waitFor(() => screen.getByText('rendered'))
+    fireEvent.click(rendered.getByLabelText('toggle'))
+    await waitFor(() => rendered.getByText('rendered'))
 
     expect(queryCache.find({ queryKey: key })?.getObserversCount()).toBe(1)
 
-    fireEvent.click(screen.getByLabelText('toggle'))
+    fireEvent.click(rendered.getByLabelText('toggle'))
 
-    expect(screen.queryByText('rendered')).toBeNull()
+    expect(rendered.queryByText('rendered')).toBeNull()
     expect(queryCache.find({ queryKey: key })?.getObserversCount()).toBe(0)
   })
 
@@ -246,7 +246,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary
           fallback={(_err, resetSolid) => (
@@ -270,15 +270,15 @@ describe("useQuery's in Suspense mode", () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('Loading...'))
 
-    await waitFor(() => screen.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('error boundary'))
 
-    await waitFor(() => screen.getByText('retry'))
+    await waitFor(() => rendered.getByText('retry'))
 
-    fireEvent.click(screen.getByText('retry'))
+    fireEvent.click(rendered.getByText('retry'))
 
-    await waitFor(() => screen.getByText('rendered'))
+    await waitFor(() => rendered.getByText('rendered'))
   })
 
   it('should retry fetch if the reset error boundary has been reset', async () => {
@@ -309,7 +309,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary
           fallback={(_err, resetSolid) => (
@@ -332,15 +332,15 @@ describe("useQuery's in Suspense mode", () => {
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText('error boundary'))
-    await waitFor(() => screen.getByText('retry'))
-    fireEvent.click(screen.getByText('retry'))
-    await waitFor(() => screen.getByText('error boundary'))
-    await waitFor(() => screen.getByText('retry'))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('retry'))
+    fireEvent.click(rendered.getByText('retry'))
+    await waitFor(() => rendered.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('retry'))
     succeed = true
-    fireEvent.click(screen.getByText('retry'))
-    await waitFor(() => screen.getByText('rendered'))
+    fireEvent.click(rendered.getByText('retry'))
+    await waitFor(() => rendered.getByText('rendered'))
   })
 
   it('should refetch when re-mounting', async () => {
@@ -384,22 +384,22 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText('data: 1'))
-    await waitFor(() => screen.getByText('fetching: false'))
-    await waitFor(() => screen.getByText('hide'))
-    fireEvent.click(screen.getByText('hide'))
-    await waitFor(() => screen.getByText('show'))
-    fireEvent.click(screen.getByText('show'))
-    await waitFor(() => screen.getByText('fetching: true'))
-    await waitFor(() => screen.getByText('data: 2'))
-    await waitFor(() => screen.getByText('fetching: false'))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('data: 1'))
+    await waitFor(() => rendered.getByText('fetching: false'))
+    await waitFor(() => rendered.getByText('hide'))
+    fireEvent.click(rendered.getByText('hide'))
+    await waitFor(() => rendered.getByText('show'))
+    fireEvent.click(rendered.getByText('show'))
+    await waitFor(() => rendered.getByText('fetching: true'))
+    await waitFor(() => rendered.getByText('data: 2'))
+    await waitFor(() => rendered.getByText('fetching: false'))
   })
 
   it('should suspend when switching to a new query', async () => {
@@ -437,17 +437,17 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText(`data: ${key1}`))
-    fireEvent.click(screen.getByText('switch'))
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText(`data: ${key2}`))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText(`data: ${key1}`))
+    fireEvent.click(rendered.getByText('switch'))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText(`data: ${key2}`))
   })
 
   it('should throw errors to the error boundary by default', async () => {
@@ -493,14 +493,14 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('error boundary'))
 
     consoleMock.mockRestore()
   })
@@ -544,14 +544,14 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText('rendered'))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('rendered'))
   })
 
   it('should throw errors to the error boundary when a throwOnError function returns true', async () => {
@@ -597,14 +597,14 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('error boundary'))
 
     consoleMock.mockRestore()
   })
@@ -650,14 +650,14 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Loading...'))
-    await waitFor(() => screen.getByText('rendered'))
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('rendered'))
   })
 
   it('should not call the queryFn when not enabled', async () => {
@@ -686,7 +686,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Suspense fallback="loading">
           <Page />
@@ -696,10 +696,10 @@ describe("useQuery's in Suspense mode", () => {
 
     expect(queryFn).toHaveBeenCalledTimes(0)
     await sleep(5)
-    fireEvent.click(screen.getByRole('button', { name: /fire/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /fire/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('heading').textContent).toBe('23')
+      expect(rendered.getByRole('heading').textContent).toBe('23')
     })
 
     expect(queryFn).toHaveBeenCalledTimes(1)
@@ -755,23 +755,23 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
     // render suspense fallback (Loading...)
-    await waitFor(() => screen.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('Loading...'))
     // resolve promise -> render Page (rendered)
-    await waitFor(() => screen.getByText('rendered'))
+    await waitFor(() => rendered.getByText('rendered'))
 
     // change query key
     succeed = false
     // reset query -> and throw error
-    fireEvent.click(screen.getByLabelText('fail'))
+    fireEvent.click(rendered.getByLabelText('fail'))
     // render error boundary fallback (error boundary)
-    await waitFor(() => screen.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('error boundary'))
 
     consoleMock.mockRestore()
   })
@@ -819,23 +819,23 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
     // render suspense fallback (Loading...)
-    await waitFor(() => screen.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('Loading...'))
     // resolve promise -> render Page (rendered)
-    await waitFor(() => screen.getByText('rendered'))
+    await waitFor(() => rendered.getByText('rendered'))
 
     // change promise result to error
     succeed = false
     // change query key
-    fireEvent.click(screen.getByLabelText('fail'))
+    fireEvent.click(rendered.getByLabelText('fail'))
     // render error boundary fallback (error boundary)
-    await waitFor(() => screen.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('error boundary'))
 
     consoleMock.mockRestore()
   })
@@ -885,23 +885,23 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     ))
 
     // render empty data with 'rendered' when enabled is false
-    await waitFor(() => screen.getByText('rendered'))
+    await waitFor(() => rendered.getByText('rendered'))
 
     // change enabled to true
-    fireEvent.click(screen.getByLabelText('fail'))
+    fireEvent.click(rendered.getByLabelText('fail'))
 
     // render pending fallback
-    await waitFor(() => screen.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('Loading...'))
 
     // render error boundary fallback (error boundary)
-    await waitFor(() => screen.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('error boundary'))
 
     consoleMock.mockRestore()
   })
@@ -937,7 +937,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Suspense fallback="loading">
           <Page />
@@ -953,6 +953,6 @@ describe("useQuery's in Suspense mode", () => {
     )
 
     expect(renders).toBe(2)
-    expect(screen.queryByText('rendered')).not.toBeNull()
+    expect(rendered.queryByText('rendered')).not.toBeNull()
   })
 })

--- a/packages/solid-query/src/__tests__/transition.test.tsx
+++ b/packages/solid-query/src/__tests__/transition.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { Show, Suspense, createSignal, startTransition } from 'solid-js'
 import { QueryCache, QueryClientProvider, createQuery } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
@@ -44,17 +44,17 @@ describe("createQuery's in Suspense mode with transitions", () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await waitFor(() => screen.getByText('Show'))
-    fireEvent.click(screen.getByLabelText('toggle'))
+    await waitFor(() => rendered.getByText('Show'))
+    fireEvent.click(rendered.getByLabelText('toggle'))
 
-    await waitFor(() => screen.getByText('Message'))
+    await waitFor(() => rendered.getByText('Message'))
     // verify that the button also updated. See https://github.com/solidjs/solid/issues/1249
-    await waitFor(() => screen.getByText('Hide'))
+    await waitFor(() => rendered.getByText('Hide'))
   })
 })

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
 import { QueryCache, QueryClientProvider, createQuery, useIsFetching } from '..'
 import { createQueryClient, queryKey, setActTimeout, sleep } from './utils'
@@ -40,16 +40,16 @@ describe('useIsFetching', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('isFetching: 0')
-    fireEvent.click(screen.getByRole('button', { name: /setReady/i }))
-    await screen.findByText('isFetching: 1')
-    await screen.findByText('isFetching: 0')
+    await rendered.findByText('isFetching: 0')
+    fireEvent.click(rendered.getByRole('button', { name: /setReady/i }))
+    await rendered.findByText('isFetching: 1')
+    await rendered.findByText('isFetching: 0')
   })
 
   it('should not update state while rendering', async () => {
@@ -173,16 +173,16 @@ describe('useIsFetching', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('isFetching: 0')
-    fireEvent.click(screen.getByRole('button', { name: /setStarted/i }))
-    await screen.findByText('isFetching: 1')
-    await screen.findByText('isFetching: 0')
+    await rendered.findByText('isFetching: 0')
+    fireEvent.click(rendered.getByRole('button', { name: /setStarted/i }))
+    await rendered.findByText('isFetching: 1')
+    await rendered.findByText('isFetching: 0')
     // at no point should we have isFetching: 2
     expect(isFetchings).toEqual(expect.not.arrayContaining([2]))
   })
@@ -209,14 +209,14 @@ describe('useIsFetching', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
 
-    await screen.findByText('isFetching: 1')
-    await screen.findByText('isFetching: 0')
+    await rendered.findByText('isFetching: 1')
+    await rendered.findByText('isFetching: 0')
   })
 
   it('should use provided custom queryClient', async () => {
@@ -244,8 +244,8 @@ describe('useIsFetching', () => {
       )
     }
 
-    render(() => <Page></Page>)
+    const rendered = render(() => <Page></Page>)
 
-    await screen.findByText('isFetching: 1')
+    await rendered.findByText('isFetching: 1')
   })
 })

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
 import * as QueryCore from '@tanstack/query-core'
 import { QueryClientProvider, createMutation, useIsMutating } from '..'
@@ -157,6 +157,7 @@ describe('useIsMutating', () => {
 
   it('should use provided custom queryClient', async () => {
     const queryClient = createQueryClient()
+
     function Page() {
       const isMutating = useIsMutating(undefined, () => queryClient)
       const { mutate } = createMutation(
@@ -178,8 +179,10 @@ describe('useIsMutating', () => {
         </div>
       )
     }
-    render(() => <Page></Page>)
-    await waitFor(() => screen.findByText('mutating: 1'))
+
+    const rendered = render(() => <Page></Page>)
+
+    await waitFor(() => rendered.findByText('mutating: 1'))
   })
 
   it('should not change state if unmounted', async () => {
@@ -229,12 +232,12 @@ describe('useIsMutating', () => {
       )
     }
 
-    render(() => (
+    const rendered = render(() => (
       <QueryClientProvider client={queryClient}>
         <Page />
       </QueryClientProvider>
     ))
-    fireEvent.click(screen.getByText('unmount'))
+    fireEvent.click(rendered.getByText('unmount'))
 
     // Should not display the console error
     // "Warning: Can't perform a React state update on an unmounted component"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^18.4.3
         version: 18.4.3
       '@solidjs/testing-library':
-        specifier: ^0.5.1
-        version: 0.5.1(solid-js@1.8.7)
+        specifier: ^0.7.1
+        version: 0.7.1(solid-js@1.8.7)
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.5(vitest@0.33.0)
@@ -2529,14 +2529,6 @@ packages:
     dependencies:
       '@babel/highlight': 7.23.4
 
-  /@babel/code-frame@7.22.13:
-    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.22.20
-      chalk: 2.4.2
-    dev: true
-
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
@@ -2959,15 +2951,6 @@ packages:
       '@babel/types': 7.23.6
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/highlight@7.22.20:
-    resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
 
   /@babel/highlight@7.23.4:
     resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
@@ -8743,13 +8726,13 @@ packages:
     dependencies:
       solid-js: 1.8.7
 
-  /@solidjs/testing-library@0.5.1(solid-js@1.8.7):
-    resolution: {integrity: sha512-UVwYzSTRHwxiW7jdgKFP3NERbMtA748MIOQFzF1f4tg1XYl8ACybwlrVPqaiKnPevUCcM2ED+Wsp6Yd5JA//yg==}
+  /@solidjs/testing-library@0.7.1(solid-js@1.8.7):
+    resolution: {integrity: sha512-TRDsCx2R4LZYOEZ36EjmYn9O+de7o3U/D30YMlcyaagu3OlNGJubidBIdeOE5HcVIE2ojHRo6CHWdQAisUVrzg==}
     engines: {node: '>= 14'}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
-      '@testing-library/dom': 8.20.1
+      '@testing-library/dom': 9.3.3
       solid-js: 1.8.7
     dev: true
 
@@ -8997,20 +8980,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
-
-  /@testing-library/dom@8.20.1:
-    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/code-frame': 7.22.13
-      '@babel/runtime': 7.23.2
-      '@types/aria-query': 5.0.3
-      aria-query: 5.1.3
-      chalk: 4.1.2
-      dom-accessibility-api: 0.5.16
-      lz-string: 1.5.0
-      pretty-format: 27.5.1
-    dev: true
 
   /@testing-library/dom@9.3.3:
     resolution: {integrity: sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         version: 18.4.3
       '@solidjs/testing-library':
         specifier: ^0.5.1
-        version: 0.5.1(solid-js@1.8.1)
+        version: 0.5.1(solid-js@1.8.7)
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.5(vitest@0.33.0)
@@ -143,8 +143,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
       stream-to-array:
         specifier: ^2.3.0
         version: 2.3.0
@@ -1020,8 +1020,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(graphql@16.8.1)
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
     devDependencies:
       typescript:
         specifier: 5.2.2
@@ -1031,7 +1031,7 @@ importers:
         version: 4.5.1(@types/node@18.19.3)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   examples/solid/basic-typescript:
     dependencies:
@@ -1042,8 +1042,8 @@ importers:
         specifier: ^5.0.0
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
     devDependencies:
       typescript:
         specifier: 5.2.2
@@ -1053,7 +1053,7 @@ importers:
         version: 4.5.1(@types/node@18.19.3)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   examples/solid/default-query-function:
     dependencies:
@@ -1064,8 +1064,8 @@ importers:
         specifier: ^5.0.0
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
     devDependencies:
       typescript:
         specifier: 5.2.2
@@ -1075,7 +1075,7 @@ importers:
         version: 4.5.1(@types/node@18.19.3)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   examples/solid/simple:
     dependencies:
@@ -1086,8 +1086,8 @@ importers:
         specifier: ^5.0.0
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
     devDependencies:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.0.0
@@ -1100,16 +1100,16 @@ importers:
         version: 4.5.1(@types/node@18.19.3)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   examples/solid/solid-start-streaming:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.28.6
-        version: 0.28.6(solid-js@1.8.1)
+        version: 0.28.6(solid-js@1.8.7)
       '@solidjs/router':
         specifier: ^0.8.3
-        version: 0.8.3(solid-js@1.8.1)
+        version: 0.8.3(solid-js@1.8.7)
       '@tanstack/solid-query':
         specifier: ^5.0.0
         version: link:../../../packages/solid-query
@@ -1117,11 +1117,11 @@ importers:
         specifier: ^5.0.0
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
       solid-start:
         specifier: ^0.3.7
-        version: 0.3.7(@solidjs/meta@0.28.6)(@solidjs/router@0.8.3)(solid-js@1.8.1)(solid-start-node@0.3.7)(vite@4.5.1)
+        version: 0.3.7(@solidjs/meta@0.28.6)(@solidjs/router@0.8.3)(solid-js@1.8.7)(solid-start-node@0.3.7)(vite@4.5.1)
       undici:
         specifier: ^5.28.2
         version: 5.28.2
@@ -1611,14 +1611,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/solid-query-devtools
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
       vite:
         specifier: ^4.5.1
         version: 4.5.1(@types/node@18.19.3)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   integrations/svelte-vite:
     devDependencies:
@@ -1764,16 +1764,16 @@ importers:
     devDependencies:
       '@kobalte/core':
         specifier: ^0.11.2
-        version: 0.11.2(solid-js@1.8.1)
+        version: 0.11.2(solid-js@1.8.7)
       '@solid-primitives/keyed':
         specifier: ^1.2.0
-        version: 1.2.0(solid-js@1.8.1)
+        version: 1.2.0(solid-js@1.8.7)
       '@solid-primitives/resize-observer':
         specifier: ^2.0.22
-        version: 2.0.22(solid-js@1.8.1)
+        version: 2.0.22(solid-js@1.8.7)
       '@solid-primitives/storage':
         specifier: ^1.3.11
-        version: 1.3.11(solid-js@1.8.1)
+        version: 1.3.11(solid-js@1.8.7)
       '@tanstack/match-sorter-utils':
         specifier: ^8.8.4
         version: 8.8.4
@@ -1787,20 +1787,20 @@ importers:
         specifier: ^2.1.13
         version: 2.1.13(csstype@3.1.2)
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
       solid-transition-group:
         specifier: ^0.2.3
-        version: 0.2.3(solid-js@1.8.1)
+        version: 0.2.3(solid-js@1.8.7)
       superjson:
         specifier: ^1.13.3
         version: 1.13.3
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.1)(tsup@8.0.1)
+        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.7)(tsup@8.0.1)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   packages/query-persist-client-core:
     dependencies:
@@ -1892,15 +1892,15 @@ importers:
         specifier: workspace:*
         version: link:../query-core
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
     devDependencies:
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.1)(tsup@8.0.1)
+        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.7)(tsup@8.0.1)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   packages/solid-query-devtools:
     dependencies:
@@ -1912,14 +1912,14 @@ importers:
         specifier: workspace:^
         version: link:../solid-query
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.1)(tsup@8.0.1)
+        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.7)(tsup@8.0.1)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   packages/solid-query-persist-client:
     dependencies:
@@ -1931,14 +1931,14 @@ importers:
         version: link:../solid-query
     devDependencies:
       solid-js:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.8.7
+        version: 1.8.7
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.1)(tsup@8.0.1)
+        version: 2.2.0(esbuild@0.19.5)(solid-js@1.8.7)(tsup@8.0.1)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+        version: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
 
   packages/svelte-query:
     dependencies:
@@ -7081,7 +7081,7 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@kobalte/core@0.11.2(solid-js@1.8.1):
+  /@kobalte/core@0.11.2(solid-js@1.8.7):
     resolution: {integrity: sha512-B19TvpmR0E8n7LJqopF0lbMayBErnWJ5MlTTnrgVAFU1up/2Bo1O6ldTK1c5NikmpppzIK2A8ovUwIhRqw/3Uw==}
     peerDependencies:
       solid-js: ^1.7.11
@@ -7090,23 +7090,23 @@ packages:
       '@internationalized/date': 3.5.0
       '@internationalized/message': 3.1.1
       '@internationalized/number': 3.3.0
-      '@kobalte/utils': 0.9.0(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@kobalte/utils': 0.9.0(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@kobalte/utils@0.9.0(solid-js@1.8.1):
+  /@kobalte/utils@0.9.0(solid-js@1.8.7):
     resolution: {integrity: sha512-TYVCpQcpqo1+0HBn3NXoGEBzxd4tH6Um1oc07nrYw1V7Qq0qbMaYAOnfBc1qhlh7sGV4XZldmb0j13Of0FrZQg==}
     peerDependencies:
       solid-js: ^1.7.11
     dependencies:
-      '@solid-primitives/event-listener': 2.3.0(solid-js@1.8.1)
-      '@solid-primitives/keyed': 1.2.0(solid-js@1.8.1)
-      '@solid-primitives/map': 0.4.8(solid-js@1.8.1)
-      '@solid-primitives/media': 2.2.5(solid-js@1.8.1)
-      '@solid-primitives/props': 3.1.8(solid-js@1.8.1)
-      '@solid-primitives/refs': 1.0.5(solid-js@1.8.1)
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/event-listener': 2.3.0(solid-js@1.8.7)
+      '@solid-primitives/keyed': 1.2.0(solid-js@1.8.7)
+      '@solid-primitives/map': 0.4.8(solid-js@1.8.7)
+      '@solid-primitives/media': 2.2.5(solid-js@1.8.7)
+      '@solid-primitives/props': 3.1.8(solid-js@1.8.7)
+      '@solid-primitives/refs': 1.0.5(solid-js@1.8.7)
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
   /@leichtgewicht/ip-codec@2.0.4:
@@ -8609,148 +8609,148 @@ packages:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: true
 
-  /@solid-primitives/event-listener@2.3.0(solid-js@1.8.1):
+  /@solid-primitives/event-listener@2.3.0(solid-js@1.8.7):
     resolution: {integrity: sha512-0DS7DQZvCExWSpurVZC9/wjI8RmkhuOtWOy6Pp1Woq9ElMT9/bfjNpkwXsOwisLpcTqh9eUs17kp7jtpWcC20w==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/keyed@1.2.0(solid-js@1.8.1):
+  /@solid-primitives/keyed@1.2.0(solid-js@1.8.7):
     resolution: {integrity: sha512-0DuTeJdxWjCTu73XnDZs24JzfXckBnpvCfQ6Mf/kTPKkMZJh7tjkBnZEk48ckrE9xmwat9stIdfrBmZctsepIw==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      solid-js: 1.8.1
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/map@0.4.8(solid-js@1.8.1):
+  /@solid-primitives/map@0.4.8(solid-js@1.8.7):
     resolution: {integrity: sha512-p9zhIaIWOQVxLaUEjg6nzrBLZUOzozJFHatdKqISSIq7iJhVXX1M1MPzDHHqKyJw/nSENoKgvZehnG3HErnamw==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/trigger': 1.0.8(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/trigger': 1.0.8(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/media@2.2.5(solid-js@1.8.1):
+  /@solid-primitives/media@2.2.5(solid-js@1.8.7):
     resolution: {integrity: sha512-wTESNFteSwOZsNIBPLMIVLuOHIIzt2AIZdaCYYxfsJIr/xjDqSomlmdFlAmxfJD3ondO7fwtWfc0rcmAvjoPCA==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/event-listener': 2.3.0(solid-js@1.8.1)
-      '@solid-primitives/rootless': 1.4.2(solid-js@1.8.1)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.8.1)
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/event-listener': 2.3.0(solid-js@1.8.7)
+      '@solid-primitives/rootless': 1.4.2(solid-js@1.8.7)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.8.7)
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/props@3.1.8(solid-js@1.8.1):
+  /@solid-primitives/props@3.1.8(solid-js@1.8.7):
     resolution: {integrity: sha512-38ERNFhl87emUDPRlYvCmlbvEcK2mOJB38SU22YS2QXFDK7TQf/7P46XZacs7oODc/fckhfZTitht71FMEDe2g==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/refs@1.0.5(solid-js@1.8.1):
+  /@solid-primitives/refs@1.0.5(solid-js@1.8.7):
     resolution: {integrity: sha512-5hmYmYbm6rs43nMHHozyyUngGA7P7q2WtlaCLJEfmlUJf67GWI1PZmqAiol6m9F37XSMZRuvZLoQ7HA/0q3GYg==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/resize-observer@2.0.22(solid-js@1.8.1):
+  /@solid-primitives/resize-observer@2.0.22(solid-js@1.8.7):
     resolution: {integrity: sha512-ps8UIFiGsNxZaWBKSH0Py0Nx5PDd7NtUGHkN/04SNRYgtTvlPF768rk0ksPlDgpIwYmBLIoC9qvQmQPaHF4F5w==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/event-listener': 2.3.0(solid-js@1.8.1)
-      '@solid-primitives/rootless': 1.4.2(solid-js@1.8.1)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.8.1)
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/event-listener': 2.3.0(solid-js@1.8.7)
+      '@solid-primitives/rootless': 1.4.2(solid-js@1.8.7)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.8.7)
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/rootless@1.4.2(solid-js@1.8.1):
+  /@solid-primitives/rootless@1.4.2(solid-js@1.8.7):
     resolution: {integrity: sha512-ynI/2aEOPyc14IKCX6yDBqnsAYCoLbaP9V/jejEWMVKOT2ZdV2ZxdftaLimOpWPpvjyti5DUJIGTOfLaNb7jlg==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/static-store@0.0.5(solid-js@1.8.1):
+  /@solid-primitives/static-store@0.0.5(solid-js@1.8.7):
     resolution: {integrity: sha512-ssQ+s/wrlFAEE4Zw8GV499yBfvWx7SMm+ZVc11wvao4T5xg9VfXCL9Oa+x4h+vPMvSV/Knv5LrsLiUa+wlJUXQ==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/storage@1.3.11(solid-js@1.8.1):
+  /@solid-primitives/storage@1.3.11(solid-js@1.8.7):
     resolution: {integrity: sha512-PpQWR3TaTxHIJFbI9ZssYTM4Aa67g1vJIgps4TPhcXzHqqomrPAIveFC2FG7SDQoi9YQia8FVBjigELziJpfIg==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/transition-group@1.0.3(solid-js@1.8.1):
+  /@solid-primitives/transition-group@1.0.3(solid-js@1.8.7):
     resolution: {integrity: sha512-TnFADZhx9sibdoW5gxkU1QmLabzV2H2OBKYGS2aR5IC61Q/+7v8wlxOJEevxXNbPiRo6qlE3STLU3L9XS8hDbA==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      solid-js: 1.8.1
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/trigger@1.0.8(solid-js@1.8.1):
+  /@solid-primitives/trigger@1.0.8(solid-js@1.8.7):
     resolution: {integrity: sha512-p9e3FGhCk8sRPxDiCT8vnTE+DOEtrAnJZP4zV0NAV6YGnpV50JATVXNiLjKgyiI/mTIRkWB0+9c5SUbRlqFx6A==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/utils': 6.2.1(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/utils': 6.2.1(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
-  /@solid-primitives/utils@6.2.1(solid-js@1.8.1):
+  /@solid-primitives/utils@6.2.1(solid-js@1.8.7):
     resolution: {integrity: sha512-TsecNzxiO5bLfzqb4OOuzfUmdOROcssuGqgh5rXMMaasoFZ3GoveUgdY1wcf17frMJM7kCNGNuK34EjErneZkg==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      solid-js: 1.8.1
+      solid-js: 1.8.7
     dev: true
 
-  /@solidjs/meta@0.28.6(solid-js@1.8.1):
+  /@solidjs/meta@0.28.6(solid-js@1.8.7):
     resolution: {integrity: sha512-mplUfmp7tjGgDTiVbEAqkWDLpr0ZNyR1+OOETNyJt759MqPzh979X3oJUk8SZisGII0BNycmHDIGc0Shqx7bIg==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
-      solid-js: 1.8.1
+      solid-js: 1.8.7
 
-  /@solidjs/router@0.8.3(solid-js@1.8.1):
+  /@solidjs/router@0.8.3(solid-js@1.8.7):
     resolution: {integrity: sha512-oJuqQo10rVTiQYhe1qXIG1NyZIZ2YOwHnlLc8Xx+g/iJhFCJo1saLOIrD/Dkh2fpIaIny5ZMkz1cYYqoTYGJbg==}
     peerDependencies:
       solid-js: ^1.5.3
     dependencies:
-      solid-js: 1.8.1
+      solid-js: 1.8.7
 
-  /@solidjs/testing-library@0.5.1(solid-js@1.8.1):
+  /@solidjs/testing-library@0.5.1(solid-js@1.8.7):
     resolution: {integrity: sha512-UVwYzSTRHwxiW7jdgKFP3NERbMtA748MIOQFzF1f4tg1XYl8ACybwlrVPqaiKnPevUCcM2ED+Wsp6Yd5JA//yg==}
     engines: {node: '>= 14'}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
       '@testing-library/dom': 8.20.1
-      solid-js: 1.8.1
+      solid-js: 1.8.7
     dev: true
 
   /@surma/rollup-plugin-off-main-thread@1.4.2:
@@ -14328,7 +14328,7 @@ packages:
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /esbuild-plugin-solid@0.5.0(esbuild@0.17.19)(solid-js@1.8.1):
+  /esbuild-plugin-solid@0.5.0(esbuild@0.17.19)(solid-js@1.8.7):
     resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -14338,11 +14338,11 @@ packages:
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.6)
       babel-preset-solid: 1.8.2(@babel/core@7.23.6)
       esbuild: 0.17.19
-      solid-js: 1.8.1
+      solid-js: 1.8.7
     transitivePeerDependencies:
       - supports-color
 
-  /esbuild-plugin-solid@0.5.0(esbuild@0.19.5)(solid-js@1.8.1):
+  /esbuild-plugin-solid@0.5.0(esbuild@0.19.5)(solid-js@1.8.7):
     resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -14352,7 +14352,7 @@ packages:
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.6)
       babel-preset-solid: 1.8.2(@babel/core@7.23.6)
       esbuild: 0.19.5
-      solid-js: 1.8.1
+      solid-js: 1.8.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -25685,8 +25685,8 @@ packages:
     dependencies:
       randombytes: 2.1.0
 
-  /seroval@0.10.4:
-    resolution: {integrity: sha512-TdaE9JkoATjKu+vjwllieX8zWyBTUVxbgWDnOsDJFfmKbM7vLSukuCXuD3pO3kkCtX4daywOW8ps2VCdPhS8/w==}
+  /seroval@0.15.1:
+    resolution: {integrity: sha512-OPVtf0qmeC7RW+ScVX+7aOS+xoIM7pWcZ0jOWg2aTZigCydgRB04adfteBRbecZnnrO1WuGQ+C3tLeBBzX2zSQ==}
     engines: {node: '>=10'}
 
   /serve-index@1.9.1(supports-color@6.1.0):
@@ -26081,13 +26081,13 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
-  /solid-js@1.8.1:
-    resolution: {integrity: sha512-HU4tB/vWY5/0P9GzbvePjK1aucNqUcF1XlAirZBjKkrkWG8XNIN9HSjscTC/nbl3A6JWjrW+OLcPEvWxsMhdng==}
+  /solid-js@1.8.7:
+    resolution: {integrity: sha512-9dzrSVieh2zj3SnJ02II6xZkonR6c+j/91b7XZUNcC6xSaldlqjjGh98F1fk5cRJ8ZTkzqF5fPIWDxEOs6QZXA==}
     dependencies:
       csstype: 3.1.2
-      seroval: 0.10.4
+      seroval: 0.15.1
 
-  /solid-refresh@0.5.3(solid-js@1.8.1):
+  /solid-refresh@0.5.3(solid-js@1.8.7):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
       solid-js: ^1.3
@@ -26095,7 +26095,7 @@ packages:
       '@babel/generator': 7.23.6
       '@babel/helper-module-imports': 7.22.15
       '@babel/types': 7.23.6
-      solid-js: 1.8.1
+      solid-js: 1.8.7
 
   /solid-start-node@0.3.7(solid-start@0.3.7)(vite@4.5.1):
     resolution: {integrity: sha512-BV7jJYM4mQTI7S1YJR1o5+6sK/mGms0/zG5qN+OdC7lrJir13d834MJOJSuhgu8LUMKN/iEG06uPfnbNMFd89A==}
@@ -26110,13 +26110,13 @@ packages:
       polka: 1.0.0-next.22
       rollup: 3.29.4
       sirv: 2.0.3
-      solid-start: 0.3.7(@solidjs/meta@0.28.6)(@solidjs/router@0.8.3)(solid-js@1.8.1)(solid-start-node@0.3.7)(vite@4.5.1)
+      solid-start: 0.3.7(@solidjs/meta@0.28.6)(@solidjs/router@0.8.3)(solid-js@1.8.7)(solid-start-node@0.3.7)(vite@4.5.1)
       terser: 5.22.0
       vite: 4.5.1(@types/node@18.19.3)
     transitivePeerDependencies:
       - supports-color
 
-  /solid-start@0.3.7(@solidjs/meta@0.28.6)(@solidjs/router@0.8.3)(solid-js@1.8.1)(solid-start-node@0.3.7)(vite@4.5.1):
+  /solid-start@0.3.7(@solidjs/meta@0.28.6)(@solidjs/router@0.8.3)(solid-js@1.8.7)(solid-start-node@0.3.7)(vite@4.5.1):
     resolution: {integrity: sha512-16L+yaLbxjcovYwBovcdv9wi0zD8/SsHL9XYusqoxri1Xg2xy+uUPBWdmhOAUq6+R7qjyHJPX53ILUVJTj1qng==}
     hasBin: true
     peerDependencies:
@@ -26156,8 +26156,8 @@ packages:
       '@babel/preset-env': 7.23.2(@babel/core@7.23.6)
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.6)
       '@babel/template': 7.22.15
-      '@solidjs/meta': 0.28.6(solid-js@1.8.1)
-      '@solidjs/router': 0.8.3(solid-js@1.8.1)
+      '@solidjs/meta': 0.28.6(solid-js@1.8.7)
+      '@solidjs/router': 0.8.3(solid-js@1.8.7)
       '@types/cookie': 0.5.3
       '@types/debug': 4.1.10
       chokidar: 3.5.3
@@ -26168,7 +26168,7 @@ packages:
       dotenv: 16.3.1
       es-module-lexer: 1.3.1
       esbuild: 0.17.19
-      esbuild-plugin-solid: 0.5.0(esbuild@0.17.19)(solid-js@1.8.1)
+      esbuild-plugin-solid: 0.5.0(esbuild@0.17.19)(solid-js@1.8.7)
       fast-glob: 3.3.1
       get-port: 6.1.2
       micromorph: 0.3.1
@@ -26180,27 +26180,27 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.3
-      solid-js: 1.8.1
+      solid-js: 1.8.7
       solid-start-node: 0.3.7(solid-start@0.3.7)(vite@4.5.1)
       terser: 5.22.0
       undici: 5.28.2
       vite: 4.5.1(@types/node@18.19.3)
       vite-plugin-inspect: 0.7.40(rollup@3.29.4)(vite@4.5.1)
-      vite-plugin-solid: 2.7.2(solid-js@1.8.1)(vite@4.5.1)
+      vite-plugin-solid: 2.7.2(solid-js@1.8.7)(vite@4.5.1)
       wait-on: 6.0.1(debug@4.3.4)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
 
-  /solid-transition-group@0.2.3(solid-js@1.8.1):
+  /solid-transition-group@0.2.3(solid-js@1.8.7):
     resolution: {integrity: sha512-iB72c9N5Kz9ykRqIXl0lQohOau4t0dhel9kjwFvx81UZJbVwaChMuBuyhiZmK24b8aKEK0w3uFM96ZxzcyZGdg==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      '@solid-primitives/refs': 1.0.5(solid-js@1.8.1)
-      '@solid-primitives/transition-group': 1.0.3(solid-js@1.8.1)
-      solid-js: 1.8.1
+      '@solid-primitives/refs': 1.0.5(solid-js@1.8.7)
+      '@solid-primitives/transition-group': 1.0.3(solid-js@1.8.7)
+      solid-js: 1.8.7
     dev: true
 
   /sorcery@0.11.0:
@@ -27635,12 +27635,12 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup-preset-solid@2.2.0(esbuild@0.19.5)(solid-js@1.8.1)(tsup@8.0.1):
+  /tsup-preset-solid@2.2.0(esbuild@0.19.5)(solid-js@1.8.7)(tsup@8.0.1):
     resolution: {integrity: sha512-sPAzeArmYkVAZNRN+m4tkiojdd0GzW/lCwd4+TQDKMENe8wr2uAuro1s0Z59ASmdBbkXoxLgCiNcuQMyiidMZg==}
     peerDependencies:
       tsup: ^8.0.0
     dependencies:
-      esbuild-plugin-solid: 0.5.0(esbuild@0.19.5)(solid-js@1.8.1)
+      esbuild-plugin-solid: 0.5.0(esbuild@0.19.5)(solid-js@1.8.7)
       tsup: 8.0.1(typescript@5.2.2)
     transitivePeerDependencies:
       - esbuild
@@ -28286,7 +28286,7 @@ packages:
       - rollup
       - supports-color
 
-  /vite-plugin-solid@2.7.2(solid-js@1.8.1)(vite@4.5.1):
+  /vite-plugin-solid@2.7.2(solid-js@1.8.7)(vite@4.5.1):
     resolution: {integrity: sha512-GV2SMLAibOoXe76i02AsjAg7sbm/0lngBlERvJKVN67HOrJsHcWgkt0R6sfGLDJuFkv2aBe14Zm4vJcNME+7zw==}
     peerDependencies:
       solid-js: ^1.7.2
@@ -28297,8 +28297,8 @@ packages:
       '@types/babel__core': 7.20.3
       babel-preset-solid: 1.8.2(@babel/core@7.23.6)
       merge-anything: 5.1.7
-      solid-js: 1.8.1
-      solid-refresh: 0.5.3(solid-js@1.8.1)
+      solid-js: 1.8.7
+      solid-refresh: 0.5.3(solid-js@1.8.7)
       vite: 4.5.1(@types/node@18.19.3)
       vitefu: 0.2.5(vite@4.5.1)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^18.4.3
         version: 18.4.3
       '@solidjs/testing-library':
-        specifier: ^0.7.1
-        version: 0.7.1(solid-js@1.8.7)
+        specifier: ^0.8.5
+        version: 0.8.5(@solidjs/router@0.8.3)(solid-js@1.8.7)
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.5(vitest@0.33.0)
@@ -8726,12 +8726,14 @@ packages:
     dependencies:
       solid-js: 1.8.7
 
-  /@solidjs/testing-library@0.7.1(solid-js@1.8.7):
-    resolution: {integrity: sha512-TRDsCx2R4LZYOEZ36EjmYn9O+de7o3U/D30YMlcyaagu3OlNGJubidBIdeOE5HcVIE2ojHRo6CHWdQAisUVrzg==}
+  /@solidjs/testing-library@0.8.5(@solidjs/router@0.8.3)(solid-js@1.8.7):
+    resolution: {integrity: sha512-L9TowCoqdRQGB8ikODh9uHXrYTjCUZseVUG0tIVa836//qeSqXP4m0BKG66v9Zp1y1wRxok5qUW97GwrtEBMcw==}
     engines: {node: '>= 14'}
     peerDependencies:
+      '@solidjs/router': '>=0.6.0'
       solid-js: '>=1.0.0'
     dependencies:
+      '@solidjs/router': 0.8.3(solid-js@1.8.7)
       '@testing-library/dom': 9.3.3
       solid-js: 1.8.7
     dev: true


### PR DESCRIPTION
Consistency with all other package tests. Hoping it will fix a bug with the vitest 1.0 migration.