### PR TITLE
docs: Add example on accessing the latest data for `useMutationState`

### DIFF
--- a/docs/framework/react/reference/useMutationState.md
+++ b/docs/framework/react/reference/useMutationState.md
@@ -36,6 +36,35 @@ const data = useMutationState({
   filters: { mutationKey },
   select: (mutation) => mutation.state.data,
 })
+
+```
+
+**Example 3: Access the latest mutation data via the `mutationKey`**
+Each invocation of `mutate` adds a new entry to the mutation cache for `gcTime` milliseconds.
+
+To access the latest invocation, you can check for the last item that `useMutationState` returns.
+
+```tsx
+import { useMutation, useMutationState } from '@tanstack/react-query'
+
+const mutationKey = ['posts']
+
+// Some mutation that we want to get the state for
+const mutation = useMutation({
+  mutationKey,
+  mutationFn: (newPost) => {
+    return axios.post('/posts', newPost)
+  },
+})
+
+const data = useMutationState({
+  // this mutation key needs to match the mutation key of the given mutation (see above)
+  filters: { mutationKey },
+  select: (mutation) => mutation.state.data,
+})
+
+// Latest mutation data
+const latest = data[data.length - 1]
 ```
 
 **Options**


### PR DESCRIPTION
I just started using `useMutationState`, and from what I understand, it's perfect for my use-case of _tracking_ its state and data on other subtrees of the UI. Previously, I had to introduce new contexts just to share mutation data across components. For me though, I mostly care about the latest invocation, and thought this would save time for other people. I have a hunch that this use-case is a lot more common.

I referenced [this](https://github.com/TanStack/query/discussions/6858#discussioncomment-8755778) and [this](https://github.com/TanStack/query/discussions/6858#discussioncomment-9273247). I'm sure at the moment what's the best way to explain this, but figured this would be very helpful.

I do think `useMutationState` could be elaborated a bit further. Happy to improve based on others' inputs.