### PR TITLE
refactor(angular-query): provideAngularQuery by default instantiates QueryClient by itself

### DIFF
--- a/packages/angular-query-experimental/src/providers.ts
+++ b/packages/angular-query-experimental/src/providers.ts
@@ -9,9 +9,13 @@ import { provideQueryClient } from './inject-query-client'
 import type { EnvironmentProviders } from '@angular/core'
 
 export function provideAngularQuery(): EnvironmentProviders
-export function provideAngularQuery(queryClient: QueryClient): EnvironmentProviders
-export function provideAngularQuery(queryClient?: QueryClient): EnvironmentProviders {
-  const client =  queryClient ?? new QueryClient()
+export function provideAngularQuery(
+  queryClient: QueryClient,
+): EnvironmentProviders
+export function provideAngularQuery(
+  queryClient?: QueryClient,
+): EnvironmentProviders {
+  const client = queryClient ?? new QueryClient()
   return makeEnvironmentProviders([
     provideQueryClient(client),
     {

--- a/packages/angular-query-experimental/src/providers.ts
+++ b/packages/angular-query-experimental/src/providers.ts
@@ -4,22 +4,23 @@ import {
   inject,
   makeEnvironmentProviders,
 } from '@angular/core'
+import { QueryClient } from '@tanstack/query-core'
 import { provideQueryClient } from './inject-query-client'
 import type { EnvironmentProviders } from '@angular/core'
-import type { QueryClient } from '@tanstack/query-core'
 
-export function provideAngularQuery(
-  queryClient: QueryClient,
-): EnvironmentProviders {
+export function provideAngularQuery(): EnvironmentProviders
+export function provideAngularQuery(queryClient: QueryClient): EnvironmentProviders
+export function provideAngularQuery(queryClient?: QueryClient): EnvironmentProviders {
+  const client =  queryClient ?? new QueryClient()
   return makeEnvironmentProviders([
-    provideQueryClient(queryClient),
+    provideQueryClient(client),
     {
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,
       useValue: () => {
-        queryClient.mount()
+        client.mount()
         // Unmount the query client on application destroy
-        inject(DestroyRef).onDestroy(() => queryClient.unmount())
+        inject(DestroyRef).onDestroy(() => client.unmount())
       },
     },
   ])

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -110,12 +110,9 @@ export function useBaseQuery<
       throwOnError: defaultedOptions.throwOnError,
       query: client
         .getQueryCache()
-        .get<
-          TQueryFnData,
-          TError,
-          TQueryData,
-          TQueryKey
-        >(defaultedOptions.queryHash),
+        .get<TQueryFnData, TError, TQueryData, TQueryKey>(
+          defaultedOptions.queryHash,
+        ),
     })
   ) {
     throw result.error


### PR DESCRIPTION
Question:
What is the use case for having this signature `export function provideAngularQuery(queryClient: QueryClient): EnvironmentProviders`? 
If one wants to override the QueryCLient it can be done the "angular-way" via DI `{provide:QUERY_CLIENT, useClass: MyClient}` or `provideQueryClient(() => new MyClient)`
So I believe we can remove the signature? Or am I missing something?.
