### PR TITLE
docs(query-client): fix broken hydration link

### DIFF
--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -62,7 +62,7 @@ Its available methods are:
 - `defaultOptions?: DefaultOptions`
   - Optional
   - Define defaults for all queries and mutations using this queryClient.
-  - You can also define defaults to be used for [hydration](../../framework/react/reference/hydration.md)
+  - You can also define defaults to be used for [hydration](../../framework/react/reference/hydration)
 
 ## `queryClient.fetchQuery`
 


### PR DESCRIPTION
Fixes a minor broken link to [hydration page](https://tanstack.com/query/latest/docs/framework/react/reference/hydration) from https://tanstack.com/query/latest/docs/reference/QueryClient/#queryclient