### PR TITLE
fix(solid-query): throwOnError now throws to EB where data is accessed

### DIFF
--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -2407,6 +2407,7 @@ describe('createQuery', () => {
 
       return (
         <div>
+          <h1>{state.data}</h1>
           <h1>{state.status}</h1>
           <h2>{state.error?.message}</h2>
         </div>
@@ -2491,7 +2492,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const state = createQuery<unknown, Error>(() => ({
+      const state = createQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('Remote Error')),
         retry: false,
@@ -2500,6 +2501,7 @@ describe('createQuery', () => {
 
       return (
         <div>
+          <div>{state.data}</div>
           <h1>{state.status}</h1>
           <h2>{state.error?.message ?? ''}</h2>
         </div>


### PR DESCRIPTION
Fixes #7079 
Fixes #7083 

This change fixes the issue where the ErrorBoundary needed to be outside the component to be triggered. This change will allow the closest errorboundary from where data is accessed to trigger. Meaning that the errorboundary can reside inside the same component where createQuery is called.