### PR TITLE
ci(.prettierignore): ignore `**/tsconfig.vitest-temp.json`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@
 **/query-codemods/**/__testfixtures__
 pnpm-lock.yaml
 packages/**/tsup.config.bundled*.mjs
+**/tsconfig.vitest-temp.json


### PR DESCRIPTION
We meet test:format error in this commit https://github.com/TanStack/query/commit/39b2f81bc782a8633bd601b6d2e35d2a8c2ec4c0

So we ignore **/tsconfig.vitest-temp.json made by vitest type check
This resolve this error occurred by test:format checking vitest type test's tsconfig

https://cloud.nx.app/runs/8wBzoYASCd

<img width="1288" alt="image" src="https://github.com/TanStack/query/assets/61593290/944864c8-60bf-44c6-9bc0-3e1515ea2e53">
