### PR TITLE
test(queryClient): Remove flaky perfomance tests

### DIFF
--- a/packages/query-core/src/tests/queryClient.test.tsx
+++ b/packages/query-core/src/tests/queryClient.test.tsx
@@ -356,16 +356,6 @@ describe('queryClient', () => {
         }),
       )
     })
-
-    test('should set 10k data in less than 500ms', () => {
-      const key = queryKey()
-      const start = performance.now()
-      for (let i = 0; i < 10000; i++) {
-        queryClient.setQueryData([key, i], i)
-      }
-      const end = performance.now()
-      expect(end - start).toBeLessThan(500)
-    })
   })
 
   describe('setQueriesData', () => {
@@ -428,38 +418,6 @@ describe('queryClient', () => {
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], 'bar')
       expect(queryClient.getQueryData([key])).toBeUndefined()
-    })
-
-    test('should get 10k queries in less than 500ms', () => {
-      const key = queryKey()
-      for (let i = 0; i < 10000; i++) {
-        queryClient.setQueryData([key, i], i)
-      }
-
-      const start = performance.now()
-      for (let i = 0; i < 10000; i++) {
-        queryClient.getQueryData([key, i])
-      }
-      const end = performance.now()
-
-      expect(end - start).toBeLessThan(500)
-    })
-  })
-
-  describe('getQueryState', () => {
-    test('should get 10k queries in less than 500ms', () => {
-      const key = queryKey()
-      for (let i = 0; i < 10000; i++) {
-        queryClient.setQueryData([key, i], i)
-      }
-
-      const start = performance.now()
-      for (let i = 0; i < 10000; i++) {
-        queryClient.getQueryState([key, i])
-      }
-      const end = performance.now()
-
-      expect(end - start).toBeLessThan(500)
     })
   })
 


### PR DESCRIPTION
While investigating flaky performance tests added in #6918, I found that other unrelated tests would randomly fail.
This happened mainly to tests that relied on timers firing at exact points, such as `useIsMutating > should return the number of fetching mutations`:

```
 FAIL  |@tanstack/react-query| src/__tests__/useMutationState.test.tsx > useIsMutating > should return the number of fetching mutations
AssertionError: expected [ +0, 1, 2, +0 ] to deeply equal [ +0, 1, 2, 1, +0 ]

Ignored nodes: comments, script, style
<html>
  <head />
  <body>
    <div>
      <div />
    </div>
  </body>
</html>

- Expected
+ Received

  Array [
    0,
    1,
    2,
-   1,
    0,
  ]

 ❯ src/__tests__/useMutationState.test.tsx:62:49
```

My guess here is that the event loop is delaying the timers to such a degree that they fired back-to-back and caused React to batch the re-render. 

Possible solutions for this would be to...

- ...occasionally defer to the Task Queue while running the performance test.
- ...simplify the performance test to run in less time. This would lead to flakiness due to variance in cpu load.
- ...refactor all other tests to correctly handle delayed timer responses.
- ...run these performance tests non-concurrently, after all other tests. This would probably require a larger reorganisation of Tests since NX is running these suites concurrently, not Vitest.

All of these solutions are either impractical or disproportional to the value of the performance tests. Therefore, I think it's best to simply remove the performance tests.