### PR TITLE
fix(eslint-plugin-query): correctly handle call-expression spread

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/infinite-query-property-order.rule.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/infinite-query-property-order.rule.test.ts
@@ -13,13 +13,18 @@ import {
   generateInterleavedCombinations,
   generatePartialCombinations,
   generatePermutations,
+  normalizeIndent,
 } from './test-utils'
 import type { InfiniteQueryFunctions } from '../rules/infinite-query-property-order/constants'
 
 const ruleTester = new RuleTester()
 
 type CheckedProperties = (typeof checkedProperties)[number]
-const orderIndependentProps = ['queryKey', '...foo'] as const
+const orderIndependentProps = [
+  'queryKey',
+  '...objectExpressionSpread',
+  '...callExpressionSpread',
+] as const
 type OrderIndependentProps = (typeof orderIndependentProps)[number]
 
 interface TestCase {
@@ -84,7 +89,7 @@ export function generateInvalidPermutations(
             Math.abs(
               invalid.indexOf('getNextPageParam') -
                 invalid.indexOf('getPreviousPageParam'),
-            ) !== 1 && !invalid.includes('queryFn'),
+            ) !== 1,
         ),
     )
   }
@@ -122,6 +127,14 @@ const invalidTestMatrix = combinate({
   properties: interleavedInvalidPermutations,
 })
 
+const callExpressionSpread = normalizeIndent`
+        ...communitiesQuery({
+          filters: {
+            ...fieldValues,
+            placementFormats: [],
+          },
+        })`
+
 function getCode({
   infiniteQueryFunction: infiniteQueryFunction,
   properties,
@@ -129,10 +142,11 @@ function getCode({
   function getPropertyCode(
     property: CheckedProperties | OrderIndependentProps,
   ) {
-    if (property.startsWith('...')) {
-      return property
-    }
     switch (property) {
+      case '...objectExpressionSpread':
+        return `...objectExpressionSpread`
+      case '...callExpressionSpread':
+        return callExpressionSpread
       case 'queryKey':
         return `queryKey: ['projects']`
       case 'queryFn':
@@ -142,8 +156,6 @@ function getCode({
       case 'getNextPageParam':
         return 'getNextPageParam: (lastPage) => lastPage.nextId ?? undefined'
     }
-
-    return `${property}: () => null`
   }
   return `
     import { ${infiniteQueryFunction} } from '@tanstack/react-query'
@@ -180,3 +192,28 @@ ruleTester.run(name, rule, {
   valid: validTestCases,
   invalid: invalidTestCases,
 })
+
+// regression tests
+
+const regressionTestCases = {
+  valid: [
+    {
+      name: 'should pass with call expression spread',
+      code: normalizeIndent`
+      import { useInfiniteQuery } from '@tanstack/react-query'
+      const { data, isFetching, isLoading, hasNextPage, fetchNextPage } =
+      useInfiniteQuery({
+        ...communitiesQuery({
+          filters: {
+            ...fieldValues,
+            placementFormats: [],
+          },
+        }),
+        refetchOnMount: false,
+      })`,
+    },
+  ],
+  invalid: [],
+}
+
+ruleTester.run(name, rule, regressionTestCases)

--- a/packages/eslint-plugin-query/src/rules/infinite-query-property-order/infinite-query-property-order.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/infinite-query-property-order/infinite-query-property-order.rule.ts
@@ -65,9 +65,12 @@ export const rule = createRule({
           } else if (p.type === AST_NODE_TYPES.SpreadElement) {
             if (p.argument.type === AST_NODE_TYPES.Identifier) {
               return { name: p.argument.name, property: p }
-            } else {
-              throw new Error('Unsupported spread element')
+            } else if (p.argument.type === AST_NODE_TYPES.CallExpression) {
+              if (p.argument.callee.type === AST_NODE_TYPES.Identifier) {
+                return { name: p.argument.callee.name, property: p }
+              }
             }
+            throw new Error('Unsupported spread element')
           }
           return []
         })


### PR DESCRIPTION
this fixes the issue reported here: https://github.com/TanStack/query/pull/8074#issuecomment-2367340252