### PR TITLE
refactor(tsconfig): remove unnecessary strictNullChecks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "strictNullChecks": true,
     "target": "ES2020"
   },
   "include": [".eslintrc.cjs", "prettier.config.js", "scripts"]


### PR DESCRIPTION
I remove unnecessary strictNullChecks in root tsconfig.json

https://www.typescriptlang.org/tsconfig#strictNullChecks
With strict, we don't need to use strictNullChecks