### PR TITLE
fix(vue-query): mark the watcher as post flush

### DIFF
--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -341,7 +341,7 @@ export function useQueries<
       )
       state.value = getCombinedResultPersisted()
     },
-    { flush: 'sync' },
+    { flush: 'post' },
   )
 
   onScopeDispose(() => {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR changes the watcher mode for `useQueries` from `sync` to `post`.
The change is needed to avoid having the watcher run during component unmount.

> [!NOTE]
> This change will probably be needed on `useBaseQuery`, but I haven't tested it yet.

Related VueJS issues:
- https://github.com/vuejs/core/issues/2291
- https://github.com/vuejs/core/issues/7030
- https://github.com/vuejs/router/issues/1945
- https://github.com/vuejs/vue-router/issues/3393
- https://github.com/posva/unplugin-vue-router/issues/86

---

Currently, using the route params to define some query params triggers a new fetch when leaving a route.

For example, let's say we have the following code that runs when we are on `/players/:id`.
```ts
const route = useRoute();
const paramId = computed(() => +route.params.id);

const queries = useMyViewData(paramId)
```

- When going from `/players` to `/players/1`, TanStack Query will trigger a fetch for Player `1` **(expected)**.
- When going from `/players/1` to `/players`, TanStack Query will trigger a fetch for Player `undefined` **(unexpected)**.
- When going from `/players/1` to `/transfers/12345`, TanStack Query will trigger a fetch for Player `12345` **(unexpected)**.

This is due to the watcher running when the page changes.

I haven't created an easy and sharable reproduction. Let me know if it is needed.