### PR TITLE
fix(query-core): replaceEqualDeep correctly handles values that contain undefined

### DIFF
--- a/packages/query-core/src/tests/utils.test.tsx
+++ b/packages/query-core/src/tests/utils.test.tsx
@@ -332,6 +332,24 @@ describe('core/utils', () => {
       const result = replaceEqualDeep(obj1, obj2)
       expect(result).toStrictEqual(obj2)
     })
+
+    it('should be able to share values that contain undefined', () => {
+      const current = [
+        {
+          data: undefined,
+          foo: true,
+        },
+      ]
+
+      const next = replaceEqualDeep(current, [
+        {
+          data: undefined,
+          foo: true,
+        },
+      ])
+
+      expect(current).toBe(next)
+    })
   })
 
   describe('matchMutation', () => {

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -224,7 +224,8 @@ export function replaceEqualDeep(a: any, b: any): any {
   const array = isPlainArray(a) && isPlainArray(b)
 
   if (array || (isPlainObject(a) && isPlainObject(b))) {
-    const aSize = array ? a.length : Object.keys(a).length
+    const aItems = array ? a : Object.keys(a)
+    const aSize = aItems.length
     const bItems = array ? b : Object.keys(b)
     const bSize = bItems.length
     const copy: any = array ? [] : {}
@@ -233,9 +234,19 @@ export function replaceEqualDeep(a: any, b: any): any {
 
     for (let i = 0; i < bSize; i++) {
       const key = array ? i : bItems[i]
-      copy[key] = replaceEqualDeep(a[key], b[key])
-      if (copy[key] === a[key] && a[key] !== undefined) {
+      if (
+        !array &&
+        a[key] === undefined &&
+        b[key] === undefined &&
+        aItems.includes(key)
+      ) {
+        copy[key] = undefined
         equalItems++
+      } else {
+        copy[key] = replaceEqualDeep(a[key], b[key])
+        if (copy[key] === a[key] && a[key] !== undefined) {
+          equalItems++
+        }
       }
     }
 


### PR DESCRIPTION
fixes #6717