### PR TITLE
docs(react-query): recommend against throwing errors in `select`

### DIFF
--- a/docs/framework/react/guides/render-optimizations.md
+++ b/docs/framework/react/guides/render-optimizations.md
@@ -43,6 +43,8 @@ export const useTodoCount = () => {
 
 A component using the `useTodoCount` custom hook will only re-render if the length of the todos changes. It will **not** re-render if e.g. the name of a todo changed.
 
+> Note: `select` operates on successfully cached data and is not the appropriate place to throw errors. The source of truth for errors is the `queryFn`, and a `select` function that returns an error results in `data` being `undefined` and `isSuccess` being `true`. We recommend handling errors in the `queryFn` if you wish to have a query fail on incorrect data, or outside of the query hook if you have a error case not related to caching.
+
 ### memoization
 
 The `select` function will only re-run if:


### PR DESCRIPTION
Explaining why you should not thow errors in the select function

Closes #8039