### PR TITLE
Bugfix for #7527

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -208,7 +208,7 @@ export function createBaseQuery<
         }
         // Hydration data exists on first load after SSR,
         // and should be removed from the observer result
-        if (v.hydrationData) {
+        if (v?.hydrationData) {
           const { hydrationData, ...rest } = v
           v = rest
         }


### PR DESCRIPTION
When the createResource is rejected on ssr evaluation `v` is `undefined` which is not handled. I actually don't really understand what  `v` is.

I don't want to blame here any good open source soul, but just wanted to metion in a lovely manner that naming things in a verbose way makes the code 100% more readable for other developers :)

Actually I don't know if this is correct way to approach this issue, it could be that there is an underlying problem that causes `v` to be `undefined`

fixes #7527