### PR TITLE
docs(advanced-ssr): delete unused import

### DIFF
--- a/docs/framework/react/guides/advanced-ssr.md
+++ b/docs/framework/react/guides/advanced-ssr.md
@@ -390,11 +390,7 @@ Then, all we need to do is provide a `HydrationBoundary`, but we don't need to `
 
 ```tsx
 // app/posts/page.jsx
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query'
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { getQueryClient } from './get-query-client'
 import Posts from './posts'
 


### PR DESCRIPTION
noticed a build error in the [previous PR](https://github.com/TanStack/query/pull/7545), but after creating a new fork and running it, the pnpm run prettier command seems to work successfully now!

While reading the official SSR documentation, I found some unused imports and removed them!