### PR TITLE
Added Bun Package Manager Installation Commands 

### DIFF
--- a/docs/eslint/eslint-plugin-query.md
+++ b/docs/eslint/eslint-plugin-query.md
@@ -15,6 +15,8 @@ $ npm i -D @tanstack/eslint-plugin-query
 $ pnpm add -D @tanstack/eslint-plugin-query
 # or
 $ yarn add -D @tanstack/eslint-plugin-query
+# or 
+$ bun add -D @tanstack/eslint-plugin-query
 ```
 
 ## Usage

--- a/docs/framework/angular/devtools.md
+++ b/docs/framework/angular/devtools.md
@@ -13,6 +13,8 @@ $ npm i @tanstack/angular-query-devtools-experimental
 $ pnpm add @tanstack/angular-query-devtools-experimental
 # or
 $ yarn add @tanstack/angular-query-devtools-experimental
+# or
+$ bun add @tanstack/angular-query-devtools-experimental
 ```
 
 You can import the devtools like this:

--- a/docs/framework/angular/installation.md
+++ b/docs/framework/angular/installation.md
@@ -15,6 +15,8 @@ $ npm i @tanstack/angular-query-experimental
 $ pnpm add @tanstack/angular-query-experimental
 # or
 $ yarn add @tanstack/angular-query-experimental
+# or
+$ bun add @tanstack/angular-query-experimental
 ```
 
 > Wanna give it a spin before you download? Try out the [simple](./examples/simple) or [basic](./examples/basic) examples!

--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -23,6 +23,8 @@ $ npm i @tanstack/react-query-devtools
 $ pnpm add @tanstack/react-query-devtools
 # or
 $ yarn add @tanstack/react-query-devtools
+# or
+$ bun add @tanstack/react-query-devtools
 ```
 
 For Next 13+ App Dir you must install it as a dev dependency for it to work.

--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -15,6 +15,8 @@ $ npm i @tanstack/react-query
 $ pnpm add @tanstack/react-query
 # or
 $ yarn add @tanstack/react-query
+# or
+$ bun add @tanstack/react-query
 ```
 
 React Query is compatible with React v18+ and works with ReactDOM and React Native.
@@ -60,4 +62,6 @@ $ npm i -D @tanstack/eslint-plugin-query
 $ pnpm add -D @tanstack/eslint-plugin-query
 # or
 $ yarn add -D @tanstack/eslint-plugin-query
+# or
+$ bun add -D @tanstack/eslint-plugin-query
 ```

--- a/docs/framework/react/plugins/createAsyncStoragePersister.md
+++ b/docs/framework/react/plugins/createAsyncStoragePersister.md
@@ -23,6 +23,12 @@ or
 yarn add @tanstack/query-async-storage-persister @tanstack/react-query-persist-client
 ```
 
+or
+
+```bash
+bun add @tanstack/query-async-storage-persister @tanstack/react-query-persist-client
+```
+
 ## Usage
 
 - Import the `createAsyncStoragePersister` function

--- a/docs/framework/react/plugins/createPersister.md
+++ b/docs/framework/react/plugins/createPersister.md
@@ -23,6 +23,12 @@ or
 yarn add @tanstack/query-persist-client-core
 ```
 
+or
+
+```bash
+bun add @tanstack/query-persist-client-core
+```
+
 > Note: This util is also included in the `@tanstack/react-query-persist-client` package, so you do not need to install it separately if you are using that package.
 
 ## Usage

--- a/docs/framework/react/plugins/createSyncStoragePersister.md
+++ b/docs/framework/react/plugins/createSyncStoragePersister.md
@@ -23,6 +23,12 @@ or
 yarn add @tanstack/query-sync-storage-persister @tanstack/react-query-persist-client
 ```
 
+or
+
+```bash
+bun add @tanstack/query-sync-storage-persister @tanstack/react-query-persist-client
+```
+
 ## Usage
 
 - Import the `createSyncStoragePersister` function

--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -19,7 +19,10 @@ $ npm i @tanstack/solid-query-devtools
 $ pnpm add @tanstack/solid-query-devtools
 # or
 $ yarn add @tanstack/solid-query-devtools
+# or
+$ bun add @tanstack/solid-query-devtools
 ```
+
 
 You can import the devtools like this:
 

--- a/docs/framework/svelte/installation.md
+++ b/docs/framework/svelte/installation.md
@@ -15,6 +15,8 @@ $ npm i @tanstack/svelte-query
 $ pnpm add @tanstack/svelte-query
 # or
 $ yarn add @tanstack/svelte-query
+# or
+$ bun add @tanstack/svelte-query
 ```
 
 > Wanna give it a spin before you download? Try out the [basic](./examples/basic) example!

--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -25,6 +25,8 @@ $ npm i @tanstack/vue-query-devtools
 $ pnpm add @tanstack/vue-query-devtools
 # or
 $ yarn add @tanstack/vue-query-devtools
+# or
+$ bun add @tanstack/vue-query-devtools
 ```
 
 By default, Vue Query Devtools are only included in bundles when `process.env.NODE_ENV === 'development'`, so you don't need to worry about excluding them during a production build.

--- a/docs/framework/vue/installation.md
+++ b/docs/framework/vue/installation.md
@@ -15,6 +15,8 @@ $ npm i @tanstack/vue-query
 $ pnpm add @tanstack/vue-query
 # or
 $ yarn add @tanstack/vue-query
+# or
+$ bun add @tanstack/vue-query
 ```
 
 > Wanna give it a spin before you download? Try out the [basic](./examples/basic) example!

--- a/examples/angular/basic/README.md
+++ b/examples/angular/basic/README.md
@@ -2,5 +2,5 @@
 
 To run this example:
 
-- `npm install` or `yarn` or `pnpm i`
-- `npm run start` or `yarn start` or `pnpm start`
+- `npm install` or `yarn` or `pnpm i` or `bun i`
+- `npm run start` or `yarn start` or `pnpm start` or `bun start`

--- a/examples/angular/infinite-query-with-max-pages/README.md
+++ b/examples/angular/infinite-query-with-max-pages/README.md
@@ -2,5 +2,5 @@
 
 To run this example:
 
-- `npm install` or `yarn` or `pnpm i`
-- `npm run start` or `yarn start` or `pnpm start`
+- `npm install` or `yarn` or `pnpm i` or `bun i`
+- `npm run start` or `yarn start` or `pnpm start` or `bun start`

--- a/examples/angular/router/README.md
+++ b/examples/angular/router/README.md
@@ -2,5 +2,5 @@
 
 To run this example:
 
-- `npm install` or `yarn` or `pnpm i`
-- `npm run start` or `yarn start` or `pnpm start`
+- `npm install` or `yarn` or `pnpm i` or `bun i`
+- `npm run start` or `yarn start` or `pnpm start` or `bun start`

--- a/examples/angular/simple/README.md
+++ b/examples/angular/simple/README.md
@@ -2,5 +2,5 @@
 
 To run this example:
 
-- `npm install` or `yarn` or `pnpm i`
-- `npm run start` or `yarn start` or `pnpm start`
+- `npm install` or `yarn` or `pnpm i` or `bun i`
+- `npm run start` or `yarn start` or `pnpm start` or `bun start`

--- a/examples/svelte/auto-refetching/README.md
+++ b/examples/svelte/auto-refetching/README.md
@@ -16,7 +16,7 @@ npm create svelte@latest my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn` or `bun install`), start a development server:
 
 ```bash
 npm run dev

--- a/examples/svelte/basic/README.md
+++ b/examples/svelte/basic/README.md
@@ -16,7 +16,7 @@ npm create svelte@latest my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn` or `bun install`), start a development server:
 
 ```bash
 npm run dev

--- a/examples/svelte/load-more-infinite-scroll/README.md
+++ b/examples/svelte/load-more-infinite-scroll/README.md
@@ -16,7 +16,7 @@ npm create svelte@latest my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn` or `bun install`), start a development server:
 
 ```bash
 npm run dev

--- a/examples/svelte/optimistic-updates-typescript/README.md
+++ b/examples/svelte/optimistic-updates-typescript/README.md
@@ -16,7 +16,7 @@ npm create svelte@latest my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn` or `bun install`), start a development server:
 
 ```bash
 npm run dev

--- a/examples/svelte/ssr/README.md
+++ b/examples/svelte/ssr/README.md
@@ -16,7 +16,7 @@ npm create svelte@latest my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn` or `bun install`), start a development server:
 
 ```bash
 npm run dev

--- a/examples/vue/2.6-basic/README.md
+++ b/examples/vue/2.6-basic/README.md
@@ -2,5 +2,5 @@
 
 To run this example:
 
-- `npm install` or `yarn` or `pnpm i`
-- `npm run dev` or `yarn dev` or `pnpm dev`
+- `npm install` or `yarn` or `pnpm i` or `bun i`
+- `npm run dev` or `yarn dev` or `pnpm dev` or `bun dev`

--- a/examples/vue/basic/README.md
+++ b/examples/vue/basic/README.md
@@ -2,5 +2,5 @@
 
 To run this example:
 
-- `npm install` or `yarn` or `pnpm i`
-- `npm run dev` or `yarn dev` or `pnpm dev`
+- `npm install` or `yarn` or `pnpm i` or `bun i`
+- `npm run dev` or `yarn dev` or `pnpm dev` or `bun dev`

--- a/examples/vue/simple/README.md
+++ b/examples/vue/simple/README.md
@@ -2,5 +2,5 @@
 
 To run this example:
 
-- `npm install` or `yarn` or `pnpm i`
-- `npm run dev` or `yarn dev` or `pnpm dev`
+- `npm install` or `yarn` or `pnpm i` or `bun i`
+- `npm run dev` or `yarn dev` or `pnpm dev` or `bun dev`

--- a/packages/angular-query-experimental/README.md
+++ b/packages/angular-query-experimental/README.md
@@ -39,6 +39,8 @@ Visit https://tanstack.com/query/latest/docs/angular/overview
    $ pnpm add @tanstack/angular-query-experimental
    # or
    $ yarn add @tanstack/angular-query-experimental
+   # or
+   $ bun add @tanstack/angular-query-experimental
    ```
 
 2. Initialize **Angular Query** by adding **provideAngularQuery** to your application

--- a/packages/vue-query/README.md
+++ b/packages/vue-query/README.md
@@ -40,6 +40,8 @@ Visit https://tanstack.com/query/latest/docs/vue/overview
    $ pnpm add @tanstack/vue-query
    # or
    $ yarn add @tanstack/vue-query
+   # or
+   $ bun add @tanstack/vue-query
    ```
 
    > If you are using Vue 2.6, make sure to also setup [@vue/composition-api](https://github.com/vuejs/composition-api)


### PR DESCRIPTION
This Pull Request adds instructions for using the 'bun' package manager across the different guides available in the project. The 'bun' commands have been included alongside the existing installation instructions using npm, yarn, and pnpm. By adding these commands, users who prefer 'bun' as their package manager now have clear guidance.