### PR TITLE
fix(query-core): `replaceEqualDeep` now handles objects with the same numb…

### DIFF
--- a/packages/query-core/src/tests/utils.test.tsx
+++ b/packages/query-core/src/tests/utils.test.tsx
@@ -325,6 +325,13 @@ describe('core/utils', () => {
       expect(result.todos[0]?.state.done).toBe(next.todos[0]?.state.done)
       expect(result.todos[1]).toBe(prev.todos[1])
     })
+
+    it('should correctly handle objects with the same number of properties and one property being undefined', () => {
+      const obj1 = { a: 2, c: 123 }
+      const obj2 = { a: 2, b: undefined }
+      const result = replaceEqualDeep(obj1, obj2)
+      expect(result).toStrictEqual(obj2)
+    })
   })
 
   describe('matchMutation', () => {

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -234,7 +234,7 @@ export function replaceEqualDeep(a: any, b: any): any {
     for (let i = 0; i < bSize; i++) {
       const key = array ? i : bItems[i]
       copy[key] = replaceEqualDeep(a[key], b[key])
-      if (copy[key] === a[key]) {
+      if (copy[key] === a[key] && a[key] !== undefined) {
         equalItems++
       }
     }


### PR DESCRIPTION
…er of properties and one property being undefined

this was previously fixed in router: https://github.com/TanStack/router/pull/903