### PR TITLE
fix(solid-query): Correct error handling after SSR error

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -187,7 +187,12 @@ export function createBaseQuery<
 
         // If the query has data we don't suspend but instead mutate the resource
         // This could happen when placeholderData/initialData is defined
-        if (queryResource()?.data && result.data && !queryResource.loading) {
+        if (
+          !queryResource.error &&
+          queryResource()?.data &&
+          result.data &&
+          !queryResource.loading
+        ) {
           setState((store) => {
             return reconcileFn(
               store,
@@ -273,7 +278,10 @@ export function createBaseQuery<
          * even if `staleTime` is not set.
          */
         const newOptions = { ...initialOptions }
-        if (initialOptions.staleTime || !initialOptions.initialData) {
+        if (
+          (initialOptions.staleTime || !initialOptions.initialData) &&
+          info.value
+        ) {
           newOptions.refetchOnMount = false
         }
         // Setting the options as an immutable object to prevent


### PR DESCRIPTION
Fixes downstream issue in `solid-trpc` mentioned [here](https://github.com/solidjs-community/mediakit/issues/27#issuecomment-2037829578)

This fix fixes the issue where a query failing on initial SSR would cause the app to crash. This was because the error resides on the queryResource instead of residing in the query cache. Added additional checks to fix this issue