### PR TITLE
fix(react): re-introduce setting options before suspending

### DIFF
--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -104,6 +104,10 @@ export function useBaseQuery<
 
   // Handle suspense
   if (shouldSuspend(defaultedOptions, result)) {
+    // Do the same thing as the effect right above because the effect won't run
+    // when we suspend but also, the component won't re-mount so our observer would
+    // be out of date.
+    observer.setOptions(defaultedOptions, { listeners: false })
     throw fetchOptimistic(defaultedOptions, observer, errorResetBoundary)
   }
 

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -321,6 +321,13 @@ export function useQueries<
     : []
 
   if (suspensePromises.length > 0) {
+    observer.setQueries(
+      defaultedQueries,
+      options as QueriesObserverOptions<TCombinedResult>,
+      {
+        listeners: false,
+      },
+    )
     throw Promise.all(suspensePromises)
   }
   const firstSingleResultWhichShouldThrow = optimisticResult.find(


### PR DESCRIPTION
if some options are set on the useSuspenseQuery observer instance, they won't be set in cases where the query fails and thus never re-mounts the observer. This is troublesome for e.g. the `retry` option because it means setting retries will not be respected. retry is needed when erroring, so it might be specific to that, but also, a lower `gcTime` would not not be set properly for example.