### PR TITLE
docs(react-query): fix queryClient description of useMutation and use…

### DIFF
--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -20,21 +20,24 @@ const {
   status,
   submittedAt,
   variables,
-} = useMutation({
-  mutationFn,
-  gcTime,
-  meta,
-  mutationKey,
-  networkMode,
-  onError,
-  onMutate,
-  onSettled,
-  onSuccess,
-  retry,
-  retryDelay,
-  scope,
-  throwOnError,
-})
+} = useMutation(
+  {
+    mutationFn,
+    gcTime,
+    meta,
+    mutationKey,  
+    networkMode,
+    onError,
+    onMutate,
+    onSettled,
+    onSuccess,
+    retry,
+    retryDelay,
+    scope,
+    throwOnError,
+  }, 
+  queryClient,
+)
 
 mutate(variables, {
   onError,
@@ -43,7 +46,7 @@ mutate(variables, {
 })
 ```
 
-**Options**
+**Parameter1 (Options)**
 
 - `mutationFn: (variables: TVariables) => Promise<TData>`
   - **Required, but only if no default mutation function has been defined**
@@ -98,6 +101,9 @@ mutate(variables, {
 - `meta: Record<string, unknown>`
   - Optional
   - If set, stores additional information on the mutation cache entry that can be used as needed. It will be accessible wherever the `mutation` is available (eg. `onError`, `onSuccess` functions of the `MutationCache`).
+
+**Parameter2 (QueryClient)**
+
 - `queryClient?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 

--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -25,7 +25,7 @@ const {
     mutationFn,
     gcTime,
     meta,
-    mutationKey,  
+    mutationKey,
     networkMode,
     onError,
     onMutate,
@@ -35,7 +35,7 @@ const {
     retryDelay,
     scope,
     throwOnError,
-  }, 
+  },
   queryClient,
 )
 

--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -58,7 +58,7 @@ const {
 )
 ```
 
-**Options**
+**Parameter1 (Options)**
 
 - `queryKey: unknown[]`
   - **Required**
@@ -168,6 +168,9 @@ const {
 - `meta: Record<string, unknown>`
   - Optional
   - If set, stores additional information on the query cache entry that can be used as needed. It will be accessible wherever the `query` is available, and is also part of the `QueryFunctionContext` provided to the `queryFn`.
+
+**Parameter2 (QueryClient)**
+
 - `queryClient?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 


### PR DESCRIPTION
`queryClient` object could be passed into second parameter of `useQuery` and `useMutation`.
But, current description explains it could be passed with `options` parameter so it should be fixed.

(Related to #7946)