### PR TITLE
Don't use $ prefix in Bash examples

### DIFF
--- a/docs/eslint/eslint-plugin-query.md
+++ b/docs/eslint/eslint-plugin-query.md
@@ -10,25 +10,25 @@ TanStack Query comes with its own ESLint plugin. This plugin is used to enforce 
 The plugin is a separate package that you need to install:
 
 ```bash
-$ npm i -D @tanstack/eslint-plugin-query
+npm i -D @tanstack/eslint-plugin-query
 ```
 
 or
 
 ```bash
-$ pnpm add -D @tanstack/eslint-plugin-query
+pnpm add -D @tanstack/eslint-plugin-query
 ```
 
 or
 
 ```bash
-$ yarn add -D @tanstack/eslint-plugin-query
+yarn add -D @tanstack/eslint-plugin-query
 ```
 
 or
 
 ```bash
-$ bun add -D @tanstack/eslint-plugin-query
+bun add -D @tanstack/eslint-plugin-query
 ```
 
 ## Flat Config (`eslint.config.js`)


### PR DESCRIPTION
On https://tanstack.com/query/latest/docs/framework/react/installation for example, the Bash snippets do *not* have a leading `$` character. So you can click the clipboard and then paste these into your terminal.  Doesn't work if there's a `$ ` prefix on the bash command.