### PR TITLE
docs: use nuxt `import.meta.*` properties

### DIFF
--- a/docs/framework/vue/guides/ssr.md
+++ b/docs/framework/vue/guides/ssr.md
@@ -86,7 +86,7 @@ export default (context) => {
 
   Vue.use(VueQueryPlugin, options)
 
-  if (import.meta.client) {
+  if (process.client) {
     if (context.nuxtState && context.nuxtState.vueQueryState) {
       hydrate(queryClient, context.nuxtState.vueQueryState)
     }

--- a/docs/framework/vue/guides/ssr.md
+++ b/docs/framework/vue/guides/ssr.md
@@ -36,13 +36,13 @@ export default defineNuxtPlugin((nuxt) => {
 
   nuxt.vueApp.use(VueQueryPlugin, options)
 
-  if (process.server) {
+  if (import.meta.server) {
     nuxt.hooks.hook('app:rendered', () => {
       vueQueryState.value = dehydrate(queryClient)
     })
   }
 
-  if (process.client) {
+  if (import.meta.client) {
     hydrate(queryClient, vueQueryState.value)
   }
 })
@@ -86,7 +86,7 @@ export default (context) => {
 
   Vue.use(VueQueryPlugin, options)
 
-  if (process.client) {
+  if (import.meta.client) {
     if (context.nuxtState && context.nuxtState.vueQueryState) {
       hydrate(queryClient, context.nuxtState.vueQueryState)
     }

--- a/examples/vue/nuxt3/plugins/vue-query.ts
+++ b/examples/vue/nuxt3/plugins/vue-query.ts
@@ -22,13 +22,13 @@ export default defineNuxtPlugin((nuxt) => {
 
   nuxt.vueApp.use(VueQueryPlugin, options)
 
-  if (process.server) {
+  if (import.meta.server) {
     nuxt.hooks.hook('app:rendered', () => {
       vueQueryState.value = dehydrate(queryClient)
     })
   }
 
-  if (process.client) {
+  if (import.meta.client) {
     nuxt.hooks.hook('app:created', () => {
       hydrate(queryClient, vueQueryState.value)
     })


### PR DESCRIPTION
This is a very early PR to make these docs compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

These variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.