### PR TITLE
chore: Replace plugin:react/recommended with plugin:react/jsx-runtime

### DIFF
--- a/examples/react/algolia/.eslintrc
+++ b/examples/react/algolia/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:@tanstack/eslint-plugin-query/recommended"
   ]

--- a/examples/react/basic-graphql-request/.eslintrc
+++ b/examples/react/basic-graphql-request/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/basic-typescript/.eslintrc
+++ b/examples/react/basic-typescript/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:@tanstack/eslint-plugin-query/recommended"
   ]

--- a/examples/react/basic/.eslintrc
+++ b/examples/react/basic/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:@tanstack/eslint-plugin-query/recommended"
   ]

--- a/examples/react/default-query-function/.eslintrc
+++ b/examples/react/default-query-function/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/offline/.eslintrc
+++ b/examples/react/offline/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/playground/.eslintrc
+++ b/examples/react/playground/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/react-router/.eslintrc
+++ b/examples/react/react-router/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/rick-morty/.eslintrc
+++ b/examples/react/rick-morty/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/simple/.eslintrc
+++ b/examples/react/simple/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/star-wars/.eslintrc
+++ b/examples/react/star-wars/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/examples/react/suspense/.eslintrc
+++ b/examples/react/suspense/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"]
+  "extends": ["plugin:react/jsx-runtime", "plugin:react-hooks/recommended"]
 }

--- a/integrations/react-cra4/.eslintrc.cjs
+++ b/integrations/react-cra4/.eslintrc.cjs
@@ -1,11 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  root: true,
-  extends: [
-    '../../.eslintrc.cjs',
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-  ],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   settings: {
     react: {
       version: 'detect',

--- a/integrations/react-cra5/.eslintrc.cjs
+++ b/integrations/react-cra5/.eslintrc.cjs
@@ -1,11 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  root: true,
-  extends: [
-    '../../.eslintrc.cjs',
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-  ],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   settings: {
     react: {
       version: 'detect',

--- a/integrations/react-next/.eslintrc.cjs
+++ b/integrations/react-next/.eslintrc.cjs
@@ -1,11 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  root: true,
-  extends: [
-    '../../.eslintrc.cjs',
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-  ],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   settings: {
     react: {
       version: 'detect',

--- a/integrations/react-vite/.eslintrc.cjs
+++ b/integrations/react-vite/.eslintrc.cjs
@@ -1,11 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  root: true,
-  extends: [
-    '../../.eslintrc.cjs',
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-  ],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   settings: {
     react: {
       version: 'detect',

--- a/packages/react-query-devtools/.eslintrc.cjs
+++ b/packages/react-query-devtools/.eslintrc.cjs
@@ -2,7 +2,7 @@
 
 /** @type {import('eslint').Linter.Config} */
 const config = {
-  extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],
     'react-hooks/exhaustive-deps': 'error',

--- a/packages/react-query-devtools/tsconfig.json
+++ b/packages/react-query-devtools/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "src/**/*.ts",

--- a/packages/react-query-next-experimental/.eslintrc.cjs
+++ b/packages/react-query-next-experimental/.eslintrc.cjs
@@ -2,7 +2,7 @@
 
 /** @type {import('eslint').Linter.Config} */
 const config = {
-  extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],
     'react-hooks/exhaustive-deps': 'error',

--- a/packages/react-query-next-experimental/tsconfig.json
+++ b/packages/react-query-next-experimental/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "src/**/*.ts",

--- a/packages/react-query-persist-client/.eslintrc.cjs
+++ b/packages/react-query-persist-client/.eslintrc.cjs
@@ -2,7 +2,7 @@
 
 /** @type {import('eslint').Linter.Config} */
 const config = {
-  extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],
     'react-hooks/exhaustive-deps': 'error',

--- a/packages/react-query-persist-client/tsconfig.json
+++ b/packages/react-query-persist-client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "src/**/*.ts",

--- a/packages/react-query/.eslintrc.cjs
+++ b/packages/react-query/.eslintrc.cjs
@@ -2,7 +2,7 @@
 
 /** @type {import('eslint').Linter.Config} */
 const config = {
-  extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  extends: ['plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   rules: {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],
     'react-hooks/exhaustive-deps': 'error',

--- a/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, test } from 'vitest'
-import * as React from 'react'
 import { render, waitFor } from '@testing-library/react'
 
 import { vi } from 'vitest'

--- a/packages/react-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/react-query/src/__tests__/ssr-hydration.test.tsx
@@ -1,5 +1,4 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import * as React from 'react'
 import ReactDOM from 'react-dom'
 import * as ReactDOMTestUtils from 'react-dom/test-utils'
 import * as ReactDOMServer from 'react-dom/server'

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Replaced `plugin:react/recommended` with `plugin:react/jsx-runtime`

Disables https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md, which causes very annoying (and incorrect) highlighting of all JSX in the React examples

This is compatible with CRA v4 (see https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

Also needed to set `"jsx"` to `"react-jsx"` in tsconfig, but this has no impact on the build output (generated by tsup).