### PR TITLE
chore: use shorthand of sherif consistently

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:ci": "nx run-many --targets=test:format,test:sherif,test:eslint,test:lib,test:types,test:build,build --exclude=examples/**",
     "test:eslint": "nx affected --target=test:eslint --exclude=examples/**",
     "test:format": "pnpm run prettier --check",
-    "test:sherif": "sherif -i react-scripts -i typescript --ignore-package react-vite5 --ignore-package react-vite4",
+    "test:sherif": "sherif -i react-scripts -i typescript -p react-vite5 -p react-vite4",
     "test:lib": "nx affected --target=test:lib --exclude=examples/**",
     "test:lib:dev": "pnpm run test:lib && nx watch --all -- pnpm run test:lib",
     "test:build": "nx affected --target=test:build --exclude=examples/**",


### PR DESCRIPTION
We can check [shorthands for sherif](https://github.com/QuiiBz/sherif?tab=readme-ov-file#rules)
I updated script `test:sherif`'s rules consistently