### PR TITLE
fix: add experimental beforeQuery and afterQuery queryClient options

### DIFF
--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -49,6 +49,10 @@ export function useBaseQuery<
   const errorResetBoundary = useQueryErrorResetBoundary()
   const defaultedOptions = client.defaultQueryOptions(options)
 
+  ;(client.getDefaultOptions() as any)._experimental_beforeQuery?.(
+    defaultedOptions,
+  )
+
   // Make sure results are optimistically set in fetching state before subscribing or updating options
   defaultedOptions._optimisticResults = isRestoring
     ? 'isRestoring'
@@ -120,6 +124,8 @@ export function useBaseQuery<
   ) {
     throw result.error
   }
+
+  ;(client.getDefaultOptions() as any).afterQuery?.(defaultedOptions, result)
 
   // Handle result property usage tracking
   return !defaultedOptions.notifyOnChangeProps


### PR DESCRIPTION
These experimental hooks will give me everything I need to write a full integration for TanStack Router. If they work out well, we can either find better names/locations/implementations for them, or stick with them and document them.