### PR TITLE
fix(types): make TVariables default to unknown on Mutation

### DIFF
--- a/packages/angular-query-experimental/src/inject-mutation-state.ts
+++ b/packages/angular-query-experimental/src/inject-mutation-state.ts
@@ -35,11 +35,7 @@ function getResult<TResult = MutationState>(
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select
-          ? options.select(
-              mutation as Mutation<unknown, DefaultError, unknown, unknown>,
-            )
-          : mutation.state) as TResult,
+        (options.select ? options.select(mutation) : mutation.state) as TResult,
     )
 }
 

--- a/packages/angular-query-experimental/src/inject-mutation-state.ts
+++ b/packages/angular-query-experimental/src/inject-mutation-state.ts
@@ -7,7 +7,6 @@ import {
   untracked,
 } from '@angular/core'
 import {
-  type DefaultError,
   type Mutation,
   type MutationCache,
   type MutationFilters,
@@ -22,9 +21,7 @@ import type { Injector, Signal } from '@angular/core'
 
 type MutationStateOptions<TResult = MutationState> = {
   filters?: MutationFilters
-  select?: (
-    mutation: Mutation<unknown, DefaultError, unknown, unknown>,
-  ) => TResult
+  select?: (mutation: Mutation) => TResult
 }
 
 function getResult<TResult = MutationState>(

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -1,4 +1,5 @@
 import type {
+  DefaultError,
   MutationKey,
   MutationMeta,
   MutationOptions,
@@ -21,7 +22,7 @@ export interface DehydrateOptions {
 export interface HydrateOptions {
   defaultOptions?: {
     queries?: QueryOptions
-    mutations?: MutationOptions
+    mutations?: MutationOptions<unknown, DefaultError, unknown, unknown>
   }
 }
 

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -23,7 +23,7 @@ interface MutationConfig<TData, TError, TVariables, TContext> {
 export interface MutationState<
   TData = unknown,
   TError = DefaultError,
-  TVariables = void,
+  TVariables = unknown,
   TContext = unknown,
 > {
   context: TContext | undefined
@@ -81,7 +81,7 @@ export type Action<TData, TError, TVariables, TContext> =
 export class Mutation<
   TData = unknown,
   TError = DefaultError,
-  TVariables = void,
+  TVariables = unknown,
   TContext = unknown,
 > extends Removable {
   state: MutationState<TData, TError, TVariables, TContext>

--- a/packages/react-query/src/useMutationState.ts
+++ b/packages/react-query/src/useMutationState.ts
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { notifyManager, replaceEqualDeep } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
-  DefaultError,
   Mutation,
   MutationCache,
   MutationFilters,
@@ -25,9 +24,7 @@ export function useIsMutating(
 
 type MutationStateOptions<TResult = MutationState> = {
   filters?: MutationFilters
-  select?: (
-    mutation: Mutation<unknown, DefaultError, unknown, unknown>,
-  ) => TResult
+  select?: (mutation: Mutation) => TResult
 }
 
 function getResult<TResult = MutationState>(

--- a/packages/react-query/src/useMutationState.ts
+++ b/packages/react-query/src/useMutationState.ts
@@ -38,11 +38,7 @@ function getResult<TResult = MutationState>(
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select
-          ? options.select(
-              mutation as Mutation<unknown, DefaultError, unknown, unknown>,
-            )
-          : mutation.state) as TResult,
+        (options.select ? options.select(mutation) : mutation.state) as TResult,
     )
 }
 

--- a/packages/solid-query/src/__tests__/useMutationState.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useMutationState.test-d.tsx
@@ -8,9 +8,7 @@ describe('useMutationState', () => {
       filters: { status: 'pending' },
     }))
 
-    expectTypeOf(result()).toEqualTypeOf<
-      Array<MutationState<unknown, Error, void, unknown>>
-    >()
+    expectTypeOf(result()).toEqualTypeOf<Array<MutationState>>()
   })
   it('should infer with select', () => {
     const result = useMutationState(() => ({

--- a/packages/solid-query/src/useMutationState.ts
+++ b/packages/solid-query/src/useMutationState.ts
@@ -2,7 +2,6 @@ import { createEffect, createMemo, createSignal, onCleanup } from 'solid-js'
 import { replaceEqualDeep } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
-  DefaultError,
   Mutation,
   MutationCache,
   MutationFilters,
@@ -13,9 +12,7 @@ import type { QueryClient } from './QueryClient'
 
 type MutationStateOptions<TResult = MutationState> = {
   filters?: MutationFilters
-  select?: (
-    mutation: Mutation<unknown, DefaultError, unknown, unknown>,
-  ) => TResult
+  select?: (mutation: Mutation) => TResult
 }
 
 function getResult<TResult = MutationState>(
@@ -26,11 +23,7 @@ function getResult<TResult = MutationState>(
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select
-          ? options.select(
-              mutation as Mutation<unknown, DefaultError, unknown, unknown>,
-            )
-          : mutation.state) as TResult,
+        (options.select ? options.select(mutation) : mutation.state) as TResult,
     )
 }
 

--- a/packages/vue-query/src/useMutationState.ts
+++ b/packages/vue-query/src/useMutationState.ts
@@ -10,7 +10,6 @@ import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref } from './utils'
 import type { DeepReadonly, Ref } from 'vue-demi'
 import type {
-  DefaultError,
   MutationFilters as MF,
   Mutation,
   MutationState,
@@ -51,9 +50,7 @@ export function useIsMutating(
 
 export type MutationStateOptions<TResult = MutationState> = {
   filters?: MutationFilters
-  select?: (
-    mutation: Mutation<unknown, DefaultError, unknown, unknown>,
-  ) => TResult
+  select?: (mutation: Mutation) => TResult
 }
 
 function getResult<TResult = MutationState>(

--- a/packages/vue-query/src/useMutationState.ts
+++ b/packages/vue-query/src/useMutationState.ts
@@ -64,11 +64,7 @@ function getResult<TResult = MutationState>(
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select
-          ? options.select(
-              mutation as Mutation<unknown, DefaultError, unknown, unknown>,
-            )
-          : mutation.state) as TResult,
+        (options.select ? options.select(mutation) : mutation.state) as TResult,
     )
 }
 


### PR DESCRIPTION
we only need `void` as the default for MutationOptions so that we can fire mutations with no parameters without passing undefined to them explicitly. For reading mutations and mutationState, unknown is better.