### PR TITLE
docs: Remove references to React.FC

### DIFF
--- a/docs/framework/react/guides/suspense.md
+++ b/docs/framework/react/guides/suspense.md
@@ -61,7 +61,7 @@ When using the component it will reset any query errors within the boundaries of
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 
-const App: React.FC = () => (
+const App = () => (
   <QueryErrorResetBoundary>
     {({ reset }) => (
       <ErrorBoundary
@@ -86,7 +86,7 @@ When using the hook it will reset any query errors within the closest `QueryErro
 import { useQueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 
-const App: React.FC = () => {
+const App = () => {
   const { reset } = useQueryErrorResetBoundary()
   return (
     <ErrorBoundary

--- a/docs/framework/react/reference/QueryErrorResetBoundary.md
+++ b/docs/framework/react/reference/QueryErrorResetBoundary.md
@@ -9,7 +9,7 @@ When using **suspense** or **throwOnError** in your queries, you need a way to l
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 
-const App: React.FC = () => (
+const App = () => (
   <QueryErrorResetBoundary>
     {({ reset }) => (
       <ErrorBoundary

--- a/docs/framework/react/reference/useQueryErrorResetBoundary.md
+++ b/docs/framework/react/reference/useQueryErrorResetBoundary.md
@@ -9,7 +9,7 @@ This hook will reset any query errors within the closest `QueryErrorResetBoundar
 import { useQueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 
-const App: React.FC = () => {
+const App = () => {
   const { reset } = useQueryErrorResetBoundary()
   return (
     <ErrorBoundary


### PR DESCRIPTION
React.FC was removed from the create-react-app template in facebook/create-react-app#8177 and is no longer recommended.