### PR TITLE
fix(solid-query): Correct types for primitives

### DIFF
--- a/packages/solid-query/src/createQueries.ts
+++ b/packages/solid-query/src/createQueries.ts
@@ -37,9 +37,16 @@ type CreateQueryOptionsForCreateQueries<
   TQueryKey extends QueryKey = QueryKey,
 > = OmitKeyof<
   SolidQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  'placeholderData'
+  'placeholderData' | 'suspense'
 > & {
   placeholderData?: TQueryFnData | QueriesPlaceholderDataFunction<TQueryFnData>
+  /**
+   * @deprecated The `suspense` option has been deprecated in v5 and will be removed in the next major version.
+   * The `data` property on createQueries is a plain object and not a SolidJS Resource.
+   * It will not suspend when the data is loading.
+   * Setting `suspense` to `true` will be a no-op.
+   */
+  suspense?: boolean
 }
 
 // Avoid TS depth-limit error in case of large array literal

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -24,14 +24,23 @@ export interface CreateBaseQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
+> extends OmitKeyof<
+    QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+    'suspense'
   > {
+  /**
+   * Only applicable while rendering queries on the server with streaming.
+   * Set `deferStream` to `true` to wait for the query to resolve on the server before flushing the stream.
+   * This can be useful to avoid sending a loading state to the client before the query has resolved.
+   * Defaults to `false`.
+   */
   deferStream?: boolean
+  /**
+   * @deprecated The `suspense` option has been deprecated in v5 and will be removed in the next major version.
+   * The `data` property on createQuery is a SolidJS resource and will automatically suspend when the data is loading.
+   * Setting `suspense` to `false` will be a no-op.
+   */
+  suspense?: boolean
 }
 
 export interface SolidQueryOptions<
@@ -93,10 +102,22 @@ export interface SolidInfiniteQueryOptions<
       TQueryKey,
       TPageParam
     >,
-    'queryKey'
+    'queryKey' | 'suspense'
   > {
   queryKey: TQueryKey
+  /**
+   * Only applicable while rendering queries on the server with streaming.
+   * Set `deferStream` to `true` to wait for the query to resolve on the server before flushing the stream.
+   * This can be useful to avoid sending a loading state to the client before the query has resolved.
+   * Defaults to `false`.
+   */
   deferStream?: boolean
+  /**
+   * @deprecated The `suspense` option has been deprecated in v5 and will be removed in the next major version.
+   * The `data` property on createInfiniteQuery is a SolidJS resource and will automatically suspend when the data is loading.
+   * Setting `suspense` to `false` will be a no-op.
+   */
+  suspense?: boolean
 }
 
 export type CreateInfiniteQueryOptions<


### PR DESCRIPTION
Fixes some of the type declarations for `solid-query` primitives

- Deprecates the `suspense` option on `createQuery`, `createInfiniteQuery` and `createQueries`
- Adds documentation on the `deferStream` option on `createQuery` and `createInfiniteQuery` option
- Removes `deferStream` option from `createQueries`