### PR TITLE
fix(core): make sure infiniteQuery always fetches the first page

### DIFF
--- a/packages/query-core/src/__tests__/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/__tests__/infiniteQueryBehavior.test.tsx
@@ -396,4 +396,32 @@ describe('InfiniteQueryBehavior', () => {
 
     expect(reFetchedData.data?.pageParams).toEqual([1, 2, 3])
   })
+
+  test('should fetch even if initialPageParam is null', async () => {
+    const key = queryKey()
+
+    const observer = new InfiniteQueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: async () => 'data',
+      getNextPageParam: () => null,
+      initialPageParam: null,
+    })
+
+    let observerResult:
+      | InfiniteQueryObserverResult<unknown, unknown>
+      | undefined
+
+    const unsubscribe = observer.subscribe((result) => {
+      observerResult = result
+    })
+
+    await waitFor(() =>
+      expect(observerResult).toMatchObject({
+        isFetching: false,
+        data: { pages: ['data'], pageParams: [null] },
+      }),
+    )
+
+    unsubscribe()
+  })
 })

--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -99,7 +99,7 @@ export function infiniteQueryBehavior<TQueryFnData, TError, TData, TPageParam>(
               currentPage === 0
                 ? (oldPageParams[0] ?? options.initialPageParam)
                 : getNextPageParam(options, result)
-            if (param == null) {
+            if (currentPage > 0 && param == null) {
               break
             }
             result = await fetchPage(result, param)


### PR DESCRIPTION
The pageParam == null bailout is meant for fetching further pages, where users can return null/undefined from getNextPageParam to stop fetching; However, after the latest refactoring, we also did this for the initial fetch. This stops fetching from working at all if the initialPageParam was set to null/undefined, which I didn't think anyone would do, but here we are.

closes #8050