### PR TITLE
fix(svelte-query): specify readonly on create-queries options

### DIFF
--- a/packages/svelte-query/src/createQueries.ts
+++ b/packages/svelte-query/src/createQueries.ts
@@ -207,7 +207,7 @@ export function createQueries<
     queries,
     ...options
   }: {
-    queries: StoreOrVal<[...QueriesOptions<T>]>
+    queries: StoreOrVal<readonly [...QueriesOptions<T>]>
     combine?: (result: QueriesResults<T>) => TCombinedResult
   },
   queryClient?: QueryClient,


### PR DESCRIPTION
The `queries` property in the first argument provided to `createQueries` should have the `readonly` modifier.

## Minimum Reproduction

```ts
import { createQueries, type QueriesOptions } from '@tanstack/svelte-query'

const a = [] as readonly QueriesOptions<any>[]

// @ts-expect-error type readonly any[] is not assignable...
createQueries({ queries: a })
```

## Expectation

A `readonly QueriesOptions<any>[]` and variations of this type should be compatible with the `createQueries` function signature.

## Context
I'm writing a utility function that generates strongly typed query options, which will be plugged into `createQueries` directly. It looks something like this:

```ts
function createTypedQueryOptions<T>(options: T): readonly [...QueriesOptions<T>] {}
```

The main points being that the function is generic, and returns a `readonly` tuple with strongly typed query options that are derived from the input generic. However, the `readonly` modifier is currently not compatible when using `createQueries` because the `queries` property is missing it...

## Other APIs
This is based on the types exported from [react-query's useQueries](https://github.com/TanStack/query/blob/main/packages/react-query/src/useQueries.ts#L231), as well as [solid-query's createQueries](https://github.com/TanStack/query/blob/main/packages/solid-query/src/createQueries.ts#L208).