### PR TITLE
fix(core): make sure to call setResult before the early bail-out

### DIFF
--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -46,8 +46,7 @@ export class QueriesObserver<
     super()
 
     this.#client = client
-    this.#queries = queries
-    this.#options = options
+    this.#queries = []
     this.#observers = []
 
     this.#setResult([])
@@ -108,12 +107,14 @@ export class QueriesObserver<
       const hasIndexChange = newObservers.some(
         (observer, index) => observer !== prevObservers[index],
       )
+
+      this.#setResult(newResult)
+
       if (prevObservers.length === newObservers.length && !hasIndexChange) {
         return
       }
 
       this.#observers = newObservers
-      this.#setResult(newResult)
 
       if (!this.hasListeners()) {
         return

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -108,13 +108,16 @@ export class QueriesObserver<
         (observer, index) => observer !== prevObservers[index],
       )
 
-      this.#setResult(newResult)
-
-      if (prevObservers.length === newObservers.length && !hasIndexChange) {
+      if (
+        prevObservers.length === newObservers.length &&
+        !hasIndexChange &&
+        newObservers.length > 0
+      ) {
         return
       }
 
       this.#observers = newObservers
+      this.#setResult(newResult)
 
       if (!this.hasListeners()) {
         return

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -1027,6 +1027,46 @@ describe('useQueries', () => {
     expect(resultChanged).toBe(1)
   })
 
+  it('should only call combine with query results', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    function Page() {
+      const result = useQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: async () => {
+              await sleep(5)
+              return Promise.resolve('query1')
+            },
+          },
+          {
+            queryKey: key2,
+            queryFn: async () => {
+              await sleep(20)
+              return Promise.resolve('query2')
+            },
+          },
+        ],
+        combine: ([query1, query2]) => {
+          return {
+            data: { query1: query1.data, query2: query2.data },
+          }
+        },
+      })
+
+      return <div>data: {JSON.stringify(result)}</div>
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+    await waitFor(() =>
+      rendered.getByText(
+        'data: {"data":{"query1":"query1","query2":"query2"}}',
+      ),
+    )
+  })
+
   it('should track property access through combine function', async () => {
     const key1 = queryKey()
     const key2 = queryKey()


### PR DESCRIPTION
The initial fix for #6369 (#6431) introduced a regression where we'd always call combine with an empty array initially.

Turns out it was actually on purpose that we didn't call combine in the constructor, but delayed that until the `setQueries` call - because there, we already have complete query result structures available

However, there is an optimization that bails out early without calling this.#setResult if "nothing changed"; however, if we call useQueries with an empty array, that means nothing every changes, and the #combinedResult is actually never set, leading to structural sharing never having anything to share with, thus yielding a new reference every time (this is the root issue for #6369).

This fix reverts those changes (to avoid calling combine with an empty array every time, thus fixing #6612) and makes sure #setResult is always invoked before bailing out, so that #combinedResult is set correctly even for this case

fixes #6612