### PR TITLE
fix(experimental_createPersister): setQueryData, ensureQueryData supports persister

### DIFF
--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -116,7 +116,7 @@ export function infiniteQueryBehavior<TQueryFnData, TError, TData, TPageParam>(
       }
       if (context.options.persister) {
         context.fetchFn = () => {
-          return context.options.persister?.(
+          return context.options.persister?.persisterFn(
             fetchFn as any,
             {
               queryKey: context.queryKey,

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -394,7 +394,7 @@ export class Query<
       }
       this.#abortSignalConsumed = false
       if (this.options.persister) {
-        return this.options.persister(
+        return this.options.persister.persisterFn(
           this.options.queryFn,
           queryFnContext as QueryFunctionContext<TQueryKey>,
           this as unknown as Query,

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
 import type { MutationState } from './mutation'
-import type { FetchDirection, Query, QueryBehavior } from './query'
+import type { FetchDirection, Query, QueryBehavior, QueryState } from './query'
 import type { RetryDelayValue, RetryValue } from './retryer'
 import type { QueryFilters, QueryTypeFilter } from './utils'
 import type { QueryCache } from './queryCache'
@@ -148,11 +148,23 @@ export interface QueryOptions<
    */
   gcTime?: number
   queryFn?: QueryFunction<TQueryFnData, TQueryKey, TPageParam>
-  persister?: QueryPersister<
-    NoInfer<TQueryFnData>,
-    NoInfer<TQueryKey>,
-    NoInfer<TPageParam>
-  >
+  persister?: {
+    persisterFn: QueryPersister<
+      NoInfer<TQueryFnData>,
+      NoInfer<TQueryKey>,
+      NoInfer<TPageParam>
+    >
+    persistQuery: (query: Query) => Promise<void>
+    restoreQuery: <T>(
+      queryHash: string,
+      afterRestoreMacroTask?: (persistedQuery: {
+        buster: string
+        queryHash: string
+        queryKey: QueryKey
+        state: QueryState
+      }) => void,
+    ) => Promise<T | undefined>
+  }
   queryHash?: string
   queryKey?: TQueryKey
   queryKeyHashFn?: QueryKeyHashFunction<TQueryKey>

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -36,7 +36,7 @@ function setupPersister(
 
   const queryFn = vi.fn()
 
-  const persisterFn = experimental_createPersister(persisterOptions)
+  const { persisterFn } = experimental_createPersister(persisterOptions)
 
   const query = new Query({
     cache: new QueryCache(),
@@ -202,7 +202,7 @@ describe('createPersister', () => {
       storageKey,
       JSON.stringify({
         buster: '',
-        state: { dataUpdatedAt },
+        state: { dataUpdatedAt, data: '' },
       }),
     )
 
@@ -231,7 +231,7 @@ describe('createPersister', () => {
       storageKey,
       JSON.stringify({
         buster: '',
-        state: { dataUpdatedAt: Date.now() },
+        state: { dataUpdatedAt: Date.now(), data: '' },
       }),
     )
 
@@ -325,7 +325,7 @@ describe('createPersister', () => {
       storageKey,
       JSON.stringify({
         buster: '',
-        state: { dataUpdatedAt: Date.now() },
+        state: { dataUpdatedAt: Date.now(), data: '' },
       }),
     )
 


### PR DESCRIPTION
fixes #6310

This PR attempts to fix some gaps of experimental persister.

- `setQueryData`/`setQueriesData` - can be kept as a sync function, which kicks persister in the background if defined
- `ensureQueryData` - it's already async, so we can just hook up before kicking of `fetch`

Also small internal restructure of  `createPersister` to allow re-usability of internals.

We still need some way to restore persisted items on-demand and in bulk.