### PR TITLE
fix(solid-query): Fix reconciliation strategy for createBaseQuery

### DIFF
--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -557,7 +557,7 @@ describe('PersistQueryClientProvider', () => {
     expect(queryFn2).toHaveBeenCalledTimes(1)
     expect(onSuccess).toHaveBeenCalledTimes(1)
 
-    expect(states).toHaveLength(4)
+    expect(states).toHaveLength(3)
 
     expect(states[0]).toMatchObject({
       status: 'pending',
@@ -566,18 +566,12 @@ describe('PersistQueryClientProvider', () => {
     })
 
     expect(states[1]).toMatchObject({
-      status: 'pending',
-      fetchStatus: 'idle',
-      data: undefined,
-    })
-
-    expect(states[2]).toMatchObject({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[3]).toMatchObject({
+    expect(states[2]).toMatchObject({
       status: 'success',
       fetchStatus: 'idle',
       data: 'queryFn2',

--- a/packages/solid-query/src/__tests__/createQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/createQuery.test.tsx
@@ -1051,7 +1051,9 @@ describe('createQuery', () => {
           count++
           return count === 1 ? result1 : result2
         },
-        reconcile: 'id',
+        reconcile: (oldData, newData) => {
+          return reconcile(newData)(oldData)
+        },
       }))
 
       createRenderEffect(() => {

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -34,13 +34,34 @@ function reconcileFn<TData, TError>(
     | string
     | false
     | ((oldData: TData | undefined, newData: TData) => TData),
+  queryHash?: string,
 ): QueryObserverResult<TData, TError> {
   if (reconcileOption === false) return result
   if (typeof reconcileOption === 'function') {
     const newData = reconcileOption(store.data, result.data as TData)
     return { ...result, data: newData } as typeof result
   }
-  const newData = reconcile(result.data, { key: reconcileOption })(store.data)
+  let data = result.data
+  if (store.data === undefined) {
+    try {
+      data = structuredClone(data)
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        if (error instanceof Error) {
+          console.warn(
+            `Unable to correctly reconcile data for query key: ${queryHash}. ` +
+              `Possibly because the query data contains data structures that aren't supported ` +
+              `by the 'structuredClone' algorithm. Consider using a callback function instead ` +
+              `to manage the reconciliation manually.\n\n Error Received: ${error.name} - ${error.message}`,
+          )
+        }
+      }
+    }
+  }
+
+  console.log('data', data)
+  console.log('store.data', store.data)
+  const newData = reconcile(data, { key: reconcileOption })(store.data)
   return { ...result, data: newData } as typeof result
 }
 
@@ -186,14 +207,16 @@ export function createBaseQuery<
   }
 
   function setStateWithReconciliation(res: typeof observerResult) {
+    const opts = observer().options
     // @ts-expect-error - Reconcile option is not correctly typed internally
-    const reconcileOptions = observer().options.reconcile
+    const reconcileOptions = opts.reconcile
 
     setState((store) => {
       return reconcileFn(
         store,
         res,
         reconcileOptions === undefined ? false : reconcileOptions,
+        opts.queryHash,
       )
     })
   }
@@ -290,7 +313,7 @@ export function createBaseQuery<
         // Setting the options as an immutable object to prevent
         // wonky behavior with observer subscriptions
         observer().setOptions(newOptions)
-        setState(observer().getOptimisticResult(newOptions))
+        setStateWithReconciliation(observer().getOptimisticResult(newOptions))
         unsubscribe = createClientSubscriber()
       },
     },
@@ -353,8 +376,7 @@ export function createBaseQuery<
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
       if (prop === 'data') {
-        const opts = observer().options
-        if (opts.placeholderData) {
+        if (state.data !== undefined) {
           return queryResource.latest?.data
         }
         return queryResource()?.data

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -58,9 +58,6 @@ function reconcileFn<TData, TError>(
       }
     }
   }
-
-  console.log('data', data)
-  console.log('store.data', store.data)
   const newData = reconcile(data, { key: reconcileOption })(store.data)
   return { ...result, data: newData } as typeof result
 }


### PR DESCRIPTION
Fixes #7173
Fixes #7001 

The reconciliation strategy for createQuery and createInfiniteQuery has been updated. Previously, the issue with reconciliation was that to preserve the same data reference across different keys, the initial data within the observer was modified to align with the newly fetched data when the query key changed. As this data is also stored in the query cache, such modifications caused the initial data to remain altered. This issue persists on the createResource primitive itself and it makes sense for it since the previous data from a resource cannot be accessed arbitrarily and it also doesn't cache the data. To address this, we now deeply clone the initial data whenever the query data transitions from 'undefined' to any structured form, such as an object or array, using the structuredClone algorithm. This approach ensures that the data associated with the initial queryKey remains unchanged without any mutations. 

In the reconcile function callback, we opt not to clone the initial data, instead passing the cached data directly to allow for greater flexibility. However, to ensure proper reconciliation of data between updates, a similar approach to the one outlined in the example below should be followed:

```tsx

const query = createQuery(() => ({
  queryKey: ["todos", count()],
  reconcile: (oldData, newData) => {
    let data = newData;
    if (oldData === undefined) {
      // Can provide a custom cloning function here
      // This method makes sure that the initial data on the query cache
      // is not modified on queryKey changes
      data = structuredClone(newData);
    }
    return reconcile(data, { key: "id" })(oldData);
  },
}));

```

We can provide a utility function that does something similar in the future like `keepPreviousData`. I will also document this in the docs since I am already working on a rewrite there too
