### PR TITLE
fix(experimental_createQueryPersister): return more utilities, rename persister

### DIFF
--- a/docs/framework/react/plugins/createPersister.md
+++ b/docs/framework/react/plugins/createPersister.md
@@ -1,6 +1,6 @@
 ---
 id: createPersister
-title: experimental_createPersister
+title: experimental_createQueryPersister
 ---
 
 ## Installation
@@ -33,8 +33,8 @@ bun add @tanstack/query-persist-client-core
 
 ## Usage
 
-- Import the `experimental_createPersister` function
-- Create a new `experimental_createPersister`
+- Import the `experimental_createQueryPersister` function
+- Create a new `experimental_createQueryPersister`
   - you can pass any `storage` to it that adheres to the `AsyncStorage` or `Storage` interface - the example below uses the async-storage from React Native.
 - Pass that `persister` as an option to your Query. This can be done either by passing it to the `defaultOptions` of the `QueryClient` or to any `useQuery` hook instance.
   - If you pass this `persister` as `defaultOptions`, all queries will be persisted to the provided `storage`. You can additionally narrow this down by passing `filters`. In contrast to the `persistClient` plugin, this will not persist the whole query client as a single item, but each query separately. As a key, the query hash is used.
@@ -48,16 +48,18 @@ Garbage collecting a Query from memory **does not** affect the persisted data. T
 ```tsx
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { QueryClient } from '@tanstack/react-query'
-import { experimental_createPersister } from '@tanstack/query-persist-client-core'
+import { experimental_createQueryPersister } from '@tanstack/query-persist-client-core'
+
+const persister = experimental_createQueryPersister({
+  storage: AsyncStorage,
+  maxAge: 1000 * 60 * 60 * 12, // 12 hours
+})
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       gcTime: 1000 * 30, // 30 seconds
-      persister: experimental_createPersister({
-        storage: AsyncStorage,
-        maxAge: 1000 * 60 * 60 * 12, // 12 hours
-      }),
+      persister: persister.persisterFn,
     },
   },
 })
@@ -69,10 +71,10 @@ The `createPersister` plugin technically wraps the `queryFn`, so it doesn't rest
 
 ## API
 
-### `experimental_createPersister`
+### `experimental_createQueryPersister`
 
 ```tsx
-experimental_createPersister(options: StoragePersisterOptions)
+experimental_createQueryPersister(options: StoragePersisterOptions)
 ```
 
 #### `Options`

--- a/docs/framework/react/plugins/createPersister.md
+++ b/docs/framework/react/plugins/createPersister.md
@@ -35,7 +35,7 @@ bun add @tanstack/query-persist-client-core
 
 - Import the `experimental_createQueryPersister` function
 - Create a new `experimental_createQueryPersister`
-  - you can pass any `storage` to it that adheres to the `AsyncStorage` or `Storage` interface - the example below uses the async-storage from React Native.
+  - you can pass any `storage` to it that adheres to the `AsyncStorage` interface - the example below uses the async-storage from React Native.
 - Pass that `persister` as an option to your Query. This can be done either by passing it to the `defaultOptions` of the `QueryClient` or to any `useQuery` hook instance.
   - If you pass this `persister` as `defaultOptions`, all queries will be persisted to the provided `storage`. You can additionally narrow this down by passing `filters`. In contrast to the `persistClient` plugin, this will not persist the whole query client as a single item, but each query separately. As a key, the query hash is used.
   - If you provide this `persister` to a single `useQuery` hook, only this Query will be persisted.
@@ -68,6 +68,56 @@ const queryClient = new QueryClient({
 ### Adapted defaults
 
 The `createPersister` plugin technically wraps the `queryFn`, so it doesn't restore if the `queryFn` doesn't run. In that way, it acts as a caching layer between the Query and the network. Thus, the `networkMode` defaults to `'offlineFirst'` when a persister is used, so that restoring from the persistent storage can also happen even if there is no network connection.
+
+## Additional utilities
+
+Invoking `experimental_createQueryPersister` returns additional utilities in addition to `persisterFn` for easier implementation of userland functionalities.
+
+### `persistQueryByKey(queryKey: QueryKey, queryClient: QueryClient): Promise<void>`
+
+This function will persist `Query` to storage and key defined when creating persister.  
+This utility might be used along `setQueryData` to persist optimistic update to storage without waiting for invalidation.
+
+```tsx
+const persister = experimental_createQueryPersister({
+  storage: AsyncStorage,
+  maxAge: 1000 * 60 * 60 * 12, // 12 hours
+})
+
+const queryClient = useQueryClient()
+
+useMutation({
+  mutationFn: updateTodo,
+  onMutate: async (newTodo) => {
+    ...
+    // Optimistically update to the new value
+    queryClient.setQueryData(['todos'], (old) => [...old, newTodo])
+    // And persist it to storage
+    persister.persistQueryByKey(['todos'], queryClient)
+    ...
+  },
+})
+```
+
+### `retrieveQuery<T>(queryHash: string): Promise<T | undefined>`
+
+This function would attempt to retrieve persisted query by `queryHash`.  
+If `query` is `expired`, `busted` or `malformed` it would be removed from the storage instead, and `undefined` would be returned.
+
+### `persisterGc(): Promise<void>`
+
+This function can be used to sporadically clean up stoage from `expired`, `busted` or `malformed` entries.
+
+For this function to work, your storage must expose `entries` method that would return a `key-value tuple array`.  
+For example `Object.entries(localStorage)` for `localStorage` or `entries` from `idb-keyval`.
+
+### `persisterRestoreAll(queryClient: QueryClient): Promise<void>`
+
+This function can be used to restore all queries that are currently stored by persister in one go.  
+For example when your app is starting up in offline mode, or you want data from previous session to be immediately available without intermediate `loading` state.
+
+For this function to work, your storage must expose `entries` method that would return a `key-value tuple array`.  
+For example `Object.entries(localStorage)` for `localStorage` or `entries` from `idb-keyval`.
 
 ## API
 
@@ -118,10 +168,11 @@ export interface StoragePersisterOptions {
   filters?: QueryFilters
 }
 
-interface AsyncStorage {
-  getItem: (key: string) => Promise<string | undefined | null>
-  setItem: (key: string, value: string) => Promise<unknown>
-  removeItem: (key: string) => Promise<void>
+interface AsyncStorage<TStorageValue = string> {
+  getItem: (key: string) => MaybePromise<TStorageValue | undefined | null>
+  setItem: (key: string, value: TStorageValue) => MaybePromise<unknown>
+  removeItem: (key: string) => MaybePromise<void>
+  entries?: () => MaybePromise<Array<[key: string, value: TStorageValue]>>
 }
 ```
 

--- a/docs/framework/vue/plugins/createPersister.md
+++ b/docs/framework/vue/plugins/createPersister.md
@@ -1,6 +1,6 @@
 ---
 id: createPersister
-title: experimental_createPersister
+title: experimental_createQueryPersister
 ---
 
 ## Installation
@@ -31,8 +31,8 @@ bun add @tanstack/query-persist-client-core
 
 ## Usage
 
-- Import the `experimental_createPersister` function
-- Create a new `experimental_createPersister`
+- Import the `experimental_createQueryPersister` function
+- Create a new `experimental_createQueryPersister`
   - you can pass any `storage` to it that adheres to the `AsyncStorage` or `Storage` interface
 - Pass that `persister` as an option to your Query. This can be done either by passing it to the `defaultOptions` of the `QueryClient` or to any `useQuery` hook instance.
   - If you pass this `persister` as `defaultOptions`, all queries will be persisted to the provided `storage`. You can additionally narrow this down by passing `filters`. In contrast to the `persistClient` plugin, this will not persist the whole query client as a single item, but each query separately. As a key, the query hash is used.
@@ -44,16 +44,18 @@ Garbage collecting a Query from memory **does not** affect the persisted data. T
 
 ```tsx
 import { QueryClient } from '@tanstack/vue-query'
-import { experimental_createPersister } from '@tanstack/query-persist-client-core'
+import { experimental_createQueryPersister } from '@tanstack/query-persist-client-core'
+
+const persister = experimental_createQueryPersister({
+  storage: AsyncStorage,
+  maxAge: 1000 * 60 * 60 * 12, // 12 hours
+})
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       gcTime: 1000 * 30, // 30 seconds
-      persister: experimental_createPersister({
-        storage: localStorage,
-        maxAge: 1000 * 60 * 60 * 12, // 12 hours
-      }),
+      persister: persister.persisterFn,
     },
   },
 })
@@ -65,10 +67,10 @@ The `createPersister` plugin technically wraps the `queryFn`, so it doesn't rest
 
 ## API
 
-### `experimental_createPersister`
+### `experimental_createQueryPersister`
 
 ```tsx
-experimental_createPersister(options: StoragePersisterOptions)
+experimental_createQueryPersister(options: StoragePersisterOptions)
 ```
 
 #### `Options`

--- a/examples/vue/persister/src/Post.vue
+++ b/examples/vue/persister/src/Post.vue
@@ -29,7 +29,7 @@ export default defineComponent({
           getItem: (key: string) => get(key),
           setItem: (key: string, value: string) => set(key, value),
           removeItem: (key: string) => del(key),
-          entries: () => entries<string>()
+          entries: () => entries<string>(),
         },
       }).persisterFn,
     })

--- a/examples/vue/persister/src/Post.vue
+++ b/examples/vue/persister/src/Post.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { get, set, del } from 'idb-keyval'
+import { get, set, del, entries } from 'idb-keyval'
 import { defineComponent } from 'vue'
 import { useQuery } from '@tanstack/vue-query'
 
@@ -29,6 +29,7 @@ export default defineComponent({
           getItem: (key: string) => get(key),
           setItem: (key: string, value: string) => set(key, value),
           removeItem: (key: string) => del(key),
+          entries: () => entries<string>()
         },
       }).persisterFn,
     })

--- a/examples/vue/persister/src/Post.vue
+++ b/examples/vue/persister/src/Post.vue
@@ -4,7 +4,7 @@ import { defineComponent } from 'vue'
 import { useQuery } from '@tanstack/vue-query'
 
 import { Post } from './types'
-import { experimental_createPersister } from '@tanstack/query-persist-client-core'
+import { experimental_createQueryPersister } from '@tanstack/query-persist-client-core'
 
 const fetcher = async (id: number): Promise<Post> =>
   await fetch(`https://jsonplaceholder.typicode.com/posts/${id}`).then(
@@ -24,13 +24,13 @@ export default defineComponent({
     const { isPending, isError, isFetching, data, error } = useQuery({
       queryKey: ['post', props.postId] as const,
       queryFn: () => fetcher(props.postId),
-      persister: experimental_createPersister({
+      persister: experimental_createQueryPersister({
         storage: {
           getItem: (key: string) => get(key),
           setItem: (key: string, value: string) => set(key, value),
           removeItem: (key: string) => del(key),
         },
-      }),
+      }).persisterFn,
     })
 
     return { isPending, isError, isFetching, data, error }

--- a/examples/vue/persister/src/Posts.vue
+++ b/examples/vue/persister/src/Posts.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { useQuery } from '@tanstack/vue-query'
-import { experimental_createPersister } from '@tanstack/query-persist-client-core'
+import { experimental_createQueryPersister } from '@tanstack/query-persist-client-core'
 
 import { Post } from './types'
 
@@ -34,9 +34,9 @@ export default defineComponent({
     } = useQuery({
       queryKey: ['posts'] as const,
       queryFn: () => fetcher(),
-      persister: experimental_createPersister({
+      persister: experimental_createQueryPersister({
         storage: localStorage,
-      }),
+      }).persisterFn,
       staleTime: 5000,
     })
 

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { Query, QueryClient, hashKey } from '@tanstack/query-core'
 import {
   PERSISTER_KEY_PREFIX,
-  experimental_createPersister,
+  experimental_createQueryPersister,
 } from '../createPersister'
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
 import type { StoragePersisterOptions } from '../createPersister'
@@ -39,7 +39,7 @@ function setupPersister(
 
   const queryFn = vi.fn()
 
-  const persisterFn = experimental_createPersister(persisterOptions)
+  const { persisterFn } = experimental_createQueryPersister(persisterOptions)
 
   const query = new Query({
     client,
@@ -213,7 +213,7 @@ describe('createPersister', () => {
       storageKey,
       JSON.stringify({
         buster: '',
-        state: { dataUpdatedAt },
+        state: { dataUpdatedAt, data: '' },
       }),
     )
 
@@ -242,7 +242,7 @@ describe('createPersister', () => {
       storageKey,
       JSON.stringify({
         buster: '',
-        state: { dataUpdatedAt: Date.now() },
+        state: { dataUpdatedAt: Date.now(), data: '' },
       }),
     )
 
@@ -336,7 +336,7 @@ describe('createPersister', () => {
       storageKey,
       JSON.stringify({
         buster: '',
-        state: { dataUpdatedAt: Date.now() },
+        state: { dataUpdatedAt: Date.now(), data: '' },
       }),
     )
 

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -19,6 +19,9 @@ function getFreshStorage() {
       storage.delete(key)
       return Promise.resolve()
     },
+    entries: () => {
+      return Promise.resolve(Array.from(storage.entries()))
+    }
   }
 }
 
@@ -39,7 +42,7 @@ function setupPersister(
 
   const queryFn = vi.fn()
 
-  const { persisterFn } = experimental_createQueryPersister(persisterOptions)
+  const persister = experimental_createQueryPersister(persisterOptions)
 
   const query = new Query({
     client,
@@ -48,8 +51,9 @@ function setupPersister(
   })
 
   return {
+    client,
     context,
-    persisterFn,
+    persister,
     query,
     queryFn,
     queryHash,
@@ -68,11 +72,11 @@ describe('createPersister', () => {
   })
 
   test('should fetch if storage is not provided', async () => {
-    const { context, persisterFn, query, queryFn } = setupPersister(['foo'], {
+    const { context, persister, query, queryFn } = setupPersister(['foo'], {
       storage: undefined,
     })
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
 
     expect(queryFn).toHaveBeenCalledOnce()
     expect(queryFn).toHaveBeenCalledWith(context)
@@ -80,11 +84,11 @@ describe('createPersister', () => {
 
   test('should fetch if there is no stored data', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn } = setupPersister(['foo'], {
+    const { context, persister, query, queryFn } = setupPersister(['foo'], {
       storage,
     })
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
 
     expect(queryFn).toHaveBeenCalledOnce()
     expect(queryFn).toHaveBeenCalledWith(context)
@@ -92,12 +96,12 @@ describe('createPersister', () => {
 
   test('should fetch if query already has data', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn } = setupPersister(['foo'], {
+    const { context, persister, query, queryFn } = setupPersister(['foo'], {
       storage,
     })
     query.state.data = 'baz'
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
 
     expect(queryFn).toHaveBeenCalledOnce()
     expect(queryFn).toHaveBeenCalledWith(context)
@@ -105,7 +109,7 @@ describe('createPersister', () => {
 
   test('should fetch if deserialization fails', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -114,7 +118,7 @@ describe('createPersister', () => {
 
     await storage.setItem(storageKey, '{invalid[item')
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
 
     expect(await storage.getItem(storageKey)).toBeUndefined()
 
@@ -124,7 +128,7 @@ describe('createPersister', () => {
 
   test('should remove stored item if `dataUpdatedAt` is empty', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -139,7 +143,7 @@ describe('createPersister', () => {
       }),
     )
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
 
     expect(await storage.getItem(storageKey)).toBeUndefined()
 
@@ -149,7 +153,7 @@ describe('createPersister', () => {
 
   test('should remove stored item if its expired', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -165,7 +169,7 @@ describe('createPersister', () => {
       }),
     )
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
 
     expect(await storage.getItem(storageKey)).toBeUndefined()
 
@@ -175,7 +179,7 @@ describe('createPersister', () => {
 
   test('should remove stored item if its busted', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -190,7 +194,7 @@ describe('createPersister', () => {
       }),
     )
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
 
     expect(await storage.getItem(storageKey)).toBeUndefined()
 
@@ -200,7 +204,7 @@ describe('createPersister', () => {
 
   test('should restore item from the storage and set proper `updatedAt` values', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -217,7 +221,7 @@ describe('createPersister', () => {
       }),
     )
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
     query.state.data = 'data0'
     query.fetch = vi.fn()
     expect(query.state.dataUpdatedAt).toEqual(0)
@@ -231,7 +235,7 @@ describe('createPersister', () => {
 
   test('should restore item from the storage and refetch when `stale`', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -246,7 +250,7 @@ describe('createPersister', () => {
       }),
     )
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
     query.state.isInvalidated = true
     query.fetch = vi.fn()
 
@@ -260,7 +264,7 @@ describe('createPersister', () => {
     const storage = getFreshStorage()
     const {
       context,
-      persisterFn,
+      persister,
       query,
       queryFn,
       queryHash,
@@ -270,7 +274,7 @@ describe('createPersister', () => {
       storage,
     })
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
     query.setData('baz')
 
     await vi.advanceTimersByTimeAsync(0)
@@ -290,7 +294,7 @@ describe('createPersister', () => {
 
   test('should skip stored item if not matched by filters', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -312,7 +316,7 @@ describe('createPersister', () => {
       }),
     )
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
     query.fetch = vi.fn()
 
     await vi.advanceTimersByTimeAsync(0)
@@ -323,7 +327,7 @@ describe('createPersister', () => {
 
   test('should restore item from the storage with async deserializer', async () => {
     const storage = getFreshStorage()
-    const { context, persisterFn, query, queryFn, storageKey } = setupPersister(
+    const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
       {
         storage,
@@ -340,7 +344,7 @@ describe('createPersister', () => {
       }),
     )
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
     query.state.isInvalidated = true
     query.fetch = vi.fn()
 
@@ -354,7 +358,7 @@ describe('createPersister', () => {
     const storage = getFreshStorage()
     const {
       context,
-      persisterFn,
+      persister,
       query,
       queryFn,
       queryHash,
@@ -366,7 +370,7 @@ describe('createPersister', () => {
         new Promise((resolve) => resolve(JSON.stringify(persistedQuery))),
     })
 
-    await persisterFn(queryFn, context, query)
+    await persister.persisterFn(queryFn, context, query)
     query.setData('baz')
 
     await vi.advanceTimersByTimeAsync(0)
@@ -381,6 +385,190 @@ describe('createPersister', () => {
       state: {
         data: 'baz',
       },
+    })
+  })
+
+  describe("persistQuery", () => {
+    test("Should properly persiste basic query", async () => {
+      const storage = getFreshStorage()
+      const {
+        persister,
+        query,
+        queryHash,
+        queryKey,
+        storageKey,
+      } = setupPersister(['foo'], {
+        storage,
+      })
+
+      query.setData('baz')
+      await persister.persistQuery(query)
+
+      expect(JSON.parse(await storage.getItem(storageKey))).toMatchObject({
+        buster: '',
+        queryHash,
+        queryKey,
+        state: {
+          "dataUpdateCount": 1,
+          data: "baz",
+          "status": "success",
+        },
+      })
+    })
+
+    test("Should skip persistance if storage is not provided", async () => {
+      const serializeMock = vi.fn()
+      const {
+        persister,
+        query,
+      } = setupPersister(['foo'], {
+        storage: null,
+        serialize: serializeMock
+      })
+
+      query.setData('baz')
+      await persister.persistQuery(query)
+
+      expect(serializeMock).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe("persistQueryByKey", () => {
+    test("Should skip persistance if storage is not provided", async () => {
+      const serializeMock = vi.fn()
+      const {
+        persister,
+        client,
+        queryKey,
+      } = setupPersister(['foo'], {
+        storage: null,
+        serialize: serializeMock
+      })
+
+      client.setQueryData(queryKey, "baz")
+      await persister.persistQueryByKey(queryKey, client)
+
+      expect(serializeMock).toHaveBeenCalledTimes(0)
+    })
+
+    test("should skip persistance if query was not found", async () => {
+      const serializeMock = vi.fn()
+      const storage = getFreshStorage()
+      const {
+        client,
+        persister,
+        queryKey,
+      } = setupPersister(['foo'], {
+        storage,
+        serialize: serializeMock
+      })
+
+      client.setQueryData(queryKey, "baz")
+      await persister.persistQueryByKey(['foo2'], client)
+
+      expect(serializeMock).toHaveBeenCalledTimes(0)
+    })
+
+    test("Should properly persiste basic query", async () => {
+      const storage = getFreshStorage()
+      const {
+        persister,
+        client,
+        queryHash,
+        queryKey,
+        storageKey,
+      } = setupPersister(['foo'], {
+        storage,
+      })
+
+      client.setQueryData(queryKey, "baz")
+      await persister.persistQueryByKey(queryKey, client)
+
+      expect(JSON.parse(await storage.getItem(storageKey))).toMatchObject({
+        buster: '',
+        queryHash,
+        queryKey,
+        state: {
+          "dataUpdateCount": 1,
+          data: "baz",
+          "status": "success",
+        },
+      })
+    })
+  })
+
+  describe("persisterGc", () => {
+    test("should properly clean storage from busted entries", async () => {
+      const storage = getFreshStorage()
+      const {
+        persister,
+        client,
+        query,
+        queryKey
+      } = setupPersister(['foo'], {
+        storage,
+      })
+      query.setState({
+        dataUpdatedAt: 1,
+        data: 'f'
+      })
+      client.getQueryCache().add(query)
+
+      await persister.persistQueryByKey(queryKey, client)
+
+      expect(await storage.entries()).toHaveLength(1)
+
+      await persister.persisterGc()
+      expect(await storage.entries()).toHaveLength(0)
+    })
+  })
+
+  describe("persisterRestoreAll", () => {
+    test("should properly clean storage from busted entries", async () => {
+      const storage = getFreshStorage()
+      const {
+        persister,
+        client,
+        query,
+        queryKey
+      } = setupPersister(['foo'], {
+        storage,
+      })
+      query.setState({
+        dataUpdatedAt: 1,
+        data: 'f'
+      })
+      client.getQueryCache().add(query)
+
+      await persister.persistQueryByKey(queryKey, client)
+
+      expect(await storage.entries()).toHaveLength(1)
+
+      await persister.persisterRestoreAll(client)
+      expect(await storage.entries()).toHaveLength(0)
+    })
+
+    test("should properly restore queries from cache", async () => {
+      const storage = getFreshStorage()
+      const {
+        persister,
+        client,
+        queryKey
+      } = setupPersister(['foo'], {
+        storage,
+      })
+      client.setQueryData(queryKey, "foo")
+
+      await persister.persistQueryByKey(queryKey, client)
+
+      expect(await storage.entries()).toHaveLength(1)
+      client.clear()
+      expect(client.getQueryCache().getAll()).toHaveLength(0)
+
+      await persister.persisterRestoreAll(client)
+      expect(client.getQueryCache().getAll()).toHaveLength(1)
+
+      expect(client.getQueryData(queryKey)).toEqual("foo")
     })
   })
 })

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -21,7 +21,7 @@ function getFreshStorage() {
     },
     entries: () => {
       return Promise.resolve(Array.from(storage.entries()))
-    }
+    },
   }
 }
 
@@ -388,18 +388,13 @@ describe('createPersister', () => {
     })
   })
 
-  describe("persistQuery", () => {
-    test("Should properly persiste basic query", async () => {
+  describe('persistQuery', () => {
+    test('Should properly persiste basic query', async () => {
       const storage = getFreshStorage()
-      const {
-        persister,
-        query,
-        queryHash,
-        queryKey,
-        storageKey,
-      } = setupPersister(['foo'], {
-        storage,
-      })
+      const { persister, query, queryHash, queryKey, storageKey } =
+        setupPersister(['foo'], {
+          storage,
+        })
 
       query.setData('baz')
       await persister.persistQuery(query)
@@ -409,21 +404,18 @@ describe('createPersister', () => {
         queryHash,
         queryKey,
         state: {
-          "dataUpdateCount": 1,
-          data: "baz",
-          "status": "success",
+          dataUpdateCount: 1,
+          data: 'baz',
+          status: 'success',
         },
       })
     })
 
-    test("Should skip persistance if storage is not provided", async () => {
+    test('Should skip persistance if storage is not provided', async () => {
       const serializeMock = vi.fn()
-      const {
-        persister,
-        query,
-      } = setupPersister(['foo'], {
+      const { persister, query } = setupPersister(['foo'], {
         storage: null,
-        serialize: serializeMock
+        serialize: serializeMock,
       })
 
       query.setData('baz')
@@ -433,55 +425,42 @@ describe('createPersister', () => {
     })
   })
 
-  describe("persistQueryByKey", () => {
-    test("Should skip persistance if storage is not provided", async () => {
+  describe('persistQueryByKey', () => {
+    test('Should skip persistance if storage is not provided', async () => {
       const serializeMock = vi.fn()
-      const {
-        persister,
-        client,
-        queryKey,
-      } = setupPersister(['foo'], {
+      const { persister, client, queryKey } = setupPersister(['foo'], {
         storage: null,
-        serialize: serializeMock
+        serialize: serializeMock,
       })
 
-      client.setQueryData(queryKey, "baz")
+      client.setQueryData(queryKey, 'baz')
       await persister.persistQueryByKey(queryKey, client)
 
       expect(serializeMock).toHaveBeenCalledTimes(0)
     })
 
-    test("should skip persistance if query was not found", async () => {
+    test('should skip persistance if query was not found', async () => {
       const serializeMock = vi.fn()
       const storage = getFreshStorage()
-      const {
-        client,
-        persister,
-        queryKey,
-      } = setupPersister(['foo'], {
+      const { client, persister, queryKey } = setupPersister(['foo'], {
         storage,
-        serialize: serializeMock
+        serialize: serializeMock,
       })
 
-      client.setQueryData(queryKey, "baz")
+      client.setQueryData(queryKey, 'baz')
       await persister.persistQueryByKey(['foo2'], client)
 
       expect(serializeMock).toHaveBeenCalledTimes(0)
     })
 
-    test("Should properly persiste basic query", async () => {
+    test('Should properly persiste basic query', async () => {
       const storage = getFreshStorage()
-      const {
-        persister,
-        client,
-        queryHash,
-        queryKey,
-        storageKey,
-      } = setupPersister(['foo'], {
-        storage,
-      })
+      const { persister, client, queryHash, queryKey, storageKey } =
+        setupPersister(['foo'], {
+          storage,
+        })
 
-      client.setQueryData(queryKey, "baz")
+      client.setQueryData(queryKey, 'baz')
       await persister.persistQueryByKey(queryKey, client)
 
       expect(JSON.parse(await storage.getItem(storageKey))).toMatchObject({
@@ -489,28 +468,23 @@ describe('createPersister', () => {
         queryHash,
         queryKey,
         state: {
-          "dataUpdateCount": 1,
-          data: "baz",
-          "status": "success",
+          dataUpdateCount: 1,
+          data: 'baz',
+          status: 'success',
         },
       })
     })
   })
 
-  describe("persisterGc", () => {
-    test("should properly clean storage from busted entries", async () => {
+  describe('persisterGc', () => {
+    test('should properly clean storage from busted entries', async () => {
       const storage = getFreshStorage()
-      const {
-        persister,
-        client,
-        query,
-        queryKey
-      } = setupPersister(['foo'], {
+      const { persister, client, query, queryKey } = setupPersister(['foo'], {
         storage,
       })
       query.setState({
         dataUpdatedAt: 1,
-        data: 'f'
+        data: 'f',
       })
       client.getQueryCache().add(query)
 
@@ -523,20 +497,15 @@ describe('createPersister', () => {
     })
   })
 
-  describe("persisterRestoreAll", () => {
-    test("should properly clean storage from busted entries", async () => {
+  describe('persisterRestoreAll', () => {
+    test('should properly clean storage from busted entries', async () => {
       const storage = getFreshStorage()
-      const {
-        persister,
-        client,
-        query,
-        queryKey
-      } = setupPersister(['foo'], {
+      const { persister, client, query, queryKey } = setupPersister(['foo'], {
         storage,
       })
       query.setState({
         dataUpdatedAt: 1,
-        data: 'f'
+        data: 'f',
       })
       client.getQueryCache().add(query)
 
@@ -548,16 +517,12 @@ describe('createPersister', () => {
       expect(await storage.entries()).toHaveLength(0)
     })
 
-    test("should properly restore queries from cache", async () => {
+    test('should properly restore queries from cache', async () => {
       const storage = getFreshStorage()
-      const {
-        persister,
-        client,
-        queryKey
-      } = setupPersister(['foo'], {
+      const { persister, client, queryKey } = setupPersister(['foo'], {
         storage,
       })
-      client.setQueryData(queryKey, "foo")
+      client.setQueryData(queryKey, 'foo')
 
       await persister.persistQueryByKey(queryKey, client)
 
@@ -568,7 +533,7 @@ describe('createPersister', () => {
       await persister.persisterRestoreAll(client)
       expect(client.getQueryCache().getAll()).toHaveLength(1)
 
-      expect(client.getQueryData(queryKey)).toEqual("foo")
+      expect(client.getQueryData(queryKey)).toEqual('foo')
     })
   })
 })

--- a/packages/query-persist-client-core/src/createPersister.ts
+++ b/packages/query-persist-client-core/src/createPersister.ts
@@ -145,7 +145,10 @@ export function experimental_createQueryPersister<TStorageValue = string>({
     return
   }
 
-  async function persistQueryByKey(queryKey: QueryKey, queryClient: QueryClient) {
+  async function persistQueryByKey(
+    queryKey: QueryKey,
+    queryClient: QueryClient,
+  ) {
     if (storage != null) {
       const query = queryClient.getQueryCache().find({ queryKey })
       if (query) {
@@ -154,7 +157,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
         if (process.env.NODE_ENV === 'development') {
           console.warn(
             'Could not find query to be persisted. QueryKey:',
-            JSON.stringify(queryKey)
+            JSON.stringify(queryKey),
           )
         }
       }

--- a/packages/query-persist-client-core/src/createPersister.ts
+++ b/packages/query-persist-client-core/src/createPersister.ts
@@ -152,7 +152,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
     if (storage != null) {
       const query = queryClient.getQueryCache().find({ queryKey })
       if (query) {
-        persistQuery(query)
+        await persistQuery(query)
       } else {
         if (process.env.NODE_ENV === 'development') {
           console.warn(

--- a/packages/query-persist-client-core/src/createPersister.ts
+++ b/packages/query-persist-client-core/src/createPersister.ts
@@ -145,6 +145,22 @@ export function experimental_createQueryPersister<TStorageValue = string>({
     return
   }
 
+  async function persistQueryByKey(queryKey: QueryKey, queryClient: QueryClient) {
+    if (storage != null) {
+      const query = queryClient.getQueryCache().find({ queryKey })
+      if (query) {
+        persistQuery(query)
+      } else {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn(
+            'Could not find query to be persisted. QueryKey:',
+            JSON.stringify(queryKey)
+          )
+        }
+      }
+    }
+  }
+
   async function persistQuery(query: Query) {
     if (storage != null) {
       const storageKey = `${prefix}-${query.queryHash}`
@@ -251,6 +267,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
   return {
     persisterFn,
     persistQuery,
+    persistQueryByKey,
     retrieveQuery,
     persisterGc,
     persisterRestoreAll,

--- a/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
+++ b/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
 import {
   PERSISTER_KEY_PREFIX,
-  experimental_createPersister,
+  experimental_createQueryPersister,
 } from '@tanstack/query-persist-client-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryCache, QueryClient, hashKey, useQuery } from '..'
@@ -57,9 +57,9 @@ describe('fine grained persister', () => {
       const { data } = useQuery({
         queryKey: key,
         queryFn: spy,
-        persister: experimental_createPersister({
+        persister: experimental_createQueryPersister({
           storage,
-        }),
+        }).persisterFn,
         staleTime: 5000,
       })
 
@@ -113,9 +113,9 @@ describe('fine grained persister', () => {
       const { data } = useQuery({
         queryKey: key,
         queryFn: spy,
-        persister: experimental_createPersister({
+        persister: experimental_createQueryPersister({
           storage,
-        }),
+        }).persisterFn,
       })
 
       return <div ref={(value) => setRef(value)}>{data}</div>
@@ -152,9 +152,9 @@ describe('fine grained persister', () => {
       const { data } = useQuery({
         queryKey: key,
         queryFn: spy,
-        persister: experimental_createPersister({
+        persister: experimental_createQueryPersister({
           storage,
-        }),
+        }).persisterFn,
       })
 
       return <div ref={(value) => setRef(value)}>{data}</div>


### PR DESCRIPTION
Restructure plugin to expose more utilities useful in user-land.

Returned utilities:
- persisterFn - main persister function that can be passed to `useQuery`
- persistQueryByKey - persist query to persister storage. Ex call it just after `setQueryData`
- retrieveQuery - retrieve one query from persister storage
- persisterGc - gc pass for the persister storage to clean up unusable entries
- persisterRestoreAll - restore are persisted queries from storage

TODO:
- [x] tests