### PR TITLE
chore: Update Nx caching inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - uses: pnpm/action-setup@v2
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
         with:
           version: 8
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,7 @@
   "namedInputs": {
     "sharedGlobals": [
       "{workspaceRoot}/.eslintrc.cjs",
+      "{workspaceRoot}/.nvmrc",
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/scripts/getTsupConfig.js",
       "{workspaceRoot}/tsconfig.json"


### PR DESCRIPTION
`.nvmrc` was missing from `"namedInputs"`. This meant the repo's Node version could be changed without invalidating Nx cache. 