### PR TITLE
docs(installation):remove prompt symbol from installation commands(#7293)

### DIFF
--- a/docs/framework/angular/installation.md
+++ b/docs/framework/angular/installation.md
@@ -10,13 +10,13 @@ title: Installation
 _Angular Query is compatible with Angular v16 and higher_
 
 ```bash
-$ npm i @tanstack/angular-query-experimental
+npm i @tanstack/angular-query-experimental
 # or
-$ pnpm add @tanstack/angular-query-experimental
+pnpm add @tanstack/angular-query-experimental
 # or
-$ yarn add @tanstack/angular-query-experimental
+yarn add @tanstack/angular-query-experimental
 # or
-$ bun add @tanstack/angular-query-experimental
+bun add @tanstack/angular-query-experimental
 ```
 
 > Wanna give it a spin before you download? Try out the [simple](../examples/simple) or [basic](../examples/basic) examples!

--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -10,13 +10,13 @@ or a good ol' `<script>` via
 ### NPM
 
 ```bash
-$ npm i @tanstack/react-query
+npm i @tanstack/react-query
 # or
-$ pnpm add @tanstack/react-query
+pnpm add @tanstack/react-query
 # or
-$ yarn add @tanstack/react-query
+yarn add @tanstack/react-query
 # or
-$ bun add @tanstack/react-query
+bun add @tanstack/react-query
 ```
 
 React Query is compatible with React v18+ and works with ReactDOM and React Native.
@@ -57,11 +57,11 @@ Opera >= 77
 It is recommended to also use our [ESLint Plugin Query](../../../eslint/eslint-plugin-query) to help you catch bugs and inconsistencies while you code. You can install it via:
 
 ```bash
-$ npm i -D @tanstack/eslint-plugin-query
+npm i -D @tanstack/eslint-plugin-query
 # or
-$ pnpm add -D @tanstack/eslint-plugin-query
+pnpm add -D @tanstack/eslint-plugin-query
 # or
-$ yarn add -D @tanstack/eslint-plugin-query
+yarn add -D @tanstack/eslint-plugin-query
 # or
-$ bun add -D @tanstack/eslint-plugin-query
+bun add -D @tanstack/eslint-plugin-query
 ```

--- a/docs/framework/solid/installation.md
+++ b/docs/framework/solid/installation.md
@@ -10,13 +10,13 @@ or a good ol' `<script>` via
 ### NPM
 
 ```bash
-$ npm i @tanstack/solid-query
+npm i @tanstack/solid-query
 # or
-$ pnpm add @tanstack/solid-query
+pnpm add @tanstack/solid-query
 # or
-$ yarn add @tanstack/solid-query
+yarn add @tanstack/solid-query
 # or
-$ bun add @tanstack/solid-query
+bun add @tanstack/solid-query
 ```
 
 > Wanna give it a spin before you download? Try out the [simple](../examples/simple) or [basic](../examples/basic) examples!

--- a/docs/framework/svelte/installation.md
+++ b/docs/framework/svelte/installation.md
@@ -10,13 +10,13 @@ You can install Svelte Query via [NPM](https://npmjs.com).
 ### NPM
 
 ```bash
-$ npm i @tanstack/svelte-query
+npm i @tanstack/svelte-query
 # or
-$ pnpm add @tanstack/svelte-query
+pnpm add @tanstack/svelte-query
 # or
-$ yarn add @tanstack/svelte-query
+yarn add @tanstack/svelte-query
 # or
-$ bun add @tanstack/svelte-query
+bun add @tanstack/svelte-query
 ```
 
 > Wanna give it a spin before you download? Try out the [basic](../examples/basic) example!

--- a/docs/framework/vue/installation.md
+++ b/docs/framework/vue/installation.md
@@ -8,13 +8,13 @@ You can install Vue Query via [NPM](https://npmjs.com).
 ### NPM
 
 ```bash
-$ npm i @tanstack/vue-query
+npm i @tanstack/vue-query
 # or
-$ pnpm add @tanstack/vue-query
+pnpm add @tanstack/vue-query
 # or
-$ yarn add @tanstack/vue-query
+yarn add @tanstack/vue-query
 # or
-$ bun add @tanstack/vue-query
+bun add @tanstack/vue-query
 ```
 
 > Wanna give it a spin before you download? Try out the [basic](../examples/basic) example!


### PR DESCRIPTION


Installation commands for various framework includes prompt symbol. On execution of same commands IDE throws error
as IDEs by default includes prompt symbol.
This commit resolve this issue