### PR TITLE
 perf(vue-query): use `shallowRef` instead of `ref`

### DIFF
--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -294,7 +294,7 @@ export function useQueries<
     defaultedQueries.value,
     (options as QueriesObserverOptions<TCombinedResult>).combine,
   )
-  const state = shallowRef(getCombinedResult()) 
+  const state = shallowRef(getCombinedResult())
 
   let unsubscribe = () => {
     // noop

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -294,7 +294,7 @@ export function useQueries<
     defaultedQueries.value,
     (options as QueriesObserverOptions<TCombinedResult>).combine,
   )
-  const state = shallowRef(getCombinedResult()) as ShallowRef<TCombinedResult>
+  const state = shallowRef(getCombinedResult()) 
 
   let unsubscribe = () => {
     // noop

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -5,13 +5,13 @@ import {
   getCurrentScope,
   onScopeDispose,
   readonly,
-  ref,
+  shallowRef,
   watch,
 } from 'vue-demi'
 
 import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref } from './utils'
-import type { Ref } from 'vue-demi'
+import type { ShallowRef } from 'vue-demi'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
@@ -259,7 +259,7 @@ export function useQueries<
     combine?: (result: UseQueriesResults<T>) => TCombinedResult
   },
   queryClient?: QueryClient,
-): Readonly<Ref<TCombinedResult>> {
+): Readonly<ShallowRef<TCombinedResult>> {
   if (process.env.NODE_ENV === 'development') {
     if (!getCurrentScope()) {
       console.warn(
@@ -294,7 +294,7 @@ export function useQueries<
     defaultedQueries.value,
     (options as QueriesObserverOptions<TCombinedResult>).combine,
   )
-  const state = ref(getCombinedResult()) as Ref<TCombinedResult>
+  const state = shallowRef(getCombinedResult()) as ShallowRef<TCombinedResult>
 
   let unsubscribe = () => {
     // noop
@@ -343,5 +343,5 @@ export function useQueries<
     unsubscribe()
   })
 
-  return readonly(state) as Readonly<Ref<TCombinedResult>>
+  return readonly(state) as Readonly<ShallowRef<TCombinedResult>>
 }


### PR DESCRIPTION
When only replacing the whole `ref` and *not* changing nested values, `shallowRef` allows performance improvements. More details in the [Vue docs](https://vuejs.org/api/reactivity-advanced.html#shallowref) and [my video](https://www.youtube.com/watch?v=HdDVfiHtWHE).

This comes especially handy when using data fetching.

(PS: [This comment](https://www.youtube.com/watch?v=njsGVmcWviY&lc=UgzU0RDqZGTl-oVBVGt4AaABAg) was suggesting this PR, so here I am 😂)