### PR TITLE
chore: Enable `@typescript-eslint/stylistic` config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ const config = {
     'eslint:recommended',
     'plugin:@cspell/recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/stylistic',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'prettier',
@@ -64,6 +65,7 @@ const config = {
     ],
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/consistent-type-imports': [
       'error',
       { prefer: 'type-imports' },
@@ -83,6 +85,7 @@ const config = {
         },
       },
     ],
+    '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',

--- a/.gitignore
+++ b/.gitignore
@@ -7,18 +7,9 @@ package-lock.json
 yarn.lock
 
 # builds
-types
-*/**/.angular
-*/**/.svelte-kit
-*/**/.tsup
-*/**/build
-*/**/dist
-*/**/lib
-*/**/es
-artifacts
-.rpt2_cache
+build
 coverage
-*.tgz
+dist
 
 # misc
 .DS_Store
@@ -41,9 +32,13 @@ stats.html
 
 *.log
 *.tsbuildinfo
-.DS_Store
+.angular
 .cache
-.pnpm-store
 .idea
-
 .nx/cache
+.pnpm-store
+.svelte-kit
+.tsup
+
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@4/schema.json",
   "ignoreWorkspaces": ["examples/**", "integrations/**"],
-  "ignore": ["**/react-app-env.d.ts", "**/vite-env.d.ts"],
   "workspaces": {
     "packages/codemods": {
       "entry": ["src/v4/*.js", "src/v5/*/*.js"],

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -64,7 +64,7 @@ export class QueryObserver<
   #staleTimeoutId?: ReturnType<typeof setTimeout>
   #refetchIntervalId?: ReturnType<typeof setInterval>
   #currentRefetchInterval?: number | false
-  #trackedProps: Set<keyof QueryObserverResult> = new Set()
+  #trackedProps = new Set<keyof QueryObserverResult>()
 
   constructor(
     client: QueryClient,

--- a/packages/react-query-next-experimental/src/htmlescape.ts
+++ b/packages/react-query-next-experimental/src/htmlescape.ts
@@ -9,7 +9,7 @@
 // This utility is based on https://github.com/zertosh/htmlescape
 // License: https://github.com/zertosh/htmlescape/blob/0527ca7156a524d256101bb310a9f970f63078ad/LICENSE
 
-const ESCAPE_LOOKUP: { [match: string]: string } = {
+const ESCAPE_LOOKUP: Record<string, string> = {
   '&': '\\u0026',
   '>': '\\u003e',
   '<': '\\u003c',


### PR DESCRIPTION
The stylistic config is recommended by [typescript-eslint](https://typescript-eslint.io/blog/announcing-typescript-eslint-v6), and is used by other TanStack projects. Some undesired rules (e.g. turning all types into interfaces) have been turned off.