### PR TITLE
fix(angular-query): consistent injector parameter

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -1,6 +1,8 @@
+import { Injector } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import { QueryClient } from '@tanstack/query-core'
-import { afterEach } from 'vitest'
+// NOTE: do not import test from 'vitest' here - only global test function is patched for Angular zone
+import { afterEach, describe, expect } from 'vitest'
 import { injectInfiniteQuery } from '../inject-infinite-query'
 import { provideAngularQuery } from '../providers'
 import { expectSignals, infiniteFetcher } from './test-utils'
@@ -59,6 +61,35 @@ describe('injectInfiniteQuery', () => {
         pages: ['data on page 0', 'data on page 12'],
       },
       status: 'success',
+    })
+  })
+
+  describe('injection context', () => {
+    test('throws NG0203 outside injection context', () => {
+      expect(() => {
+        injectInfiniteQuery(() => ({
+          queryKey: ['injectionContextError'],
+          queryFn: infiniteFetcher,
+          initialPageParam: 0,
+          getNextPageParam: () => 12,
+        }))
+      }).toThrowError(
+        'NG0203: injectInfiniteQuery() can only be used within an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`. Find more at https://angular.io/errors/NG0203',
+      )
+    })
+
+    test('can be used outside injection context when passing an injector', () => {
+      const query = injectInfiniteQuery(
+        () => ({
+          queryKey: ['manualInjector'],
+          queryFn: infiniteFetcher,
+          initialPageParam: 0,
+          getNextPageParam: () => 12,
+        }),
+        TestBed.inject(Injector),
+      )
+
+      expect(query.status()).toBe('pending')
     })
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
@@ -1,5 +1,7 @@
+import { Injector } from '@angular/core'
 import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing'
 import { QueryClient } from '@tanstack/query-core'
+// NOTE: do not import test from 'vitest' here - only global test function is patched for Angular zone
 import { beforeEach, describe, expect } from 'vitest'
 import { injectIsFetching } from '../inject-is-fetching'
 import { injectQuery } from '../inject-query'
@@ -32,4 +34,20 @@ describe('injectIsFetching', () => {
     flush()
     expect(isFetching()).toStrictEqual(0)
   }))
+
+  describe('injection context', () => {
+    test('throws NG0203 outside injection context', () => {
+      expect(() => {
+        injectIsFetching()
+      }).toThrowError(
+        'NG0203: injectIsFetching() can only be used within an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`. Find more at https://angular.io/errors/NG0203',
+      )
+    })
+
+    test('can be used outside injection context when passing an injector', () => {
+      expect(
+        injectIsFetching(undefined, TestBed.inject(Injector)),
+      ).not.toThrow()
+    })
+  })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
@@ -1,5 +1,7 @@
+import { Injector } from '@angular/core'
 import { QueryClient } from '@tanstack/query-core'
-import { beforeEach, describe } from 'vitest'
+// NOTE: do not import test from 'vitest' here - only global test function is patched for Angular zone
+import { beforeEach, describe, expect } from 'vitest'
 import { TestBed, fakeAsync, tick } from '@angular/core/testing'
 import { injectIsMutating } from '../inject-is-mutating'
 import { injectMutation } from '../inject-mutation'
@@ -36,4 +38,20 @@ describe('injectIsMutating', () => {
       expect(isMutating()).toBe(1)
     })
   }))
+
+  describe('injection context', () => {
+    test('throws NG0203 outside injection context', () => {
+      expect(() => {
+        injectIsMutating()
+      }).toThrowError(
+        'NG0203: injectIsMutating() can only be used within an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`. Find more at https://angular.io/errors/NG0203',
+      )
+    })
+
+    test('can be used outside injection context when passing an injector', () => {
+      expect(
+        injectIsMutating(undefined, TestBed.inject(Injector)),
+      ).not.toThrow()
+    })
+  })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
@@ -1,7 +1,8 @@
-import { Component, input, signal } from '@angular/core'
+import { Component, Injector, input, signal } from '@angular/core'
 import { QueryClient } from '@tanstack/query-core'
 import { TestBed } from '@angular/core/testing'
-import { describe, expect, test, vi } from 'vitest'
+// NOTE: do not import test from 'vitest' here - only global test function is patched for Angular zone
+import { describe, expect, vi } from 'vitest'
 import { By } from '@angular/platform-browser'
 import { JsonPipe } from '@angular/common'
 import { injectMutation } from '../inject-mutation'
@@ -172,6 +173,22 @@ describe('injectMutationState', () => {
         .map((span) => span.nativeNode.textContent)
 
       expect(spans).toEqual(['success', 'error'])
+    })
+
+    describe('injection context', () => {
+      test('throws NG0203 outside injection context', () => {
+        expect(() => {
+          injectMutationState()
+        }).toThrowError(
+          'NG0203: injectMutationState() can only be used within an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`. Find more at https://angular.io/errors/NG0203',
+        )
+      })
+
+      test('can be used outside injection context when passing an injector', () => {
+        expect(
+          injectMutationState(undefined, TestBed.inject(Injector)),
+        ).not.toThrow()
+      })
     })
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -1,6 +1,7 @@
-import { Component, input, signal } from '@angular/core'
+import { Component, Injector, input, signal } from '@angular/core'
 import { QueryClient } from '@tanstack/query-core'
 import { TestBed } from '@angular/core/testing'
+// NOTE: do not import test from 'vitest' here - only global test function is patched for Angular zone
 import { describe, expect, vi } from 'vitest'
 import { By } from '@angular/platform-browser'
 import { injectMutation } from '../inject-mutation'
@@ -454,5 +455,30 @@ describe('injectMutation', () => {
     })
 
     await expect(() => mutateAsync()).rejects.toThrowError(err)
+  })
+
+  describe('injection context', () => {
+    test('throws NG0203 outside injection context', () => {
+      expect(() => {
+        injectMutation(() => ({
+          mutationKey: ['injectionContextError'],
+          mutationFn: () => Promise.resolve(),
+        }))
+      }).toThrowError(
+        'NG0203: injectMutation() can only be used within an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`. Find more at https://angular.io/errors/NG0203',
+      )
+    })
+
+    test('can be used outside injection context when passing an injector', () => {
+      expect(() => {
+        injectMutation(
+          () => ({
+            mutationKey: ['injectionContextError'],
+            mutationFn: () => Promise.resolve(),
+          }),
+          TestBed.inject(Injector),
+        )
+      }).not.toThrow()
+    })
   })
 })

--- a/packages/angular-query-experimental/src/inject-mutation-state.ts
+++ b/packages/angular-query-experimental/src/inject-mutation-state.ts
@@ -43,22 +43,18 @@ function getResult<TResult = MutationState>(
     )
 }
 
-export interface InjectMutationStateOptions {
-  injector?: Injector
-}
-
 export function injectMutationState<TResult = MutationState>(
   mutationStateOptionsFn: () => MutationStateOptions<TResult> = () => ({}),
-  options?: InjectMutationStateOptions,
+  injector?: Injector,
 ): Signal<Array<TResult>> {
-  return assertInjector(injectMutationState, options?.injector, () => {
+  return assertInjector(injectMutationState, injector, () => {
     const destroyRef = inject(DestroyRef)
     const queryClient = injectQueryClient()
     const ngZone = inject(NgZone)
 
     const mutationCache = queryClient.getMutationCache()
 
-    return lazySignalInitializer((injector) => {
+    return lazySignalInitializer((lazyInitializerInjector) => {
       const result = signal<Array<TResult>>(
         getResult(mutationCache, mutationStateOptionsFn()),
       )
@@ -72,7 +68,7 @@ export function injectMutationState<TResult = MutationState>(
             result.set(getResult(mutationCache, mutationStateOptions))
           })
         },
-        { injector },
+        { injector: lazyInitializerInjector },
       )
 
       const unsubscribe = mutationCache.subscribe(


### PR DESCRIPTION
Opted for an injector parameter for all inject* functions. An options object having an injector property might be preferable to easily add additional options in the future. But having two options objects (e.g. query options and additional options having the injector) would be confusing and the first options object should be consistent with other adapters.