### PR TITLE
fix(eslint-plugin-query): get scope from sourceCode

### DIFF
--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -248,10 +248,16 @@ export const ASTUtils = {
   }) {
     const { node, context } = params
 
-    const resolvedNode = context
-      .getScope()
-      .references.find((ref) => ref.identifier === node)?.resolved?.defs[0]
-      ?.node
+    // we need the fallbacks for backwards compat with eslint < 8.37.0
+    // eslint-disable-next-line ts/no-unnecessary-condition
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
+    // eslint-disable-next-line ts/no-unnecessary-condition
+    const scope = context.sourceCode.getScope(node)
+      ? sourceCode.getScope(node)
+      : context.getScope()
+
+    const resolvedNode = scope.references.find((ref) => ref.identifier === node)
+      ?.resolved?.defs[0]?.node
 
     if (resolvedNode?.type !== AST_NODE_TYPES.VariableDeclarator) {
       return null


### PR DESCRIPTION
in eslint v9, context.getScope() doesn't exist anymore. see: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getscope()