### PR TITLE
fix(query-core): Remove error thrown inside `replaceData`

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -362,8 +362,6 @@ export function replaceData<
         console.error(
           `StructuralSharing requires data to be JSON serializable. To fix this, turn off structuralSharing or return JSON-serializable data from your queryFn. [${options.queryHash}]: ${error}`,
         )
-
-        throw new Error('Data is not serializable')
       }
     }
 


### PR DESCRIPTION
Regarding this [comment](https://github.com/TanStack/query/pull/7966#discussion_r1739645324), there was a decision to remove the error thrown from `replaceData`.