### PR TITLE
Add context as second parameter for the mutation function

### DIFF
--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -45,10 +45,11 @@ mutate(variables, {
 
 **Options**
 
-- `mutationFn: (variables: TVariables) => Promise<TData>`
+- `mutationFn: (variables: TVariables, context: MutationFunctionContext) => Promise<TData>`
   - **Required, but only if no default mutation function has been defined**
   - A function that performs an asynchronous task and returns a promise.
   - `variables` is an object that `mutate` will pass to your `mutationFn`
+  - `context` is an object containing the `mutationKey` and the mutation's `meta`
 - `gcTime: number | Infinity`
   - The time in milliseconds that unused/inactive cache data remains in memory. When a mutation's cache becomes unused or inactive, that cache data will be garbage collected after this duration. When different cache times are specified, the longest one will be used.
   - If set to `Infinity`, will disable garbage collection

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -3,6 +3,7 @@ import { Removable } from './removable'
 import { createRetryer } from './retryer'
 import type {
   DefaultError,
+  MutationFunctionContext,
   MutationMeta,
   MutationOptions,
   MutationStatus,
@@ -167,7 +168,11 @@ export class Mutation<
         if (!this.options.mutationFn) {
           return Promise.reject(new Error('No mutationFn found'))
         }
-        return this.options.mutationFn(variables)
+        const mutationFnContext: MutationFunctionContext = {
+          mutationKey: this.options.mutationKey,
+          meta: this.meta,
+        }
+        return this.options.mutationFn(variables, mutationFnContext)
       },
       onFail: (failureCount, error) => {
         this.#dispatch({ type: 'failed', failureCount, error })

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -897,8 +897,14 @@ export type MutationMeta = Register extends {
     : Record<string, unknown>
   : Record<string, unknown>
 
+export type MutationFunctionContext = {
+  mutationKey?: MutationKey
+  meta: MutationMeta | undefined
+}
+
 export type MutationFunction<TData = unknown, TVariables = unknown> = (
   variables: TVariables,
+  context: MutationFunctionContext,
 ) => Promise<TData>
 
 export interface MutationOptions<


### PR DESCRIPTION
This PR adds a context that's passed as the second parameter to the `mutationFn` in a mutation. This change allows access to the mutation's `meta` (similar to query functions), which I find useful for passing in configurations (similarly as the case mentioned in https://github.com/TanStack/query/discussions/7045#discussioncomment-9151048). I've also included the `mutationKey` in the context, since it came up in a similar discussion #3504. 

While this context could eventually include other information, I kept this initial contribution small and simple as to not get all tangled up with all the typing :sweat_smile: