### PR TITLE
fix(angular-query): missing exports InitialDataInfiniteOptions types

### DIFF
--- a/packages/angular-query-experimental/.prettierignore
+++ b/packages/angular-query-experimental/.prettierignore
@@ -1,2 +1,2 @@
 # API extractor
-*.api.md
+etc/**

--- a/packages/angular-query-experimental/etc/angular-query-experimental.api.md
+++ b/packages/angular-query-experimental/etc/angular-query-experimental.api.md
@@ -285,6 +285,26 @@ export type DefinedCreateQueryResult<
 > = MapToSignals<TDefinedQueryObserver>
 
 // @public (undocumented)
+export type DefinedInitialDataInfiniteOptions<
+  TQueryFnData,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+> = CreateInfiniteQueryOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryFnData,
+  TQueryKey,
+  TPageParam
+> & {
+  initialData:
+    | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
+    | (() => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>)
+}
+
+// @public (undocumented)
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -296,8 +316,6 @@ export type DefinedInitialDataOptions<
     | (() => NonUndefinedGuard<TQueryFnData>)
 }
 
-// Warning: (ae-forgotten-export) The symbol "UndefinedInitialDataInfiniteOptions" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function infiniteQueryOptions<
   TQueryFnData,
@@ -323,8 +341,6 @@ export function infiniteQueryOptions<
   queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>>
 }
 
-// Warning: (ae-forgotten-export) The symbol "DefinedInitialDataInfiniteOptions" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function infiniteQueryOptions<
   TQueryFnData,
@@ -521,6 +537,9 @@ export const injectQueryClient: {
   ): QueryClient
 }
 
+// @public (undocumented)
+export type NonUndefinedGuard<T> = T extends undefined ? never : T
+
 // @public
 export function provideAngularQuery(
   queryClient: QueryClient,
@@ -633,6 +652,24 @@ export function queryOptions<
 }
 
 // @public (undocumented)
+export type UndefinedInitialDataInfiniteOptions<
+  TQueryFnData,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+> = CreateInfiniteQueryOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryFnData,
+  TQueryKey,
+  TPageParam
+> & {
+  initialData?: undefined
+}
+
+// @public (undocumented)
 export type UndefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -643,10 +680,6 @@ export type UndefinedInitialDataOptions<
 }
 
 export * from '@tanstack/query-core'
-
-// Warnings were encountered during analysis:
-//
-// src/query-options.ts:27:3 - (ae-forgotten-export) The symbol "NonUndefinedGuard" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/angular-query-experimental/src/index.ts
+++ b/packages/angular-query-experimental/src/index.ts
@@ -11,6 +11,10 @@ export type {
 } from './query-options'
 export { queryOptions } from './query-options'
 
+export type {
+  DefinedInitialDataInfiniteOptions,
+  UndefinedInitialDataInfiniteOptions,
+} from './infinite-query-options'
 export { infiniteQueryOptions } from './infinite-query-options'
 
 export * from './inject-infinite-query'

--- a/packages/angular-query-experimental/src/infinite-query-options.ts
+++ b/packages/angular-query-experimental/src/infinite-query-options.ts
@@ -3,6 +3,9 @@ import type { InfiniteData } from '@tanstack/query-core'
 import type { CreateInfiniteQueryOptions } from './types'
 import type { DefaultError, QueryKey } from '@tanstack/query-core'
 
+/**
+ * @public
+ */
 export type UndefinedInitialDataInfiniteOptions<
   TQueryFnData,
   TError = DefaultError,
@@ -22,6 +25,9 @@ export type UndefinedInitialDataInfiniteOptions<
 
 type NonUndefinedGuard<T> = T extends undefined ? never : T
 
+/**
+ * @public
+ */
 export type DefinedInitialDataInfiniteOptions<
   TQueryFnData,
   TError = DefaultError,

--- a/packages/angular-query-experimental/src/infinite-query-options.ts
+++ b/packages/angular-query-experimental/src/infinite-query-options.ts
@@ -1,6 +1,6 @@
 import type { DataTag } from '@tanstack/query-core'
 import type { InfiniteData } from '@tanstack/query-core'
-import type { CreateInfiniteQueryOptions } from './types'
+import type { CreateInfiniteQueryOptions, NonUndefinedGuard } from './types'
 import type { DefaultError, QueryKey } from '@tanstack/query-core'
 
 /**
@@ -22,8 +22,6 @@ export type UndefinedInitialDataInfiniteOptions<
 > & {
   initialData?: undefined
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 /**
  * @public

--- a/packages/angular-query-experimental/src/query-options.ts
+++ b/packages/angular-query-experimental/src/query-options.ts
@@ -1,5 +1,5 @@
 import type { DataTag, DefaultError, QueryKey } from '@tanstack/query-core'
-import type { CreateQueryOptions } from './types'
+import type { CreateQueryOptions, NonUndefinedGuard } from './types'
 
 /**
  * @public
@@ -12,8 +12,6 @@ export type UndefinedInitialDataOptions<
 > = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
   initialData?: undefined
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 /**
  * @public

--- a/packages/angular-query-experimental/src/types.ts
+++ b/packages/angular-query-experimental/src/types.ts
@@ -309,3 +309,8 @@ type Override<TTargetA, TTargetB> = {
     ? TTargetB[AKey]
     : TTargetA[AKey]
 }
+
+/**
+ * @public
+ */
+export type NonUndefinedGuard<T> = T extends undefined ? never : T


### PR DESCRIPTION
Add missing `@public` js-doc comments in infinite-query-options.ts to fix type exports. 

Currently the InitialDataInfiniteOptions types are not exported and can't be used. I assume this is due to the change to jsdoc and missing the `@public` comment for these types. This change would make this consistent with similar InitialDataOptions types form (query-options.ts).