### PR TITLE
fix(queriesObserver): always use latest combine function

### DIFF
--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -236,8 +236,10 @@ export function injectQueries<
       )
     })
 
-    const [, getCombinedResult] =
-      observer.getOptimisticResult(defaultedQueries())
+    const [, getCombinedResult] = observer.getOptimisticResult(
+      defaultedQueries(),
+      (options as QueriesObserverOptions<TCombinedResult>).combine,
+    )
 
     const result = signal(getCombinedResult() as any)
 

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -282,7 +282,10 @@ export function useQueries<
   )
 
   const [optimisticResult, getCombinedResult, trackResult] =
-    observer.getOptimisticResult(defaultedQueries)
+    observer.getOptimisticResult(
+      defaultedQueries,
+      (options as QueriesObserverOptions<TCombinedResult>).combine,
+    )
 
   React.useSyncExternalStore(
     React.useCallback(

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -239,13 +239,23 @@ export function createQueries<
   )
 
   const [state, setState] = createStore<TCombinedResult>(
-    observer.getOptimisticResult(defaultedQueries())[1](),
+    observer.getOptimisticResult(
+      defaultedQueries(),
+      (queriesOptions() as QueriesObserverOptions<TCombinedResult>).combine,
+    )[1](),
   )
 
   createRenderEffect(
     on(
       () => queriesOptions().queries.length,
-      () => setState(observer.getOptimisticResult(defaultedQueries())[1]()),
+      () =>
+        setState(
+          observer.getOptimisticResult(
+            defaultedQueries(),
+            (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
+              .combine,
+          )[1](),
+        ),
     ),
   )
 

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -256,7 +256,10 @@ export function createQueries<
     // @ts-ignore svelte-check thinks this is unused
     ([$result, $defaultedQueriesStore]) => {
       const [rawResult, combineResult, trackResult] =
-        observer.getOptimisticResult($defaultedQueriesStore)
+        observer.getOptimisticResult(
+          $defaultedQueriesStore,
+          (options as QueriesObserverOptions<TCombinedResult>).combine,
+        )
       $result = rawResult
       return combineResult(trackResult())
     },

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -292,6 +292,7 @@ export function useQueries<
   )
   const [, getCombinedResult] = observer.getOptimisticResult(
     defaultedQueries.value,
+    (options as QueriesObserverOptions<TCombinedResult>).combine,
   )
   const state = ref(getCombinedResult()) as Ref<TCombinedResult>
 
@@ -307,12 +308,14 @@ export function useQueries<
         unsubscribe = observer.subscribe(() => {
           const [, getCombinedResultRestoring] = observer.getOptimisticResult(
             defaultedQueries.value,
+            (options as QueriesObserverOptions<TCombinedResult>).combine,
           )
           state.value = getCombinedResultRestoring()
         })
         // Subscription would not fire for persisted results
         const [, getCombinedResultPersisted] = observer.getOptimisticResult(
           defaultedQueries.value,
+          (options as QueriesObserverOptions<TCombinedResult>).combine,
         )
         state.value = getCombinedResultPersisted()
       }
@@ -329,6 +332,7 @@ export function useQueries<
       )
       const [, getCombinedResultPersisted] = observer.getOptimisticResult(
         defaultedQueries.value,
+        (options as QueriesObserverOptions<TCombinedResult>).combine,
       )
       state.value = getCombinedResultPersisted()
     },


### PR DESCRIPTION
computing the optimistic result didn't use the latest combine function, but the one set from setOptions (which runs in an effect, but is too late)

fixes #6648