### PR TITLE
Add npm package version to v4 eslint docs

### DIFF
--- a/docs/eslint/eslint-plugin-query.md
+++ b/docs/eslint/eslint-plugin-query.md
@@ -10,11 +10,11 @@ TanStack Query comes with its own ESLint plugin. This plugin is used to enforce 
 The plugin is a separate package that you need to install:
 
 ```bash
-$ npm i -D @tanstack/eslint-plugin-query
+$ npm i -D @tanstack/eslint-plugin-query@4
 # or
-$ pnpm add -D @tanstack/eslint-plugin-query
+$ pnpm add -D @tanstack/eslint-plugin-query@4
 # or
-$ yarn add -D @tanstack/eslint-plugin-query
+$ yarn add -D @tanstack/eslint-plugin-query@4
 ```
 
 ## Usage


### PR DESCRIPTION
Installing the eslint plugin without specifying a version gives v5, which has a different set of rules.