### PR TITLE
fix: repair wrong types passed to `DataTag`

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -78,7 +78,7 @@ test('should tag the queryKey with the result type of the QueryFn if select is u
     select: (data) => data.toString(),
   })
 
-  assertType<string>(queryKey[dataTagSymbol])
+  assertType<number>(queryKey[dataTagSymbol])
 })
 
 test('should return the proper type when passed to getQueryData', () => {

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -78,7 +78,7 @@ test('should tag the queryKey with the result type of the QueryFn if select is u
     select: (data) => data.toString(),
   })
 
-  assertType<unknown>(queryKey[dataTagSymbol])
+  assertType<string>(queryKey[dataTagSymbol])
 })
 
 test('should return the proper type when passed to getQueryData', () => {

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -51,6 +51,8 @@ test('should tag the queryKey with the result type of the QueryFn', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
+    // select to ensure type of Data in queryKey does not change
+    select: (data) => data.toString(),
   })
   assertType<number>(queryKey[dataTagSymbol])
 })
@@ -59,6 +61,8 @@ test('should tag the queryKey even if no promise is returned', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => 5,
+    // select to ensure type of Data in queryKey does not change
+    select: (data) => data.toString(),
   })
   assertType<number>(queryKey[dataTagSymbol])
 })
@@ -75,6 +79,8 @@ test('should return the proper type when passed to getQueryData', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
+    // select to ensure type of Data in queryKey does not change
+    select: (data) => data.toString(),
   })
 
   const queryClient = new QueryClient()
@@ -87,6 +93,8 @@ test('should properly type updaterFn when passed to setQueryData', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
+    // select to ensure type of Data in queryKey does not change
+    select: (data) => data.toString(),
   })
 
   const queryClient = new QueryClient()
@@ -102,6 +110,8 @@ test('should properly type value when passed to setQueryData', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
+    // select to ensure type of Data in queryKey does not change
+    select: (data) => data.toString(),
   })
 
   const queryClient = new QueryClient()

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -51,8 +51,6 @@ test('should tag the queryKey with the result type of the QueryFn', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
-    // select to ensure type of Data in queryKey does not change
-    select: (data) => data.toString(),
   })
   assertType<number>(queryKey[dataTagSymbol])
 })
@@ -61,8 +59,6 @@ test('should tag the queryKey even if no promise is returned', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => 5,
-    // select to ensure type of Data in queryKey does not change
-    select: (data) => data.toString(),
   })
   assertType<number>(queryKey[dataTagSymbol])
 })
@@ -75,12 +71,20 @@ test('should tag the queryKey with unknown if there is no queryFn', () => {
   assertType<unknown>(queryKey[dataTagSymbol])
 })
 
+test('should tag the queryKey with the result type of the QueryFn if select is used', () => {
+  const { queryKey } = queryOptions({
+    queryKey: ['key'],
+    queryFn: () => Promise.resolve(5),
+    select: (data) => data.toString(),
+  })
+
+  assertType<unknown>(queryKey[dataTagSymbol])
+})
+
 test('should return the proper type when passed to getQueryData', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
-    // select to ensure type of Data in queryKey does not change
-    select: (data) => data.toString(),
   })
 
   const queryClient = new QueryClient()
@@ -93,8 +97,6 @@ test('should properly type updaterFn when passed to setQueryData', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
-    // select to ensure type of Data in queryKey does not change
-    select: (data) => data.toString(),
   })
 
   const queryClient = new QueryClient()
@@ -110,8 +112,6 @@ test('should properly type value when passed to setQueryData', () => {
   const { queryKey } = queryOptions({
     queryKey: ['key'],
     queryFn: () => Promise.resolve(5),
-    // select to ensure type of Data in queryKey does not change
-    select: (data) => data.toString(),
   })
 
   const queryClient = new QueryClient()

--- a/packages/angular-query-experimental/src/query-options.ts
+++ b/packages/angular-query-experimental/src/query-options.ts
@@ -31,7 +31,7 @@ export function queryOptions<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, TQueryFnData>
 }
 
 export function queryOptions<
@@ -42,7 +42,7 @@ export function queryOptions<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, TQueryFnData>
 }
 
 export function queryOptions(options: unknown) {

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.types.test.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.types.test.tsx
@@ -92,8 +92,6 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve('string'),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
       })
@@ -109,7 +107,21 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => 'string',
-        // select to ensure type of Data in queryKey does not change
+        getNextPageParam: () => 1,
+        initialPageParam: 1,
+      })
+
+      const result: Expect<
+        Equal<(typeof queryKey)[typeof dataTagSymbol], InfiniteData<string>>
+      > = true
+      return result
+    })
+  })
+  it('should tag the queryKey with the result type of the QueryFn if select is used', () => {
+    doNotExecute(() => {
+      const { queryKey } = infiniteQueryOptions({
+        queryKey: ['key'],
+        queryFn: () => Promise.resolve('string'),
         select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
@@ -126,8 +138,6 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve('string'),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
       })
@@ -146,8 +156,6 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve('string'),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
       })

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.types.test.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.types.test.tsx
@@ -92,6 +92,8 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve('string'),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
       })
@@ -107,6 +109,8 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => 'string',
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
       })
@@ -122,6 +126,8 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve('string'),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
       })
@@ -140,6 +146,8 @@ describe('queryOptions', () => {
       const { queryKey } = infiniteQueryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve('string'),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.pages,
         getNextPageParam: () => 1,
         initialPageParam: 1,
       })

--- a/packages/react-query/src/__tests__/queryOptions.types.test.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.types.test.tsx
@@ -91,6 +91,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -104,6 +106,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => 5,
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -129,6 +133,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -143,6 +149,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -160,6 +168,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()

--- a/packages/react-query/src/__tests__/queryOptions.types.test.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.types.test.tsx
@@ -91,8 +91,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -106,8 +104,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => 5,
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -128,13 +124,25 @@ describe('queryOptions', () => {
       return result
     })
   })
+  it('should tag the queryKey with the result type of the QueryFn if select is used', () => {
+    doNotExecute(() => {
+      const { queryKey } = queryOptions({
+        queryKey: ['key'],
+        queryFn: () => Promise.resolve(5),
+        select: (data) => data.toString(),
+      })
+
+      const result: Expect<
+        Equal<(typeof queryKey)[typeof dataTagSymbol], number>
+      > = true
+      return result
+    })
+  })
   it('should return the proper type when passed to getQueryData', () => {
     doNotExecute(() => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -149,8 +157,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -168,8 +174,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()

--- a/packages/react-query/src/infiniteQueryOptions.ts
+++ b/packages/react-query/src/infiniteQueryOptions.ts
@@ -62,7 +62,7 @@ export function infiniteQueryOptions<
   TQueryKey,
   TPageParam
 > & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>>
 }
 
 export function infiniteQueryOptions<
@@ -86,7 +86,7 @@ export function infiniteQueryOptions<
   TQueryKey,
   TPageParam
 > & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>>
 }
 
 export function infiniteQueryOptions(options: unknown) {

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -31,7 +31,7 @@ export function queryOptions<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, TQueryFnData>
 }
 
 export function queryOptions<
@@ -42,7 +42,7 @@ export function queryOptions<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, TQueryFnData>
 }
 
 export function queryOptions(options: unknown) {

--- a/packages/vue-query/src/__tests__/queryOptions.types.test.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.types.test.ts
@@ -50,6 +50,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -63,6 +65,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => 5,
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -88,6 +92,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -102,6 +108,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -119,6 +127,8 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
+        // select to ensure type of Data in queryKey does not change
+        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()

--- a/packages/vue-query/src/__tests__/queryOptions.types.test.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.types.test.ts
@@ -50,8 +50,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -65,8 +63,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => 5,
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const result: Expect<
@@ -87,13 +83,25 @@ describe('queryOptions', () => {
       return result
     })
   })
+  it('should tag the queryKey with the result type of the QueryFn if select is used', () => {
+    doNotExecute(() => {
+      const { queryKey } = queryOptions({
+        queryKey: ['key'],
+        queryFn: () => Promise.resolve(5),
+        select: (data) => data.toString(),
+      })
+
+      const result: Expect<
+        Equal<(typeof queryKey)[typeof dataTagSymbol], number>
+      > = true
+      return result
+    })
+  })
   it('should return the proper type when passed to getQueryData', () => {
     doNotExecute(() => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -108,8 +116,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()
@@ -127,8 +133,6 @@ describe('queryOptions', () => {
       const { queryKey } = queryOptions({
         queryKey: ['key'],
         queryFn: () => Promise.resolve(5),
-        // select to ensure type of Data in queryKey does not change
-        select: (data) => data.toString(),
       })
 
       const queryClient = new QueryClient()

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -12,7 +12,7 @@ export function queryOptions<
 >(
   options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, TQueryFnData>
 }
 
 export function queryOptions<
@@ -23,7 +23,7 @@ export function queryOptions<
 >(
   options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TData>
+  queryKey: DataTag<TQueryKey, TQueryFnData>
 }
 
 export function queryOptions(options: unknown) {


### PR DESCRIPTION
This PR fixes the types that `DataTag` uses to define the type of data in the cache. It was initially using `TData`, but if `select` was used in `queryOptions`, this type would change to the transformed selected data, which is wrong.
The changes in this PR consist of using `TQueryFnData` instead, and add `select` to the type tests to ensure the correct value is being used, since the lack of this prop led to false test positives