### PR TITLE
fix(react-query): Add missing React 19 peer dependency.

### DIFF
--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -71,6 +71,6 @@
     "react-error-boundary": "^4.0.13"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18 || ^19"
   }
 }


### PR DESCRIPTION
PR https://github.com/TanStack/query/pull/7476 is done, but it seems to miss including it in react-query