### PR TITLE
fix(*): infer data type correctly when conditional skipToken is passed to useQueries

### DIFF
--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -136,7 +136,7 @@ export type QueriesOptions<
             [...TResult, GetOptions<Head>],
             [...TDepth, 1]
           >
-        : Array<unknown> extends T
+        : ReadonlyArray<unknown> extends T
           ? T
           : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
             // use this to infer the param types in the case of Array.map() argument
@@ -219,7 +219,13 @@ export function injectQueries<
         // Make sure the results are already in fetching state before subscribing or updating options
         defaultedOptions._optimisticResults = 'optimistic'
 
-        return defaultedOptions
+        return defaultedOptions as QueryObserverOptions<
+          unknown,
+          Error,
+          unknown,
+          unknown,
+          QueryKey
+        >
       })
     })
 

--- a/packages/react-query/src/__tests__/useQueries.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test-d.tsx
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { queryOptions } from '../queryOptions'
+import { skipToken } from '..'
 import { useQueries } from '../useQueries'
+import { queryOptions } from '../queryOptions'
 import type { UseQueryOptions } from '../types'
 
 describe('UseQueries config object overload', () => {
@@ -122,5 +123,20 @@ describe('UseQueries config object overload', () => {
 
       expectTypeOf(data).toEqualTypeOf<Data | undefined>()
     })
+  })
+
+  it('TData should have correct type when conditional skipToken is passed', () => {
+    const queryResults = useQueries({
+      queries: [
+        {
+          queryKey: ['withSkipToken'],
+          queryFn: Math.random() > 0.5 ? skipToken : () => Promise.resolve(5),
+        },
+      ],
+    })
+
+    const data = queryResults[0].data
+
+    expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 })

--- a/packages/react-query/src/__tests__/useQueries.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test-d.tsx
@@ -2,6 +2,7 @@ import { describe, expectTypeOf, it } from 'vitest'
 import { skipToken } from '..'
 import { useQueries } from '../useQueries'
 import { queryOptions } from '../queryOptions'
+import type { OmitKeyof } from '..'
 import type { UseQueryOptions } from '../types'
 
 describe('UseQueries config object overload', () => {

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -32,6 +32,7 @@ import type {
   QueryClient,
   QueryFunction,
   QueryKey,
+  QueryObserverOptions,
   SkipToken,
   ThrowOnError,
 } from '@tanstack/query-core'
@@ -177,7 +178,7 @@ export type QueriesOptions<
             [...TResult, GetOptions<Head>],
             [...TDepth, 1]
           >
-        : Array<unknown> extends T
+        : ReadonlyArray<unknown> extends T
           ? T
           : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
             // use this to infer the param types in the case of Array.map() argument
@@ -257,7 +258,15 @@ export function useQueries<
   const defaultedQueries = React.useMemo(
     () =>
       queries.map((opts) => {
-        const defaultedOptions = client.defaultQueryOptions(opts)
+        const defaultedOptions = client.defaultQueryOptions(
+          opts as QueryObserverOptions<
+            unknown,
+            Error,
+            unknown,
+            unknown,
+            QueryKey
+          >,
+        )
 
         // Make sure the results are already in fetching state before subscribing or updating options
         defaultedOptions._optimisticResults = isRestoring

--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -148,7 +148,7 @@ type QueriesOptions<
             [...TResult, GetOptions<Head>],
             [...TDepth, 1]
           >
-        : Array<unknown> extends T
+        : ReadonlyArray<unknown> extends T
           ? T
           : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
             // use this to infer the param types in the case of Array.map() argument
@@ -221,7 +221,7 @@ export function createQueries<
   const client = createMemo(() => useQueryClient(queryClient?.()))
   const isRestoring = useIsRestoring()
 
-  const defaultedQueries = createMemo(() =>
+  const defaultedQueries: QueriesOptions<any> = createMemo(() =>
     queriesOptions().queries.map((options) =>
       mergeProps(client().defaultQueryOptions(options), {
         get _optimisticResults() {

--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -139,7 +139,7 @@ export type QueriesOptions<
             [...TResult, GetOptions<Head>],
             [...TDepth, 1]
           >
-        : Array<unknown> extends T
+        : Readonly<unknown> extends T
           ? T
           : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
             // use this to infer the param types in the case of Array.map() argument
@@ -221,7 +221,15 @@ export function createQueries<
     [queriesStore, isRestoring],
     ([$queries, $isRestoring]) => {
       return $queries.map((opts) => {
-        const defaultedOptions = client.defaultQueryOptions(opts)
+        const defaultedOptions = client.defaultQueryOptions(
+          opts as QueryObserverOptions<
+            unknown,
+            Error,
+            unknown,
+            unknown,
+            QueryKey
+          >,
+        )
         // Make sure the results are already in fetching state before subscribing or updating options
         defaultedOptions._optimisticResults = $isRestoring
           ? 'isRestoring'

--- a/packages/vue-query/src/__tests__/useQueries.types.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.types.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 import { reactive } from 'vue'
-import { useQueries } from '..'
+import { skipToken, useQueries } from '..'
 import { queryOptions } from '../queryOptions'
 import { doNotExecute } from './test-utils'
 import type { OmitKeyof } from '..'
@@ -120,6 +120,24 @@ describe('UseQueries config object overload', () => {
 
       const result: Expect<Equal<{ wow: boolean } | undefined, typeof data>> =
         true
+      return result
+    })
+  })
+
+  it('TData should have correct type when conditional skipToken is passed', () => {
+    doNotExecute(() => {
+      const { value: queriesState } = useQueries({
+        queries: [
+          {
+            queryKey: ['key'],
+            queryFn: Math.random() > 0.5 ? skipToken : () => Promise.resolve(5),
+          },
+        ],
+      })
+
+      const data = queriesState[0].data
+
+      const result: Expect<Equal<number | undefined, typeof data>> = true
       return result
     })
   })

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -182,7 +182,7 @@ export type UseQueriesOptions<
             [...TResult, GetOptions<Head>],
             [...TDepth, 1]
           >
-        : Array<unknown> extends T
+        : Readonly<unknown> extends T
           ? T
           : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
             // use this to infer the param types in the case of Array.map() argument
@@ -270,18 +270,20 @@ export function useQueries<
   const client = queryClient || useQueryClient()
 
   const defaultedQueries = computed(() =>
-    cloneDeepUnref(queries).map((queryOptions) => {
-      if (typeof queryOptions.enabled === 'function') {
-        queryOptions.enabled = queryOptions.enabled()
-      }
+    cloneDeepUnref(queries as MaybeRefDeep<UseQueriesOptionsArg<any>>).map(
+      (queryOptions) => {
+        if (typeof queryOptions.enabled === 'function') {
+          queryOptions.enabled = queryOptions.enabled()
+        }
 
-      const defaulted = client.defaultQueryOptions(queryOptions)
-      defaulted._optimisticResults = client.isRestoring.value
-        ? 'isRestoring'
-        : 'optimistic'
+        const defaulted = client.defaultQueryOptions(queryOptions)
+        defaulted._optimisticResults = client.isRestoring.value
+          ? 'isRestoring'
+          : 'optimistic'
 
-      return defaulted
-    }),
+        return defaulted
+      },
+    ),
   )
 
   const observer = new QueriesObserver<TCombinedResult>(


### PR DESCRIPTION
Hello, I'm a huge enthusiast of TanStack-query! 👋

I've fixed the issue. closes: #7035
In my quest for a better solution, I've explored several alternatives, yet this appears to be the best I could come up with. Frankly, I don't find this fix particularly elegant or "cool", so I'm open to suggestions for enhancement.

I've run the test and everything checks out, so I'm sending over this PR.

Thank you!