### PR TITLE
fix(svelte-query): fix create queries get results type

### DIFF
--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -110,7 +110,7 @@ type GetResults<T> =
                     unknown extends TError ? DefaultError : TError
                   >
                 : T extends {
-                      queryFn?: QueryFunction<infer TQueryFnData, any>
+                      queryFn?: QueryFunction<infer TQueryFnData, any> | SkipToken
                       throwOnError?: ThrowOnError<any, infer TError, any, any>
                     }
                   ? QueryObserverResult<

--- a/packages/svelte-query/src/index.ts
+++ b/packages/svelte-query/src/index.ts
@@ -8,6 +8,7 @@ export * from './types'
 export * from './context'
 
 export { createQuery } from './createQuery'
+export type { QueriesResults, QueriesOptions } from './createQueries'
 export type {
   DefinedInitialDataOptions,
   UndefinedInitialDataOptions,


### PR DESCRIPTION
# Fix
The typeof `QueryOptions.queryFn` is a union between `SkipToken` and `QueryFunction` by default. The `GetResults` type in react-query seems to handle this, but svelte-query currently omits this.