### PR TITLE
docs: update react-native.md

### DIFF
--- a/docs/react/react-native.md
+++ b/docs/react/react-native.md
@@ -134,6 +134,6 @@ function MyComponent() {
     notifyOnChangeProps,
   });
 
-  return <div>DataUpdatedAt: {dataUpdatedAt}</div>;
+  return <Text>DataUpdatedAt: {dataUpdatedAt}</Text>;
 };
 ```


### PR DESCRIPTION
Seeing `div` in a React Native specific guide threw me off for a second, as I thought I may not be in RN land but DOM land. Simple change but should hopefully prevent anyone else from thinking similarly.