### PR TITLE
fix(react-query): do not use global `JSX` namespace

### DIFF
--- a/packages/react-query/src/QueryClientProvider.tsx
+++ b/packages/react-query/src/QueryClientProvider.tsx
@@ -29,7 +29,7 @@ export type QueryClientProviderProps = {
 export const QueryClientProvider = ({
   client,
   children,
-}: QueryClientProviderProps): JSX.Element => {
+}: QueryClientProviderProps): React.JSX.Element => {
   React.useEffect(() => {
     client.mount()
     return () => {


### PR DESCRIPTION
This does not work with React 19 types.

https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript