### PR TITLE
chore(angular-query): disable cache in Angular examples

### DIFF
--- a/examples/angular/basic/angular.json
+++ b/examples/angular/basic/angular.json
@@ -3,7 +3,10 @@
   "version": 1,
   "cli": {
     "packageManager": "pnpm",
-    "analytics": false
+    "analytics": false,
+    "cache": {
+      "enabled": false
+    }
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/examples/angular/infinite-query-with-max-pages/angular.json
+++ b/examples/angular/infinite-query-with-max-pages/angular.json
@@ -3,7 +3,10 @@
   "version": 1,
   "cli": {
     "packageManager": "pnpm",
-    "analytics": false
+    "analytics": false,
+    "cache": {
+      "enabled": false
+    }
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/examples/angular/router/angular.json
+++ b/examples/angular/router/angular.json
@@ -3,7 +3,10 @@
   "version": 1,
   "cli": {
     "packageManager": "pnpm",
-    "analytics": false
+    "analytics": false,
+    "cache": {
+      "enabled": false
+    }
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/examples/angular/simple/angular.json
+++ b/examples/angular/simple/angular.json
@@ -3,7 +3,10 @@
   "version": 1,
   "cli": {
     "packageManager": "pnpm",
-    "analytics": false
+    "analytics": false,
+    "cache": {
+      "enabled": false
+    }
   },
   "newProjectRoot": "projects",
   "projects": {


### PR DESCRIPTION
Caching has no real benefit in small examples and when using the examples to develop the adapter it has to be disabled.