### PR TITLE
fix(solid-query): Prevent infinite refetch with Astro when initialData is provided

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -303,7 +303,7 @@ export function createBaseQuery<
   )
 
   createComputed(() => {
-    if (!isRestoring()) {
+    if (!isRestoring() && !isServer) {
       refetch()
     }
   })


### PR DESCRIPTION
Fixes #7007 

Prevents infinite refetch of queries with Astro when initialData is provided.