### PR TITLE
fix(eslint-plugin): type config names

### DIFF
--- a/packages/eslint-plugin-query/src/index.ts
+++ b/packages/eslint-plugin-query/src/index.ts
@@ -7,7 +7,7 @@ type RuleKey = keyof typeof rules
 interface Plugin extends Omit<ESLint.Plugin, 'rules'> {
   rules: Record<RuleKey, RuleModule<any, any, any>>
   configs: Record<
-    string,
+    "recommended" | "flat/recommended",
     ESLint.ConfigData | Linter.FlatConfig | Array<Linter.FlatConfig>
   >
 }
@@ -16,7 +16,7 @@ const plugin: Plugin = {
   meta: {
     name: '@tanstack/eslint-plugin-query',
   },
-  configs: {},
+  configs: {} as Plugin['configs'],
   rules,
 }
 

--- a/packages/eslint-plugin-query/src/index.ts
+++ b/packages/eslint-plugin-query/src/index.ts
@@ -7,7 +7,7 @@ type RuleKey = keyof typeof rules
 interface Plugin extends Omit<ESLint.Plugin, 'rules'> {
   rules: Record<RuleKey, RuleModule<any, any, any>>
   configs: Record<
-    "recommended" | "flat/recommended",
+    'recommended' | 'flat/recommended',
     ESLint.ConfigData | Linter.FlatConfig | Array<Linter.FlatConfig>
   >
 }


### PR DESCRIPTION
When configuring the eslint plugin with `// @ts-check` at the top of `eslint.config.js` there is no suggestions for config names because it's of type `string`

```js
// @ts-check
import query from "@tanstack/eslint-plugin-query";

export default defineConfig(
  query.config.whateverConfigName, // no completion or type checking
)
```

This PR fixes