### PR TITLE
chore: add new tests

### DIFF
--- a/packages/react-query/src/__tests__/prefetch.test.tsx
+++ b/packages/react-query/src/__tests__/prefetch.test.tsx
@@ -156,7 +156,7 @@ describe('usePrefetchQuery', () => {
     expect(queryOpts.queryFn).not.toHaveBeenCalled()
   })
 
-  it('should not create a endless loop when using inside a suspense boundary', async () => {
+  it('should not create an endless loop when using inside a suspense boundary', async () => {
     const queryFn = generateQueryFn('prefetchedQuery')
 
     const queryOpts = {
@@ -395,7 +395,7 @@ describe('usePrefetchInfiniteQuery', () => {
     expect(Fallback).not.toHaveBeenCalled()
   })
 
-  it('should not create a endless loop when using inside a suspense boundary', async () => {
+  it('should not create an endless loop when using inside a suspense boundary', async () => {
     const queryOpts = {
       queryKey: queryKey(),
       ...generateInfiniteQueryOptions([


### PR DESCRIPTION
Add new tests to the PR #7582:

- [x] Assert that the correct `queryFn` is called when prefetching
- [x] Assert that endless loops don't occur when using `usePrefetchQuery` or `usePrefetchInfiniteQuery` inside a suspense boundary
- [x] Assert that the query state is `fetching` after rendering a component calling the `usePrefetchQuery` hook