### PR TITLE
feat(svelte-5-adapter): require options to be passed as function

### DIFF
--- a/examples/svelte/basic/src/lib/Post.svelte
+++ b/examples/svelte/basic/src/lib/Post.svelte
@@ -5,10 +5,10 @@
 
   const { postId }: { postId: number } = $props()
 
-  const post = createQuery<Post>({
+  const post = createQuery<Post>(() => ({
     queryKey: ['post', postId],
     queryFn: () => getPostById(postId),
-  })
+  }))
 </script>
 
 <div>

--- a/examples/svelte/basic/src/lib/Posts.svelte
+++ b/examples/svelte/basic/src/lib/Posts.svelte
@@ -9,10 +9,10 @@
   const posts = createQuery<
     { id: number; title: string; body: string }[],
     Error
-  >({
+  >(() => ({
     queryKey: ['posts', limit],
     queryFn: () => getPosts(limit),
-  })
+  }))
 </script>
 
 <div>

--- a/examples/svelte/load-more-infinite-scroll/src/lib/LoadMore.svelte
+++ b/examples/svelte/load-more-infinite-scroll/src/lib/LoadMore.svelte
@@ -6,7 +6,7 @@
   const fetchPlanets = async ({ pageParam = 1 }) =>
     await fetch(`${endPoint}/planets/?page=${pageParam}`).then((r) => r.json())
 
-  const query = createInfiniteQuery({
+  const query = createInfiniteQuery(() => ({
     queryKey: ['planets'],
     queryFn: ({ pageParam }) => fetchPlanets({ pageParam }),
     initialPageParam: 1,
@@ -20,7 +20,7 @@
       }
       return undefined
     },
-  })
+  }))
 </script>
 
 {#if query.isPending}

--- a/examples/svelte/optimistic-updates/src/routes/+page.svelte
+++ b/examples/svelte/optimistic-updates/src/routes/+page.svelte
@@ -36,10 +36,10 @@
       }),
     }).then((res) => res.json())
 
-  const todos = createQuery<Todos>({
+  const todos = createQuery<Todos>(() => ({
     queryKey: ['optimistic'],
     queryFn: fetchTodos,
-  })
+  }))
 
   const addTodoMutation = createMutation({
     mutationFn: createTodo,

--- a/examples/svelte/playground/src/routes/AddTodo.svelte
+++ b/examples/svelte/playground/src/routes/AddTodo.svelte
@@ -20,7 +20,13 @@
         () => {
           if (Math.random() < errorRate.value) {
             return reject(
-              new Error(JSON.stringify({ postTodo: { name, notes } }, null, 2)),
+              new Error(
+                JSON.stringify(
+                  { postTodo: { name: $state.snapshot(name), notes } },
+                  null,
+                  2,
+                ),
+              ),
             )
           }
           const todo = { name, notes, id: id.value }

--- a/examples/svelte/playground/src/routes/EditTodo.svelte
+++ b/examples/svelte/playground/src/routes/EditTodo.svelte
@@ -55,7 +55,7 @@
           }
           list.value = list.value.map((d) => {
             if (d.id === todo.id) {
-              return todo
+              return $state.snapshot(todo)
             }
             return d
           })
@@ -67,11 +67,11 @@
     })
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['todo', { id: editingIndex.value }],
     queryFn: () => fetchTodoById({ id: editingIndex.value || 0 }),
     enabled: editingIndex.value !== null,
-  })
+  }))
 
   const saveMutation = createMutation({
     mutationFn: patchTodo,

--- a/examples/svelte/simple/src/lib/Simple.svelte
+++ b/examples/svelte/simple/src/lib/Simple.svelte
@@ -9,13 +9,13 @@
     forks_count: number
   }
 
-  const query = createQuery<Repo>({
+  const query = createQuery<Repo>(() => ({
     queryKey: ['repoData'],
     queryFn: async () =>
       await fetch('https://api.github.com/repos/TanStack/query').then((r) =>
         r.json(),
       ),
-  })
+  }))
 </script>
 
 <h1>Simple</h1>

--- a/examples/svelte/ssr/src/lib/Post.svelte
+++ b/examples/svelte/ssr/src/lib/Post.svelte
@@ -5,10 +5,10 @@
 
   const { postId }: { postId: number } = $props()
 
-  const post = createQuery<Post>({
+  const post = createQuery<Post>(() => ({
     queryKey: ['post', postId],
     queryFn: () => api().getPostById(postId),
-  })
+  }))
 </script>
 
 <div>

--- a/examples/svelte/ssr/src/lib/Posts.svelte
+++ b/examples/svelte/ssr/src/lib/Posts.svelte
@@ -9,10 +9,10 @@
   const posts = createQuery<
     { id: number; title: string; body: string }[],
     Error
-  >({
+  >(() => ({
     queryKey: ['posts', limit],
     queryFn: () => api().getPosts(limit),
-  })
+  }))
 </script>
 
 <div>

--- a/examples/svelte/star-wars/src/routes/characters/+page.svelte
+++ b/examples/svelte/star-wars/src/routes/characters/+page.svelte
@@ -6,10 +6,10 @@
     return await res.json()
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['characters'],
     queryFn: getCharacters,
-  })
+  }))
 </script>
 
 {#if query.status === 'pending'}

--- a/examples/svelte/star-wars/src/routes/characters/[characterId]/+page.svelte
+++ b/examples/svelte/star-wars/src/routes/characters/[characterId]/+page.svelte
@@ -12,10 +12,10 @@
     return await res.json()
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['character', data.params.characterId],
     queryFn: getCharacter,
-  })
+  }))
 </script>
 
 {#if query.status === 'pending'}

--- a/examples/svelte/star-wars/src/routes/characters/[characterId]/Film.svelte
+++ b/examples/svelte/star-wars/src/routes/characters/[characterId]/Film.svelte
@@ -8,10 +8,10 @@
     return await res.json()
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['film', filmId],
     queryFn: getFilm,
-  })
+  }))
 </script>
 
 {#if query.status === 'success'}

--- a/examples/svelte/star-wars/src/routes/characters/[characterId]/Homeworld.svelte
+++ b/examples/svelte/star-wars/src/routes/characters/[characterId]/Homeworld.svelte
@@ -8,10 +8,10 @@
     return await res.json()
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['homeworld', homeworldId],
     queryFn: getHomeworld,
-  })
+  }))
 </script>
 
 {#if query.status === 'success'}

--- a/examples/svelte/star-wars/src/routes/films/+page.svelte
+++ b/examples/svelte/star-wars/src/routes/films/+page.svelte
@@ -6,10 +6,10 @@
     return await res.json()
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['films'],
     queryFn: getFilms,
-  })
+  }))
 </script>
 
 {#if query.status === 'pending'}

--- a/examples/svelte/star-wars/src/routes/films/[filmId]/+page.svelte
+++ b/examples/svelte/star-wars/src/routes/films/[filmId]/+page.svelte
@@ -11,10 +11,10 @@
     return await res.json()
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['film', data.params.filmId],
     queryFn: getFilm,
-  })
+  }))
 </script>
 
 {#if query.status === 'pending'}

--- a/examples/svelte/star-wars/src/routes/films/[filmId]/Character.svelte
+++ b/examples/svelte/star-wars/src/routes/films/[filmId]/Character.svelte
@@ -8,10 +8,10 @@
     return await res.json()
   }
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['character', characterId],
     queryFn: getCharacter,
-  })
+  }))
 </script>
 
 {#if query.status === 'success'}

--- a/packages/svelte-query-persist-client/tests/AwaitOnSuccess/AwaitOnSuccess.svelte
+++ b/packages/svelte-query-persist-client/tests/AwaitOnSuccess/AwaitOnSuccess.svelte
@@ -4,7 +4,7 @@
 
   let { states }: { states: Array<string> } = $props()
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['test'],
     queryFn: async () => {
       states.push('fetching')
@@ -12,7 +12,7 @@
       states.push('fetched')
       return 'fetched'
     },
-  })
+  }))
 </script>
 
 <div>{query.data}</div>

--- a/packages/svelte-query-persist-client/tests/FreshData/FreshData.svelte
+++ b/packages/svelte-query-persist-client/tests/FreshData/FreshData.svelte
@@ -12,7 +12,7 @@
     fetched: boolean
   } = $props()
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['test'],
     queryFn: async () => {
       fetched = true
@@ -21,7 +21,7 @@
     },
 
     staleTime: Infinity,
-  })
+  }))
 
   $effect(() => {
     states.value = [...untrack(() => states.value), $state.snapshot(query)]

--- a/packages/svelte-query-persist-client/tests/InitialData/InitialData.svelte
+++ b/packages/svelte-query-persist-client/tests/InitialData/InitialData.svelte
@@ -6,7 +6,7 @@
 
   let { states }: { states: { value: Array<StatusResult<string>> } } = $props()
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['test'],
     queryFn: async () => {
       await sleep(5)
@@ -17,7 +17,7 @@
     // make sure that initial data is older than the hydration data
     // otherwise initialData would be newer and takes precedence
     initialDataUpdatedAt: 1,
-  })
+  }))
 
   $effect(() => {
     states.value = [...untrack(() => states.value), $state.snapshot(query)]

--- a/packages/svelte-query-persist-client/tests/OnSuccess/OnSuccess.svelte
+++ b/packages/svelte-query-persist-client/tests/OnSuccess/OnSuccess.svelte
@@ -2,13 +2,13 @@
   import { createQuery } from '@tanstack/svelte-query'
   import { sleep } from '../utils.svelte'
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['test'],
     queryFn: async () => {
       await sleep(5)
       return 'fetched'
     },
-  })
+  }))
 </script>
 
 <div>{query.data}</div>

--- a/packages/svelte-query-persist-client/tests/RemoveCache/RemoveCache.svelte
+++ b/packages/svelte-query-persist-client/tests/RemoveCache/RemoveCache.svelte
@@ -2,13 +2,13 @@
   import { createQuery } from '@tanstack/svelte-query'
   import { sleep } from '../utils.svelte'
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['test'],
     queryFn: async () => {
       await sleep(5)
       return 'fetched'
     },
-  })
+  }))
 </script>
 
 <div>{query.data}</div>

--- a/packages/svelte-query-persist-client/tests/RestoreCache/RestoreCache.svelte
+++ b/packages/svelte-query-persist-client/tests/RestoreCache/RestoreCache.svelte
@@ -6,13 +6,13 @@
 
   let { states }: { states: { value: Array<StatusResult<string>> } } = $props()
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['test'],
     queryFn: async () => {
       await sleep(5)
       return 'fetched'
     },
-  })
+  }))
 
   $effect(() => {
     states.value = [...untrack(() => states.value), $state.snapshot(query)]

--- a/packages/svelte-query-persist-client/tests/UseQueries/UseQueries.svelte
+++ b/packages/svelte-query-persist-client/tests/UseQueries/UseQueries.svelte
@@ -7,7 +7,7 @@
   let { states }: { states: { value: Array<StatusResult<string>> } } = $props()
 
   const queries = createQueries({
-    queries: [
+    queries: () => [
       {
         queryKey: ['test'],
         queryFn: async (): Promise<string> => {

--- a/packages/svelte-query/src/createInfiniteQuery.ts
+++ b/packages/svelte-query/src/createInfiniteQuery.ts
@@ -10,6 +10,7 @@ import type {
 import type {
   CreateInfiniteQueryOptions,
   CreateInfiniteQueryResult,
+  FunctionedParams,
 } from './types'
 
 export function createInfiniteQuery<
@@ -19,13 +20,15 @@ export function createInfiniteQuery<
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 >(
-  options: CreateInfiniteQueryOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryFnData,
-    TQueryKey,
-    TPageParam
+  options: FunctionedParams<
+    CreateInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey,
+      TPageParam
+    >
   >,
   queryClient?: QueryClient,
 ): CreateInfiniteQueryResult<TData, TError> {

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -2,7 +2,7 @@ import { untrack } from 'svelte'
 import { QueriesObserver, notifyManager } from '@tanstack/query-core'
 import { useIsRestoring } from './useIsRestoring'
 import { useQueryClient } from './useQueryClient'
-import type { FnOrVal } from '.'
+import type { FunctionedParams } from './types'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
@@ -208,7 +208,7 @@ export function createQueries<
     queries,
     ...options
   }: {
-    queries: FnOrVal<[...QueriesOptions<T>]>
+    queries: FunctionedParams<[...QueriesOptions<T>]>
     combine?: (result: QueriesResults<T>) => TCombinedResult
   },
   queryClient?: QueryClient,

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -216,12 +216,8 @@ export function createQueries<
   const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
 
-  const queriesStore = $derived(
-    typeof queries != 'function' ? () => queries : queries,
-  )
-
   const defaultedQueriesStore = $derived(() => {
-    return queriesStore().map((opts) => {
+    return queries().map((opts) => {
       const defaultedOptions = client.defaultQueryOptions(opts)
       // Make sure the results are already in fetching state before subscribing or updating options
       defaultedOptions._optimisticResults = isRestoring()

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -5,6 +5,7 @@ import type {
   CreateQueryOptions,
   CreateQueryResult,
   DefinedCreateQueryResult,
+  FunctionedParams,
 } from './types'
 import type {
   DefinedInitialDataOptions,
@@ -17,7 +18,9 @@ export function createQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: FunctionedParams<
+    DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
+  >,
   queryClient?: QueryClient,
 ): DefinedCreateQueryResult<TData, TError>
 
@@ -27,7 +30,9 @@ export function createQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: FunctionedParams<
+    UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
+  >,
   queryClient?: QueryClient,
 ): CreateQueryResult<TData, TError>
 
@@ -37,12 +42,14 @@ export function createQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: FunctionedParams<
+    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+  >,
   queryClient?: QueryClient,
 ): CreateQueryResult<TData, TError>
 
 export function createQuery(
-  options: CreateQueryOptions,
+  options: FunctionedParams<CreateQueryOptions>,
   queryClient?: QueryClient,
 ) {
   return createBaseQuery(options, QueryObserver, queryClient)

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -16,7 +16,7 @@ import type {
   QueryObserverResult,
 } from '@tanstack/query-core'
 
-export type FnOrVal<T> = (() => T) | T // can be a fn that returns reactive statement or $state or $derived deep states
+export type FunctionedParams<T> = () => T
 
 /** Options for createBaseQuery */
 export type CreateBaseQueryOptions<
@@ -25,12 +25,7 @@ export type CreateBaseQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = FnOrVal<
-  Omit<
-    QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
-    'queryKey' | 'enabled'
-  > & { enabled?: FnOrVal<boolean>; queryKey: FnOrVal<TQueryKey> }
->
+> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
 
 /** Result from createBaseQuery */
 export type CreateBaseQueryResult<
@@ -60,18 +55,13 @@ export type CreateInfiniteQueryOptions<
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
-> = FnOrVal<
-  Omit<
-    InfiniteQueryObserverOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryData,
-      TQueryKey,
-      TPageParam
-    >,
-    'queryKey' | 'enabled'
-  > & { enabled?: FnOrVal<boolean>; queryKey: FnOrVal<TQueryKey> }
+> = InfiniteQueryObserverOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryData,
+  TQueryKey,
+  TPageParam
 >
 
 /** Result from createInfiniteQuery */

--- a/packages/svelte-query/tests/QueryClientProvider/ChildComponent.svelte
+++ b/packages/svelte-query/tests/QueryClientProvider/ChildComponent.svelte
@@ -2,13 +2,13 @@
   import { createQuery } from '../../src/createQuery'
   import { sleep } from '../utils.svelte'
 
-  const query = createQuery({
+  const query = createQuery(() => ({
     queryKey: ['hello'],
     queryFn: async () => {
       await sleep(5)
       return 'test'
     },
-  })
+  }))
 </script>
 
 <div>Data: {query.data ?? 'undefined'}</div>

--- a/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
@@ -10,7 +10,7 @@
   const queryClient = new QueryClient()
 
   const query = createInfiniteQuery(
-    {
+    () => ({
       queryKey: ['test'],
       queryFn: async ({ pageParam }) => {
         await sleep(5)
@@ -18,7 +18,7 @@
       },
       getNextPageParam: (lastPage) => lastPage + 1,
       initialPageParam: 0,
-    },
+    }),
     queryClient,
   )
 

--- a/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
@@ -9,7 +9,7 @@
   const queryClient = new QueryClient()
 
   const query = createInfiniteQuery(
-    {
+    () => ({
       queryKey: ['test'],
       queryFn: () => Promise.resolve({ count: 1 }),
       select: (data) => ({
@@ -18,7 +18,7 @@
       }),
       getNextPageParam: () => undefined,
       initialPageParam: 0,
-    },
+    }),
     queryClient,
   )
 

--- a/packages/svelte-query/tests/createQueries/BaseExample.svelte
+++ b/packages/svelte-query/tests/createQueries/BaseExample.svelte
@@ -10,8 +10,8 @@
     options,
     queryClient,
   }: {
-    options: () => {
-      queries: [...QueriesOptions<any>]
+    options: {
+      queries: () => [...QueriesOptions<any>]
       combine?: (result: QueriesResults<Array<any>>) => any
     }
     queryClient: QueryClient

--- a/packages/svelte-query/tests/createQueries/BaseExample.svelte
+++ b/packages/svelte-query/tests/createQueries/BaseExample.svelte
@@ -10,7 +10,7 @@
     options,
     queryClient,
   }: {
-    options: {
+    options: () => {
       queries: [...QueriesOptions<any>]
       combine?: (result: QueriesResults<Array<any>>) => any
     }

--- a/packages/svelte-query/tests/createQueries/CombineExample.svelte
+++ b/packages/svelte-query/tests/createQueries/CombineExample.svelte
@@ -9,13 +9,14 @@
 
   const queries = createQueries(
     {
-      queries: ids.map((id) => ({
-        queryKey: [id],
-        queryFn: async () => {
-          await sleep(5)
-          return id
-        },
-      })),
+      queries: () =>
+        ids.map((id) => ({
+          queryKey: [id],
+          queryFn: async () => {
+            await sleep(5)
+            return id
+          },
+        })),
       combine: (results) => {
         return {
           isPending: results.some((result) => result.isPending),
@@ -29,4 +30,4 @@
 </script>
 
 <div>isPending: {queries.isPending}</div>
-<div>Data: {queries.data ?? 'undefined'}</div>
+<div>Data: {queries.data}</div>

--- a/packages/svelte-query/tests/createQueries/createQueries.test-d.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.test-d.ts
@@ -17,7 +17,7 @@ describe('createQueries', () => {
         wow: true,
       },
     })
-    const queryResults = createQueries(() => ({ queries: [options] }))
+    const queryResults = createQueries({ queries: () => [options] })
 
     const data = queryResults[0].data
 
@@ -29,7 +29,7 @@ describe('createQueries', () => {
 
     const useCustomQueries = (options?: CreateQueryOptions<Data>) => {
       return createQueries({
-        queries: [
+        queries: () => [
           {
             ...options,
             queryKey: ['todos-key'],
@@ -47,7 +47,7 @@ describe('createQueries', () => {
 
   test('TData should have correct type when conditional skipToken is passed', () => {
     const queryResults = createQueries({
-      queries: [
+      queries: () => [
         {
           queryKey: ['withSkipToken'],
           queryFn: Math.random() > 0.5 ? skipToken : () => Promise.resolve(5),

--- a/packages/svelte-query/tests/createQueries/createQueries.test-d.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.test-d.ts
@@ -17,7 +17,7 @@ describe('createQueries', () => {
         wow: true,
       },
     })
-    const queryResults = createQueries({ queries: [options] })
+    const queryResults = createQueries(() => ({ queries: [options] }))
 
     const data = queryResults[0].data
 

--- a/packages/svelte-query/tests/createQueries/createQueries.test.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.test.ts
@@ -9,7 +9,7 @@ describe('createQueries', () => {
   test('Render and wait for success', async () => {
     const rendered = render(BaseExample, {
       props: {
-        options: {
+        options: () => ({
           queries: [
             {
               queryKey: ['key-1'],
@@ -26,7 +26,7 @@ describe('createQueries', () => {
               },
             },
           ],
-        },
+        }),
         queryClient: new QueryClient(),
       },
     })

--- a/packages/svelte-query/tests/createQueries/createQueries.test.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.test.ts
@@ -9,8 +9,8 @@ describe('createQueries', () => {
   test('Render and wait for success', async () => {
     const rendered = render(BaseExample, {
       props: {
-        options: () => ({
-          queries: [
+        options: {
+          queries: () => [
             {
               queryKey: ['key-1'],
               queryFn: async () => {
@@ -26,7 +26,7 @@ describe('createQueries', () => {
               },
             },
           ],
-        }),
+        },
         queryClient: new QueryClient(),
       },
     })

--- a/packages/svelte-query/tests/createQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createQuery/BaseExample.svelte
@@ -2,14 +2,14 @@
   import { untrack } from 'svelte'
   import { createQuery } from '../../src'
   import type { QueryClient, QueryObserverResult } from '@tanstack/query-core'
-  import type { CreateQueryOptions } from '../../src/types'
+  import type { CreateQueryOptions, FunctionedParams } from '../../src/types'
 
   let {
     options,
     queryClient,
     states,
   }: {
-    options: CreateQueryOptions<any>
+    options: FunctionedParams<CreateQueryOptions<any>>
     queryClient: QueryClient
     states: { value: Array<QueryObserverResult> }
   } = $props()

--- a/packages/svelte-query/tests/createQuery/DisabledExample.svelte
+++ b/packages/svelte-query/tests/createQuery/DisabledExample.svelte
@@ -14,16 +14,17 @@
   const queryClient = new QueryClient()
   let count = $state(0)
 
-  const options = $derived({
-    queryKey: () => ['test', count],
-    queryFn: async () => {
-      await sleep(5)
-      return count
-    },
-    enabled: () => count === 0,
-  })
-
-  const query = createQuery(options, queryClient)
+  const query = createQuery(
+    () => ({
+      queryKey: ['test', count],
+      queryFn: async () => {
+        await sleep(5)
+        return count
+      },
+      enabled: count === 0,
+    }),
+    queryClient,
+  )
 
   $effect(() => {
     states.value = [

--- a/packages/svelte-query/tests/createQuery/PlaceholderData.svelte
+++ b/packages/svelte-query/tests/createQuery/PlaceholderData.svelte
@@ -14,16 +14,17 @@
 
   let count = $state(0)
 
-  const options = $derived(() => ({
-    queryKey: ['test', count],
-    queryFn: async () => {
-      await sleep(5)
-      return count
-    },
-    placeholderData: keepPreviousData,
-  }))
-
-  const query = createQuery(options, queryClient)
+  const query = createQuery(
+    () => ({
+      queryKey: ['test', count],
+      queryFn: async () => {
+        await sleep(5)
+        return count
+      },
+      placeholderData: keepPreviousData,
+    }),
+    queryClient,
+  )
 
   $effect(() => {
     states.value = [...untrack(() => states.value), $state.snapshot(query)]

--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -21,7 +21,7 @@ describe('createQuery', () => {
 
     const rendered = render(BaseExample, {
       props: {
-        options,
+        options: () => options,
         queryClient: new QueryClient(),
         states,
       },
@@ -100,7 +100,7 @@ describe('createQuery', () => {
 
     const rendered = render(BaseExample, {
       props: {
-        options,
+        options: () => options,
         queryClient: new QueryClient(),
         states,
       },
@@ -195,13 +195,13 @@ describe('createQuery', () => {
   test('Accept a writable store for options', async () => {
     let states = ref<Array<QueryObserverResult>>([])
 
-    const optionsStore = $state({
+    const optionsStore = $state(() => ({
       queryKey: ['test'],
       queryFn: async () => {
         await sleep(5)
         return 'Success'
       },
-    })
+    }))
 
     const rendered = render(BaseExample, {
       props: {
@@ -247,13 +247,13 @@ describe('createQuery', () => {
 
     let writableStore = $state(1)
 
-    const derivedStore = $derived({
-      queryKey: () => [writableStore],
+    const derivedStore = $derived(() => ({
+      queryKey: [writableStore],
       queryFn: async () => {
         await sleep(5)
         return writableStore
       },
-    })
+    }))
 
     const rendered = render(BaseExample, {
       props: {

--- a/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
@@ -4,11 +4,11 @@ import type { CreateQueryOptions } from '../../src/index'
 
 describe('createQuery', () => {
   test('TData should always be defined when initialData is provided as an object', () => {
-    const query = createQuery({
+    const query = createQuery(() => ({
       queryKey: ['key'],
       queryFn: () => ({ wow: true }),
       initialData: { wow: true },
-    })
+    }))
 
     expectTypeOf(query.data).toEqualTypeOf<{ wow: boolean }>()
   })
@@ -25,20 +25,20 @@ describe('createQuery', () => {
         wow: true,
       },
     })
-    const query = createQuery(options)
+    const query = createQuery(() => options)
 
     expectTypeOf(query.data).toEqualTypeOf<{ wow: boolean }>()
   })
 
   test('TData should have undefined in the union when initialData is NOT provided', () => {
-    const query = createQuery({
+    const query = createQuery(() => ({
       queryKey: ['key'],
       queryFn: () => {
         return {
           wow: true,
         }
       },
-    })
+    }))
 
     expectTypeOf(query.data).toEqualTypeOf<{ wow: boolean } | undefined>()
   })
@@ -47,11 +47,11 @@ describe('createQuery', () => {
     type Data = string
 
     const useCustomQuery = (options?: CreateQueryOptions<Data>) => {
-      return createQuery({
+      return createQuery(() => ({
         ...options,
         queryKey: ['todos-key'],
         queryFn: () => Promise.resolve('data'),
-      })
+      }))
     }
 
     const query = useCustomQuery()

--- a/packages/svelte-query/tests/infiniteQueryOptions/infiniteQueryOptions.test-d.ts
+++ b/packages/svelte-query/tests/infiniteQueryOptions/infiniteQueryOptions.test-d.ts
@@ -36,7 +36,7 @@ describe('queryOptions', () => {
       initialPageParam: 1,
     })
 
-    const query = createInfiniteQuery(options)
+    const query = createInfiniteQuery(() => options)
 
     // known issue: type of pageParams is unknown when returned from useInfiniteQuery
     expectTypeOf(query.data).toEqualTypeOf<

--- a/packages/svelte-query/tests/queryOptions/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions/queryOptions.test-d.ts
@@ -46,7 +46,7 @@ describe('queryOptions', () => {
     })
 
     const queries = createQueries({
-      queries: [options],
+      queries: () => [options],
     })
 
     expectTypeOf(queries[0].data).toEqualTypeOf<number | undefined>()

--- a/packages/svelte-query/tests/useIsFetching/BaseExample.svelte
+++ b/packages/svelte-query/tests/useIsFetching/BaseExample.svelte
@@ -9,16 +9,17 @@
 
   const isFetching = useIsFetching(undefined, queryClient)
 
-  const options = $derived({
-    queryKey: ['test'],
-    queryFn: async () => {
-      await sleep(5)
-      return 'test'
-    },
-    enabled: ready,
-  })
-
-  const query = createQuery(options, queryClient)
+  const query = createQuery(
+    () => ({
+      queryKey: ['test'],
+      queryFn: async () => {
+        await sleep(5)
+        return 'test'
+      },
+      enabled: ready,
+    }),
+    queryClient,
+  )
 </script>
 
 <button onclick={() => (ready = true)}>setReady</button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1516,43 +1516,6 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3(@types/node@20.14.10)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
 
-  examples/svelte/svelte-melt:
-    dependencies:
-      '@tanstack/query-sync-storage-persister':
-        specifier: ^5.51.1
-        version: link:../../../packages/query-sync-storage-persister
-      '@tanstack/svelte-query':
-        specifier: ^5.51.1
-        version: link:../../../packages/svelte-query
-      '@tanstack/svelte-query-devtools':
-        specifier: ^5.51.1
-        version: link:../../../packages/svelte-query-devtools
-      '@tanstack/svelte-query-persist-client':
-        specifier: ^5.51.1
-        version: link:../../../packages/svelte-query-persist-client
-    devDependencies:
-      '@sveltejs/adapter-auto':
-        specifier: ^3.2.2
-        version: 3.2.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@4.0.0-next.4(svelte@5.0.0-next.192)(vite@5.3.3(@types/node@20.14.10)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)))(svelte@5.0.0-next.192)(vite@5.3.3(@types/node@20.14.10)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)))
-      '@sveltejs/kit':
-        specifier: ^2.5.18
-        version: 2.5.18(@sveltejs/vite-plugin-svelte@4.0.0-next.4(svelte@5.0.0-next.192)(vite@5.3.3(@types/node@20.14.10)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)))(svelte@5.0.0-next.192)(vite@5.3.3(@types/node@20.14.10)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
-      '@sveltejs/vite-plugin-svelte':
-        specifier: ^4.0.0-next.4
-        version: 4.0.0-next.4(svelte@5.0.0-next.192)(vite@5.3.3(@types/node@20.14.10)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
-      svelte:
-        specifier: 5.0.0-next.192
-        version: 5.0.0-next.192
-      svelte-check:
-        specifier: ^3.8.4
-        version: 3.8.4(@babel/core@7.24.6)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.39))(postcss@8.4.39)(sass@1.71.1)(svelte@5.0.0-next.192)
-      typescript:
-        specifier: 5.3.3
-        version: 5.3.3
-      vite:
-        specifier: ^5.3.3
-        version: 5.3.3(@types/node@20.14.10)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
-
   examples/vue/basic:
     dependencies:
       '@tanstack/vue-query':


### PR DESCRIPTION
A very common error that keeps coming up for work on the svelte 5 adapter is `state_referenced_locally`:

```
State referenced in its own scope will never update. Did you mean to reference it inside a closure? svelte(state_referenced_locally)
```

With the svelte 4 adapter, you can pass options as either a raw object, or a store of the object. In the initial work on the svelte 5 adapter, you could pass options as either a raw object, or a function returning the object. This PR removes the first method.

This is identical to how `@tanstack/solid-query` works: https://tanstack.com/query/latest/docs/framework/solid/quick-start

### Before

```js
const post = createQuery({
  queryKey: ['post', postId], // Won't detect if postId changes
  queryFn: () => getPostById(postId),
})
```

### After

```js
const post = createQuery(() => ({
  queryKey: ['post', postId],
  queryFn: () => getPostById(postId),
}))
```