### PR TITLE
ci(eslint): add vue-demi as cspell words

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -50,12 +50,13 @@ const config = {
             'extralight', // Our public interface
             'codemod', // We support our codemod
             'typecheck', // Field of vite.config.ts
-
+            
             'TSES', // @typescript-eslint package's interface
             'tsup', // We use tsup as builder
             'solidjs', // Our target framework
             'tabular-nums', // https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric
             'todos', // Too general word to be caught as error
+            'vue-demi', // dependency of @tanstack/vue-query
           ],
         },
       },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -50,7 +50,6 @@ const config = {
             'extralight', // Our public interface
             'codemod', // We support our codemod
             'typecheck', // Field of vite.config.ts
-            
             'TSES', // @typescript-eslint package's interface
             'tsup', // We use tsup as builder
             'solidjs', // Our target framework


### PR DESCRIPTION
Simply resolve this error

![image](https://github.com/TanStack/query/assets/61593290/9cc13f36-db09-4a96-bc74-ea656130af19)
