### PR TITLE
docs: broken top-level relative pathing on links

### DIFF
--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -54,7 +54,7 @@ Opera >= 77
 
 ### Recommendations
 
-It is recommended to also use our [ESLint Plugin Query](./eslint/eslint-plugin-query) to help you catch bugs and inconsistencies while you code. You can install it via:
+It is recommended to also use our [ESLint Plugin Query](../../../eslint/eslint-plugin-query) to help you catch bugs and inconsistencies while you code. You can install it via:
 
 ```bash
 $ npm i -D @tanstack/eslint-plugin-query

--- a/docs/framework/react/overview.md
+++ b/docs/framework/react/overview.md
@@ -96,6 +96,6 @@ function Example() {
 ## You talked me into it, so what now?
 
 - Consider taking the official [React Query Course](https://query.gg?s=tanstack) (or buying it for your whole team!)
-- Learn React Query at your own pace with our amazingly thorough [Walkthrough Guide](./installation) and [API Reference](../useQuery)
+- Learn React Query at your own pace with our amazingly thorough [Walkthrough Guide](../installation) and [API Reference](../reference/useQuery)
 
 [//]: # 'Materials'

--- a/docs/framework/react/plugins/createAsyncStoragePersister.md
+++ b/docs/framework/react/plugins/createAsyncStoragePersister.md
@@ -34,7 +34,7 @@ bun add @tanstack/query-async-storage-persister @tanstack/react-query-persist-cl
 - Import the `createAsyncStoragePersister` function
 - Create a new asyncStoragePersister
   - you can pass any `storage` to it that adheres to the `AsyncStorage` interface - the example below uses the async-storage from React Native
-- Wrap your app by using [`PersistQueryClientProvider`](../persistQueryClient.md#persistqueryclientprovider) component.
+- Wrap your app by using [`PersistQueryClientProvider`](../persistQueryClient#persistqueryclientprovider) component.
 
 ```tsx
 import AsyncStorage from '@react-native-async-storage/async-storage'

--- a/docs/framework/react/typescript.md
+++ b/docs/framework/react/typescript.md
@@ -157,7 +157,7 @@ const { error } = useQuery({ queryKey: ['groups'], queryFn: fetchGroups })
 
 ### Registering global Meta
 
-Similarly to registering a [global error type](#registering-a-global-error) you can also register a global `Meta` type. This ensures the optional `meta` field on [queries](../useQuery.md) and [mutations](../useMutation.md) stays consistent and is type-safe. Note that the registered type must extend `Record<string, unknown>` so that `meta` remains an object.
+Similarly to registering a [global error type](#registering-a-global-error) you can also register a global `Meta` type. This ensures the optional `meta` field on [queries](../reference/useQuery) and [mutations](../reference/useMutation) stays consistent and is type-safe. Note that the registered type must extend `Record<string, unknown>` so that `meta` remains an object.
 
 ```ts
 import '@tanstack/react-query'
@@ -223,12 +223,12 @@ const data = queryClient.getQueryData<Group[]>(['groups'])
 
 ## Further Reading
 
-For tips and tricks around type inference, have a look at [React Query and TypeScript](../tkdodos-blog#6-react-query-and-typescript) from
-the Community Resources. To find out how to get the best possible type-safety, you can read [Type-safe React Query](../tkdodos-blog#19-type-safe-react-query).
+For tips and tricks around type inference, have a look at [React Query and TypeScript](../community/tkdodos-blog#6-react-query-and-typescript) from
+the Community Resources. To find out how to get the best possible type-safety, you can read [Type-safe React Query](../community/tkdodos-blog#19-type-safe-react-query).
 
 [//]: # 'Materials'
 
 ## Typesafe disabling of queries using `skipToken`
 
 If you are using TypeScript, you can use the `skipToken` to disable a query. This is useful when you want to disable a query based on a condition, but you still want to keep the query to be type safe.
-Read more about it in the [Disabling Queries](../disabling-queries) guide.
+Read more about it in the [Disabling Queries](../guides/disabling-queries) guide.

--- a/docs/framework/svelte/overview.md
+++ b/docs/framework/svelte/overview.md
@@ -71,4 +71,4 @@ Svelte Query offers useful functions and components that will make managing serv
 Svelte Query offers an API similar to React Query, but there are some key differences to be mindful of.
 
 - Many of the functions in Svelte Query return a Svelte store. To access values on these stores reactively, you need to prefix the store with a `$`. You can learn more about Svelte stores [here](https://svelte.dev/tutorial/writable-stores).
-- If your query or mutation depends on variables, you must use a store for the options. You can read more about this [here](./reactivity).
+- If your query or mutation depends on variables, you must use a store for the options. You can read more about this [here](../reactivity).

--- a/docs/framework/vue/overview.md
+++ b/docs/framework/vue/overview.md
@@ -11,6 +11,6 @@ replace: { 'React': 'Vue', 'react-query': 'vue-query' }
 
 ## You talked me into it, so what now?
 
-- Learn Vue Query at your own pace with our amazingly thorough [Walkthrough Guide](./installation) and [API Reference](../useQuery)
+- Learn Vue Query at your own pace with our amazingly thorough [Walkthrough Guide](../installation) and [API Reference](../reference/useQuery)
 
 [//]: # 'Materials'


### PR DESCRIPTION
Something I found in the docs for Router, that looks to be broken on the other TanStack projects as well.

The relative navigation for top-level docs, looks to only be broken in the React, Vue, and Svelte documentation.