### PR TITLE
When a query function rejects, fire the `'abort'` event on its `AbortSignal`

### DIFF
--- a/packages/query-core/src/retryer.ts
+++ b/packages/query-core/src/retryer.ts
@@ -8,7 +8,7 @@ import type { CancelOptions, DefaultError, NetworkMode } from './types'
 interface RetryerConfig<TData = unknown, TError = DefaultError> {
   fn: () => TData | Promise<TData>
   initialPromise?: Promise<TData>
-  abort?: () => void
+  abort?: (reason?: unknown) => void
   onError?: (error: TError) => void
   onSuccess?: (data: TData) => void
   onFail?: (failureCount: number, error: TError) => void
@@ -119,6 +119,7 @@ export function createRetryer<TData = unknown, TError = DefaultError>(
       config.onError?.(value)
       continueFn?.()
       promiseReject(value)
+      config.abort?.(value)
     }
   }
 


### PR DESCRIPTION
A query function might have multiple concurrent requests in flight at the moment that the _entire_ query is invalidated by the rejection of _one_ of them.

Consider [this example](https://github.com/TanStack/query/blob/79e52029975d8a889ffafd7e161010d4997af219/docs/framework/angular/guides/query-cancellation.md?plain=1#L37-L53) from the TanStack Query docs. Imagine that when one of the todo details fetches fails, the entire query should error out. The `AbortSignal` supplied to the `fetchFn` by TanStack Query should fire the `abort` event in this case, to cancel pending requests, but it does not.

In this PR, we fire the `'abort'` event upon such a rejection, so that the in-flight requests might decide whether or not to cancel themselves, depending on the value of `signal.reason`.

More information in the linked issue.

Closes #7724.