### PR TITLE
docs(react-query): correct links in `usePrefetchQuery`

### DIFF
--- a/docs/framework/react/reference/usePrefetchInfiniteQuery.md
+++ b/docs/framework/react/reference/usePrefetchInfiniteQuery.md
@@ -9,7 +9,7 @@ usePrefetchInfiniteQuery(options)
 
 **Options**
 
-You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`queryClient.prefetchInfiniteQuery`](../../../reference/QueryClient#queryclientprefetchinfinitequery). Remember that some of them are required as below:
+You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`queryClient.prefetchInfiniteQuery`](../../../../reference/QueryClient#queryclientprefetchinfinitequery). Remember that some of them are required as below:
 
 - `queryKey: QueryKey`
 
@@ -34,4 +34,4 @@ You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`que
 
 - **Returns**
 
-The `usePrefetchInfiniteQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseInfiniteQuery`](../reference/useSuspenseInfiniteQuery)
+The `usePrefetchInfiniteQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseInfiniteQuery`](../useSuspenseInfiniteQuery)

--- a/docs/framework/react/reference/usePrefetchQuery.md
+++ b/docs/framework/react/reference/usePrefetchQuery.md
@@ -9,7 +9,7 @@ usePrefetchQuery(options)
 
 **Options**
 
-You can pass everything to `usePrefetchQuery` that you can pass to [`queryClient.prefetchQuery`](../../../reference/QueryClient#queryclientprefetchquery). Remember that some of them are required as below:
+You can pass everything to `usePrefetchQuery` that you can pass to [`queryClient.prefetchQuery`](../../../../reference/QueryClient#queryclientprefetchquery). Remember that some of them are required as below:
 
 - `queryKey: QueryKey`
 
@@ -21,4 +21,4 @@ You can pass everything to `usePrefetchQuery` that you can pass to [`queryClient
 
 **Returns**
 
-The `usePrefetchQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseQuery`](../reference/useSuspenseQuery).
+The `usePrefetchQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseQuery`](../useSuspenseQuery).


### PR DESCRIPTION
The links within the content of [`usePrefetchQuery`](https://tanstack.com/query/latest/docs/framework/react/reference/usePrefetchInfiniteQuery) and [`usePrefetchInfiniteQuery`](http://localhost:3000/query/latest/docs/framework/react/reference/usePrefetchInfiniteQuery) do not correspond to the URL paths, resulting in a 404 error page when clicked.

## Before

https://github.com/TanStack/query/assets/26923823/332062ed-21e3-4aab-b936-37c19768c38b

## After

https://github.com/TanStack/query/assets/26923823/2bfe2bf2-3e2f-4bae-9ed9-b161c53cd8c9

