### PR TITLE
fix(query-core): computed properties of QueryObserverResult

### DIFF
--- a/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
+++ b/packages/query-core/src/tests/infiniteQueryObserver.test.tsx
@@ -1,7 +1,15 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+  vi,
+} from 'vitest'
 import { InfiniteQueryObserver } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
-import type { QueryClient } from '..'
+import type { InfiniteData, QueryClient } from '..'
 
 describe('InfiniteQueryObserver', () => {
   let queryClient: QueryClient
@@ -155,5 +163,46 @@ describe('InfiniteQueryObserver', () => {
     expect(observer.getCurrentResult().data?.pages).toEqual(['1'])
     expect(queryFn).toBeCalledTimes(3)
     expect(observer.getCurrentResult().hasNextPage).toBe(false)
+  })
+
+  test('should be inferred as a correct result type', async () => {
+    const key = queryKey()
+    const next: number | undefined = 2
+    const queryFn = vi.fn(({ pageParam }) => String(pageParam))
+    const observer = new InfiniteQueryObserver(queryClient, {
+      queryKey: key,
+      queryFn,
+      initialPageParam: 1,
+      getNextPageParam: () => next,
+    })
+
+    const result = observer.getCurrentResult()
+
+    result.isPending &&
+      expectTypeOf<undefined>(result.data) &&
+      expectTypeOf<null>(result.error) &&
+      expectTypeOf<boolean>(result.isLoading) &&
+      expectTypeOf<'pending'>(result.status)
+
+    result.isLoading &&
+      expectTypeOf<undefined>(result.data) &&
+      expectTypeOf<null>(result.error) &&
+      expectTypeOf<true>(result.isPending) &&
+      expectTypeOf<'pending'>(result.status)
+
+    result.isLoadingError &&
+      expectTypeOf<undefined>(result.data) &&
+      expectTypeOf<Error>(result.error) &&
+      expectTypeOf<'error'>(result.status)
+
+    result.isRefetchError &&
+      expectTypeOf<InfiniteData<string>>(result.data) &&
+      expectTypeOf<Error>(result.error) &&
+      expectTypeOf<'error'>(result.status)
+
+    result.isSuccess &&
+      expectTypeOf<InfiniteData<string>>(result.data) &&
+      expectTypeOf<null>(result.error) &&
+      expectTypeOf<'success'>(result.status)
   })
 })

--- a/packages/query-core/src/tests/queryObserver.test.tsx
+++ b/packages/query-core/src/tests/queryObserver.test.tsx
@@ -894,4 +894,42 @@ describe('queryObserver', () => {
 
     unsubscribe()
   })
+
+  test('should be inferred as a correct result type', async () => {
+    const key = queryKey()
+    const data = { value: 'data' }
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => Promise.resolve(data),
+    })
+
+    const result = observer.getCurrentResult()
+
+    result.isPending &&
+      expectTypeOf<undefined>(result.data) &&
+      expectTypeOf<null>(result.error) &&
+      expectTypeOf<boolean>(result.isLoading) &&
+      expectTypeOf<'pending'>(result.status)
+
+    result.isLoading &&
+      expectTypeOf<undefined>(result.data) &&
+      expectTypeOf<null>(result.error) &&
+      expectTypeOf<true>(result.isPending) &&
+      expectTypeOf<'pending'>(result.status)
+
+    result.isLoadingError &&
+      expectTypeOf<undefined>(result.data) &&
+      expectTypeOf<Error>(result.error) &&
+      expectTypeOf<'error'>(result.status)
+
+    result.isRefetchError &&
+      expectTypeOf<{ value: string }>(result.data) &&
+      expectTypeOf<Error>(result.error) &&
+      expectTypeOf<'error'>(result.status)
+
+    result.isSuccess &&
+      expectTypeOf<{ value: string }>(result.data) &&
+      expectTypeOf<null>(result.error) &&
+      expectTypeOf<'success'>(result.status)
+  })
 })

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -488,6 +488,20 @@ export interface QueryObserverBaseResult<
   fetchStatus: FetchStatus
 }
 
+export interface QueryObserverPendingResult<
+  TData = unknown,
+  TError = DefaultError,
+> extends QueryObserverBaseResult<TData, TError> {
+  data: undefined
+  error: null
+  isError: false
+  isPending: true
+  isLoadingError: false
+  isRefetchError: false
+  isSuccess: false
+  status: 'pending'
+}
+
 export interface QueryObserverLoadingResult<
   TData = unknown,
   TError = DefaultError,
@@ -496,6 +510,7 @@ export interface QueryObserverLoadingResult<
   error: null
   isError: false
   isPending: true
+  isLoading: true
   isLoadingError: false
   isRefetchError: false
   isSuccess: false
@@ -510,6 +525,7 @@ export interface QueryObserverLoadingErrorResult<
   error: TError
   isError: true
   isPending: false
+  isLoading: false
   isLoadingError: true
   isRefetchError: false
   isSuccess: false
@@ -524,6 +540,7 @@ export interface QueryObserverRefetchErrorResult<
   error: TError
   isError: true
   isPending: false
+  isLoading: false
   isLoadingError: false
   isRefetchError: true
   isSuccess: false
@@ -538,6 +555,7 @@ export interface QueryObserverSuccessResult<
   error: null
   isError: false
   isPending: false
+  isLoading: false
   isLoadingError: false
   isRefetchError: false
   isSuccess: true
@@ -555,6 +573,7 @@ export type QueryObserverResult<TData = unknown, TError = DefaultError> =
   | DefinedQueryObserverResult<TData, TError>
   | QueryObserverLoadingErrorResult<TData, TError>
   | QueryObserverLoadingResult<TData, TError>
+  | QueryObserverPendingResult<TData, TError>
 
 export interface InfiniteQueryObserverBaseResult<
   TData = unknown,
@@ -572,6 +591,20 @@ export interface InfiniteQueryObserverBaseResult<
   isFetchingPreviousPage: boolean
 }
 
+export interface InfiniteQueryObserverPendingResult<
+  TData = unknown,
+  TError = DefaultError,
+> extends InfiniteQueryObserverBaseResult<TData, TError> {
+  data: undefined
+  error: null
+  isError: false
+  isPending: true
+  isLoadingError: false
+  isRefetchError: false
+  isSuccess: false
+  status: 'pending'
+}
+
 export interface InfiniteQueryObserverLoadingResult<
   TData = unknown,
   TError = DefaultError,
@@ -580,6 +613,7 @@ export interface InfiniteQueryObserverLoadingResult<
   error: null
   isError: false
   isPending: true
+  isLoading: true
   isLoadingError: false
   isRefetchError: false
   isSuccess: false
@@ -594,6 +628,7 @@ export interface InfiniteQueryObserverLoadingErrorResult<
   error: TError
   isError: true
   isPending: false
+  isLoading: false
   isLoadingError: true
   isRefetchError: false
   isSuccess: false
@@ -608,6 +643,7 @@ export interface InfiniteQueryObserverRefetchErrorResult<
   error: TError
   isError: true
   isPending: false
+  isLoading: false
   isLoadingError: false
   isRefetchError: true
   isSuccess: false
@@ -622,6 +658,7 @@ export interface InfiniteQueryObserverSuccessResult<
   error: null
   isError: false
   isPending: false
+  isLoading: false
   isLoadingError: false
   isRefetchError: false
   isSuccess: true
@@ -639,9 +676,10 @@ export type InfiniteQueryObserverResult<
   TData = unknown,
   TError = DefaultError,
 > =
+  | DefinedInfiniteQueryObserverResult<TData, TError>
   | InfiniteQueryObserverLoadingErrorResult<TData, TError>
   | InfiniteQueryObserverLoadingResult<TData, TError>
-  | DefinedInfiniteQueryObserverResult<TData, TError>
+  | InfiniteQueryObserverPendingResult<TData, TError>
 
 export type MutationKey = ReadonlyArray<unknown>
 


### PR DESCRIPTION
`isLoading` (isPending && isFetching) is a value calculated from `isPending`.

Therefore, if **isPending is false, isLoading becomes false**, and if **isLoading is true, isPending also becomes true**, so modify the related type.