### PR TITLE
fix(solid): Correct deps/devDeps/peerDeps

### DIFF
--- a/examples/solid/astro/package.json
+++ b/examples/solid/astro/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.7.0",
+    "@astrojs/node": "^8.2.5",
     "@astrojs/solid-js": "^4.2.0",
     "@astrojs/tailwind": "^5.1.0",
     "@astrojs/vercel": "^7.6.0",
-    "@astrojs/node": "^8.2.5",
     "@tanstack/solid-query": "^5.50.1",
     "@tanstack/solid-query-devtools": "^5.50.1",
     "astro": "^4.8.6",

--- a/integrations/angular-cli-standalone-17/package.json
+++ b/integrations/angular-cli-standalone-17/package.json
@@ -8,8 +8,8 @@
     "@angular/common": "^17.3.10",
     "@angular/core": "^17.3.10",
     "@angular/platform-browser": "^17.3.10",
-    "@tanstack/angular-query-experimental": "workspace:*",
     "@tanstack/angular-query-devtools-experimental": "workspace:*",
+    "@tanstack/angular-query-experimental": "workspace:*",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2",
     "zone.js": "^0.14.6"

--- a/packages/angular-query-devtools-experimental/package.json
+++ b/packages/angular-query-devtools-experimental/package.json
@@ -47,9 +47,9 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
+    "@angular/common": "^17.3.10",
     "@angular/compiler-cli": "^17.3.10",
     "@angular/core": "^17.3.10",
-    "@angular/common": "^17.3.10",
     "@tanstack/angular-query-experimental": "workspace:*",
     "eslint-plugin-jsdoc": "^48.2.13",
     "ng-packagr": "^17.3.0",

--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -72,14 +72,14 @@
     "@angular/core": "^17.3.10",
     "@angular/platform-browser": "^17.3.10",
     "@angular/platform-browser-dynamic": "^17.3.10",
-    "eslint-plugin-jsdoc": "^48.2.13",
     "@microsoft/api-extractor": "^7.46.2",
+    "eslint-plugin-jsdoc": "^48.2.13",
     "ng-packagr": "^17.3.0",
     "typescript": "5.3.3",
     "zone.js": "^0.14.6"
   },
   "peerDependencies": {
-    "@angular/core": ">=16.0.0",
-    "@angular/common": ">=16.0.0"
+    "@angular/common": ">=16.0.0",
+    "@angular/core": ">=16.0.0"
   }
 }

--- a/packages/solid-query-devtools/package.json
+++ b/packages/solid-query-devtools/package.json
@@ -57,8 +57,8 @@
     "@tanstack/query-devtools": "workspace:*"
   },
   "devDependencies": {
+    "@tanstack/solid-query": "workspace:*",
     "solid-js": "^1.8.17",
-    "@tanstack/solid-query": "workspace:^",
     "tsup-preset-solid": "^2.2.0",
     "vite-plugin-solid": "^2.10.2"
   },

--- a/packages/solid-query-persist-client/package.json
+++ b/packages/solid-query-persist-client/package.json
@@ -60,12 +60,13 @@
     "@tanstack/query-persist-client-core": "workspace:*"
   },
   "devDependencies": {
+    "@tanstack/solid-query": "workspace:*",
+    "solid-js": "^1.8.17",
     "tsup-preset-solid": "^2.2.0",
-    "vite-plugin-solid": "^2.10.2",
-    "solid-js": "^1.8.17"
+    "vite-plugin-solid": "^2.10.2"
   },
   "peerDependencies": {
-    "@tanstack/solid-query": "workspace:*",
+    "@tanstack/solid-query": "workspace:^",
     "solid-js": "^1.6.0"
   }
 }

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -59,11 +59,11 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/query-core": "workspace:*",
-    "solid-js": "^1.8.17"
+    "@tanstack/query-core": "workspace:*"
   },
   "devDependencies": {
     "tsup-preset-solid": "^2.2.0",
+    "solid-js": "^1.8.17",
     "vite-plugin-solid": "^2.10.2"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2141,10 +2141,10 @@ importers:
       '@tanstack/query-core':
         specifier: workspace:*
         version: link:../query-core
+    devDependencies:
       solid-js:
         specifier: ^1.8.17
         version: 1.8.17
-    devDependencies:
       tsup-preset-solid:
         specifier: ^2.2.0
         version: 2.2.0(esbuild@0.21.3)(solid-js@1.8.17)(tsup@8.0.2(@microsoft/api-extractor@7.46.2(@types/node@20.12.12))(postcss@8.4.38)(typescript@5.4.2))
@@ -2159,7 +2159,7 @@ importers:
         version: link:../query-devtools
     devDependencies:
       '@tanstack/solid-query':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../solid-query
       solid-js:
         specifier: ^1.8.17
@@ -2176,10 +2176,10 @@ importers:
       '@tanstack/query-persist-client-core':
         specifier: workspace:*
         version: link:../query-persist-client-core
+    devDependencies:
       '@tanstack/solid-query':
         specifier: workspace:*
         version: link:../solid-query
-    devDependencies:
       solid-js:
         specifier: ^1.8.17
         version: 1.8.17
@@ -22657,11 +22657,7 @@ snapshots:
       jest-runner: 26.6.3
       jest-runtime: 26.6.3
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   '@jest/test-sequencer@27.5.1':
     dependencies:
@@ -31413,11 +31409,7 @@ snapshots:
       stack-utils: 2.0.6
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-circus@27.5.1:
     dependencies:


### PR DESCRIPTION
- Used [manypkg](https://github.com/Thinkmill/manypkg) to identify issues with deps/devDeps/peerDeps
- Mainly identified issues with solid packages (e.g. `"solid-js"` was installed as a dep rather than a devDep so the peerDep range was not respected)
- It also corrected alphabetical sorting of packages