### PR TITLE
docs: Install v4 of the react devtools in the v4 docs

### DIFF
--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -13,14 +13,16 @@ When you begin your React Query journey, you'll want these devtools by your side
 
 ## Install and Import the Devtools
 
-The devtools are a separate package that you need to install:
+The devtools are a separate package that you need to install.
+
+The major version of all the packages must be in sync.
 
 ```bash
-$ npm i @tanstack/react-query-devtools
+$ npm i @tanstack/react-query-devtools@4
 # or
-$ pnpm add @tanstack/react-query-devtools
+$ pnpm add @tanstack/react-query-devtools@4
 # or
-$ yarn add @tanstack/react-query-devtools
+$ yarn add @tanstack/react-query-devtools@4
 ```
 
 You can import the devtools like this:


### PR DESCRIPTION
Updating the v4 docs so that we install the v4 devtools (instead of the latest)

https://github.com/TanStack/query/discussions/6861