### PR TITLE
refactor(query-core): replace `getQueryCache()` with `#queryCache` for consistency

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -154,7 +154,7 @@ export class QueryClient {
   getQueriesData<TQueryFnData = unknown>(
     filters: QueryFilters,
   ): Array<[QueryKey, TQueryFnData | undefined]> {
-    return this.getQueryCache()
+    return this.#queryCache
       .findAll(filters)
       .map(({ queryKey, state }) => {
         const data = state.data as TQueryFnData | undefined
@@ -208,7 +208,7 @@ export class QueryClient {
     options?: SetDataOptions,
   ): Array<[QueryKey, TQueryFnData | undefined]> {
     return notifyManager.batch(() =>
-      this.getQueryCache()
+      this.#queryCache
         .findAll(filters)
         .map(({ queryKey }) => [
           queryKey,


### PR DESCRIPTION
I've noticed that within our `queryClient` implementation, we currently utilize two methods to retrieve `queryCache`: one is by using `this.#queryCache`, and the other is via `this.getQueryCache()`.

Both approaches are functionally equivalent. To improve code consistency and readability, I have replaced instances of `this.getQueryCache()` with `this.#queryCache` internally.

This refactor does not alter the behavior of `queryClient` in any way. I am very open to hearing your thoughts, especially if there's something I might have overlooked.