### PR TITLE
fix(solid-query): Persist client implementation

### DIFF
--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -49,7 +49,8 @@
     "test:lib": "vitest --retry=3",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "tsup"
+    "build": "tsup",
+    "build:watch": "tsup --watch"
   },
   "files": [
     "build",


### PR DESCRIPTION
This change fixes some loose ends with the solid query's implementation of the persist client

1. It simplifies the implementation using the new `persistQueryClientRestore` and `persistQueryClientSubscribe` functions
2. Gets rid of extra computations in `createBaseQuery`
3. Also fixes some underlying bugs mentioned in #6930 (thanks to @Brendonovich)



