### PR TITLE
fix(query-next-experimental): escape </ when hydrating

### DIFF
--- a/packages/react-query-next-experimental/src/HydrationStreamProvider.tsx
+++ b/packages/react-query-next-experimental/src/HydrationStreamProvider.tsx
@@ -130,7 +130,7 @@ export function createHydrationStreamProvider<TShape>() {
         <script
           key={count.current++}
           dangerouslySetInnerHTML={{
-            __html: html.join(''),
+            __html: html.join('').replaceAll('</', '<\\/'),
           }}
         />
       )


### PR DESCRIPTION
Escape </ when hydrating so that it doesn't break rendering. The recommendation after some light reading (https://stackoverflow.com/questions/14780858/escape-in-script-tag-contents) seems to be to escape all `</` in script tags with `<\/`

Fixes #6735

See attached pull request for reproduction.

Test Plan: Tested this locally by running the example attached in the pull request with this fix in place.