### PR TITLE
fix: notify queryCache after updateQuery()

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -146,14 +146,6 @@ export class QueryObserver<
 
     this.options = this.#client.defaultQueryOptions(options)
 
-    if (!shallowEqualObjects(this.options, prevOptions)) {
-      this.#client.getQueryCache().notify({
-        type: 'observerOptionsUpdated',
-        query: this.#currentQuery,
-        observer: this,
-      })
-    }
-
     if (
       typeof this.options.enabled !== 'undefined' &&
       typeof this.options.enabled !== 'boolean'
@@ -162,6 +154,14 @@ export class QueryObserver<
     }
 
     this.#updateQuery()
+
+    if (!shallowEqualObjects(this.options, prevOptions)) {
+      this.#client.getQueryCache().notify({
+        type: 'observerOptionsUpdated',
+        query: this.#currentQuery,
+        observer: this,
+      })
+    }
 
     const mounted = this.hasListeners()
 

--- a/packages/query-core/src/tests/queryCache.test.tsx
+++ b/packages/query-core/src/tests/queryCache.test.tsx
@@ -40,8 +40,10 @@ describe('queryCache', () => {
     test('should notify query cache when a query becomes stale', async () => {
       const key = queryKey()
       const events: Array<string> = []
+      const queries: Array<unknown> = []
       const unsubscribe = queryCache.subscribe((event) => {
         events.push(event.type)
+        queries.push(event.query)
       })
 
       const observer = new QueryObserver(queryClient, {
@@ -57,8 +59,8 @@ describe('queryCache', () => {
       })
 
       expect(events).toEqual([
-        'observerOptionsUpdated',
         'added', // 1. Query added -> loading
+        'observerOptionsUpdated',
         'observerResultsUpdated', // 2. Observer result updated -> loading
         'observerAdded', // 3. Observer added
         'observerResultsUpdated', // 4. Observer result updated -> fetching
@@ -67,6 +69,10 @@ describe('queryCache', () => {
         'updated', // 7. Query updated -> success
         'observerResultsUpdated', // 8. Observer result updated -> stale
       ])
+
+      queries.forEach((query) => {
+        expect(query).toBeDefined()
+      })
 
       unsubscribe()
       unsubScribeObserver()


### PR DESCRIPTION
so that it's never undefined

fixes #6933