### PR TITLE
docs(tanstack.com): Remove `Infinity` type

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -94,7 +94,7 @@ const {
   - The time in milliseconds after data is considered stale. This value only applies to the hook it is defined on.
   - If set to `Infinity`, the data will never be considered stale
   - If set to a function, the function will be executed with the query to compute a `staleTime`.
-- `gcTime: number | Infinity`
+- `gcTime: number`
   - Defaults to `5 * 60 * 1000` (5 minutes) or `Infinity` during SSR
   - The time in milliseconds that unused/inactive cache data remains in memory. When a query's cache becomes unused or inactive, that cache data will be garbage collected after this duration. When different garbage collection times are specified, the longest one will be used.
   - Note: the maximum allowed time is about 24 days. See [more](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value).


### PR DESCRIPTION
This PR removes the type `Infinity` for `gcTime`, because the type of `Infinity` is already "number".

Also, there is no `Inifinity` here:
https://github.com/TanStack/query/blob/59a6d3df3035d6effeaed884f4575b1a0ef8e788/packages/query-core/src/types.ts#L189
therefore, removed it from the docs.

Thanks!