### PR TITLE
docs(react-query): fix typo in useMutation data attribute

### DIFF
--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -129,7 +129,7 @@ mutate(variables, {
   - see [Network Mode](./guides/network-mode) for more information.
 - `data: undefined | unknown`
   - Defaults to `undefined`
-  - The last successfully resolved data for the query.
+  - The last successfully resolved data for the mutation.
 - `error: null | TError`
   - The error object for the query, if an error was encountered.
 - `reset: () => void`


### PR DESCRIPTION
This resolves #6822 by fixing a typo in the documentation.