### PR TITLE
fix(query-core): make sure accessing one property on a query result in useQueries tracks properties across all observers

### DIFF
--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -168,19 +168,17 @@ export class QueriesObserver<
         return this.#combineResult(r ?? result, combine)
       },
       () => {
-        const trackedMatches = matches.map((match, index) => {
+        return matches.map((match, index) => {
           const observerResult = result[index]!
           return !match.defaultedQueryOptions.notifyOnChangeProps
-            ? match.observer.trackResult(observerResult, (accessedKey) => {
-                // invoke getter on all observers to ensure proper (synchronized) tracking (#7000)
-                matches.forEach((_, i) => {
-                  void trackedMatches[i]![accessedKey]
+            ? match.observer.trackResult(observerResult, (accessedProp) => {
+                // track property on all observers to ensure proper (synchronized) tracking (#7000)
+                matches.forEach((m) => {
+                  m.observer.trackProp(accessedProp)
                 })
               })
             : observerResult
         })
-
-        return trackedMatches
       },
     ]
   }

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -168,12 +168,19 @@ export class QueriesObserver<
         return this.#combineResult(r ?? result, combine)
       },
       () => {
-        return matches.map((match, index) => {
+        const trackedMatches = matches.map((match, index) => {
           const observerResult = result[index]!
           return !match.defaultedQueryOptions.notifyOnChangeProps
-            ? match.observer.trackResult(observerResult)
+            ? match.observer.trackResult(observerResult, (accessedKey) => {
+                // invoke getter on all observers to ensure proper (synchronized) tracking (#7000)
+                matches.forEach((_, i) => {
+                  void trackedMatches[i]![accessedKey]
+                })
+              })
             : observerResult
         })
+
+        return trackedMatches
       },
     ]
   }

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -247,6 +247,7 @@ export class QueryObserver<
 
   trackResult(
     result: QueryObserverResult<TData, TError>,
+    onPropertyTracked?: (key: keyof QueryObserverResult) => void,
   ): QueryObserverResult<TData, TError> {
     const trackedResult = {} as QueryObserverResult<TData, TError>
 
@@ -255,7 +256,10 @@ export class QueryObserver<
         configurable: false,
         enumerable: true,
         get: () => {
-          this.#trackedProps.add(key as keyof QueryObserverResult)
+          if (!this.#trackedProps.has(key as keyof QueryObserverResult)) {
+            this.#trackedProps.add(key as keyof QueryObserverResult)
+            onPropertyTracked?.(key as keyof QueryObserverResult)
+          }
           return result[key as keyof QueryObserverResult]
         },
       })

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -247,7 +247,7 @@ export class QueryObserver<
 
   trackResult(
     result: QueryObserverResult<TData, TError>,
-    onPropertyTracked?: (key: keyof QueryObserverResult) => void,
+    onPropTracked?: (key: keyof QueryObserverResult) => void,
   ): QueryObserverResult<TData, TError> {
     const trackedResult = {} as QueryObserverResult<TData, TError>
 
@@ -256,16 +256,18 @@ export class QueryObserver<
         configurable: false,
         enumerable: true,
         get: () => {
-          if (!this.#trackedProps.has(key as keyof QueryObserverResult)) {
-            this.#trackedProps.add(key as keyof QueryObserverResult)
-            onPropertyTracked?.(key as keyof QueryObserverResult)
-          }
+          this.trackProp(key as keyof QueryObserverResult)
+          onPropTracked?.(key as keyof QueryObserverResult)
           return result[key as keyof QueryObserverResult]
         },
       })
     })
 
     return trackedResult
+  }
+
+  trackProp(key: keyof QueryObserverResult) {
+    this.#trackedProps.add(key)
   }
 
   getCurrentQuery(): Query<TQueryFnData, TError, TQueryData, TQueryKey> {


### PR DESCRIPTION
In useQueries, property tracking is still performed on each individual observer. However, not all invocations will access the property on all observers. For example:

```
results.some((result) => result.isLoading)
```

will only track the `isLoading` property of the first query in the array if `isLoading` is true, because the loop will eagerly abort, and thus the property isn't accessed at all on other observer, which can lead to missing re-renders.

This fix adds a callback to `trackProperties`, which will be invoked when we start to track a property on an observer. Then, in useQueries, we can use this callback to track the property manually for all observers.

That makes sure that if a property like `isLoading` is accessed on one observer, it is tracked for all of them.

fixes #7000 