### PR TITLE
docs: correct useQuery `status` type

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -172,7 +172,7 @@ const {
 
 **Returns**
 
-- `status: String`
+- `status: QueryStatus`
   - Will be:
     - `pending` if there's no cached data and no query attempt was finished yet.
     - `error` if the query attempt resulted in an error. The corresponding `error` property has the error received from the attempted fetch


### PR DESCRIPTION
since the type is just a union of three string literals, i could also see using those explicitly. but they're listed right below, so the named type makes more sense to me.

See: https://github.com/TanStack/query/blob/main/packages/query-core/src/query.ts#L49