### PR TITLE
Docs: Update React Native Example code to Match React Native syntax.

### DIFF
--- a/docs/framework/react/react-native.md
+++ b/docs/framework/react/react-native.md
@@ -138,6 +138,6 @@ function MyComponent() {
     notifyOnChangeProps,
   })
 
-  return <div>DataUpdatedAt: {dataUpdatedAt}</div>
+  return <Text>DataUpdatedAt: {dataUpdatedAt}</Text>
 }
 ```


### PR DESCRIPTION
The React Native example previously used `<div> </div>` tags and as we all know, divs are a react thing.

This PR fixes that by using the intended (I believe) `<Text> </Text>` tags