### PR TITLE
docs: Fix formatting, run CI on docs changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,9 +3,7 @@ name: pr
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
       - 'media/**'
-      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/docs/framework/react/reference/useQueries.md
+++ b/docs/framework/react/reference/useQueries.md
@@ -6,11 +6,13 @@ title: useQueries
 The `useQueries` hook can be used to fetch a variable number of queries:
 
 ```tsx
-const ids = [1,2,3]
+const ids = [1, 2, 3]
 const results = useQueries({
-  queries: ids.map(id => (
-    { queryKey: ['post', id], queryFn: () => fetchPost(id), staleTime: Infinity }
-  )),
+  queries: ids.map((id) => ({
+    queryKey: ['post', id],
+    queryFn: () => fetchPost(id),
+    staleTime: Infinity,
+  })),
 })
 ```
 
@@ -38,17 +40,18 @@ The `useQueries` hook returns an array with all the query results. The order ret
 If you want to combine `data` (or other Query information) from the results into a single value, you can use the `combine` option. The result will be structurally shared to be as referentially stable as possible.
 
 ```tsx
-const ids = [1,2,3]
+const ids = [1, 2, 3]
 const combinedQueries = useQueries({
-  queries: ids.map(id => (
-    { queryKey: ['post', id], queryFn: () => fetchPost(id) }
-  )),
+  queries: ids.map((id) => ({
+    queryKey: ['post', id],
+    queryFn: () => fetchPost(id),
+  })),
   combine: (results) => {
-    return ({
-      data: results.map(result => result.data),
-      pending: results.some(result => result.isPending),
-    })
-  }
+    return {
+      data: results.map((result) => result.data),
+      pending: results.some((result) => result.isPending),
+    }
+  },
 })
 ```
 


### PR DESCRIPTION
Removes markdown files from paths-ignore. Nx caching will correctly recognise that the package tasks don't need to run for docs-only PRs.