### PR TITLE
fix(solid-query): Fix race condition issues with createQuery

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -179,7 +179,11 @@ export function createBaseQuery<
     const obs = observer()
     return obs.subscribe((result) => {
       observerResult = result
-      queueMicrotask(() => refetch())
+      queueMicrotask(() => {
+        if (unsubscribe) {
+          refetch()
+        }
+      })
     })
   }
 


### PR DESCRIPTION
Fixes #7711 

Fixes a race condition with the `createQuery` primitive that would keep an observer subscribed even when the component that spawned the query was unmounted. 

I have also added broken tests that have been fixed now