### PR TITLE
feat(query-core): add support for symbol in cache

### DIFF
--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -347,4 +347,28 @@ describe('queryCache', () => {
       expect(queryCache.getAll().length).toEqual(1)
     })
   })
+
+  describe('Symbol', () => {
+    test('should allow setting in the cache', () => {
+      const key = queryKey()
+
+      const s = Symbol('s')
+
+      queryClient.setQueryData(key, { [s]: 1 })
+      expect(queryClient.getQueryData(key)).toEqual({ [s]: 1 })
+    })
+
+    test('should allow setting multiple in the cache', () => {
+      const key = queryKey()
+
+      const s = Symbol('s')
+
+      queryClient.setQueryData(key, { [s]: 1, a: 1 })
+      expect(queryClient.getQueryData(key)).toEqual({ [s]: 1, a: 1 })
+      queryClient.setQueryData(key, { [s]: 1, a: 2 })
+      expect(queryClient.getQueryData(key)).toEqual({ [s]: 1, a: 2 })
+      queryClient.setQueryData(key, { [s]: 2, a: 2 })
+      expect(queryClient.getQueryData(key)).toEqual({ [s]: 2, a: 2 })
+    })
+  })
 })

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -12,27 +12,38 @@ import {
 import { Mutation } from '../mutation'
 import { createQueryClient } from './utils'
 
+const s = Symbol('s')
+const t = Symbol('t')
+
 describe('core/utils', () => {
   describe('shallowEqualObjects', () => {
     it('should return `true` for shallow equal objects', () => {
       expect(shallowEqualObjects({ a: 1 }, { a: 1 })).toEqual(true)
+      expect(shallowEqualObjects({ [s]: 1 }, { [s]: 1 })).toEqual(true)
     })
 
     it('should return `false` for non shallow equal objects', () => {
       expect(shallowEqualObjects({ a: 1 }, { a: 2 })).toEqual(false)
+      expect(shallowEqualObjects({ [s]: 1 }, { [s]: 2 })).toEqual(false)
     })
 
     it('should return `false` if lengths are not equal', () => {
       expect(shallowEqualObjects({ a: 1 }, { a: 1, b: 2 })).toEqual(false)
+      expect(shallowEqualObjects({ a: 1 }, { a: 1, [s]: 2 })).toEqual(false)
     })
 
     it('should return false if b is undefined', () => {
       expect(shallowEqualObjects({ a: 1 }, undefined)).toEqual(false)
+      expect(shallowEqualObjects({ [s]: 1 }, undefined)).toEqual(false)
     })
   })
   describe('isPlainObject', () => {
     it('should return `true` for a plain object', () => {
       expect(isPlainObject({})).toEqual(true)
+    })
+
+    it('should return `true` for a object containing a symbol', () => {
+      expect(isPlainObject({ [s]: 1 })).toEqual(true)
     })
 
     it('should return `false` for an array', () => {
@@ -214,14 +225,21 @@ describe('core/utils', () => {
       expect(replaceEqualDeep(prev, next)).toBe(prev)
     })
 
+    it('should return the previous value when the next value is an equal object with symbols', () => {
+      const prev = { [s]: 's' }
+      const next = { [s]: 's' }
+      expect(replaceEqualDeep(prev, next)).toBe(prev)
+    })
+
     it('should replace different values in objects', () => {
-      const prev = { a: { b: 'b' }, c: 'c' }
-      const next = { a: { b: 'b' }, c: 'd' }
+      const prev = { a: { b: 'b' }, c: 'c', [s]: 's', [t]: 't' }
+      const next = { a: { b: 'b' }, c: 'd', [s]: 's', [t]: 'u' }
       const result = replaceEqualDeep(prev, next)
       expect(result).toEqual(next)
       expect(result).not.toBe(prev)
       expect(result).not.toBe(next)
       expect(result.a).toBe(prev.a)
+      expect(result[s]).toBe(prev[s])
       expect(result.c).toBe(next.c)
     })
 

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -113,6 +113,10 @@ export function resolveEnabled<
   return typeof enabled === 'function' ? enabled(query) : enabled
 }
 
+function objectKeys(obj: object) {
+  return [...Object.keys(obj), ...Object.getOwnPropertySymbols(obj)]
+}
+
 export function matchQuery(
   filters: QueryFilters,
   query: Query<any, any, any, any>,
@@ -249,9 +253,9 @@ export function replaceEqualDeep(a: any, b: any): any {
   const array = isPlainArray(a) && isPlainArray(b)
 
   if (array || (isPlainObject(a) && isPlainObject(b))) {
-    const aItems = array ? a : Object.keys(a)
+    const aItems = array ? a : objectKeys(a)
     const aSize = aItems.length
-    const bItems = array ? b : Object.keys(b)
+    const bItems = array ? b : objectKeys(b)
     const bSize = bItems.length
     const copy: any = array ? [] : {}
 
@@ -283,11 +287,11 @@ export function replaceEqualDeep(a: any, b: any): any {
 /**
  * Shallow compare objects.
  */
-export function shallowEqualObjects<T extends Record<string, any>>(
+export function shallowEqualObjects<T extends Record<string | symbol, any>>(
   a: T,
   b: T | undefined,
 ): boolean {
-  if (!b || Object.keys(a).length !== Object.keys(b).length) {
+  if (!b || objectKeys(a).length !== objectKeys(b).length) {
     return false
   }
 
@@ -297,11 +301,17 @@ export function shallowEqualObjects<T extends Record<string, any>>(
     }
   }
 
+  for (const key of Object.getOwnPropertySymbols(a)) {
+    if (a[key] !== b[key]) {
+      return false
+    }
+  }
+
   return true
 }
 
 export function isPlainArray(value: unknown) {
-  return Array.isArray(value) && value.length === Object.keys(value).length
+  return Array.isArray(value) && value.length === objectKeys(value).length
 }
 
 // Copied from: https://github.com/jonschlinkert/is-plain-object


### PR DESCRIPTION
I noticed when I was using symbols as keys in the value of objects with `queryCache.setQueryData()` that keys containing symbol were sometimes stripped out

This PR addresses this by using `Object.getOwnPropertySymbols()` to iterate over symbol keys in the cache

I added new tests & ran test before and after my changes and they indeed fail on before, and pass after

Before | After
-|-
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/cb12507f-b63d-4ec2-afc0-a6e5d530592a"> | <img width="929" alt="image" src="https://github.com/user-attachments/assets/cd92f821-b1d5-4f77-aaf9-7493eb5804d3">

