### PR TITLE
fix(vue-query): export `InitialQueryOptions` types

### DIFF
--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -24,6 +24,8 @@ export type {
   UseQueryOptions,
   UseQueryReturnType,
   UseQueryDefinedReturnType,
+  UndefinedInitialQueryOptions,
+  DefinedInitialQueryOptions,
 } from './useQuery'
 export type {
   UseInfiniteQueryOptions,


### PR DESCRIPTION
These types are exported from react-query. Not exporting them will cause Typescript to complain when using `queryOptions`:

```ts
// From the official Query Options example:
// https://tanstack.com/query/latest/docs/framework/vue/guides/query-options
import { queryOptions } from '@tanstack/vue-query'

export function groupOptions(id: number) {
  return queryOptions({
    queryKey: ['groups', id],
    queryFn: () => fetchGroups(id),
    staleTime: 5 * 1000,
  })
}
```

> **ts(2742)** The inferred type of 'groupOptions' cannot be named without a reference to '../node_modules/@tanstack/vue-query/build/modern/useQuery-JLP2sK49'. This is likely not portable. A type annotation is necessary.

This is a bug similar to #6318, the latter of which is about `useQuery`. This PR fixes `queryOptions`.