### PR TITLE
fix(query-core): Change to prevent `undefined` from overriding Mutation default side effects.

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -580,7 +580,7 @@ export class QueryClient {
       ...this.#defaultOptions.mutations,
       ...(options?.mutationKey &&
         this.getMutationDefaults(options.mutationKey)),
-      ...options,
+      ...extractOverrideMutationOptions(options),
       _defaulted: true,
     } as T
   }
@@ -589,4 +589,35 @@ export class QueryClient {
     this.#queryCache.clear()
     this.#mutationCache.clear()
   }
+}
+
+/**
+ * if side effects are `undefined`, the side effects in the default options will be retained.
+ */
+function extractOverrideMutationOptions(
+  options: MutationOptions<any, any, any, any> = {},
+): MutationOptions<any, any, any, any> {
+  const { onError, onSuccess, onSettled, onMutate, ...restOptions } = options
+
+  const overrideOptions: MutationOptions<any, any, any, any> = {
+    ...restOptions,
+  }
+
+  if (onSuccess !== undefined) {
+    overrideOptions.onSuccess = onSuccess
+  }
+
+  if (onError !== undefined) {
+    overrideOptions.onError = onError
+  }
+
+  if (onSettled !== undefined) {
+    overrideOptions.onSettled = onSettled
+  }
+
+  if (onMutate !== undefined) {
+    overrideOptions.onMutate = onMutate
+  }
+
+  return overrideOptions
 }

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -901,33 +901,13 @@ export type MutationFunction<TData = unknown, TVariables = unknown> = (
   variables: TVariables,
 ) => Promise<TData>
 
-export interface MutationOptions<
+export interface MutationBaseOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
 > {
   mutationFn?: MutationFunction<TData, TVariables>
   mutationKey?: MutationKey
-  onMutate?: (
-    variables: TVariables,
-  ) => Promise<TContext | undefined> | TContext | undefined
-  onSuccess?: (
-    data: TData,
-    variables: TVariables,
-    context: TContext,
-  ) => Promise<unknown> | unknown
-  onError?: (
-    error: TError,
-    variables: TVariables,
-    context: TContext | undefined,
-  ) => Promise<unknown> | unknown
-  onSettled?: (
-    data: TData | undefined,
-    error: TError | null,
-    variables: TVariables,
-    context: TContext | undefined,
-  ) => Promise<unknown> | unknown
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
   networkMode?: NetworkMode
@@ -935,6 +915,41 @@ export interface MutationOptions<
   _defaulted?: boolean
   meta?: MutationMeta
   scope?: MutationScope
+}
+
+export interface MutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TContext = unknown,
+> extends MutationBaseOptions<TData, TError, TVariables> {
+  onMutate?:
+    | ((
+        variables: TVariables,
+      ) => Promise<TContext | undefined> | TContext | undefined)
+    | null
+  onSuccess?:
+    | ((
+        data: TData,
+        variables: TVariables,
+        context: TContext,
+      ) => Promise<unknown> | unknown)
+    | null
+  onError?:
+    | ((
+        error: TError,
+        variables: TVariables,
+        context: TContext | undefined,
+      ) => Promise<unknown> | unknown)
+    | null
+  onSettled?:
+    | ((
+        data: TData | undefined,
+        error: TError | null,
+        variables: TVariables,
+        context: TContext | undefined,
+      ) => Promise<unknown> | unknown)
+    | null
 }
 
 export interface MutationObserverOptions<


### PR DESCRIPTION
## Problem
`undefined` means a variable that has not been assigned. Therefore, when the `onError` property in `useMutation` receives `undefined`, the side effects of the default options are retained and are expected to be invoked, as in the below example. However, It overrides default `onError` to `undefined`.

```ts
// You can pass `onError` callback optionally.
// If you intend to retain default `onError` callback,
// you will invoke this hook without any parameters.
const useLogin = (onError?) => {
 return useMutation({
    mutationFn: login,
    onError: onError,
    meta: {
      showToast: true,
    },
  })
}
```

```ts
// But if the useLogin is called without its parameters,
// default `onError` options will not be triggered.
new QueryClient({
  defaultOptions: {
    // ...
    mutations: {
      onError(error) {
        if (isHttpError(error)) {
          defaultErrorHandlers(error)
        }
      },
    },
  },
}),
```

## Suggestion
To clarify the intention of not using side effects of default options, assign `null` to the side effects. Because `null` means absence of any value, you can predict that the side effects will not be invoked.

```ts
const useLogin = (onError?) => {
 return useMutation({
    mutationFn: login,
    onError: onError,
    meta: {
      showToast: true,
    },
  })
}

// This `mutate` call will not trigger any `onError` side effects, including the default `onError`.
const { mutate } = useLogin(null)

// This `mutate` call will not trigger the default `onError`, but `errorHandler` will be called.
const { mutate } = useLogin(errorHandler)

// These `mutate` calls will trigger the default `onError`.
const { mutate } = useLogin()
const { mutate } = useLogin(undefined)
```
