### PR TITLE
docs(react-query):fix-missing-isServer-import

### DIFF
--- a/docs/framework/react/guides/advanced-ssr.md
+++ b/docs/framework/react/guides/advanced-ssr.md
@@ -371,7 +371,11 @@ We will also need to move the `getQueryClient()` function out of our `app/provid
 
 ```tsx
 // app/get-query-client.ts
-import { QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query'
+import {
+  isServer,
+  QueryClient,
+  defaultShouldDehydrateQuery,
+} from '@tanstack/react-query'
 
 function makeQueryClient() {
   return new QueryClient({


### PR DESCRIPTION
---

This PR adds the missing import for the isServer variable in the app/get-query-client.ts file example in the official documentation.

---

### Issue
The `isServer` variable is used in the `getQueryClient` function but is not imported, causing a reference error when the code is executed.

The issue is present in the documentation at:
https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr

---

before:

```typescript
// app/get-query-client.ts
import { QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query'

// ...

export function getQueryClient() {
  if (isServer) { // -----> missing import
    // Server: always make a new query client
    return makeQueryClient()
  } else {
    // ...
  }
}
```

after

```typescript
// app/get-query-client.ts
import {
  isServer, // <----- add import
  QueryClient,
  defaultShouldDehydrateQuery,
} from '@tanstack/react-query'

// ...

export function getQueryClient() {
  if (isServer) {
    // Server: always make a new query client
    return makeQueryClient()
  } else {
    // ...
  }
}
```