### PR TITLE
chore: Remove `entries` field from script config

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -11,107 +11,86 @@ export const packages = [
   {
     name: '@tanstack/eslint-plugin-query',
     packageDir: 'packages/eslint-plugin-query',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-async-storage-persister',
     packageDir: 'packages/query-async-storage-persister',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-broadcast-client-experimental',
     packageDir: 'packages/query-broadcast-client-experimental',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-core',
     packageDir: 'packages/query-core',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-devtools',
     packageDir: 'packages/query-devtools',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-persist-client-core',
     packageDir: 'packages/query-persist-client-core',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/query-sync-storage-persister',
     packageDir: 'packages/query-sync-storage-persister',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/react-query',
     packageDir: 'packages/react-query',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/react-query-devtools',
     packageDir: 'packages/react-query-devtools',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/react-query-persist-client',
     packageDir: 'packages/react-query-persist-client',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/react-query-next-experimental',
     packageDir: 'packages/react-query-next-experimental',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/solid-query',
     packageDir: 'packages/solid-query',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/solid-query-devtools',
     packageDir: 'packages/solid-query-devtools',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/solid-query-persist-client',
     packageDir: 'packages/solid-query-persist-client',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/svelte-query',
     packageDir: 'packages/svelte-query',
-    entries: ['module', 'svelte', 'types'],
   },
   {
     name: '@tanstack/svelte-query-devtools',
     packageDir: 'packages/svelte-query-devtools',
-    entries: ['module', 'svelte', 'types'],
   },
   {
     name: '@tanstack/svelte-query-persist-client',
     packageDir: 'packages/svelte-query-persist-client',
-    entries: ['module', 'svelte', 'types'],
   },
   {
     name: '@tanstack/vue-query',
     packageDir: 'packages/vue-query',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/vue-query-devtools',
     packageDir: 'packages/vue-query-devtools',
-    entries: ['main', 'module', 'types'],
   },
   {
     name: '@tanstack/angular-query-devtools-experimental',
     packageDir: 'packages/angular-query-devtools-experimental',
-    entries: ['module', 'types'],
   },
   {
     name: '@tanstack/angular-query-experimental',
     packageDir: 'packages/angular-query-experimental',
-    entries: ['module', 'types'],
   },
 ]
 

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -37,7 +37,6 @@ export type Parsed = {
 export type Package = {
   name: string
   packageDir: string
-  entries: Array<'main' | 'module' | 'svelte' | 'types'>
 }
 
 export type BranchConfig = {


### PR DESCRIPTION
This field is no longer used, since the manual validate script was replaced with publint.