### PR TITLE
fix: peer dependencies for eslint-plugin-query

### DIFF
--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -53,6 +53,6 @@
     "eslint": "^9.4.0"
   },
   "peerDependencies": {
-    "eslint": "^8.0.0 | ^9.0.0"
+    "eslint": "^8 || ^9"
   }
 }


### PR DESCRIPTION
Fixes an issue with `peerDependencies` introduced with #7543 