### PR TITLE
docs: remove suspense reference to useQuery

### DIFF
--- a/docs/framework/react/reference/useSuspenseQuery.md
+++ b/docs/framework/react/reference/useSuspenseQuery.md
@@ -11,7 +11,6 @@ const result = useSuspenseQuery(options)
 
 The same as for [useQuery](../useQuery), except for:
 
-- `suspense`
 - `throwOnError`
 - `enabled`
 - `placeholderData`


### PR DESCRIPTION
useQuery has no suspense option