### PR TITLE
feat(query-devtools): Persist picture-in-picture mode through reloads

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -228,19 +228,6 @@ const PiPProvider = (props: PiPProviderProps) => {
     setPipWindow(pip)
   }
 
-  // createEffect(() => {
-  //   // Close pipWindow when the main window is closed
-  //   const closePipWindowOnUnload = () => {
-  //     closePipWindow()
-  //   }
-
-  //   window.addEventListener('beforeunload', closePipWindowOnUnload)
-
-  //   onCleanup(() => {
-  //     window.removeEventListener('beforeunload', closePipWindowOnUnload)
-  //   })
-  // })
-
   createEffect(() => {
     const pip_open = (props.localStore.pip_open ?? 'false') as 'true' | 'false'
     if (pip_open === 'true') {

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -378,7 +378,7 @@ const Devtools: Component<DevtoolsPanelProps> = (props) => {
 
   return (
     <>
-      <Show when={pip().pipWindow}>
+      <Show when={pip().pipWindow && pip_open() == 'true'}>
         <Portal mount={pip().pipWindow?.document.body}>
           <PiPPanel>
             <ContentView
@@ -2363,6 +2363,7 @@ const queryCacheMap = new Map<
 >()
 
 const setupQueryCacheSubscription = () => {
+  console.log('setup query cache subscription')
   const queryCache = createMemo(() => {
     const client = useQueryDevtoolsContext().client
     return client.getQueryCache()

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -2363,7 +2363,6 @@ const queryCacheMap = new Map<
 >()
 
 const setupQueryCacheSubscription = () => {
-  console.log('setup query cache subscription')
   const queryCache = createMemo(() => {
     const client = useQueryDevtoolsContext().client
     return client.getQueryCache()


### PR DESCRIPTION
This feature allows the picture-in-picture mode of the devtools to persists through page reloads.

The popup will remain open and will be re-used between page refreshes. Demo below




https://github.com/TanStack/query/assets/45807386/04bb474d-edeb-43d3-ba6b-282fee588265

