### PR TITLE
Add date comparison to replaceEqualDeep

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -214,6 +214,10 @@ export function partialMatchKey(a: any, b: any): boolean {
  */
 export function replaceEqualDeep<T>(a: unknown, b: T): T
 export function replaceEqualDeep(a: any, b: any): any {
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime() ? a : b;
+  }
+  
   if (a === b) {
     return a
   }


### PR DESCRIPTION
In my project, I needed to set the `structuralSharing` function just to enable comparison of date objects. Before, there was no way of keeping the same reference for the same object, because any date property was considered different, even if it corresponded to the same date.

Is there a simpler way to do this? I understand that you might not want to have `replaceEqualDeep` handle Date objects.

In my project, I had to copy the whole code for `replaceEqualDeep`, `isPlainArray`, `isPlainObject` and `hasObjectPrototype`, because the last three functions are not exposed by `@tanstack/query-core`. This is a lot of copied code only to add 3 lines to `replaceEqualDeep`, I'm thinking that there should be a better way to extend `replaceEqualDeep`. Perhaps there could be a factory function that creates a `replaceEqualDeep` function and accepts a callback function?