### PR TITLE
refactor(eslint-plugin-query): Use `@tanstack/config` build

### DIFF
--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -15,34 +15,33 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
-  "main": "build/legacy/index.cjs",
-  "module": "build/legacy/index.js",
+  "types": "dist/esm/index.d.ts",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": {
-        "types": "./build/legacy/index.d.ts",
-        "default": "./build/legacy/index.js"
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
       },
       "require": {
-        "types": "./build/legacy/index.d.cts",
-        "default": "./build/legacy/index.cjs"
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
       }
     },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "clean": "rimraf ./build && rimraf ./coverage",
-    "dev": "tsup --watch --sourcemap",
+    "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc",
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "tsup"
+    "build": "vite build"
   },
   "files": [
-    "build",
+    "dist",
     "src"
   ],
   "dependencies": {

--- a/packages/eslint-plugin-query/src/utils/object-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/object-utils.ts
@@ -1,5 +1,0 @@
-export function objectKeys<T extends Record<string, unknown>>(
-  obj: T,
-): Array<keyof T> {
-  return Object.keys(obj) as Array<keyof T>
-}

--- a/packages/eslint-plugin-query/tsconfig.json
+++ b/packages/eslint-plugin-query/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    ".eslintrc.cjs",
-    "tsup.config.js",
-    "vite.config.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/eslint-plugin-query/tsup.config.js
+++ b/packages/eslint-plugin-query/tsup.config.js
@@ -1,6 +1,0 @@
-// @ts-check
-
-import { defineConfig } from 'tsup'
-import { legacyConfig } from '../../scripts/getTsupConfig.js'
-
-export default defineConfig([legacyConfig({ entry: ['src/**/*.ts'] })])

--- a/packages/eslint-plugin-query/vite.config.ts
+++ b/packages/eslint-plugin-query/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackBuildConfig } from '@tanstack/config/build'
 
-export default defineConfig({
+const config = defineConfig({
   test: {
     name: 'eslint-plugin-query',
     dir: './src',
@@ -10,3 +11,12 @@ export default defineConfig({
     typecheck: { enabled: true },
   },
 })
+
+export default mergeConfig(
+  config,
+  tanstackBuildConfig({
+    entry: './src/index.ts',
+    srcDir: './src',
+    exclude: ['./src/__tests__'],
+  }),
+)


### PR DESCRIPTION
This package used only the legacy tsup config, which is comparable to the Vite build config.