### PR TITLE
fix(angular-query): type narrowing on query and mutation results

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
@@ -1,0 +1,73 @@
+import { describe, expectTypeOf } from 'vitest'
+import { injectMutation } from '../inject-mutation'
+import { successMutator } from './test-utils'
+import type { Signal } from '@angular/core'
+
+describe('Discriminated union return type', () => {
+  test('data should be possibly undefined by default', () => {
+    const mutation = injectMutation(() => ({
+      mutationFn: successMutator<string>,
+    }))
+
+    expectTypeOf(mutation.data).toEqualTypeOf<
+      Signal<string> | Signal<undefined>
+    >()
+  })
+
+  test('data should be defined when mutation is success', () => {
+    const mutation = injectMutation(() => ({
+      mutationFn: successMutator<string>,
+    }))
+
+    if (mutation.isSuccess()) {
+      expectTypeOf(mutation.data).toEqualTypeOf<Signal<string>>()
+    }
+  })
+
+  test('error should be null when mutation is success', () => {
+    const mutation = injectMutation(() => ({
+      mutationFn: successMutator<string>,
+    }))
+
+    if (mutation.isSuccess()) {
+      expectTypeOf(mutation.error).toEqualTypeOf<Signal<null>>()
+    }
+  })
+
+  test('data should be undefined when mutation is pending', () => {
+    const mutation = injectMutation(() => ({
+      mutationFn: successMutator<string>,
+    }))
+
+    if (mutation.isPending()) {
+      expectTypeOf(mutation.data).toEqualTypeOf<Signal<undefined>>()
+    }
+  })
+
+  test('error should be defined when mutation is error', () => {
+    const mutation = injectMutation(() => ({
+      mutationFn: successMutator<string>,
+    }))
+
+    if (mutation.isError()) {
+      expectTypeOf(mutation.error).toEqualTypeOf<Signal<Error>>()
+    }
+  })
+
+  test('should narrow variables', () => {
+    const mutation = injectMutation(() => ({
+      mutationFn: successMutator<string>,
+    }))
+
+    if (mutation.isIdle()) {
+      expectTypeOf(mutation.variables).toEqualTypeOf<Signal<undefined>>()
+    }
+    if (mutation.isPending()) {
+      expectTypeOf(mutation.variables).toEqualTypeOf<Signal<string>>()
+    }
+    if (mutation.isSuccess()) {
+      expectTypeOf(mutation.variables).toEqualTypeOf<Signal<string>>()
+    }
+    expectTypeOf(mutation.variables).toEqualTypeOf<Signal<string>>()
+  })
+})

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -1,0 +1,59 @@
+import { describe, expectTypeOf } from 'vitest'
+import { injectQuery } from '../inject-query'
+import { simpleFetcher } from './test-utils'
+import type { Signal } from '@angular/core'
+
+describe('Discriminated union return type', () => {
+  test('data should be possibly undefined by default', () => {
+    const query = injectQuery(() => ({
+      queryKey: ['key'],
+      queryFn: simpleFetcher,
+    }))
+
+    expectTypeOf(query.data).toEqualTypeOf<Signal<string> | Signal<undefined>>()
+  })
+
+  test('data should be defined when query is success', () => {
+    const query = injectQuery(() => ({
+      queryKey: ['key'],
+      queryFn: simpleFetcher,
+    }))
+
+    if (query.isSuccess()) {
+      expectTypeOf(query.data).toEqualTypeOf<Signal<string>>()
+    }
+  })
+
+  test('error should be null when query is success', () => {
+    const query = injectQuery(() => ({
+      queryKey: ['key'],
+      queryFn: simpleFetcher,
+    }))
+
+    if (query.isSuccess()) {
+      expectTypeOf(query.error).toEqualTypeOf<Signal<null>>()
+    }
+  })
+
+  test('data should be undefined when query is pending', () => {
+    const query = injectQuery(() => ({
+      queryKey: ['key'],
+      queryFn: simpleFetcher,
+    }))
+
+    if (query.isPending()) {
+      expectTypeOf(query.data).toEqualTypeOf<Signal<undefined>>()
+    }
+  })
+
+  test('error should be defined when query is error', () => {
+    const query = injectQuery(() => ({
+      queryKey: ['key'],
+      queryFn: simpleFetcher,
+    }))
+
+    if (query.isError()) {
+      expectTypeOf(query.error).toEqualTypeOf<Signal<Error>>()
+    }
+  })
+})


### PR DESCRIPTION
For now this PR only contains type tests ported from Vue Query to demonstrate the problem