### PR TITLE
examples(svelte-query): fix svelte auto-refetching styling

### DIFF
--- a/examples/svelte/auto-refetching/src/routes/+page.svelte
+++ b/examples/svelte/auto-refetching/src/routes/+page.svelte
@@ -50,9 +50,9 @@
           width:.75rem;
           height:.75rem; 
           background: {$todos.isFetching ? 'green' : 'transparent'};
-          transition:: {!$todos.isFetching ? 'all .3s ease' : 'none'};
+          transition: {!$todos.isFetching ? 'all .3s ease' : 'none'};
           border-radius: 100%;
-          transform: 'scale(2)"
+          transform: scale(1.5)"
     ></span>
   </div>
 </label>

--- a/examples/svelte/auto-refetching/src/routes/api/data/+server.ts
+++ b/examples/svelte/auto-refetching/src/routes/api/data/+server.ts
@@ -15,6 +15,6 @@ export const GET: RequestHandler = async ({ url }) => {
   } else if (clear) {
     list.items = []
   }
-  await new Promise((r) => setTimeout(r, 1000))
+  await new Promise((r) => setTimeout(r, 200))
   return json(list, { status: 200 })
 }


### PR DESCRIPTION
Noticed in https://github.com/TanStack/query/pull/6981#discussion_r1702840727

I've also decreased the API endpoint's artificial delay (the react example is only 100ms)