### PR TITLE
docs: add queryClient to useQuery signature

### DIFF
--- a/docs/react/reference/useQuery.md
+++ b/docs/react/reference/useQuery.md
@@ -52,7 +52,7 @@ const {
   staleTime,
   structuralSharing,
   throwOnError,
-})
+}, queryClient)
 ```
 
 **Options**


### PR DESCRIPTION
Tiny docs update, just noticed it wasn't in the documented signature (it's in the list of options below)