### PR TITLE
fix(types): add pageParam and direction as optional to "normal" queryFn

### DIFF
--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -208,7 +208,6 @@ describe('query', () => {
     expect(queryFn).toHaveBeenCalledTimes(1)
     const args = queryFn.mock.calls[0]![0]
     expect(args).toBeDefined()
-    // @ts-expect-error page param should be undefined
     expect(args.pageParam).toBeUndefined()
     expect(args.queryKey).toEqual(key)
     expect(args.signal).toBeInstanceOf(AbortSignal)

--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { QueryClient } from '../queryClient'
-import type { DataTag, InfiniteData } from '../types'
+import type { FetchDirection } from '../query'
+import type { DataTag, InfiniteData, QueryKey } from '../types'
 
 describe('getQueryData', () => {
   it('should be typed if key is tagged', () => {
@@ -130,6 +131,27 @@ describe('fetchInfiniteQuery', () => {
       queryFn: () => Promise.resolve('string'),
       initialPageParam: 1,
       pages: 5,
+    })
+  })
+})
+
+describe('defaultOptions', () => {
+  it('should have a typed QueryFunctionContext', () => {
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          queryFn: (context) => {
+            expectTypeOf(context).toEqualTypeOf<{
+              queryKey: QueryKey
+              meta: Record<string, unknown> | undefined
+              signal: AbortSignal
+              pageParam?: unknown
+              direction?: FetchDirection
+            }>()
+            return Promise.resolve('data')
+          },
+        },
+      },
     })
   })
 })

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -67,7 +67,7 @@ export type QueryFunctionContext<
       signal: AbortSignal
       meta: QueryMeta | undefined
       pageParam?: unknown
-      direction?: FetchDirection
+      direction?: 'forward' | 'backward'
     }
   : {
       queryKey: TQueryKey

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -66,6 +66,8 @@ export type QueryFunctionContext<
       queryKey: TQueryKey
       signal: AbortSignal
       meta: QueryMeta | undefined
+      pageParam?: unknown
+      direction?: FetchDirection
     }
   : {
       queryKey: TQueryKey

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -27,26 +27,6 @@ describe('pageParam', () => {
     })
   })
 
-  it('there should be no pageParam passed to the queryFn of useQuery', () => {
-    useQuery({
-      queryKey: ['key'],
-      // @ts-expect-error there should be no pageParam passed to queryFn of useQuery
-      queryFn: ({ pageParam }) => {
-        return String(pageParam)
-      },
-    })
-  })
-
-  it('there should be no direction passed to the queryFn of useQuery', () => {
-    useQuery({
-      queryKey: ['key'],
-      // @ts-expect-error there should be no pageParam passed to queryFn of useQuery
-      queryFn: ({ direction }) => {
-        return String(direction)
-      },
-    })
-  })
-
   it('initialPageParam should define type of param passed to queryFunctionContext for fetchInfiniteQuery', () => {
     const queryClient = new QueryClient()
     queryClient.fetchInfiniteQuery({

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -1,7 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { useInfiniteQuery } from '../useInfiniteQuery'
-import { useQuery } from '../useQuery'
 import type { InfiniteData } from '@tanstack/query-core'
 
 describe('pageParam', () => {


### PR DESCRIPTION
because that's what we get when using a defaultQueryFn

closes #6715