### PR TITLE
docs: Fix usage of removeEventListener

### DIFF
--- a/docs/framework/react/guides/window-focus-refetching.md
+++ b/docs/framework/react/guides/window-focus-refetching.md
@@ -50,10 +50,13 @@ In rare circumstances, you may want to manage your own window focus events that 
 focusManager.setEventListener((handleFocus) => {
   // Listen to visibilitychange
   if (typeof window !== 'undefined' && window.addEventListener) {
-    window.addEventListener('visibilitychange', () => handleFocus(), false)
+    const visibilitychangeHandler = () => {
+      handleFocus(document.visibilityState === 'visible')
+    }
+    window.addEventListener('visibilitychange', visibilitychangeHandler, false)
     return () => {
       // Be sure to unsubscribe if a new handler is set
-      window.removeEventListener('visibilitychange', () => handleFocus())
+      window.removeEventListener('visibilitychange', visibilitychangeHandler)
     }
   }
 })


### PR DESCRIPTION
[Doc for custom-window-focus-event](https://tanstack.com/query/v5/docs/framework/react/guides/window-focus-refetching#custom-window-focus-event) has a misusage of removeEventListener. It may mislead the user.
As described in #7391 