### PR TITLE
fix(query-core): replaceEqualDeep correctly handles arrays that conta…

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -376,6 +376,20 @@ describe('core/utils', () => {
 
       expect(current).toBe(next)
     })
+
+    it('should return the previous value when both values are an array of undefined', () => {
+      const current = [undefined]
+      const next = replaceEqualDeep(current, [undefined])
+
+      expect(next).toBe(current)
+    })
+
+    it('should return the previous value when both values are an array that contains undefined', () => {
+      const current = [{ foo: 1 }, undefined]
+      const next = replaceEqualDeep(current, [{ foo: 1 }, undefined])
+
+      expect(next).toBe(current)
+    })
   })
 
   describe('matchMutation', () => {

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -232,10 +232,9 @@ export function replaceEqualDeep(a: any, b: any): any {
     for (let i = 0; i < bSize; i++) {
       const key = array ? i : bItems[i]
       if (
-        !array &&
+        ((!array && aItems.includes(key)) || array) &&
         a[key] === undefined &&
-        b[key] === undefined &&
-        aItems.includes(key)
+        b[key] === undefined
       ) {
         copy[key] = undefined
         equalItems++


### PR DESCRIPTION
…in undefined