### PR TITLE
fix(eslint-plugin): strictly type config keys

### DIFF
--- a/packages/eslint-plugin-query/src/index.ts
+++ b/packages/eslint-plugin-query/src/index.ts
@@ -6,10 +6,10 @@ type RuleKey = keyof typeof rules
 
 interface Plugin extends Omit<ESLint.Plugin, 'rules'> {
   rules: Record<RuleKey, RuleModule<any, any, any>>
-  configs: Record<
-    'recommended' | 'flat/recommended',
-    ESLint.ConfigData | Linter.FlatConfig | Array<Linter.FlatConfig>
-  >
+  configs: {
+    recommended: ESLint.ConfigData | Linter.FlatConfig
+    'flat/recommended': Array<Linter.FlatConfig>
+  }
 }
 
 const plugin: Plugin = {

--- a/packages/eslint-plugin-query/src/index.ts
+++ b/packages/eslint-plugin-query/src/index.ts
@@ -7,7 +7,7 @@ type RuleKey = keyof typeof rules
 interface Plugin extends Omit<ESLint.Plugin, 'rules'> {
   rules: Record<RuleKey, RuleModule<any, any, any>>
   configs: {
-    recommended: ESLint.ConfigData | Linter.FlatConfig
+    recommended: ESLint.ConfigData
     'flat/recommended': Array<Linter.FlatConfig>
   }
 }


### PR DESCRIPTION
This is a follow-up from #7766.

While the changes made in #7766 are a good step forward to having a properly typed config, it still doesn't fully work and properly represent the actual code. This PR aims to change that.

With the changes from #7766 pulled in users still run into a typing issue as shown below. This is because of the union of `ESLint.ConfigData | Linter.FlatConfig` cannot be spread, because they are objects and not arrays. By strictly specifying the types of the different keys this can be resolved. 

![ishare-1721808850](https://github.com/user-attachments/assets/5d2862d6-a081-491a-aa58-3ab6bb869789)

With this change the config is fully compatible and no `ts-expect-error` / `ts-ignore` will be required:

![ishare-1721809149](https://github.com/user-attachments/assets/145f2491-dc73-4b1b-b94c-0fe8e885010c)
