### PR TITLE
refactor(angular-query): align inject-query and inject-infinite-query implementations, refactor create-base-query

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -1,8 +1,6 @@
 import { TestBed } from '@angular/core/testing'
-import { QueryClient } from '@tanstack/query-core'
 import { afterEach } from 'vitest'
-import { injectInfiniteQuery } from '../inject-infinite-query'
-import { provideAngularQuery } from '../providers'
+import { QueryClient, injectInfiniteQuery, provideAngularQuery } from '..'
 import { expectSignals, infiniteFetcher } from './test-utils'
 
 const QUERY_DURATION = 1000

--- a/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
@@ -1,9 +1,11 @@
 import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing'
-import { QueryClient } from '@tanstack/query-core'
 import { beforeEach, describe, expect } from 'vitest'
-import { injectIsFetching } from '../inject-is-fetching'
-import { injectQuery } from '../inject-query'
-import { provideAngularQuery } from '../providers'
+import {
+  QueryClient,
+  injectIsFetching,
+  injectQuery,
+  provideAngularQuery,
+} from '..'
 import { delayedFetcher } from './test-utils'
 
 describe('injectIsFetching', () => {

--- a/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
@@ -1,9 +1,11 @@
-import { QueryClient } from '@tanstack/query-core'
 import { beforeEach, describe } from 'vitest'
 import { TestBed, fakeAsync, tick } from '@angular/core/testing'
-import { injectIsMutating } from '../inject-is-mutating'
-import { injectMutation } from '../inject-mutation'
-import { provideAngularQuery } from '../providers'
+import {
+  QueryClient,
+  injectIsMutating,
+  injectMutation,
+  provideAngularQuery,
+} from '..'
 import { successMutator } from './test-utils'
 
 describe('injectIsMutating', () => {

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf } from 'vitest'
-import { injectMutationState } from '../inject-mutation-state'
-import type { MutationState, MutationStatus } from '@tanstack/query-core'
+import { injectMutationState } from '..'
+import type { MutationState, MutationStatus } from '..'
 
 describe('injectMutationState', () => {
   it('should default to QueryState', () => {

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
@@ -1,11 +1,13 @@
 import { Component, input, signal } from '@angular/core'
-import { QueryClient } from '@tanstack/query-core'
 import { TestBed } from '@angular/core/testing'
 import { describe, expect, test, vi } from 'vitest'
 import { By } from '@angular/platform-browser'
-import { injectMutation } from '../inject-mutation'
-import { injectMutationState } from '../inject-mutation-state'
-import { provideAngularQuery } from '../providers'
+import {
+  QueryClient,
+  injectMutation,
+  injectMutationState,
+  provideAngularQuery,
+} from '..'
 import { setFixtureSignalInputs, successMutator } from './test-utils'
 
 const MUTATION_DURATION = 1000

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf } from 'vitest'
-import { injectMutation } from '../inject-mutation'
+import { injectMutation } from '..'
 import { successMutator } from './test-utils'
 import type { Signal } from '@angular/core'
 

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -1,10 +1,8 @@
 import { Component, input, signal } from '@angular/core'
-import { QueryClient } from '@tanstack/query-core'
 import { TestBed } from '@angular/core/testing'
 import { describe, expect, vi } from 'vitest'
 import { By } from '@angular/platform-browser'
-import { injectMutation } from '../inject-mutation'
-import { provideAngularQuery } from '../providers'
+import { QueryClient, injectMutation, provideAngularQuery } from '..'
 import {
   errorMutator,
   expectSignals,

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf } from 'vitest'
-import { injectQuery } from '../inject-query'
+import { injectQuery } from '..'
 import { simpleFetcher } from './test-utils'
 import type { Signal } from '@angular/core'
 

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -1,8 +1,5 @@
 import { assertType, describe, expectTypeOf } from 'vitest'
-import { QueryClient } from '@tanstack/query-core'
-import { dataTagSymbol } from '@tanstack/query-core'
-import { queryOptions } from '../query-options'
-import { injectQuery } from '../inject-query'
+import { QueryClient, dataTagSymbol, injectQuery, queryOptions } from '..'
 import type { Signal } from '@angular/core'
 
 describe('queryOptions', () => {

--- a/packages/angular-query-experimental/src/__tests__/test-utils.ts
+++ b/packages/angular-query-experimental/src/__tests__/test-utils.ts
@@ -2,6 +2,12 @@ import { type InputSignal, isSignal, untracked } from '@angular/core'
 import { SIGNAL, signalSetFn } from '@angular/core/primitives/signals'
 import type { ComponentFixture } from '@angular/core/testing'
 
+let queryKeyCount = 0
+export function queryKey() {
+  queryKeyCount++
+  return [`query_${queryKeyCount}`]
+}
+
 export function simpleFetcher(): Promise<string> {
   return new Promise((resolve) => {
     setTimeout(() => {

--- a/packages/angular-query-experimental/src/inject-infinite-query.ts
+++ b/packages/angular-query-experimental/src/inject-infinite-query.ts
@@ -1,6 +1,5 @@
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { createBaseQuery } from './create-base-query'
-import { injectQueryClient } from './inject-query-client'
 import { assertInjector } from './util/assert-injector/assert-injector'
 import type { Injector } from '@angular/core'
 import type {
@@ -114,12 +113,7 @@ export function injectInfiniteQuery(
   optionsFn: (client: QueryClient) => CreateInfiniteQueryOptions,
   injector?: Injector,
 ) {
-  return assertInjector(injectInfiniteQuery, injector, () => {
-    const queryClient = injectQueryClient()
-    return createBaseQuery(
-      optionsFn,
-      InfiniteQueryObserver as typeof QueryObserver,
-      queryClient,
-    )
-  })
+  return assertInjector(injectInfiniteQuery, injector, () =>
+    createBaseQuery(optionsFn, InfiniteQueryObserver as typeof QueryObserver),
+  )
 }

--- a/packages/angular-query-experimental/src/inject-query.ts
+++ b/packages/angular-query-experimental/src/inject-query.ts
@@ -1,10 +1,8 @@
 import { QueryObserver } from '@tanstack/query-core'
-import { runInInjectionContext } from '@angular/core'
 import { assertInjector } from './util/assert-injector/assert-injector'
-import { injectQueryClient } from './inject-query-client'
 import { createBaseQuery } from './create-base-query'
-import type { DefaultError, QueryClient, QueryKey } from '@tanstack/query-core'
 import type { Injector } from '@angular/core'
+import type { DefaultError, QueryClient, QueryKey } from '@tanstack/query-core'
 import type {
   CreateQueryOptions,
   CreateQueryResult,
@@ -203,14 +201,7 @@ export function injectQuery(
   optionsFn: (client: QueryClient) => CreateQueryOptions,
   injector?: Injector,
 ) {
-  const assertedInjector = assertInjector(injectQuery, injector)
-  return assertInjector(injectQuery, injector, () => {
-    const queryClient = injectQueryClient()
-    return createBaseQuery(
-      (client) =>
-        runInInjectionContext(assertedInjector, () => optionsFn(client)),
-      QueryObserver,
-      queryClient,
-    )
-  })
+  return assertInjector(injectQuery, injector, () =>
+    createBaseQuery(optionsFn, QueryObserver),
+  )
 }


### PR DESCRIPTION
The company I work for is moving from our custom query wrapper to the official one. I had some time to audit the code and refactored a bit.  

Aligned the `injectQuery` and `injectInfiniteQuery` implementations. These are simpler now and refactored the queryclient to createBaseQuery closer to where it's actually used. This can be changed again once there is a new API to provide a custom queryClient to injectQuery.

Had some time left to add types tests to the injectQuery tests.
Hope this is useful and that I get some more time in the future to contribute more.

Test are passing, and I've tested these changes in the examples and our company app.