### PR TITLE
fix(query-devtools): Update default devtools button position to bottom-right 🌱

### DIFF
--- a/docs/angular/devtools.md
+++ b/docs/angular/devtools.md
@@ -46,7 +46,7 @@ import { Component } from '@angular/core';
 - `initialIsOpen: Boolean`
   - Set this `true` if you want the dev tools to default to being open
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
-  - Defaults to `bottom-left`
+  - Defaults to `bottom-right`
   - The position of the TanStack logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`

--- a/docs/react/devtools.md
+++ b/docs/react/devtools.md
@@ -57,7 +57,7 @@ function App() {
 - `initialIsOpen: Boolean`
   - Set this `true` if you want the dev tools to default to being open
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
-  - Defaults to `bottom-left`
+  - Defaults to `bottom-right`
   - The position of the React Query logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`

--- a/docs/solid/devtools.md
+++ b/docs/solid/devtools.md
@@ -53,7 +53,7 @@ function App() {
 - `initialIsOpen: Boolean`
   - Set this `true` if you want the dev tools to default to being open
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
-  - Defaults to `bottom-left`
+  - Defaults to `bottom-right`
   - The position of the Solid Query logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`

--- a/docs/vue/devtools.md
+++ b/docs/vue/devtools.md
@@ -49,7 +49,7 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
 - `initialIsOpen: Boolean`
   - Set this `true` if you want the dev tools to default to being open
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
-  - Defaults to `bottom-left`
+  - Defaults to `bottom-right`
   - The position of the React Query logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -17,7 +17,7 @@ export interface DevtoolsOptions {
   /**
    * The position of the React Query logo to open and close the devtools panel.
    * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-   * Defaults to 'bottom-left'.
+   * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition
   /**

--- a/packages/solid-query-devtools/src/devtools.tsx
+++ b/packages/solid-query-devtools/src/devtools.tsx
@@ -27,7 +27,7 @@ interface DevtoolsOptions {
   /**
    * The position of the React Query logo to open and close the devtools panel.
    * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-   * Defaults to 'bottom-left'.
+   * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition
   /**

--- a/packages/svelte-query-devtools/src/Devtools.svelte
+++ b/packages/svelte-query-devtools/src/Devtools.svelte
@@ -11,7 +11,7 @@
   } from '@tanstack/query-devtools'
 
   export let initialIsOpen = false
-  export let buttonPosition: DevtoolsButtonPosition = 'bottom-left'
+  export let buttonPosition: DevtoolsButtonPosition = 'bottom-right'
   export let position: DevtoolsPosition = 'bottom'
   export let client: QueryClient = useQueryClient()
   export let errorTypes: Array<DevToolsErrorType> = []

--- a/packages/vue-query-devtools/src/devtools.vue
+++ b/packages/vue-query-devtools/src/devtools.vue
@@ -21,7 +21,7 @@ const devtools = new TanstackQueryDevtools({
 })
 
 watchEffect(() => {
-  devtools.setButtonPosition(props.buttonPosition || 'bottom-left')
+  devtools.setButtonPosition(props.buttonPosition || 'bottom-right')
   devtools.setPosition(props.position || 'bottom')
   devtools.setInitialIsOpen(props.initialIsOpen)
   devtools.setErrorTypes(props.errorTypes || [])

--- a/packages/vue-query-devtools/src/types.ts
+++ b/packages/vue-query-devtools/src/types.ts
@@ -13,7 +13,7 @@ export interface DevtoolsOptions {
   /**
    * The position of the React Query logo to open and close the devtools panel.
    * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-   * Defaults to 'bottom-left'.
+   * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition
   /**


### PR DESCRIPTION
## Summary
This pull request addresses a comment from the maintainers regarding the default position of the query devtools. The change aligns the default devtools position with the bottom-right corner to maintain consistency between adapters and documentation.

## Changes Made
Updated the default position of the query devtools to bottom-right.
Adjusted relevant documentation to reflect the updated default position.

## Context
The maintainers suggested aligning the default devtools position with the bottom-right corner to maintain consistency across adapters and documentation. This adjustment ensures a unified experience for users and developers using the query library.

## Related Issues
Closes #6242
<img width="960" alt="Screenshot 2024-01-16 at 16 14 36" src="https://github.com/TanStack/query/assets/20648944/a43572a0-66ea-440c-aaf9-db2d19467ad3">
