### PR TITLE
fix(angular-query): fix NG0602 error

### DIFF
--- a/packages/angular-query-experimental/src/create-base-query.ts
+++ b/packages/angular-query-experimental/src/create-base-query.ts
@@ -67,17 +67,20 @@ export function createBaseQuery<
         observer.getOptimisticResult(defaultedOptionsSignal()),
       )
 
-      effect(() => {
-        const defaultedOptions = defaultedOptionsSignal()
-        observer.setOptions(defaultedOptions, {
-          // Do not notify on updates because of changes in the options because
-          // these changes should already be reflected in the optimistic result.
-          listeners: false,
-        })
-        untracked(() => {
-          resultSignal.set(observer.getOptimisticResult(defaultedOptions))
-        })
-      })
+      // Effects should not be called inside reactive contexts
+      untracked(() =>
+        effect(() => {
+          const defaultedOptions = defaultedOptionsSignal()
+          observer.setOptions(defaultedOptions, {
+            // Do not notify on updates because of changes in the options because
+            // these changes should already be reflected in the optimistic result.
+            listeners: false,
+          })
+          untracked(() => {
+            resultSignal.set(observer.getOptimisticResult(defaultedOptions))
+          })
+        }),
+      )
 
       // observer.trackResult is not used as this optimization is not needed for Angular
       const unsubscribe = observer.subscribe(

--- a/packages/angular-query-experimental/src/lazy-init.ts
+++ b/packages/angular-query-experimental/src/lazy-init.ts
@@ -7,7 +7,7 @@ export function lazyInit<T extends object>(initializer: () => T): T {
     }
   }
 
-  queueMicrotask(() => initializeObject());
+  queueMicrotask(() => initializeObject())
 
   return new Proxy<T>({} as T, {
     get(_, prop, receiver) {

--- a/packages/angular-query-experimental/src/lazy-init.ts
+++ b/packages/angular-query-experimental/src/lazy-init.ts
@@ -7,9 +7,7 @@ export function lazyInit<T extends object>(initializer: () => T): T {
     }
   }
 
-  Promise.resolve().then(() => {
-    initializeObject()
-  })
+  queueMicrotask(() => initializeObject());
 
   return new Proxy<T>({} as T, {
     get(_, prop, receiver) {


### PR DESCRIPTION
This pr fixes the [NG0602](https://angular.io/errors/NG0602) error while using angular-query.

Since the latest update, consuming the signals inside the templates caused to log the error. 

<img width="412" alt="Screenshot 2024-02-24 alle 15 13 25" src="https://github.com/TanStack/query/assets/37072694/2e4f6b91-c2f4-43e8-ace0-5a2e7efcaf49">

Wrapping the effect inside the `untracked` function, in combination to `runInInjectionContext` at the top level (which is already present), seems resolving the issue without preventing the effect from running without registering dependencies. The effect as I understood must be executed whenever the `defaultedOptionsSignal` changes, therefore the behavior would remain unchanged.

I'm relatively new to Angular signals, I have much more experience using solid-js ones. Personally I would have solved it using nested effects but I think angular does not support them, like tracking dependencies after the first run 🤔

Also, I changed the Promise.resolve.then() using `queueMicrotask`. I think it is more suitable in this case. Is there a particular reason why Promise.resolve was used? 

PS.
While debugging using the angular query examples, I had some troubles to get the updated code after building the library. I just had to disable the ng cache in order to let it work..I think this should  be a default option for that repo examples

```json
"cli": {
  "packageManager": "pnpm",
  "analytics": false,
  "cache": {
    "enabled": false
  }
},
```

@arnoud-dv 