### PR TITLE
fix(vue-query-devtools): Use `vue-tsc` to test types

### DIFF
--- a/packages/vue-query-devtools/package.json
+++ b/packages/vue-query-devtools/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
-    "test:types": "tsc",
+    "test:types": "vue-tsc",
     "test:build": "publint --strict",
     "build": "vite build && vue-tsc"
   },

--- a/packages/vue-query-devtools/package.json
+++ b/packages/vue-query-devtools/package.json
@@ -56,6 +56,7 @@
     "vue-tsc": "^1.8.26"
   },
   "peerDependencies": {
+    "@tanstack/vue-query": "workspace:^",
     "vue": "^3.3.0"
   }
 }

--- a/packages/vue-query-devtools/src/shims-vue.d.ts
+++ b/packages/vue-query-devtools/src/shims-vue.d.ts
@@ -1,6 +1,0 @@
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue'
-
-  const component: DefineComponent<{}, {}, any>
-  export default component
-}

--- a/packages/vue-query-devtools/tsconfig.json
+++ b/packages/vue-query-devtools/tsconfig.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts", "src/**/*.vue", "shims-vue.d.ts"]
+  "include": ["src/**/*.ts", "src/**/*.vue"]
 }


### PR DESCRIPTION
The `.vue` files were effectively being ignored during `test:types`, but are now correctly parsed. I also added `@tanstack/vue-query` as a peerDep.