### PR TITLE
Docs: Fix link to `community/tkdodos-blog`

### DIFF
--- a/docs/framework/react/typescript.md
+++ b/docs/framework/react/typescript.md
@@ -223,8 +223,8 @@ const data = queryClient.getQueryData<Group[]>(['groups'])
 
 ## Further Reading
 
-For tips and tricks around type inference, have a look at [React Query and TypeScript](../tkdodos-blog#6-react-query-and-typescript) from
-the Community Resources. To find out how to get the best possible type-safety, you can read [Type-safe React Query](../tkdodos-blog#19-type-safe-react-query).
+For tips and tricks around type inference, have a look at [React Query and TypeScript](../community/tkdodos-blog#6-react-query-and-typescript) from
+the Community Resources. To find out how to get the best possible type-safety, you can read [Type-safe React Query](../community/tkdodos-blog#19-type-safe-react-query).
 
 [//]: # 'Materials'
 


### PR DESCRIPTION
The links on https://tanstack.com/query/v5/docs/framework/react/typescript/#further-reading are broken.

Note: I did not check other places of the code, which should probably happen as well.