### PR TITLE
fix: deprecate direction passed to QueryFunctionContext

### DIFF
--- a/docs/framework/react/guides/query-functions.md
+++ b/docs/framework/react/guides/query-functions.md
@@ -111,4 +111,6 @@ Additionally, [Infinite Queries](../infinite-queries) get the following options 
 - `pageParam: TPageParam`
   - the page parameter used to fetch the current page
 - `direction: 'forward' | 'backward'`
+  - **deprecated**
   - the direction of the current page fetch
+  - To get access to the direction of the current page fetch, please add a direction to `pageParam` from `getNextPageParam` and `getPreviousPageParam`.

--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -1,6 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { QueryClient } from '../queryClient'
-import type { FetchDirection } from '../query'
 import type { DataTag, InfiniteData, QueryKey } from '../types'
 
 describe('getQueryData', () => {
@@ -146,7 +145,7 @@ describe('defaultOptions', () => {
               meta: Record<string, unknown> | undefined
               signal: AbortSignal
               pageParam?: unknown
-              direction?: FetchDirection
+              direction?: unknown
             }>()
             return Promise.resolve('data')
           },

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -71,12 +71,20 @@ export type QueryFunctionContext<
       signal: AbortSignal
       meta: QueryMeta | undefined
       pageParam?: unknown
-      direction?: 'forward' | 'backward'
+      /**
+       * @deprecated
+       * if you want access to the direction, you can add it to the pageParam
+       */
+      direction?: unknown
     }
   : {
       queryKey: TQueryKey
       signal: AbortSignal
       pageParam: TPageParam
+      /**
+       * @deprecated
+       * if you want access to the direction, you can add it to the pageParam
+       */
       direction: FetchDirection
       meta: QueryMeta | undefined
     }


### PR DESCRIPTION
closes fixes #7203