### PR TITLE
WIP: Use @tanstack/config to generate legacy and modern builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@cspell/eslint-plugin": "^8.3.2",
     "@solidjs/testing-library": "^0.8.6",
-    "@tanstack/config": "^0.4.4",
+    "@tanstack/config": "^0.5.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@types/eslint": "^8.56.2",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -15,25 +15,25 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "build/legacy/index.d.ts",
-  "main": "build/legacy/index.cjs",
-  "module": "build/legacy/index.js",
+  "types": "dist/legacy/esm/index.d.ts",
+  "main": "dist/legacy/cjs/index.cjs",
+  "module": "dist/legacy/esm/index.js",
   "exports": {
     ".": {
       "import": {
-        "types": "./build/modern/index.d.ts",
-        "default": "./build/modern/index.js"
+        "types": "./dist/modern/esm/index.d.ts",
+        "default": "./dist/modern/esm/index.js"
       },
       "require": {
-        "types": "./build/modern/index.d.cts",
-        "default": "./build/modern/index.cjs"
+        "types": "./dist/modern/cjs/index.d.cts",
+        "default": "./dist/modern/cjs/index.cjs"
       }
     },
     "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [
-    "build",
+    "dist",
     "src"
   ],
   "scripts": {
@@ -43,6 +43,6 @@
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "tsup"
+    "build": "vite build && vite build --config vite.config.modern.ts"
   }
 }

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -5,6 +5,7 @@
     "src/**/*.tsx",
     ".eslintrc.cjs",
     "tsup.config.js",
-    "vite.config.ts"
+    "vite.config.ts",
+    "vite.config.modern.ts"
   ]
 }

--- a/packages/query-core/vite.config.modern.ts
+++ b/packages/query-core/vite.config.modern.ts
@@ -3,6 +3,9 @@ import { tanstackBuildConfig } from '@tanstack/config/build'
 import packageJson from './package.json'
 
 const config = defineConfig({
+  build: {
+    target: ['chrome91', 'firefox90', 'edge91', 'safari15', 'ios15', 'opera77'],
+  },
   test: {
     name: packageJson.name,
     dir: './src',
@@ -19,6 +22,6 @@ export default mergeConfig(
     entry: './src/index.ts',
     srcDir: './src',
     exclude: ['./src/tests'],
-    outDir: './dist/legacy',
+    outDir: './dist/modern',
   }),
 )

--- a/packages/query-core/vite.config.modern.ts
+++ b/packages/query-core/vite.config.modern.ts
@@ -1,18 +1,9 @@
 import { defineConfig, mergeConfig } from 'vite'
 import { tanstackBuildConfig } from '@tanstack/config/build'
-import packageJson from './package.json'
 
 const config = defineConfig({
   build: {
     target: ['chrome91', 'firefox90', 'edge91', 'safari15', 'ios15', 'opera77'],
-  },
-  test: {
-    name: packageJson.name,
-    dir: './src',
-    watch: false,
-    environment: 'jsdom',
-    coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
-    typecheck: { enabled: true },
   },
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^0.8.6
         version: 0.8.6(@solidjs/router@0.12.0)(solid-js@1.8.14)
       '@tanstack/config':
-        specifier: ^0.4.4
-        version: 0.4.4(@types/node@18.19.3)(esbuild@0.19.11)(rollup@4.6.0)(typescript@5.2.2)(vite@5.1.1)
+        specifier: ^0.5.0
+        version: 0.5.0(@types/node@18.19.3)(esbuild@0.19.11)(rollup@4.6.0)(typescript@5.2.2)(vite@5.1.1)
       '@testing-library/jest-dom':
         specifier: ^6.4.2
         version: 6.4.2(vitest@1.2.2)
@@ -4379,17 +4379,17 @@ packages:
       minimist: 1.2.8
     dev: false
 
-  /@commitlint/parse@18.6.0:
-    resolution: {integrity: sha512-Y/G++GJpATFw54O0jikc/h2ibyGHgghtPnwsOk3O/aU092ydJ5XEHYcd7xGNQYuLweLzQis2uEwRNk9AVIPbQQ==}
+  /@commitlint/parse@18.6.1:
+    resolution: {integrity: sha512-eS/3GREtvVJqGZrwAGRwR9Gdno3YcZ6Xvuaa+vUF8j++wsmxrA2En3n0ccfVO2qVOLJC41ni7jSZhQiJpMPGOQ==}
     engines: {node: '>=v18'}
     dependencies:
-      '@commitlint/types': 18.6.0
+      '@commitlint/types': 18.6.1
       conventional-changelog-angular: 7.0.0
       conventional-commits-parser: 5.0.0
     dev: true
 
-  /@commitlint/types@18.6.0:
-    resolution: {integrity: sha512-oavoKLML/eJa2rJeyYSbyGAYzTxQ6voG5oeX3OrxpfrkRWhJfm4ACnhoRf5tgiybx2MZ+EVFqC1Lw3W8/uwpZA==}
+  /@commitlint/types@18.6.1:
+    resolution: {integrity: sha512-gwRLBLra/Dozj2OywopeuHj2ac26gjGkz2cZ+86cTJOdtWfiRRr4+e77ZDAGc6MDWxaWheI+mAV5TLWWRwqrFg==}
     engines: {node: '>=v18'}
     dependencies:
       chalk: 4.1.2
@@ -8931,14 +8931,15 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@tanstack/config@0.4.4(@types/node@18.19.3)(esbuild@0.19.11)(rollup@4.6.0)(typescript@5.2.2)(vite@5.1.1):
-    resolution: {integrity: sha512-8WBvww2SHhN2YAQvvlmL7wwaspFnEwWVeyO7nWYXEp6Ho1WAkvRgzwofz7iGTmRVAAFsM8jAn4oawkHqvZBxeA==}
+  /@tanstack/config@0.5.0(@types/node@18.19.3)(esbuild@0.19.11)(rollup@4.6.0)(typescript@5.2.2)(vite@5.1.1):
+    resolution: {integrity: sha512-/9GBWJX0V22z6mdJgnArZq9XF5+x4nyhP/OInsq+/YU6QIl0KiPTAidaL42+0+M7JHXwvZH52NJw/vH99FPlTg==}
     engines: {node: '>=18'}
     hasBin: true
+    requiresBuild: true
     dependencies:
-      '@commitlint/parse': 18.6.0
+      '@commitlint/parse': 18.6.1
       chalk: 5.3.0
-      commander: 11.1.0
+      commander: 12.0.0
       current-git-branch: 1.1.0
       esbuild-register: 3.5.0(esbuild@0.19.11)
       git-log-parser: 1.2.0
@@ -8947,7 +8948,7 @@ packages:
       liftoff: 4.0.0
       luxon: 3.4.4
       minimist: 1.2.8
-      rollup-plugin-preserve-directives: 0.3.1(rollup@4.6.0)
+      rollup-plugin-preserve-directives: 0.4.0(rollup@4.6.0)
       semver: 7.6.0
       stream-to-array: 2.3.0
       v8flags: 4.0.1
@@ -12629,6 +12630,11 @@ packages:
   /commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+    dev: true
+
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
     dev: true
 
   /commander@2.20.3:
@@ -19965,6 +19971,8 @@ packages:
     peerDependenciesMeta:
       webpack:
         optional: true
+      webpack-sources:
+        optional: true
     dependencies:
       webpack: 5.89.0(esbuild@0.19.11)
       webpack-sources: 3.2.3
@@ -25835,11 +25843,12 @@ packages:
       rollup-pluginutils: 2.8.2
     dev: false
 
-  /rollup-plugin-preserve-directives@0.3.1(rollup@4.6.0):
-    resolution: {integrity: sha512-Jn1gWU7G55A1sU6eFpXmwknfBasF0XbBzRqsE6nqrb/gun+mGV7nx++CwOSGPJQpFzFqvKm5U4XNKo3LTLi4Hg==}
+  /rollup-plugin-preserve-directives@0.4.0(rollup@4.6.0):
+    resolution: {integrity: sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==}
     peerDependencies:
       rollup: 2.x || 3.x || 4.x
     dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.6.0)
       magic-string: 0.30.5
       rollup: 4.6.0
     dev: true


### PR DESCRIPTION
- With `@tanstack/config` 0.5.0, you can now specify an output directory
- To generate outputs for 2 different targets, 2 different vite config files are needed
- `vite.config.ts` generates the "legacy" (`[es2020]`) target
- `vite.config.modern.ts` generates the "modern" (`['chrome91', 'firefox90', 'edge91', 'safari15', 'ios15', 'opera77']`) target

Fixes #6318, #6670
