### PR TITLE
Use `isInternetReachable` instead of `isConnected` in the online manager example

### DIFF
--- a/docs/framework/react/react-native.md
+++ b/docs/framework/react/react-native.md
@@ -20,7 +20,7 @@ import { onlineManager } from 'react-query'
 
 onlineManager.setEventListener(setOnline => {
   return NetInfo.addEventListener(state => {
-    setOnline(state.isConnected)
+    setOnline(state.isInternetReachable)
   })
 })
 ```


### PR DESCRIPTION
The `isConnected` property actually only conveys that the network connection has been established (e.g. Wi-Fi connection), which not necessarily implies that there is a working _internet_ connection.

So I as wondering if it is not better to use `isInternetReachable` instead? Although I am aware (and thus a bit hesitant as well) that the netinfo library implements this through a HEAD request to a Google URL.