### PR TITLE
fix(query-core): do not call resumePausedMutations while we are offline

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -80,8 +80,8 @@ export class QueryClient {
         this.#queryCache.onFocus()
       }
     })
-    this.#unsubscribeOnline = onlineManager.subscribe(() => {
-      if (onlineManager.isOnline()) {
+    this.#unsubscribeOnline = onlineManager.subscribe((online) => {
+      if (online) {
         this.resumePausedMutations()
         this.#queryCache.onOnline()
       }
@@ -391,7 +391,10 @@ export class QueryClient {
   }
 
   resumePausedMutations(): Promise<unknown> {
-    return this.#mutationCache.resumePausedMutations()
+    if (onlineManager.isOnline()) {
+      return this.#mutationCache.resumePausedMutations()
+    }
+    return Promise.resolve()
   }
 
   getQueryCache(): QueryCache {


### PR DESCRIPTION
when mutations are resumed after they have been restored from an external storage, there is no retryer that can pick up the mutation where it left off, so we need to re-execute it from scratch. However, this doesn't really happen if we are offline - the promise will be pending until we go online again; only "continue" from the retryer can immediately resolve a Promise here - execute needs to wait until it's really finished. But since mutations run in serial when resumed, this will lead to a forever hanging promise.

With this fix, `queryClient.resumePausedMutations` will only resume them if we are currently online to avoid this state.

closes #5847