### PR TITLE
docs: Update link address

### DIFF
--- a/docs/framework/react/guides/caching.md
+++ b/docs/framework/react/guides/caching.md
@@ -3,7 +3,7 @@ id: caching
 title: Caching Examples
 ---
 
-> Please thoroughly read the [Important Defaults](./guides/important-defaults) before reading this guide
+> Please thoroughly read the [Important Defaults](../important-defaults) before reading this guide
 
 ## Basic Example
 


### PR DESCRIPTION
The address of `Important Defaults` was written incorrectly. I've fixed it with the correct link.