### PR TITLE
chore(devtools): consistent casing of devtools types

### DIFF
--- a/packages/angular-query-devtools-experimental/src/angular-query-devtools.component.ts
+++ b/packages/angular-query-devtools-experimental/src/angular-query-devtools.component.ts
@@ -22,7 +22,7 @@ import type {
   SimpleChanges,
 } from '@angular/core'
 import type {
-  DevToolsErrorType,
+  DevtoolsErrorType,
   TanstackQueryDevtools,
 } from '@tanstack/query-devtools'
 
@@ -91,7 +91,7 @@ export class AngularQueryDevtools
   /**
    * Use this so you can define custom errors that can be shown in the devtools.
    */
-  @Input() errorTypes?: Array<DevToolsErrorType>
+  @Input() errorTypes?: Array<DevtoolsErrorType>
 
   @ViewChild('ref') ref!: ElementRef
 

--- a/packages/query-devtools/src/Context.ts
+++ b/packages/query-devtools/src/Context.ts
@@ -7,7 +7,7 @@ type YPosition = 'top' | 'bottom'
 export type DevtoolsPosition = XPosition | YPosition
 export type DevtoolsButtonPosition = `${YPosition}-${XPosition}` | 'relative'
 
-export interface DevToolsErrorType {
+export interface DevtoolsErrorType {
   /**
    * The name of the error.
    */
@@ -27,7 +27,7 @@ export interface QueryDevtoolsProps {
   buttonPosition?: DevtoolsButtonPosition
   position?: DevtoolsPosition
   initialIsOpen?: boolean
-  errorTypes?: Array<DevToolsErrorType>
+  errorTypes?: Array<DevtoolsErrorType>
   shadowDOMTarget?: ShadowRoot
 }
 

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -62,8 +62,8 @@ import {
   useTheme,
 } from './Context'
 import type {
-  DevToolsErrorType,
   DevtoolsButtonPosition,
+  DevtoolsErrorType,
   DevtoolsPosition,
   QueryDevtoolsProps,
 } from './Context'
@@ -1916,7 +1916,7 @@ const QueryDetails = () => {
     promise?.catch(() => {})
   }
 
-  const triggerError = (errorType?: DevToolsErrorType) => {
+  const triggerError = (errorType?: DevtoolsErrorType) => {
     const error =
       errorType?.initializer(activeQuery()!) ??
       new Error('Unknown error from devtools')

--- a/packages/query-devtools/src/index.tsx
+++ b/packages/query-devtools/src/index.tsx
@@ -7,14 +7,14 @@ import type {
 } from '@tanstack/query-core'
 import type { DevtoolsComponentType } from './Devtools'
 import type {
-  DevToolsErrorType,
   DevtoolsButtonPosition,
+  DevtoolsErrorType,
   DevtoolsPosition,
   QueryDevtoolsProps,
 } from './Context'
 import type { Signal } from 'solid-js'
 
-export type { DevtoolsButtonPosition, DevtoolsPosition, DevToolsErrorType }
+export type { DevtoolsButtonPosition, DevtoolsPosition, DevtoolsErrorType }
 export interface TanstackQueryDevtoolsConfig extends QueryDevtoolsProps {
   styleNonce?: string
   shadowDOMTarget?: ShadowRoot
@@ -31,7 +31,7 @@ class TanstackQueryDevtools {
   #buttonPosition: Signal<DevtoolsButtonPosition | undefined>
   #position: Signal<DevtoolsPosition | undefined>
   #initialIsOpen: Signal<boolean | undefined>
-  #errorTypes: Signal<Array<DevToolsErrorType> | undefined>
+  #errorTypes: Signal<Array<DevtoolsErrorType> | undefined>
   #Component: DevtoolsComponentType | undefined
   #dispose?: () => void
 
@@ -72,7 +72,7 @@ class TanstackQueryDevtools {
     this.#initialIsOpen[1](isOpen)
   }
 
-  setErrorTypes(errorTypes: Array<DevToolsErrorType>) {
+  setErrorTypes(errorTypes: Array<DevtoolsErrorType>) {
     this.#errorTypes[1](errorTypes)
   }
 

--- a/packages/react-query-devtools/src/devtools.tsx
+++ b/packages/react-query-devtools/src/devtools.tsx
@@ -3,8 +3,8 @@ import * as React from 'react'
 import { onlineManager, useQueryClient } from '@tanstack/react-query'
 import { TanstackQueryDevtools } from '@tanstack/query-devtools'
 import type {
-  DevToolsErrorType,
   DevtoolsButtonPosition,
+  DevtoolsErrorType,
   DevtoolsPosition,
 } from '@tanstack/query-devtools'
 import type { QueryClient } from '@tanstack/react-query'
@@ -33,7 +33,7 @@ export interface DevtoolsOptions {
   /**
    * Use this so you can define custom errors that can be shown in the devtools.
    */
-  errorTypes?: Array<DevToolsErrorType>
+  errorTypes?: Array<DevtoolsErrorType>
   /**
    * Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.
    */

--- a/packages/solid-query-devtools/src/devtools.tsx
+++ b/packages/solid-query-devtools/src/devtools.tsx
@@ -12,8 +12,8 @@ import { onlineManager, useQueryClient } from '@tanstack/solid-query'
 import { isServer } from 'solid-js/web'
 import { TanstackQueryDevtools } from '@tanstack/query-devtools'
 import type {
-  DevToolsErrorType,
   DevtoolsButtonPosition,
+  DevtoolsErrorType,
   DevtoolsPosition,
 } from '@tanstack/query-devtools'
 import type { QueryClient } from '@tanstack/solid-query'
@@ -43,7 +43,7 @@ interface DevtoolsOptions {
   /**
    * Use this so you can define custom errors that can be shown in the devtools.
    */
-  errorTypes?: Array<DevToolsErrorType>
+  errorTypes?: Array<DevtoolsErrorType>
   /**
    * Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.
    */

--- a/packages/svelte-query-devtools/src/Devtools.svelte
+++ b/packages/svelte-query-devtools/src/Devtools.svelte
@@ -4,8 +4,8 @@
   import { onlineManager, useQueryClient } from '@tanstack/svelte-query'
   import type { QueryClient } from '@tanstack/svelte-query'
   import type {
-    DevToolsErrorType,
     DevtoolsButtonPosition,
+    DevtoolsErrorType,
     DevtoolsPosition,
     TanstackQueryDevtools,
   } from '@tanstack/query-devtools'
@@ -14,7 +14,7 @@
   export let buttonPosition: DevtoolsButtonPosition = 'bottom-right'
   export let position: DevtoolsPosition = 'bottom'
   export let client: QueryClient = useQueryClient()
-  export let errorTypes: Array<DevToolsErrorType> = []
+  export let errorTypes: Array<DevtoolsErrorType> = []
   export let styleNonce: string | undefined = undefined
   export let shadowDOMTarget: ShadowRoot | undefined = undefined
 

--- a/packages/vue-query-devtools/src/types.ts
+++ b/packages/vue-query-devtools/src/types.ts
@@ -1,6 +1,6 @@
 import type {
-  DevToolsErrorType,
   DevtoolsButtonPosition,
+  DevtoolsErrorType,
   DevtoolsPosition,
 } from '@tanstack/query-devtools'
 import type { QueryClient } from '@tanstack/vue-query'
@@ -29,7 +29,7 @@ export interface DevtoolsOptions {
   /**
    * Use this so you can define custom errors that can be shown in the devtools.
    */
-  errorTypes?: Array<DevToolsErrorType>
+  errorTypes?: Array<DevtoolsErrorType>
   /**
    * Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.
    */


### PR DESCRIPTION
Before:
```ts
import type {
  DevToolsErrorType,
  DevtoolsButtonPosition,
  DevtoolsPosition,
} from '@tanstack/query-devtools'
```

After:
```ts
import type {
  DevtoolsButtonPosition,
  DevtoolsErrorType,
  DevtoolsPosition,
} from '@tanstack/query-devtools'
```