### PR TITLE
fix(query-devtools): typed tokens

### DIFF
--- a/packages/query-devtools/src/theme.ts
+++ b/packages/query-devtools/src/theme.ts
@@ -265,7 +265,7 @@ export const tokens = {
     96: 'calc(var(--tsqd-font-size) * 24)',
   },
   shadow: {
-    xs: (color: string = 'rgb(0 0 0 / 0.1)') =>
+    xs: (_: string = 'rgb(0 0 0 / 0.1)') =>
       `0 1px 2px 0 rgb(0 0 0 / 0.05)` as const,
     sm: (color: string = 'rgb(0 0 0 / 0.1)') =>
       `0 1px 3px 0 ${color}, 0 1px 2px -1px ${color}` as const,

--- a/packages/query-devtools/src/theme.ts
+++ b/packages/query-devtools/src/theme.ts
@@ -1,31 +1,3 @@
-const ShadowVariants = {
-  xs: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
-  sm: '0 1px 3px 0 color, 0 1px 2px -1px color',
-  md: '0 4px 6px -1px color, 0 2px 4px -2px color',
-  lg: '0 10px 15px -3px color, 0 4px 6px -4px color',
-  xl: '0 20px 25px -5px color, 0 8px 10px -6px color',
-  '2xl': '0 25px 50px -12px color',
-  inner: 'inset 0 2px 4px 0 color',
-  none: 'none',
-}
-
-type ShadowVariantType = keyof typeof ShadowVariants
-
-const getShadow = (variant: ShadowVariantType, color: string = ''): string => {
-  return ShadowVariants[variant].replace(/color/g, color)
-}
-
-const Shadow = {
-  xs: (color: string = 'rgb(0 0 0 / 0.1)') => getShadow('xs', color),
-  sm: (color: string = 'rgb(0 0 0 / 0.1)') => getShadow('sm', color),
-  md: (color: string = 'rgb(0 0 0 / 0.1)') => getShadow('md', color),
-  lg: (color: string = 'rgb(0 0 0 / 0.1)') => getShadow('lg', color),
-  xl: (color: string = 'rgb(0 0 0 / 0.1)') => getShadow('xl', color),
-  '2xl': (color: string = 'rgb(0 0 0 / 0.25)') => getShadow('2xl', color),
-  inner: (color: string = 'rgb(0 0 0 / 0.05)') => getShadow('inner', color),
-  none: () => getShadow('none'),
-}
-
 export const tokens = {
   colors: {
     inherit: 'inherit',
@@ -292,7 +264,23 @@ export const tokens = {
     80: 'calc(var(--tsqd-font-size) * 20)',
     96: 'calc(var(--tsqd-font-size) * 24)',
   },
-  shadow: Shadow,
+  shadow: {
+    xs: (color: string = 'rgb(0 0 0 / 0.1)') =>
+      `0 1px 2px 0 rgb(0 0 0 / 0.05)` as const,
+    sm: (color: string = 'rgb(0 0 0 / 0.1)') =>
+      `0 1px 3px 0 ${color}, 0 1px 2px -1px ${color}` as const,
+    md: (color: string = 'rgb(0 0 0 / 0.1)') =>
+      `0 4px 6px -1px ${color}, 0 2px 4px -2px ${color}` as const,
+    lg: (color: string = 'rgb(0 0 0 / 0.1)') =>
+      `0 10px 15px -3px ${color}, 0 4px 6px -4px ${color}` as const,
+    xl: (color: string = 'rgb(0 0 0 / 0.1)') =>
+      `0 20px 25px -5px ${color}, 0 8px 10px -6px ${color}` as const,
+    '2xl': (color: string = 'rgb(0 0 0 / 0.25)') =>
+      `0 25px 50px -12px ${color}` as const,
+    inner: (color: string = 'rgb(0 0 0 / 0.05)') =>
+      `inset 0 2px 4px 0 ${color}` as const,
+    none: () => `none` as const,
+  },
   zIndices: {
     hide: -1,
     auto: 'auto',
@@ -308,4 +296,4 @@ export const tokens = {
     toast: 1700,
     tooltip: 1800,
   },
-}
+} as const


### PR DESCRIPTION
I thought tokens should be readonly object to improve DX

### AS-IS
![image](https://github.com/TanStack/query/assets/61593290/5028dab8-22a9-4962-a8f2-ab8c663eb287)
![image](https://github.com/TanStack/query/assets/61593290/d5da72b1-8481-4362-a3d6-001e8b66450b)

### TO-BE
![image](https://github.com/TanStack/query/assets/61593290/3c66105e-9721-4ecf-8fb3-c84bf2860b53)
![image](https://github.com/TanStack/query/assets/61593290/1877ec46-6050-4a2a-9a11-cf12d6cb229c)
