### PR TITLE
fix: Enable @typescript-eslint/method-signature-style

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,6 +67,7 @@ const config = {
       { prefer: 'type-imports' },
     ],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/method-signature-style': ['error', 'property'],
     '@typescript-eslint/naming-convention': [
       'error',
       {

--- a/packages/angular-query-experimental/src/types.ts
+++ b/packages/angular-query-experimental/src/types.ts
@@ -53,23 +53,23 @@ type CreateStatusBasedQueryResult<
 > = Extract<QueryObserverResult<TData, TError>, { status: TStatus }>
 
 export interface BaseQueryNarrowing<TData = unknown, TError = DefaultError> {
-  isSuccess(
+  isSuccess: (
     this: CreateBaseQueryResult<TData, TError>,
-  ): this is CreateBaseQueryResult<
+  ) => this is CreateBaseQueryResult<
     TData,
     TError,
     CreateStatusBasedQueryResult<'success', TData, TError>
   >
-  isError(
+  isError: (
     this: CreateBaseQueryResult<TData, TError>,
-  ): this is CreateBaseQueryResult<
+  ) => this is CreateBaseQueryResult<
     TData,
     TError,
     CreateStatusBasedQueryResult<'error', TData, TError>
   >
-  isPending(
+  isPending: (
     this: CreateBaseQueryResult<TData, TError>,
-  ): this is CreateBaseQueryResult<
+  ) => this is CreateBaseQueryResult<
     TData,
     TError,
     CreateStatusBasedQueryResult<'pending', TData, TError>
@@ -185,9 +185,9 @@ export interface BaseMutationNarrowing<
   TVariables = unknown,
   TContext = unknown,
 > {
-  isSuccess(
+  isSuccess: (
     this: CreateMutationResult<TData, TError, TVariables, TContext>,
-  ): this is CreateMutationResult<
+  ) => this is CreateMutationResult<
     TData,
     TError,
     TVariables,
@@ -200,9 +200,9 @@ export interface BaseMutationNarrowing<
       TContext
     >
   >
-  isError(
+  isError: (
     this: CreateMutationResult<TData, TError, TVariables, TContext>,
-  ): this is CreateMutationResult<
+  ) => this is CreateMutationResult<
     TData,
     TError,
     TVariables,
@@ -215,9 +215,9 @@ export interface BaseMutationNarrowing<
       TContext
     >
   >
-  isPending(
+  isPending: (
     this: CreateMutationResult<TData, TError, TVariables, TContext>,
-  ): this is CreateMutationResult<
+  ) => this is CreateMutationResult<
     TData,
     TError,
     TVariables,
@@ -230,9 +230,9 @@ export interface BaseMutationNarrowing<
       TContext
     >
   >
-  isIdle(
+  isIdle: (
     this: CreateMutationResult<TData, TError, TVariables, TContext>,
-  ): this is CreateMutationResult<
+  ) => this is CreateMutationResult<
     TData,
     TError,
     TVariables,

--- a/packages/query-persist-client-core/src/persist.ts
+++ b/packages/query-persist-client-core/src/persist.ts
@@ -10,9 +10,9 @@ import type {
 export type Promisable<T> = T | PromiseLike<T>
 
 export interface Persister {
-  persistClient(persistClient: PersistedClient): Promisable<void>
-  restoreClient(): Promisable<PersistedClient | undefined>
-  removeClient(): Promisable<void>
+  persistClient: (persistClient: PersistedClient) => Promisable<void>
+  restoreClient: () => Promisable<PersistedClient | undefined>
+  removeClient: () => Promisable<void>
 }
 
 export interface PersistedClient {

--- a/packages/react-query-next-experimental/src/HydrationStreamProvider.tsx
+++ b/packages/react-query-next-experimental/src/HydrationStreamProvider.tsx
@@ -7,8 +7,8 @@ import { htmlEscapeJsonString } from './htmlescape'
 const serializedSymbol = Symbol('serialized')
 
 interface DataTransformer {
-  serialize(object: any): any
-  deserialize(object: any): any
+  serialize: (object: any) => any
+  deserialize: (object: any) => any
 }
 
 type Serialized<TData> = unknown & {


### PR DESCRIPTION
See here for more information: https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful

> This happens because the method shorthand syntax is bivariant. This means that the method can accept a type that is both narrower and wider than the original type.

> This is not the case with the object property syntax. It only accepts a type that is narrower than the original type.

> It's this unexpected bivariance that can lead to runtime errors.