### PR TITLE
chore: downgrade codecov github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ inputs.tag }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,6 @@ jobs:
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: packages


### PR DESCRIPTION
The codecov action was [upgraded to v4](https://github.com/TanStack/query/pull/7117) a few months ago but this seems to require additional configuration over v3.

Since the upgrade, no code coverage reports were uploaded for main anymore as it fails with error:

```
info - 2024-05-27 18:16:24,691 -- ci service found: github-actions
Error: Codecov token not found. Please provide Codecov token with -t flag.
Warning: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```
