### PR TITLE
fix(angular-query): Fix StackBlitz examples by downgrading piscina

### DIFF
--- a/examples/angular/basic/package.json
+++ b/examples/angular/basic/package.json
@@ -28,5 +28,10 @@
     "@angular/compiler-cli": "^17.1.3",
     "@tanstack/angular-query-devtools-experimental": "^5.22.0",
     "typescript": "5.2.2"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "~4.2.0"
+    }
   }
 }

--- a/examples/angular/infinite-query-with-max-pages/package.json
+++ b/examples/angular/infinite-query-with-max-pages/package.json
@@ -28,5 +28,10 @@
     "@angular/compiler-cli": "^17.1.3",
     "@tanstack/angular-query-devtools-experimental": "^5.22.0",
     "typescript": "5.2.2"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "~4.2.0"
+    }
   }
 }

--- a/examples/angular/router/package.json
+++ b/examples/angular/router/package.json
@@ -28,5 +28,10 @@
     "@angular/compiler-cli": "^17.1.3",
     "@tanstack/angular-query-devtools-experimental": "^5.22.0",
     "typescript": "5.2.2"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "~4.2.0"
+    }
   }
 }

--- a/examples/angular/simple/package.json
+++ b/examples/angular/simple/package.json
@@ -28,5 +28,10 @@
     "@angular/compiler-cli": "^17.1.3",
     "@tanstack/angular-query-devtools-experimental": "^5.22.0",
     "typescript": "5.2.2"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "~4.2.0"
+    }
   }
 }


### PR DESCRIPTION
StackBlitz examples fail with error `t.record is not a function`

Downgrading Piscina dependency should solve this for now:
https://x.com/Jean__Meche/status/1759244061645393978?s=20