### PR TITLE
refactor(solid-query): Ensure correct type inference when using skipToken in createQueries

### DIFF
--- a/packages/solid-query/src/__tests__/createQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test.tsx
@@ -94,8 +94,12 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result1[0]).toEqualTypeOf<CreateQueryResult<number>>()
-      expectTypeOf(result1[1]).toEqualTypeOf<CreateQueryResult<string>>()
+      expectTypeOf(result1[0]).toEqualTypeOf<
+        CreateQueryResult<number, unknown>
+      >()
+      expectTypeOf(result1[1]).toEqualTypeOf<
+        CreateQueryResult<string, unknown>
+      >()
       expectTypeOf(result1[2]).toEqualTypeOf<
         CreateQueryResult<Array<string>, boolean>
       >()
@@ -554,6 +558,26 @@ describe('useQueries', () => {
           },
         ],
       }))
+    }
+  })
+
+  it('should have correct type when conditional skipToken is passed', () => {
+    // @ts-expect-error (Page component is not rendered)
+    function Page() {
+      const results = createQueries(() => ({
+        queries: [
+          {
+            queryKey: ['withSkipToken'],
+            queryFn:
+              Math.random() > 0.5
+                ? QueryCore.skipToken
+                : () => Promise.resolve(5),
+          },
+        ],
+      }))
+
+      expectTypeOf(results[0]).toEqualTypeOf<CreateQueryResult<number, Error>>()
+      expectTypeOf(results[0].data).toEqualTypeOf<number | undefined>()
     }
   })
 


### PR DESCRIPTION
While writing test code for `solid-query`, I discovered that type inference fails when a `skipToken` is present, as shown in the attached photo below. Unlike `react-query`, it does not correctly infer types. I have made modifications to `createQueries` to ensure accurate type inference.


|react-query|solid-query|
|---|---|
|![image](https://github.com/TanStack/query/assets/39869096/c922677e-6ab8-4901-b038-fc8011a4816b)|![image](https://github.com/TanStack/query/assets/39869096/6a588b82-1fae-472f-984b-bc115f866dd3)|
