### PR TITLE
docs(eslint-plugin-query): Fix rules links

### DIFF
--- a/docs/eslint/eslint-plugin-query.md
+++ b/docs/eslint/eslint-plugin-query.md
@@ -82,5 +82,5 @@ Alternatively, add `@tanstack/eslint-plugin-query` to the plugins section, and c
 ## Rules
 
 - [@tanstack/query/exhaustive-deps](../exhaustive-deps)
-- [@tanstack/query/no-rest-destructuring](../exhaustive-deps)
-- [@tanstack/query/stable-query-client](../exhaustive-deps)
+- [@tanstack/query/no-rest-destructuring](../no-rest-destructuring)
+- [@tanstack/query/stable-query-client](../stable-query-client)


### PR DESCRIPTION
Links to the rules at the bottom of https://tanstack.com/query/latest/docs/eslint/eslint-plugin-query are wrong.