### PR TITLE
fix(svelte-query): allow returning undefined in initialData function

### DIFF
--- a/packages/svelte-query/src/queryOptions.ts
+++ b/packages/svelte-query/src/queryOptions.ts
@@ -1,4 +1,9 @@
-import type { DataTag, DefaultError, QueryKey } from '@tanstack/query-core'
+import type {
+  DataTag,
+  DefaultError,
+  InitialDataFunction,
+  QueryKey,
+} from '@tanstack/query-core'
 import type { CreateQueryOptions } from './types.js'
 
 export type UndefinedInitialDataOptions<
@@ -7,7 +12,7 @@ export type UndefinedInitialDataOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  initialData?: undefined
+  initialData?: undefined | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
 }
 
 type NonUndefinedGuard<T> = T extends undefined ? never : T

--- a/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
@@ -18,16 +18,20 @@ describe('createQuery', () => {
   test('TData should be defined when passed through queryOptions', () => {
     const options = queryOptions({
       queryKey: ['key'],
-      queryFn: () => {
-        return {
-          wow: true,
-        }
-      },
-      initialData: {
-        wow: true,
-      },
+      queryFn: () => ({ wow: true }),
+      initialData: { wow: true },
     })
     const query = createQuery(options)
+
+    expectTypeOf(get(query).data).toEqualTypeOf<{ wow: boolean }>()
+  })
+
+  test('TData should always be defined when initialData is provided as a function which ALWAYS returns the data', () => {
+    const query = createQuery({
+      queryKey: ['key'],
+      queryFn: () => ({ wow: true }),
+      initialData: () => ({ wow: true }),
+    })
 
     expectTypeOf(get(query).data).toEqualTypeOf<{ wow: boolean }>()
   })

--- a/packages/svelte-query/tests/queryOptions/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions/queryOptions.test-d.ts
@@ -176,4 +176,23 @@ describe('queryOptions', () => {
       QueriesObserver<Array<QueryObserverResult>>
     >()
   })
+
+  test('Should allow undefined response in initialData', () => {
+    return (id: string | null) =>
+      queryOptions({
+        queryKey: ['todo', id],
+        queryFn: () =>
+          Promise.resolve({
+            id: '1',
+            title: 'Do Laundry',
+          }),
+        initialData: () =>
+          !id
+            ? undefined
+            : {
+                id,
+                title: 'Initial Data',
+              },
+      })
+  })
 })


### PR DESCRIPTION
Implements #7351 for svelte-query