### PR TITLE
Remove the variable assignment from example code

### DIFF
--- a/docs/framework/react/reference/usePrefetchInfiniteQuery.md
+++ b/docs/framework/react/reference/usePrefetchInfiniteQuery.md
@@ -4,7 +4,7 @@ title: usePrefetchInfiniteQuery
 ---
 
 ```tsx
-const result = usePrefetchInfiniteQuery(options)
+usePrefetchInfiniteQuery(options)
 ```
 
 **Options**

--- a/docs/framework/react/reference/usePrefetchQuery.md
+++ b/docs/framework/react/reference/usePrefetchQuery.md
@@ -4,7 +4,7 @@ title: usePrefetchQuery
 ---
 
 ```tsx
-const result = usePrefetchQuery(options)
+usePrefetchQuery(options)
 ```
 
 **Options**


### PR DESCRIPTION
Noticed that `usePrefetchQuery`'s documentation states that it doesn't return anything but the example code shows it seemingly returning a result.