### PR TITLE
chore: Replace `@ts-ignore` with `@ts-expect-error`

### DIFF
--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -93,7 +93,7 @@ function App() {
   const [showDevtools, setShowDevtools] = React.useState(false)
 
   React.useEffect(() => {
-    // @ts-ignore
+    // @ts-expect-error
     window.toggleDevtools = () => setShowDevtools((old) => !old)
   }, [])
 

--- a/packages/angular-query-experimental/src/signal-proxy.ts
+++ b/packages/angular-query-experimental/src/signal-proxy.ts
@@ -29,7 +29,7 @@ export function signalProxy<TInput extends Record<string | symbol, any>>(
       if (typeof targetField === 'function') return targetField
 
       // finally, create a computed field, store it and return it
-      // @ts-ignore
+      // @ts-expect-error
       return (target[prop] = computed(() => inputSignal()[prop]))
     },
     has(_, prop) {

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -2101,7 +2101,6 @@ const createSubscribeToQueryCacheBatcher = <T,>(
   })
 
   onCleanup(() => {
-    // @ts-ignore
     queryCacheMap.delete(callback)
   })
 
@@ -2153,11 +2152,9 @@ const createSubscribeToMutationCacheBatcher = <T,>(
     setValue(callback(mutationCache))
   })
 
-  // @ts-ignore
   mutationCacheMap.set(callback, setValue)
 
   onCleanup(() => {
-    // @ts-ignore
     mutationCacheMap.delete(callback)
   })
 

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -28,7 +28,7 @@ function setupPersister(
   const context = {
     meta: { foo: 'bar' },
     queryKey,
-    // @ts-ignore
+    // @ts-expect-error
     signal: undefined as AbortSignal,
   }
   const queryHash = hashKey(queryKey)

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -220,7 +220,7 @@ describe('React hydration', () => {
           // Never resolve
         })
 
-        // @ts-ignore
+        // @ts-expect-error
         return null
       }
 

--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
-// @ts-ignore
 import { renderToString } from 'react-dom/server'
 import { QueryCache, QueryClientProvider, useInfiniteQuery, useQuery } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -28,7 +28,7 @@ describe('useQuery', () => {
   it('should return the correct types', () => {
     const key = queryKey()
 
-    // @ts-ignore
+    // @ts-expect-error
     function Page() {
       // unspecified query function should default to unknown
       const noQueryFn = useQuery({ queryKey: key })

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -253,7 +253,7 @@ export function createQueries<
 
   const { subscribe } = derived(
     [result, defaultedQueriesStore],
-    // @ts-ignore svelte-check thinks this is unused
+    // @ts-expect-error svelte-check thinks this is unused
     ([$result, $defaultedQueriesStore]) => {
       const [rawResult, combineResult, trackResult] =
         observer.getOptimisticResult(


### PR DESCRIPTION
Removes a bunch of unnecessary `@ts-ignore` statements

See here: https://www.totaltypescript.com/concepts/how-to-use-ts-expect-error