### PR TITLE
feat: throw when `replaceDeepEqual` contains circular references

### DIFF
--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -975,36 +975,40 @@ describe('query', () => {
 
     const queryFn = vi.fn()
 
+    const data: Array<{
+      id: number
+      name: string
+      link: null | { id: number; name: string; link: unknown }
+    }> = Array.from({ length: 5 })
+      .fill(null)
+      .map((_, index) => ({
+        id: index,
+        name: `name-${index}`,
+        link: null,
+      }))
+
+    if (data[0] && data[1]) {
+      data[0].link = data[1]
+      data[1].link = data[0]
+    }
+
     queryFn.mockImplementation(async () => {
       await sleep(10)
-
-      const data: Array<{
-        id: number
-        name: string
-        link: null | { id: number; name: string; link: unknown }
-      }> = Array.from({ length: 5 })
-        .fill(null)
-        .map((_, index) => ({
-          id: index,
-          name: `name-${index}`,
-          link: null,
-        }))
-
-      if (data[0] && data[1]) {
-        data[0].link = data[1]
-        data[1].link = data[0]
-      }
-
       return data
     })
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn })
+    await queryClient.prefetchQuery({ queryKey: key, queryFn, initialData: structuredClone(data) })
+
+    const query = queryCache.find({ queryKey: key })!
 
     expect(queryFn).toHaveBeenCalledTimes(1)
 
+    expect(query.state.status).toBe('error')
+    expect(query.state.error?.message.includes('contains non-serializable data. Error: circular reference detected.')).toBeTruthy()
+
     expect(consoleMock).toHaveBeenCalledWith(
       expect.stringContaining(
-        'StructuralSharing requires data to be JSON serializable',
+        'Structural sharing requires data to be JSON serializable',
       ),
     )
 

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -172,6 +172,20 @@ describe('core/utils', () => {
       expect(replaceEqualDeep(object, array)).toBe(array)
     })
 
+    it('should return the next value when the previous value is a circular reference', () => {
+      const value: Array<{ foo?: unknown }> = [{}]
+      value[0]!.foo = value
+
+      const value2: Array<{ foo?: unknown }> = [{}]
+      value2[0]!.foo = value2
+
+      expect(() =>
+        replaceEqualDeep(value, value2),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: circular reference detected.]`,
+      )
+    })
+
     it('should return the previous value when the next value is an equal array', () => {
       const prev = [1, 2]
       const next = [1, 2]


### PR DESCRIPTION
This PR is a follow up on #7966 to:
- not surface console errors for values that are referentially stable (e.g. `BigInt`)
- detect circular references in `replaceDeepEqual`
- catch errors from `replaceDeepEqual` in `replaceData`, and surface them in the console + propagated to the query.

This is not a breaking change as `replaceDeepEqual` would already throw a "stack too deep" error for circular references anyway – this change eagerly catches it.