### PR TITLE
chore(.vscode): codeActionsOnSave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ size-plugin.json
 stats-hydration.json
 stats.json
 stats.html
-.vscode/settings.json
 
 *.log
 *.tsbuildinfo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "eslint.workingDirectories": [{ "mode": "auto" }]
+}


### PR DESCRIPTION
If new contributors edit the markdown file with no [pnpm prepare](https://github.com/TanStack/query/blob/main/package.json#L13), husky will not work, so prettier will not work for pre-commit.

I'd like to automate these cases so this case don't keep making prettier errors. Since VSCode is the tool most used by front-end developers, I thought it would be a good idea to set prettier to run on save.

Motivating things
- https://github.com/TanStack/query/commit/2ddf8036360279fcd6e3567859ec9c68fbfc024a
- https://github.com/TanStack/query/pull/7135
- https://github.com/TanStack/query/pull/6517
- https://github.com/TanStack/query/pull/6595
- So many Pull Request that meet error of prettier

Hope we could concentrate more important things with automation