### PR TITLE
feat(react-query): add default query options provider

### DIFF
--- a/docs/framework/react/reference/QueryDefaultOptionsProvider.md
+++ b/docs/framework/react/reference/QueryDefaultOptionsProvider.md
@@ -1,0 +1,31 @@
+---
+id: QueryDefaultOptionsProvider
+title: QueryDefaultOptionsProvider
+---
+
+Use the `QueryDefaultOptionsProvider` component to dynamically set the default options inside a component subtree.
+
+```tsx
+import React from 'react'
+import { QueryDefaultOptionsProvider } from '@tanstack/react-query'
+
+function App() {
+  return (
+    <QueryDefaultOptionsProvider
+      // memoize the options object
+      options={React.useMemo(
+        () => ({ queries: { refetchInterval: 5000 } }),
+        [],
+      )}
+    >
+      ...
+    </QueryDefaultOptionsProvider>
+  )
+}
+```
+
+**Options**
+
+- `options: { queries: QueryObserverOptions }`
+  - **Required**
+  - the default options to set in this component subtree

--- a/packages/react-query/src/QueryDefaultOptionsProvider.tsx
+++ b/packages/react-query/src/QueryDefaultOptionsProvider.tsx
@@ -1,0 +1,27 @@
+'use client'
+import * as React from 'react'
+import { type DefaultOptions } from '@tanstack/query-core'
+
+export const QueryDefaultOptionsContext = React.createContext<
+  Pick<DefaultOptions, 'queries'> | undefined
+>(undefined)
+
+export const useQueryDefaultOptions = () => {
+  return React.useContext(QueryDefaultOptionsContext)
+}
+
+export type QueryDefaultOptionsProviderProps = {
+  options: Pick<DefaultOptions, 'queries'>
+  children?: React.ReactNode
+}
+
+export const QueryDefaultOptionsProvider = ({
+  options,
+  children,
+}: QueryDefaultOptionsProviderProps): JSX.Element => {
+  return (
+    <QueryDefaultOptionsContext.Provider value={options}>
+      {children}
+    </QueryDefaultOptionsContext.Provider>
+  )
+}

--- a/packages/react-query/src/__tests__/QueryDefaultOptionsProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryDefaultOptionsProvider.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+import { QueryCache, QueryClientProvider, useQuery } from '..'
+import { QueryDefaultOptionsProvider } from '../QueryDefaultOptionsProvider'
+import { createQueryClient, queryKey, sleep } from './utils'
+
+describe('QueryDefaultOptionsProvider', () => {
+  test("uses defaultOptions for queries when they don't provide their own config", async () => {
+    const key = queryKey()
+
+    const queryCache = new QueryCache()
+    const queryClient = createQueryClient({
+      queryCache,
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+        },
+      },
+    })
+
+    function Page() {
+      const { data } = useQuery({
+        queryKey: key,
+        queryFn: async () => {
+          await sleep(10)
+          return 'test'
+        },
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(
+      <QueryClientProvider client={queryClient}>
+        <QueryDefaultOptionsProvider options={{ queries: { gcTime: 1000 } }}>
+          <Page />
+        </QueryDefaultOptionsProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => rendered.getByText('test'))
+
+    expect(queryCache.find({ queryKey: key })).toBeDefined()
+    expect(queryCache.find({ queryKey: key })?.options.gcTime).toBe(1000)
+  })
+
+  test('allows different default options per React subtree', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    const queryClient = createQueryClient()
+
+    function Page1() {
+      const { data } = useQuery({
+        queryKey: key1,
+        queryFn: async () => {
+          await sleep(10)
+          return 'test1'
+        },
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+    function Page2() {
+      const { data } = useQuery({
+        queryKey: key2,
+        queryFn: async () => {
+          await sleep(10)
+          return 'test2'
+        },
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(
+      <QueryClientProvider client={queryClient}>
+        <QueryDefaultOptionsProvider options={{ queries: { gcTime: 1000 } }}>
+          <Page1 />
+        </QueryDefaultOptionsProvider>
+        <QueryDefaultOptionsProvider options={{ queries: { gcTime: 2000 } }}>
+          <Page2 />
+        </QueryDefaultOptionsProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => rendered.getByText('test1'))
+    await waitFor(() => rendered.getByText('test2'))
+
+    expect(queryClient.getQueryCache().find({ queryKey: key1 })).toBeDefined()
+    expect(
+      queryClient.getQueryCache().find({ queryKey: key1 })?.options.gcTime,
+    ).toBe(1000)
+
+    expect(queryClient.getQueryCache().find({ queryKey: key2 })).toBeDefined()
+    expect(
+      queryClient.getQueryCache().find({ queryKey: key2 })?.options.gcTime,
+    ).toBe(2000)
+  })
+})

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -31,6 +31,12 @@ export {
   useQueryClient,
 } from './QueryClientProvider'
 export type { QueryClientProviderProps } from './QueryClientProvider'
+export {
+  QueryDefaultOptionsContext,
+  QueryDefaultOptionsProvider,
+  useQueryDefaultOptions,
+} from './QueryDefaultOptionsProvider'
+export type { QueryDefaultOptionsProviderProps } from './QueryDefaultOptionsProvider'
 export type { QueryErrorResetBoundaryProps } from './QueryErrorResetBoundary'
 export { HydrationBoundary } from './HydrationBoundary'
 export type { HydrationBoundaryProps } from './HydrationBoundary'

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -11,6 +11,7 @@ import {
   useClearResetErrorBoundary,
 } from './errorBoundaryUtils'
 import { ensureStaleTime, fetchOptimistic, shouldSuspend } from './suspense'
+import { useQueryDefaultOptions } from './QueryDefaultOptionsProvider'
 import type { UseBaseQueryOptions } from './types'
 import type {
   QueryClient,
@@ -47,7 +48,11 @@ export function useBaseQuery<
   const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
   const errorResetBoundary = useQueryErrorResetBoundary()
-  const defaultedOptions = client.defaultQueryOptions(options)
+  const defaultOptions = useQueryDefaultOptions()
+  const defaultedOptions = client.defaultQueryOptions({
+    ...(defaultOptions?.queries as typeof options | undefined),
+    ...options,
+  })
 
   // Make sure results are optimistically set in fetching state before subscribing or updating options
   defaultedOptions._optimisticResults = isRestoring


### PR DESCRIPTION
The goal of this PR is to allow providing default query options to a React subtree. So basically like `queryClient.setDefaultOptions` / `queryClient.setQueryDefaults` but scoped to a component subtree.

Technically this can already be done in userland, but it would require reading in the context before each useQuery and/or creating a custom useQuery hook. This PR would allow to do it without any changes to useQuery calls.

### Example: automatic polling 

```
import { QueryDefaultOptionsProvider } from '@tanstack/react-query'

// All queries in this page will refetch every 5s
// The same queries in another page will fetch at most once on mount
export const Home = () => {
  return (
    <QueryDefaultOptionsProvider
      options={{ queries: { refetchInterval: () => 5000 } }}
    >
      ...
    </QueryDefaultOptionsProvider>
  )
}
```

### Benefits for React Native

With React Navigation (the most popular navigation library in React Native), screens in the stack history [stay mounted](https://reactnavigation.org/docs/navigation-lifecycle/). That does not work well with React Query's default `refetchOnWindowFocus` / `refetchOnMount` options that assume that if a component is mounted, then it's on screen. This PR would allow setting global navigation-aware options on queries to reconcile the two behaviors. Something along the line:
```
import { QueryDefaultOptionsProvider } from '@tanstack/react-query'

export const Screen = () => {
  const navigation = useNavigation()
  return (
    <QueryDefaultOptionsProvider
      options={{
        queries: {
          refetchOnWindowFocus: () => navigation.isFocused(),
        },
      }}
    >
      ...
    </QueryDefaultOptionsProvider>
  )
}
```

### ⚠️ Attention points

- I have reused the same interface as `queryClient.setDefaultOptions`, though this PR only supports `{ queries: ... }` for now, not `{ mutations: ... }` (slightly more work because options defaulting is not completely done in `useMutation` yet, unlike `useBaseQuery`).

- If the component rendering `<QueryDefaultOptionsProvider>` rerenders, all components calling `useQuery` (and alternatives) will rerender because the options object is not referentially stable. The user needs to memoize the options object to be safe. I've added it to the docs, but an alternative would be to expose the context itself and let the user use `QueryDefaultOptionsContext.Provider>` to benefit from this official React eslint rule : https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-constructed-context-values.md