### PR TITLE
ci(*): update codecov action version of GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ inputs.tag }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,6 @@ jobs:
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: packages


### PR DESCRIPTION
Recently codecov/codecov-action v4 was released. so I updated its version
https://github.com/codecov/codecov-action/releases