### PR TITLE
fix(query-core): Before use globalThis, check its existence.

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -62,7 +62,7 @@ export type QueryTypeFilter = 'all' | 'active' | 'inactive'
 
 // UTILS
 
-export const isServer = typeof window === 'undefined' || 'Deno' in globalThis
+export const isServer = typeof window === 'undefined' || (typeof globalThis !== 'undefined' && 'Deno' in globalThis)
 
 export function noop(): undefined {
   return undefined


### PR DESCRIPTION
I'm utilizing @tanstack/react-query within a React project operating in a unique environment. However, during runtime, the global object 'globalThis' is not available, causing errors to be displayed in the console and bringing the entire application down. I believe that implementing a check for the existence of 'globalThis' before its usage could resolve this issue.
<img width="831" alt="截屏2024-04-20 23 33 48" src="https://github.com/TanStack/query/assets/32085026/4f09cf47-34e5-493b-84f3-6322f62f3f46">