### PR TITLE
[WIP] Typings optimizations

### DIFF
--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -7,9 +7,9 @@ import type {
   QueryKey,
 } from './types'
 
-export function infiniteQueryBehavior<TQueryFnData, TError, TData, TPageParam>(
+export function infiniteQueryBehavior<TData, TError, TPageParam>(
   pages?: number,
-): QueryBehavior<TQueryFnData, TError, InfiniteData<TData, TPageParam>> {
+): QueryBehavior<InfiniteData<TData, TPageParam>, TError> {
   return {
     onFetch: (context, query) => {
       const fetchFn = async () => {

--- a/packages/query-core/src/infiniteQueryObserver.ts
+++ b/packages/query-core/src/infiniteQueryObserver.ts
@@ -23,40 +23,37 @@ type InfiniteQueryObserverListener<TData, TError> = (
 ) => void
 
 export class InfiniteQueryObserver<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = InfiniteData<TQueryFnData>,
-  TQueryData = TQueryFnData,
+  TSelectData = TData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 > extends QueryObserver<
-  TQueryFnData,
+  InfiniteData<TData, TPageParam>,
   TError,
-  TData,
-  InfiniteData<TQueryData, TPageParam>,
+  TSelectData,
   TQueryKey
 > {
   // Type override
   subscribe!: (
-    listener?: InfiniteQueryObserverListener<TData, TError>,
+    listener?: InfiniteQueryObserverListener<TSelectData, TError>,
   ) => () => void
 
   // Type override
-  getCurrentResult!: () => InfiniteQueryObserverResult<TData, TError>
+  getCurrentResult!: () => InfiniteQueryObserverResult<TSelectData, TError>
 
   // Type override
   protected fetch!: (
     fetchOptions: ObserverFetchOptions,
-  ) => Promise<InfiniteQueryObserverResult<TData, TError>>
+  ) => Promise<InfiniteQueryObserverResult<TSelectData, TError>>
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(
     client: QueryClient,
     options: InfiniteQueryObserverOptions<
-      TQueryFnData,
-      TError,
       TData,
-      TQueryData,
+      TError,
+      TSelectData,
       TQueryKey,
       TPageParam
     >,
@@ -72,10 +69,9 @@ export class InfiniteQueryObserver<
 
   setOptions(
     options?: InfiniteQueryObserverOptions<
-      TQueryFnData,
-      TError,
       TData,
-      TQueryData,
+      TError,
+      TSelectData,
       TQueryKey,
       TPageParam
     >,
@@ -92,24 +88,23 @@ export class InfiniteQueryObserver<
 
   getOptimisticResult(
     options: DefaultedInfiniteQueryObserverOptions<
-      TQueryFnData,
-      TError,
       TData,
-      TQueryData,
+      TError,
+      TSelectData,
       TQueryKey,
       TPageParam
     >,
-  ): InfiniteQueryObserverResult<TData, TError> {
+  ): InfiniteQueryObserverResult<TSelectData, TError> {
     options.behavior = infiniteQueryBehavior()
     return super.getOptimisticResult(options) as InfiniteQueryObserverResult<
-      TData,
+      TSelectData,
       TError
     >
   }
 
   fetchNextPage(
     options?: FetchNextPageOptions,
-  ): Promise<InfiniteQueryObserverResult<TData, TError>> {
+  ): Promise<InfiniteQueryObserverResult<TSelectData, TError>> {
     return this.fetch({
       ...options,
       meta: {
@@ -120,7 +115,7 @@ export class InfiniteQueryObserver<
 
   fetchPreviousPage(
     options?: FetchPreviousPageOptions,
-  ): Promise<InfiniteQueryObserverResult<TData, TError>> {
+  ): Promise<InfiniteQueryObserverResult<TSelectData, TError>> {
     return this.fetch({
       ...options,
       meta: {
@@ -131,20 +126,18 @@ export class InfiniteQueryObserver<
 
   protected createResult(
     query: Query<
-      TQueryFnData,
+      InfiniteData<TData, TPageParam>,
       TError,
-      InfiniteData<TQueryData, TPageParam>,
       TQueryKey
     >,
     options: InfiniteQueryObserverOptions<
-      TQueryFnData,
-      TError,
       TData,
-      TQueryData,
+      TError,
+      TSelectData,
       TQueryKey,
       TPageParam
     >,
-  ): InfiniteQueryObserverResult<TData, TError> {
+  ): InfiniteQueryObserverResult<TSelectData, TError> {
     const { state } = query
     const result = super.createResult(query, options)
 

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -19,53 +19,53 @@ import type { QueryObserver } from './queryObserver'
 interface QueryCacheConfig {
   onError?: (
     error: DefaultError,
-    query: Query<unknown, unknown, unknown>,
+    query: Query<unknown, unknown>,
   ) => void
-  onSuccess?: (data: unknown, query: Query<unknown, unknown, unknown>) => void
+  onSuccess?: (data: unknown, query: Query<unknown, unknown>) => void
   onSettled?: (
     data: unknown | undefined,
     error: DefaultError | null,
-    query: Query<unknown, unknown, unknown>,
+    query: Query<unknown, unknown>,
   ) => void
 }
 
 interface NotifyEventQueryAdded extends NotifyEvent {
   type: 'added'
-  query: Query<any, any, any, any>
+  query: Query<any, any, any>
 }
 
 interface NotifyEventQueryRemoved extends NotifyEvent {
   type: 'removed'
-  query: Query<any, any, any, any>
+  query: Query<any, any, any>
 }
 
 interface NotifyEventQueryUpdated extends NotifyEvent {
   type: 'updated'
-  query: Query<any, any, any, any>
+  query: Query<any, any, any>
   action: Action<any, any>
 }
 
 interface NotifyEventQueryObserverAdded extends NotifyEvent {
   type: 'observerAdded'
-  query: Query<any, any, any, any>
-  observer: QueryObserver<any, any, any, any, any>
+  query: Query<any, any, any>
+  observer: QueryObserver<any, any, any, any>
 }
 
 interface NotifyEventQueryObserverRemoved extends NotifyEvent {
   type: 'observerRemoved'
-  query: Query<any, any, any, any>
-  observer: QueryObserver<any, any, any, any, any>
+  query: Query<any, any, any>
+  observer: QueryObserver<any, any, any, any>
 }
 
 interface NotifyEventQueryObserverResultsUpdated extends NotifyEvent {
   type: 'observerResultsUpdated'
-  query: Query<any, any, any, any>
+  query: Query<any, any, any>
 }
 
 interface NotifyEventQueryObserverOptionsUpdated extends NotifyEvent {
   type: 'observerOptionsUpdated'
-  query: Query<any, any, any, any>
-  observer: QueryObserver<any, any, any, any, any>
+  query: Query<any, any, any>
+  observer: QueryObserver<any, any, any, any>
 }
 
 export type QueryCacheNotifyEvent =
@@ -97,15 +97,15 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     this.#queries = new Map<string, Query>()
   }
 
-  build<TQueryFnData, TError, TData, TQueryKey extends QueryKey>(
+  build<TData, TError, TQueryKey extends QueryKey>(
     client: QueryClient,
-    options: QueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    options: QueryOptions<TData, TError, TQueryKey>,
     state?: QueryState<TData, TError>,
-  ): Query<TQueryFnData, TError, TData, TQueryKey> {
+  ): Query<TData, TError, TQueryKey> {
     const queryKey = options.queryKey!
     const queryHash =
       options.queryHash ?? hashQueryKeyByOptions(queryKey, options)
-    let query = this.get<TQueryFnData, TError, TData, TQueryKey>(queryHash)
+    let query = this.get<TData, TError, TQueryKey>(queryHash)
 
     if (!query) {
       query = new Query({
@@ -122,7 +122,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     return query
   }
 
-  add(query: Query<any, any, any, any>): void {
+  add(query: Query<any, any, any>): void {
     if (!this.#queries.has(query.queryHash)) {
       this.#queries.set(query.queryHash, query)
 
@@ -133,7 +133,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     }
   }
 
-  remove(query: Query<any, any, any, any>): void {
+  remove(query: Query<any, any, any>): void {
     const queryInMap = this.#queries.get(query.queryHash)
 
     if (queryInMap) {
@@ -156,15 +156,14 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
   }
 
   get<
-    TQueryFnData = unknown,
+    TData = unknown,
     TError = DefaultError,
-    TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
   >(
     queryHash: string,
-  ): Query<TQueryFnData, TError, TData, TQueryKey> | undefined {
+  ): Query<TData, TError, TQueryKey> | undefined {
     return this.#queries.get(queryHash) as
-      | Query<TQueryFnData, TError, TData, TQueryKey>
+      | Query<TData, TError, TQueryKey>
       | undefined
   }
 
@@ -172,14 +171,14 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     return [...this.#queries.values()]
   }
 
-  find<TQueryFnData = unknown, TError = DefaultError, TData = TQueryFnData>(
+  find<TData = unknown, TError = DefaultError>(
     filters: WithRequired<QueryFilters, 'queryKey'>,
-  ): Query<TQueryFnData, TError, TData> | undefined {
+  ): Query<TData, TError> | undefined {
     const defaultedFilters = { exact: true, ...filters }
 
     return this.getAll().find((query) =>
       matchQuery(defaultedFilters, query),
-    ) as Query<TQueryFnData, TError, TData> | undefined
+    ) as Query<TData, TError> | undefined
   }
 
   findAll(filters: QueryFilters = {}): Array<Query> {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -109,15 +109,14 @@ export class QueryClient {
   }
 
   getQueryData<
-    TQueryFnData = unknown,
-    TaggedQueryKey extends QueryKey = QueryKey,
-    TInferredQueryFnData = TaggedQueryKey extends DataTag<
-      unknown,
-      infer TaggedValue
-    >
-      ? TaggedValue
-      : TQueryFnData,
-  >(queryKey: TaggedQueryKey): TInferredQueryFnData | undefined
+    TData = unknown,
+    TQueryKey extends QueryKey = QueryKey,
+  >(queryKey: TQueryKey): TQueryKey extends DataTag<
+  unknown,
+  infer TaggedValue
+>
+  ? TaggedValue
+  : TData | undefined
   getQueryData(queryKey: QueryKey) {
     return this.#queryCache.find({ queryKey })?.state.data
   }
@@ -125,38 +124,37 @@ export class QueryClient {
   ensureQueryData<
     TQueryFnData,
     TError = DefaultError,
-    TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
   >(
-    options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  ): Promise<TData> {
-    const cachedData = this.getQueryData<TData>(options.queryKey)
+    options: FetchQueryOptions<TQueryFnData, TError, TQueryKey>,
+  ): Promise<TQueryFnData> {
+    const cachedData = this.getQueryData<TQueryFnData>(options.queryKey)
 
     return cachedData !== undefined
       ? Promise.resolve(cachedData)
       : this.fetchQuery(options)
   }
 
-  getQueriesData<TQueryFnData = unknown>(
+  getQueriesData<TData = unknown>(
     filters: QueryFilters,
-  ): Array<[QueryKey, TQueryFnData | undefined]> {
+  ): Array<[QueryKey, TData | undefined]> {
     return this.getQueryCache()
       .findAll(filters)
       .map(({ queryKey, state }) => {
-        const data = state.data as TQueryFnData | undefined
+        const data = state.data as TData | undefined
         return [queryKey, data]
       })
   }
 
   setQueryData<
-    TQueryFnData = unknown,
+    TData = unknown,
     TaggedQueryKey extends QueryKey = QueryKey,
     TInferredQueryFnData = TaggedQueryKey extends DataTag<
       unknown,
       infer TaggedValue
     >
       ? TaggedValue
-      : TQueryFnData,
+      : TData,
   >(
     queryKey: TaggedQueryKey,
     updater: Updater<
@@ -294,16 +292,14 @@ export class QueryClient {
   }
 
   fetchQuery<
-    TQueryFnData,
+    TData,
     TError = DefaultError,
-    TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
     TPageParam = never,
   >(
     options: FetchQueryOptions<
-      TQueryFnData,
-      TError,
       TData,
+      TError,
       TQueryKey,
       TPageParam
     >,
@@ -323,51 +319,45 @@ export class QueryClient {
   }
 
   prefetchQuery<
-    TQueryFnData = unknown,
+    TData = unknown,
     TError = DefaultError,
-    TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
   >(
-    options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    options: FetchQueryOptions<TData, TError, TQueryKey>,
   ): Promise<void> {
     return this.fetchQuery(options).then(noop).catch(noop)
   }
 
   fetchInfiniteQuery<
-    TQueryFnData,
+    TData,
     TError = DefaultError,
-    TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
     TPageParam = unknown,
   >(
     options: FetchInfiniteQueryOptions<
-      TQueryFnData,
-      TError,
       TData,
+      TError,
       TQueryKey,
       TPageParam
     >,
   ): Promise<InfiniteData<TData, TPageParam>> {
     options.behavior = infiniteQueryBehavior<
-      TQueryFnData,
-      TError,
       TData,
+      TError,
       TPageParam
     >(options.pages)
     return this.fetchQuery(options)
   }
 
   prefetchInfiniteQuery<
-    TQueryFnData,
+    TData,
     TError = DefaultError,
-    TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
     TPageParam = unknown,
   >(
     options: FetchInfiniteQueryOptions<
-      TQueryFnData,
-      TError,
       TData,
+      TError,
       TQueryKey,
       TPageParam
     >,
@@ -409,10 +399,10 @@ export class QueryClient {
 
   getQueryDefaults(
     queryKey: QueryKey,
-  ): QueryObserverOptions<any, any, any, any, any> {
+  ): QueryObserverOptions<any, any, any, any> {
     const defaults = [...this.#queryDefaults.values()]
 
-    let result: QueryObserverOptions<any, any, any, any, any> = {}
+    let result: QueryObserverOptions<any, any, any, any> = {}
 
     defaults.forEach((queryDefault) => {
       if (partialMatchKey(queryKey, queryDefault.queryKey)) {
@@ -449,41 +439,36 @@ export class QueryClient {
   }
 
   defaultQueryOptions<
-    TQueryFnData = unknown,
+    TData = unknown,
     TError = DefaultError,
-    TData = TQueryFnData,
-    TQueryData = TQueryFnData,
+    TQueryData = TData,
     TQueryKey extends QueryKey = QueryKey,
     TPageParam = never,
   >(
     options?:
       | QueryObserverOptions<
-          TQueryFnData,
-          TError,
           TData,
+          TError,
           TQueryData,
           TQueryKey,
           TPageParam
         >
       | DefaultedQueryObserverOptions<
-          TQueryFnData,
-          TError,
           TData,
+          TError,
           TQueryData,
           TQueryKey
         >,
   ): DefaultedQueryObserverOptions<
-    TQueryFnData,
-    TError,
     TData,
+    TError,
     TQueryData,
     TQueryKey
   > {
     if (options?._defaulted) {
       return options as DefaultedQueryObserverOptions<
-        TQueryFnData,
-        TError,
         TData,
+        TError,
         TQueryData,
         TQueryKey
       >
@@ -520,9 +505,8 @@ export class QueryClient {
     }
 
     return defaultedOptions as DefaultedQueryObserverOptions<
-      TQueryFnData,
-      TError,
       TData,
+      TError,
       TQueryData,
       TQueryKey
     >

--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -495,7 +495,7 @@ describe('queryClient', () => {
         Promise.resolve('data')
 
       await expect(
-        queryClient.fetchQuery<StrictData, any, StrictData, StrictQueryKey>({
+        queryClient.fetchQuery<StrictData, any, StrictQueryKey>({
           queryKey: key,
           queryFn: fetchFn,
         }),
@@ -631,7 +631,6 @@ describe('queryClient', () => {
         queryClient.fetchInfiniteQuery<
           StrictData,
           any,
-          StrictData,
           StrictQueryKey,
           number
         >({ queryKey: key, queryFn: fetchFn, initialPageParam: 0 }),
@@ -669,7 +668,6 @@ describe('queryClient', () => {
       await queryClient.prefetchInfiniteQuery<
         StrictData,
         any,
-        StrictData,
         StrictQueryKey,
         number
       >({ queryKey: key, queryFn: fetchFn, initialPageParam: 0 })
@@ -752,7 +750,6 @@ describe('queryClient', () => {
       await queryClient.prefetchQuery<
         StrictData,
         any,
-        StrictData,
         StrictQueryKey
       >({ queryKey: key, queryFn: fetchFn })
 

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -574,12 +574,12 @@ describe('queryObserver', () => {
       queryKey: key,
       enabled: false,
       queryFn: () => 'data',
-      placeholderData: {},
+      placeholderData: 'placeholder',
     })
 
     const firstData = observer.getCurrentResult().data
 
-    observer.setOptions({ placeholderData: {} })
+    observer.setOptions({ placeholderData: 'placeholder' })
 
     const secondData = observer.getCurrentResult().data
 

--- a/packages/query-core/src/tests/queryObserver.types.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.types.test.tsx
@@ -4,6 +4,28 @@ import { createQueryClient, doNotExecute } from './utils'
 import type { Equal, Expect } from './utils'
 
 describe('placeholderData', () => {
+  describe('placeholderData value', () => {
+    it('should be of the same type as query data', () => {
+      doNotExecute(() => {
+        const queryData = { foo: 'bar' }
+
+        new QueryObserver(createQueryClient(), {
+          queryFn: () => queryData,
+          // @ts-ignore-error ts fail to infer TSelectData correctly for bad placeholder assignement, this raise this unrelated error on select.
+          select: (data) => data.foo,
+          // @ts-expect-error
+          placeholderData: 1
+        })
+
+        new QueryObserver(createQueryClient(), {
+          queryFn: () => queryData,
+          select: (data) => data.foo,
+          placeholderData: { foo: 'hello' }
+        })
+      })
+    })
+  })
+
   describe('placeholderData function', () => {
     it('previousQuery should have typed queryKey', () => {
       doNotExecute(() => {
@@ -56,6 +78,21 @@ describe('placeholderData', () => {
               Equal<typeof previousData, QueryData | undefined>
             > = true
             return result ? previousData : undefined
+          },
+        })
+      })
+    })
+
+    it('should have to return the same type as query data', () => {
+      doNotExecute(() => {
+        const queryData = { foo: 'bar' }
+
+        new QueryObserver(createQueryClient(), {
+          queryFn: () => queryData,
+          select: (data) => data.foo,
+          // @ts-expect-error
+          placeholderData: (previousData) => {
+            return { foo: 1 }
           },
         })
       })

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -72,14 +72,13 @@ export type InitialDataFunction<T> = () => T | undefined
 type NonFunctionGuard<T> = T extends Function ? never : T
 
 export type PlaceholderDataFunction<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = (
-  previousData: TQueryData | undefined,
-  previousQuery: Query<TQueryFnData, TError, TQueryData, TQueryKey> | undefined,
-) => TQueryData | undefined
+  previousData: TData | undefined,
+  previousQuery: Query<TData, TError, TQueryKey> | undefined,
+) => TData | undefined
 
 export type QueriesPlaceholderDataFunction<TQueryData> = (
   previousData: undefined,
@@ -125,9 +124,8 @@ export type NotifyOnChangeProps =
   | (() => Array<keyof InfiniteQueryObserverResult> | 'all')
 
 export interface QueryOptions<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = never,
 > {
@@ -147,9 +145,9 @@ export interface QueryOptions<
    * Setting it to `Infinity` will disable garbage collection.
    */
   gcTime?: number
-  queryFn?: QueryFunction<TQueryFnData, TQueryKey, TPageParam>
+  queryFn?: QueryFunction<TData, TQueryKey, TPageParam>
   persister?: QueryPersister<
-    NoInfer<TQueryFnData>,
+    NoInfer<TData>,
     NoInfer<TQueryKey>,
     NoInfer<TPageParam>
   >
@@ -158,7 +156,7 @@ export interface QueryOptions<
   queryKeyHashFn?: QueryKeyHashFunction<TQueryKey>
   initialData?: TData | InitialDataFunction<TData>
   initialDataUpdatedAt?: number | (() => number | undefined)
-  behavior?: QueryBehavior<TQueryFnData, TError, TData, TQueryKey>
+  behavior?: QueryBehavior<TData, TError, TQueryKey>
   /**
    * Set this to `false` to disable structural sharing between query results.
    * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
@@ -198,28 +196,25 @@ export interface InfiniteQueryPageParamsOptions<
 }
 
 export type ThrowOnError<
-  TQueryFnData,
+  TData,
   TError,
-  TQueryData,
   TQueryKey extends QueryKey,
 > =
   | boolean
   | ((
       error: TError,
-      query: Query<TQueryFnData, TError, TQueryData, TQueryKey>,
+      query: Query<TData, TError, TQueryKey>,
     ) => boolean)
 
 export interface QueryObserverOptions<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
+  TSelectData = TData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = never,
 > extends QueryOptions<
-    TQueryFnData,
+    TData,
     TError,
-    TQueryData,
     TQueryKey,
     TPageParam
   > {
@@ -243,7 +238,7 @@ export interface QueryObserverOptions<
     | number
     | false
     | ((
-        query: Query<TQueryFnData, TError, TQueryData, TQueryKey>,
+        query: Query<TData, TError, TQueryKey>,
       ) => number | false | undefined)
   /**
    * If set to `true`, the query will continue to refetch while their tab/window is in the background.
@@ -261,7 +256,7 @@ export interface QueryObserverOptions<
     | boolean
     | 'always'
     | ((
-        query: Query<TQueryFnData, TError, TQueryData, TQueryKey>,
+        query: Query<TData, TError, TQueryKey>,
       ) => boolean | 'always')
   /**
    * If set to `true`, the query will refetch on reconnect if the data is stale.
@@ -274,7 +269,7 @@ export interface QueryObserverOptions<
     | boolean
     | 'always'
     | ((
-        query: Query<TQueryFnData, TError, TQueryData, TQueryKey>,
+        query: Query<TData, TError, TQueryKey>,
       ) => boolean | 'always')
   /**
    * If set to `true`, the query will refetch on mount if the data is stale.
@@ -287,7 +282,7 @@ export interface QueryObserverOptions<
     | boolean
     | 'always'
     | ((
-        query: Query<TQueryFnData, TError, TQueryData, TQueryKey>,
+        query: Query<TData, TError, TQueryKey>,
       ) => boolean | 'always')
   /**
    * If set to `false`, the query will not be retried on mount if it contains an error.
@@ -309,11 +304,11 @@ export interface QueryObserverOptions<
    * If set to a function, it will be passed the error and the query, and it should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`).
    * Defaults to `false`.
    */
-  throwOnError?: ThrowOnError<TQueryFnData, TError, TQueryData, TQueryKey>
+  throwOnError?: ThrowOnError<TData, TError, TQueryKey>
   /**
    * This option can be used to transform or select a part of the data returned by the query function.
    */
-  select?: (data: TQueryData) => TData
+  select?: (data: TData) => TSelectData
   /**
    * If set to `true`, the query will suspend when `status === 'pending'`
    * and throw errors when `status === 'error'`.
@@ -324,11 +319,10 @@ export interface QueryObserverOptions<
    * If set, this value will be used as the placeholder data for this particular query observer while the query is still in the `loading` data and no initialData has been provided.
    */
   placeholderData?:
-    | NonFunctionGuard<TQueryData>
+    | NonFunctionGuard<TData>
     | PlaceholderDataFunction<
-        NonFunctionGuard<TQueryData>,
+        NonFunctionGuard<TData>,
         TError,
-        NonFunctionGuard<TQueryData>,
         TQueryKey
       >
 
@@ -338,46 +332,41 @@ export interface QueryObserverOptions<
 export type WithRequired<T, K extends keyof T> = T & { [_ in K]: {} }
 
 export type DefaultedQueryObserverOptions<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
+  TSelectData = TData,
   TQueryKey extends QueryKey = QueryKey,
 > = WithRequired<
-  QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+  QueryObserverOptions<TData, TError, TSelectData, TQueryKey>,
   'throwOnError' | 'refetchOnReconnect' | 'queryHash'
 >
 
 export interface InfiniteQueryObserverOptions<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
+  TSelectData = TData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 > extends QueryObserverOptions<
-      TQueryFnData,
+      InfiniteData<TData, TPageParam>,
       TError,
-      TData,
-      InfiniteData<TQueryData, TPageParam>,
+      TSelectData,
       TQueryKey,
       TPageParam
     >,
-    InfiniteQueryPageParamsOptions<TQueryFnData, TPageParam> {}
+    InfiniteQueryPageParamsOptions<TData, TPageParam> {}
 
 export type DefaultedInfiniteQueryObserverOptions<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
+  TSelectData = TData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 > = WithRequired<
   InfiniteQueryObserverOptions<
-    TQueryFnData,
-    TError,
     TData,
-    TQueryData,
+    TError,
+    TSelectData,
     TQueryKey,
     TPageParam
   >,
@@ -385,13 +374,12 @@ export type DefaultedInfiniteQueryObserverOptions<
 >
 
 export interface FetchQueryOptions<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = never,
 > extends WithRequired<
-    QueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>,
+    QueryOptions<TData, TError, TQueryKey, TPageParam>,
     'queryKey'
   > {
   /**
@@ -409,20 +397,18 @@ type FetchInfiniteQueryPages<TQueryFnData = unknown, TPageParam = unknown> =
     }
 
 export type FetchInfiniteQueryOptions<
-  TQueryFnData = unknown,
+  TData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 > = FetchQueryOptions<
-  TQueryFnData,
-  TError,
   InfiniteData<TData, TPageParam>,
+  TError,
   TQueryKey,
   TPageParam
 > &
   InitialPageParam<TPageParam> &
-  FetchInfiniteQueryPages<TQueryFnData, TPageParam>
+  FetchInfiniteQueryPages<TData, TPageParam>
 
 export interface ResultOptions {
   throwOnError?: boolean

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -87,7 +87,7 @@ export function timeUntilStale(updatedAt: number, staleTime?: number): number {
 
 export function matchQuery(
   filters: QueryFilters,
-  query: Query<any, any, any, any>,
+  query: Query<any, any, any>,
 ): boolean {
   const {
     type = 'all',
@@ -167,7 +167,7 @@ export function matchMutation(
 
 export function hashQueryKeyByOptions<TQueryKey extends QueryKey = QueryKey>(
   queryKey: TQueryKey,
-  options?: QueryOptions<any, any, any, TQueryKey>,
+  options?: QueryOptions<any, any, TQueryKey>,
 ): string {
   const hashFn = options?.queryKeyHashFn || hashKey
   return hashFn(queryKey)
@@ -305,7 +305,7 @@ export function sleep(ms: number): Promise<void> {
 
 export function replaceData<
   TData,
-  TOptions extends QueryOptions<any, any, any, any>,
+  TOptions extends QueryOptions<any, any, any>,
 >(prevData: TData | undefined, data: TData, options: TOptions): TData {
   if (typeof options.structuralSharing === 'function') {
     return options.structuralSharing(prevData, data)


### PR DESCRIPTION
Working on issues adapting the new queryKey typings inference to Vue. I Found few things that could be optimised on the core package. This PR is for those typings optimisations. See changes below:

- [ ] Many Types relies on useless generic TQueryFnData:
  - [ ] clean useless generic TQueryFnData
  - [x] Fix false positive test on queryObserver "should structurally share placeholder data" where placeholder is of type `{}`while the queryFn returns `string`(the error is hidden due to useless Generic that catch this bad `{}` type)
- [ ] work on query result typings, I want to include all `| undefined` union typings in the Generic TData if no initialData is defined. Then the types `DefinedInitialDataOptions`and `UndefinedInitialDataOptions` in React and Vue packages will be useless which schould solve some issues on Vue due to interactions between `& { initialData: T }`statement and `MaybeRefDeep` type
- [ ] propagate changes to framework packages
  - [ ] React
  - [ ] Vue
  - [ ] Solid
  - [ ] Svelte
- [ ] Improve Inference from QueryKey in Vue package