### PR TITLE
Refactor(utils): Ensure consistent declaration style of utility functions and standardize parameters for the sleep method

### DIFF
--- a/packages/query-core/src/__tests__/utils.ts
+++ b/packages/query-core/src/__tests__/utils.ts
@@ -32,11 +32,11 @@ export function sleep(timeout: number): Promise<void> {
   })
 }
 
-export const executeMutation = <TVariables>(
+export function executeMutation<TVariables>(
   queryClient: QueryClient,
   options: MutationOptions<any, any, TVariables, any>,
   variables: TVariables,
-) => {
+) {
   return queryClient
     .getMutationCache()
     .build(queryClient, options)

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -327,9 +327,9 @@ function hasObjectPrototype(o: any): boolean {
   return Object.prototype.toString.call(o) === '[object Object]'
 }
 
-export function sleep(ms: number): Promise<void> {
+export function sleep(timeout: number): Promise<void> {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms)
+    setTimeout(resolve, timeout)
   })
 }
 
@@ -365,7 +365,7 @@ export function addToStart<T>(items: Array<T>, item: T, max = 0): Array<T> {
 export const skipToken = Symbol()
 export type SkipToken = typeof skipToken
 
-export const ensureQueryFn = <
+export function ensureQueryFn<
   TQueryFnData = unknown,
   TQueryKey extends QueryKey = QueryKey,
 >(
@@ -374,7 +374,7 @@ export const ensureQueryFn = <
     queryHash?: string
   },
   fetchOptions?: FetchOptions<TQueryFnData>,
-): QueryFunction<TQueryFnData, TQueryKey> => {
+): QueryFunction<TQueryFnData, TQueryKey> {
   if (process.env.NODE_ENV !== 'production') {
     if (options.queryFn === skipToken) {
       console.error(

--- a/packages/query-persist-client-core/src/__tests__/utils.ts
+++ b/packages/query-persist-client-core/src/__tests__/utils.ts
@@ -13,7 +13,7 @@ export function sleep(timeout: number): Promise<void> {
   })
 }
 
-export const createMockPersister = (): Persister => {
+export function createMockPersister(): Persister {
   let storedState: PersistedClient | undefined
 
   return {
@@ -30,7 +30,7 @@ export const createMockPersister = (): Persister => {
   }
 }
 
-export const createSpyPersister = (): Persister => {
+export function createSpyPersister(): Persister {
   return {
     persistClient: vi.fn(),
     restoreClient: vi.fn(),

--- a/packages/react-query/src/__tests__/utils.tsx
+++ b/packages/react-query/src/__tests__/utils.tsx
@@ -22,13 +22,13 @@ export function renderWithClient(
   } as any
 }
 
-export const Blink = ({
+export function Blink({
   duration,
   children,
 }: {
   duration: number
   children: React.ReactNode
-}) => {
+}) {
   const [shouldShow, setShouldShow] = React.useState<boolean>(true)
 
   React.useEffect(() => {

--- a/packages/solid-query/src/__tests__/utils.tsx
+++ b/packages/solid-query/src/__tests__/utils.tsx
@@ -16,7 +16,7 @@ export function Blink(
   props: {
     duration: number
   } & ParentProps,
-){
+) {
   const [shouldShow, setShouldShow] = createSignal<boolean>(true)
 
   createEffect(() => {

--- a/packages/solid-query/src/__tests__/utils.tsx
+++ b/packages/solid-query/src/__tests__/utils.tsx
@@ -12,11 +12,11 @@ export function queryKey() {
   return [`query_${queryKeyCount}`]
 }
 
-export const Blink = (
+export function Blink(
   props: {
     duration: number
   } & ParentProps,
-) => {
+){
   const [shouldShow, setShouldShow] = createSignal<boolean>(true)
 
   createEffect(() => {


### PR DESCRIPTION
I noticed that most functions within the `packages/*/src/utils.ts` and `packages/*/src/__tests__/utils.ts` files were declared as regular functions, so I made consistent adjustments. 
While most were already in this format, I found a few arrow functions and updated them accordingly (It doesn't seem to be using the 'this"). 
Additionally, I noticed inconsistency in the parameters of the sleep function, where some used timeout while others used ms, so I unified them all to ms.