### PR TITLE
Throw-on-server-default-fix

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -156,7 +156,10 @@ export function createBaseQuery<
         const query = observer().getCurrentQuery()
         const unwrappedResult = hydratableObserverResult(query, result)
 
-        if (unwrappedResult.isError) {
+        if (unwrappedResult.isError && shouldThrowError(initialOptions.throwOnError, [
+          observerResult.error,
+          query
+        ])) {
           reject(unwrappedResult.error)
           unsubscribeIfQueued()
         } else {

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -131,8 +131,7 @@ export function createBaseQuery<
       : 'optimistic'
     defaultOptions.structuralSharing = false
     if (isServer) {
-      defaultOptions.retry = false
-      defaultOptions.throwOnError = true
+      defaultOptions.retry = false      
     }
     return defaultOptions
   })

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -131,7 +131,7 @@ export function createBaseQuery<
       : 'optimistic'
     defaultOptions.structuralSharing = false
     if (isServer) {
-      defaultOptions.retry = false      
+      defaultOptions.retry = false
     }
     return defaultOptions
   })


### PR DESCRIPTION
fix: stop defaulting to throwOnError=true when isServer===true so that SSR can render the page the same way the client will rather than showing the error boundary fallback