### PR TITLE
docs(examples): Update Vinxi

### DIFF
--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-query": "^5.20.5",
     "@tanstack/solid-query-devtools": "^5.20.5",
     "solid-js": "^1.8.14",
-    "vinxi": "^0.2.1"
+    "vinxi": "^0.3.3"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1191,7 +1191,7 @@ importers:
         version: 0.12.0(solid-js@1.8.14)
       '@solidjs/start':
         specifier: ^0.5.4
-        version: 0.5.4(@testing-library/jest-dom@6.4.2)(rollup@4.6.0)(solid-js@1.8.14)(vinxi@0.2.1)(vite@4.5.1)
+        version: 0.5.4(@testing-library/jest-dom@6.4.2)(rollup@4.6.0)(solid-js@1.8.14)(vinxi@0.3.3)(vite@4.5.1)
       '@tanstack/solid-query':
         specifier: ^5.20.5
         version: link:../../../packages/solid-query
@@ -1202,8 +1202,8 @@ importers:
         specifier: ^1.8.14
         version: 1.8.14
       vinxi:
-        specifier: ^0.2.1
-        version: 0.2.1(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
+        specifier: ^0.3.3
+        version: 0.3.3(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
 
   examples/svelte/auto-refetching:
     dependencies:
@@ -4857,6 +4857,17 @@ packages:
       postcss-selector-parser: 6.0.13
     dev: false
 
+  /@deno/shim-deno-test@0.5.0:
+    resolution: {integrity: sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==}
+    dev: false
+
+  /@deno/shim-deno@0.19.1:
+    resolution: {integrity: sha512-8hYIpmDqpG76sn+UY1853RCi+CI7ZWz9tt37nfyDL8rwr6xbW0+GHUwCLcsGbh1uMIKURuJy6xtrIcnW+a0duA==}
+    dependencies:
+      '@deno/shim-deno-test': 0.5.0
+      which: 4.0.0
+    dev: false
+
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
@@ -7526,7 +7537,7 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
-  /@preact/preset-vite@2.8.1(@babel/core@7.23.7)(preact@10.19.4)(vite@4.5.0):
+  /@preact/preset-vite@2.8.1(@babel/core@7.23.7)(preact@10.19.4)(vite@5.1.1):
     resolution: {integrity: sha512-a9KV4opdj17X2gOFuGup0aE+sXYABX/tJi/QDptOrleX4FlnoZgDWvz45tHOdVfrZX+3uvVsIYPHxRsTerkDNA==}
     peerDependencies:
       '@babel/core': 7.x
@@ -7535,7 +7546,7 @@ packages:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.7)
-      '@prefresh/vite': 2.4.5(preact@10.19.4)(vite@4.5.0)
+      '@prefresh/vite': 2.4.5(preact@10.19.4)(vite@5.1.1)
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.7)
       debug: 4.3.4(supports-color@6.1.0)
@@ -7543,7 +7554,7 @@ packages:
       magic-string: 0.30.5
       node-html-parser: 6.1.12
       resolve: 1.22.8
-      vite: 4.5.0(@types/node@18.19.3)
+      vite: 5.1.1(@types/node@18.19.3)
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -7565,7 +7576,7 @@ packages:
     resolution: {integrity: sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ==}
     dev: false
 
-  /@prefresh/vite@2.4.5(preact@10.19.4)(vite@4.5.0):
+  /@prefresh/vite@2.4.5(preact@10.19.4)(vite@5.1.1):
     resolution: {integrity: sha512-iForDVJ2M8gQYnm5pHumvTEJjGGc7YNYC0GVKnHFL+GvFfKHfH9Rpq67nUAzNbjuLEpqEOUuQVQajMazWu2ZNQ==}
     peerDependencies:
       preact: ^10.4.0
@@ -7577,7 +7588,7 @@ packages:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.19.4
-      vite: 4.5.0(@types/node@18.19.3)
+      vite: 5.1.1(@types/node@18.19.3)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8656,12 +8667,12 @@ packages:
       solid-js: 1.8.14
     dev: false
 
-  /@solidjs/start@0.5.4(@testing-library/jest-dom@6.4.2)(rollup@4.6.0)(solid-js@1.8.14)(vinxi@0.2.1)(vite@4.5.1):
+  /@solidjs/start@0.5.4(@testing-library/jest-dom@6.4.2)(rollup@4.6.0)(solid-js@1.8.14)(vinxi@0.3.3)(vite@4.5.1):
     resolution: {integrity: sha512-et6fu8GPRlzPz1nE0jJrB4QWEqKNzCMh62+FbmnZjOHA0eUldy47Aniki5RO6288eX5Oj4S6BWnvYcu1/iWkMw==}
     dependencies:
-      '@vinxi/plugin-directives': 0.2.0(vinxi@0.2.1)
-      '@vinxi/server-components': 0.2.0(vinxi@0.2.1)
-      '@vinxi/server-functions': 0.2.1(vinxi@0.2.1)
+      '@vinxi/plugin-directives': 0.2.0(vinxi@0.3.3)
+      '@vinxi/server-components': 0.2.0(vinxi@0.3.3)
+      '@vinxi/server-functions': 0.2.1(vinxi@0.3.3)
       defu: 6.1.4
       error-stack-parser: 2.1.4
       html-to-image: 1.11.11
@@ -9810,15 +9821,15 @@ packages:
       - supports-color
     dev: false
 
-  /@vinxi/devtools@0.2.0(@babel/core@7.23.7)(@testing-library/jest-dom@6.4.2)(preact@10.19.4)(rollup@4.6.0)(vite@4.5.0):
+  /@vinxi/devtools@0.2.0(@babel/core@7.23.7)(@testing-library/jest-dom@6.4.2)(preact@10.19.4)(rollup@4.6.0)(vite@5.1.1):
     resolution: {integrity: sha512-LpQp5zbiBhV4eo2w6AiJFtpZZj4LaRBOnzggIPTeSJYvgrxRMAqe/34Har3vVo+b7sPOjxFbE1zHZhLzaAcidw==}
     dependencies:
-      '@preact/preset-vite': 2.8.1(@babel/core@7.23.7)(preact@10.19.4)(vite@4.5.0)
+      '@preact/preset-vite': 2.8.1(@babel/core@7.23.7)(preact@10.19.4)(vite@5.1.1)
       '@solidjs/router': 0.8.4(solid-js@1.8.14)
       birpc: 0.2.14
       solid-js: 1.8.14
-      vite-plugin-inspect: 0.7.40(rollup@4.6.0)(vite@4.5.0)
-      vite-plugin-solid: 2.9.1(@testing-library/jest-dom@6.4.2)(solid-js@1.8.14)(vite@4.5.0)
+      vite-plugin-inspect: 0.7.40(rollup@4.6.0)(vite@5.1.1)
+      vite-plugin-solid: 2.9.1(@testing-library/jest-dom@6.4.2)(solid-js@1.8.14)(vite@5.1.1)
       ws: 8.16.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -9855,7 +9866,7 @@ packages:
       uqr: 0.1.2
     dev: false
 
-  /@vinxi/plugin-directives@0.2.0(vinxi@0.2.1):
+  /@vinxi/plugin-directives@0.2.0(vinxi@0.3.3):
     resolution: {integrity: sha512-DoYuIuvdylU+0XNOipvcbw08XDBBbEksc3euCsbApNVpmQ/mC+2CjoErHtjb4zX1RqNwe1sJ8awMK6fKUMLGRA==}
     peerDependencies:
       vinxi: ^0.2.0
@@ -9869,37 +9880,37 @@ packages:
       magicast: 0.2.11
       recast: 0.23.4
       tslib: 2.6.2
-      vinxi: 0.2.1(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
+      vinxi: 0.3.3(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
     dev: false
 
-  /@vinxi/server-components@0.2.0(vinxi@0.2.1):
+  /@vinxi/server-components@0.2.0(vinxi@0.3.3):
     resolution: {integrity: sha512-U3z6pxK5CWBxaUmyg7zdDMTl1AMa47MpYCUcs0QVOz/C8kKlT6C9Ozh5pZWuzAO0cTeueNpQumDWhQ4YTXTsZw==}
     peerDependencies:
       vinxi: ^0.2.0
     dependencies:
-      '@vinxi/plugin-directives': 0.2.0(vinxi@0.2.1)
+      '@vinxi/plugin-directives': 0.2.0(vinxi@0.3.3)
       acorn: 8.11.3
       acorn-loose: 8.4.0
       acorn-typescript: 1.4.12(acorn@8.11.3)
       astring: 1.8.6
       magicast: 0.2.11
       recast: 0.23.4
-      vinxi: 0.2.1(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
+      vinxi: 0.3.3(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
     dev: false
 
-  /@vinxi/server-functions@0.2.1(vinxi@0.2.1):
+  /@vinxi/server-functions@0.2.1(vinxi@0.3.3):
     resolution: {integrity: sha512-ir06Q6nEpJFU1uXqHdKE2OXqZFjChAIgAHpCJzMunHiutRNyYTJ7ZhbFCUk5xOx+StMpWKtqOv72TDeP/xTLtA==}
     peerDependencies:
       vinxi: ^0.2.1
     dependencies:
-      '@vinxi/plugin-directives': 0.2.0(vinxi@0.2.1)
+      '@vinxi/plugin-directives': 0.2.0(vinxi@0.3.3)
       acorn: 8.11.3
       acorn-loose: 8.4.0
       acorn-typescript: 1.4.12(acorn@8.11.3)
       astring: 1.8.6
       magicast: 0.2.11
       recast: 0.23.4
-      vinxi: 0.2.1(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
+      vinxi: 0.3.3(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0)
     dev: false
 
   /@vitejs/plugin-basic-ssl@1.0.2(vite@5.0.12):
@@ -13665,6 +13676,13 @@ packages:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
+
+  /dax-sh@0.39.1:
+    resolution: {integrity: sha512-QrVpBGbcdQWFDXVHPjR9PcoZliKJc/sRP5RU1dL+YiJZ5ZiPnjTU7hOj3E3fUy+rCZmpUBMNFVfJQabTAGUUbA==}
+    dependencies:
+      '@deno/shim-deno': 0.19.1
+      undici-types: 5.26.5
+    dev: false
 
   /dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
@@ -18119,7 +18137,6 @@ packages:
   /isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
-    dev: true
 
   /isobject@2.1.0:
     resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
@@ -19947,6 +19964,8 @@ packages:
       webpack: '*'
     peerDependenciesMeta:
       webpack:
+        optional: true
+      webpack-sources:
         optional: true
     dependencies:
       webpack: 5.89.0(esbuild@0.19.11)
@@ -28934,8 +28953,8 @@ packages:
       semver: 7.6.0
     dev: true
 
-  /vinxi@0.2.1(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0):
-    resolution: {integrity: sha512-zrgFO2XuKpdoW5VwlbieeQ0YhzMuuYCJyFWFyj41h9BnymHZ5dnKElALvFQn5JVzHhyrsdmlm8GU7tIuH786hw==}
+  /vinxi@0.3.3(@testing-library/jest-dom@6.4.2)(@types/node@18.19.3)(preact@10.19.4)(rollup@4.6.0):
+    resolution: {integrity: sha512-0KYGeNowy9SU7K2F7DTI7H4aGAelKLHzzxthf6fdd6cmokFhHM8xZ+fooTTciplbSMccW2adtsrg9Ia61jaPDg==}
     hasBin: true
     dependencies:
       '@babel/core': 7.23.7
@@ -28944,7 +28963,7 @@ packages:
       '@types/micromatch': 4.0.6
       '@types/serve-static': 1.15.4
       '@types/ws': 8.5.8
-      '@vinxi/devtools': 0.2.0(@babel/core@7.23.7)(@testing-library/jest-dom@6.4.2)(preact@10.19.4)(rollup@4.6.0)(vite@4.5.0)
+      '@vinxi/devtools': 0.2.0(@babel/core@7.23.7)(@testing-library/jest-dom@6.4.2)(preact@10.19.4)(rollup@4.6.0)(vite@5.1.1)
       '@vinxi/listhen': 1.5.6
       boxen: 7.1.1
       c12: 1.5.1
@@ -28952,6 +28971,7 @@ packages:
       citty: 0.1.5
       consola: 3.2.3
       cookie-es: 1.0.0
+      dax-sh: 0.39.1
       defu: 6.1.4
       dts-buddy: 0.2.5
       es-module-lexer: 1.3.1
@@ -28980,7 +29000,7 @@ packages:
       unenv: 1.9.0
       unimport: 3.7.0(rollup@4.6.0)
       unstorage: 1.10.1
-      vite: 4.5.0(@types/node@18.19.3)
+      vite: 5.1.1(@types/node@18.19.3)
       ws: 8.16.0
       zod: 3.22.4
     transitivePeerDependencies:
@@ -29067,30 +29087,6 @@ packages:
       vite: 5.1.1(@types/node@18.19.3)
     dev: true
 
-  /vite-plugin-inspect@0.7.40(rollup@4.6.0)(vite@4.5.0):
-    resolution: {integrity: sha512-tsfva6MCg0ch6ckReWHvJ/9xf/zjTuJvakONf2qcMBB/iu9JqiRixfxMa/yLGrlNaBe6fUZHOVhtN2Me3Kthow==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@nuxt/kit': '*'
-      vite: ^3.1.0 || ^4.0.0
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-    dependencies:
-      '@antfu/utils': 0.7.6
-      '@rollup/pluginutils': 5.1.0(rollup@4.6.0)
-      debug: 4.3.4(supports-color@6.1.0)
-      error-stack-parser-es: 0.1.1
-      fs-extra: 11.2.0
-      open: 9.1.0
-      picocolors: 1.0.0
-      sirv: 2.0.4
-      vite: 4.5.0(@types/node@18.19.3)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: false
-
   /vite-plugin-inspect@0.7.40(rollup@4.6.0)(vite@4.5.1):
     resolution: {integrity: sha512-tsfva6MCg0ch6ckReWHvJ/9xf/zjTuJvakONf2qcMBB/iu9JqiRixfxMa/yLGrlNaBe6fUZHOVhtN2Me3Kthow==}
     engines: {node: '>=14'}
@@ -29115,26 +29111,27 @@ packages:
       - supports-color
     dev: false
 
-  /vite-plugin-solid@2.9.1(@testing-library/jest-dom@6.4.2)(solid-js@1.8.14)(vite@4.5.0):
-    resolution: {integrity: sha512-RC4hj+lbvljw57BbMGDApvEOPEh14lwrr/GeXRLNQLcR1qnOdzOwwTSFy13Gj/6FNIZpBEl0bWPU+VYFawrqUw==}
+  /vite-plugin-inspect@0.7.40(rollup@4.6.0)(vite@5.1.1):
+    resolution: {integrity: sha512-tsfva6MCg0ch6ckReWHvJ/9xf/zjTuJvakONf2qcMBB/iu9JqiRixfxMa/yLGrlNaBe6fUZHOVhtN2Me3Kthow==}
+    engines: {node: '>=14'}
     peerDependencies:
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: ^1.7.2
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+      '@nuxt/kit': '*'
+      vite: ^3.1.0 || ^4.0.0
     peerDependenciesMeta:
-      '@testing-library/jest-dom':
+      '@nuxt/kit':
         optional: true
     dependencies:
-      '@babel/core': 7.23.7
-      '@testing-library/jest-dom': 6.4.2(vitest@1.2.2)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.8.6(@babel/core@7.23.7)
-      merge-anything: 5.1.7
-      solid-js: 1.8.14
-      solid-refresh: 0.6.3(solid-js@1.8.14)
-      vite: 4.5.0(@types/node@18.19.3)
-      vitefu: 0.2.5(vite@4.5.0)
+      '@antfu/utils': 0.7.6
+      '@rollup/pluginutils': 5.1.0(rollup@4.6.0)
+      debug: 4.3.4(supports-color@6.1.0)
+      error-stack-parser-es: 0.1.1
+      fs-extra: 11.2.0
+      open: 9.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vite: 5.1.1(@types/node@18.19.3)
     transitivePeerDependencies:
+      - rollup
       - supports-color
     dev: false
 
@@ -29182,42 +29179,6 @@ packages:
       vitefu: 0.2.5(vite@5.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  /vite@4.5.0(@types/node@18.19.3):
-    resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.19.3
-      esbuild: 0.18.20
-      postcss: 8.4.35
-      rollup: 3.29.4
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: false
 
   /vite@4.5.1(@types/node@18.19.3):
     resolution: {integrity: sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==}
@@ -29328,17 +29289,6 @@ packages:
       rollup: 4.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  /vitefu@0.2.5(vite@4.5.0):
-    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      vite: 4.5.0(@types/node@18.19.3)
-    dev: false
 
   /vitefu@0.2.5(vite@4.5.1):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
@@ -30041,7 +29991,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 3.1.1
-    dev: true
 
   /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}


### PR DESCRIPTION
Vinxi 0.3.0 uses Vite 5

This PR is also importantly a test of the Nx remote cache!