### PR TITLE
fix(docs): Make copyable example useful by default

### DIFF
--- a/docs/framework/angular/devtools.md
+++ b/docs/framework/angular/devtools.md
@@ -8,25 +8,25 @@ title: Devtools
 The devtools are a separate package that you need to install:
 
 ```bash
-$ npm i @tanstack/angular-query-devtools-experimental
+npm i @tanstack/angular-query-devtools-experimental
 ```
 
 or
 
 ```bash
-$ pnpm add @tanstack/angular-query-devtools-experimental
+pnpm add @tanstack/angular-query-devtools-experimental
 ```
 
 or
 
 ```bash
-$ yarn add @tanstack/angular-query-devtools-experimental
+yarn add @tanstack/angular-query-devtools-experimental
 ```
 
 or
 
 ```bash
-$ bun add @tanstack/angular-query-devtools-experimental
+bun add @tanstack/angular-query-devtools-experimental
 ```
 
 You can import the devtools like this:

--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -20,25 +20,25 @@ When you begin your React Query journey, you'll want these devtools by your side
 The devtools are a separate package that you need to install:
 
 ```bash
-$ npm i @tanstack/react-query-devtools
+npm i @tanstack/react-query-devtools
 ```
 
 or
 
 ```bash
-$ pnpm add @tanstack/react-query-devtools
+pnpm add @tanstack/react-query-devtools
 ```
 
 or
 
 ```bash
-$ yarn add @tanstack/react-query-devtools
+yarn add @tanstack/react-query-devtools
 ```
 
 or
 
 ```bash
-$ bun add @tanstack/react-query-devtools
+bun add @tanstack/react-query-devtools
 ```
 
 For Next 13+ App Dir you must install it as a dev dependency for it to work.

--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -12,25 +12,25 @@ When you begin your Solid Query journey, you'll want these devtools by your side
 The devtools are a separate package that you need to install:
 
 ```bash
-$ npm i @tanstack/solid-query-devtools
+npm i @tanstack/solid-query-devtools
 ```
 
 or
 
 ```bash
-$ pnpm add @tanstack/solid-query-devtools
+pnpm add @tanstack/solid-query-devtools
 ```
 
 or
 
 ```bash
-$ yarn add @tanstack/solid-query-devtools
+yarn add @tanstack/solid-query-devtools
 ```
 
 or
 
 ```bash
-$ bun add @tanstack/solid-query-devtools
+bun add @tanstack/solid-query-devtools
 ```
 
 You can import the devtools like this:

--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -15,25 +15,25 @@ Component-based devtools use a framework-agnostic implementation and are always 
 The devtools component is a separate package that you need to install:
 
 ```bash
-$ npm i @tanstack/vue-query-devtools
+npm i @tanstack/vue-query-devtools
 ```
 
 or
 
 ```bash
-$ pnpm add @tanstack/vue-query-devtools
+pnpm add @tanstack/vue-query-devtools
 ```
 
 or
 
 ```bash
-$ yarn add @tanstack/vue-query-devtools
+yarn add @tanstack/vue-query-devtools
 ```
 
 or
 
 ```bash
-$ bun add @tanstack/vue-query-devtools
+bun add @tanstack/vue-query-devtools
 ```
 
 By default, Vue Query Devtools are only included in bundles when `process.env.NODE_ENV === 'development'`, so you don't need to worry about excluding them during a production build.


### PR DESCRIPTION
When copying the command, the $ appears in the copied text which makes a tiny text processing required - i.e removing the prefix. Instead of being able to just paste in a terminal and get going.

This mimics the behaviour of all commands everywhere else in the docs I could find. e.g https://tanstack.com/query/latest/docs/framework/react/installation