### PR TITLE
fix(react-query): fix useSuspenseQueries broken result type (#7118)

### DIFF
--- a/packages/react-query/src/useSuspenseQueries.ts
+++ b/packages/react-query/src/useSuspenseQueries.ts
@@ -78,7 +78,7 @@ type GetSuspenseResults<T> =
               ? UseSuspenseQueryResult<TQueryFnData>
               : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
                 T extends {
-                    queryFn?: QueryFunction<infer TQueryFnData, any>
+                    queryFn?: QueryFunction<infer TQueryFnData, any> | SkipToken
                     select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
@@ -87,7 +87,9 @@ type GetSuspenseResults<T> =
                     unknown extends TError ? DefaultError : TError
                   >
                 : T extends {
-                      queryFn?: QueryFunction<infer TQueryFnData, any>
+                      queryFn?: 
+                        | QueryFunction<infer TQueryFnData, any> 
+                        | SkipToken
                       throwOnError?: ThrowOnError<any, infer TError, any, any>
                     }
                   ? UseSuspenseQueryResult<


### PR DESCRIPTION
The type inference inside `GetSuspenseResults<T>` is missing `SkipToken` as a possible return type for `queryFn`. 

This causes inference of the returned results of `useSuspenseQueries` to not work, defaulting to a `TData` of `unknown`.

This PR just quickly adds `SkipToken` in the remainder of the code to allow inference to work again.

Fixes issue #7118.