### PR TITLE
fix(eslint-plugin): fix legacy recommended config

### DIFF
--- a/docs/eslint/eslint-plugin-query.md
+++ b/docs/eslint/eslint-plugin-query.md
@@ -70,17 +70,17 @@ export default [
 
 ### Recommended setup
 
-To enable all of the recommended rules for our plugin, add `plugin:@tanstack/eslint-plugin-query/recommended` in extends:
+To enable all of the recommended rules for our plugin, add `plugin:@tanstack/query/recommended` in extends:
 
 ```json
 {
-  "extends": ["plugin:@tanstack/eslint-plugin-query/recommended"]
+  "extends": ["plugin:@tanstack/query/recommended"]
 }
 ```
 
 ### Custom setup
 
-Alternatively, add `@tanstack/eslint-plugin-query` to the plugins section, and configure the rules you want to use:
+Alternatively, add `@tanstack/query` to the plugins section, and configure the rules you want to use:
 
 ```json
 {

--- a/examples/react/algolia/.eslintrc
+++ b/examples/react/algolia/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "extends": [
-    "plugin:react/jsx-runtime",
-    "plugin:react-hooks/recommended",
-    "plugin:@tanstack/eslint-plugin-query/recommended"
-  ]
-}

--- a/examples/react/algolia/eslint.config.js
+++ b/examples/react/algolia/eslint.config.js
@@ -1,0 +1,19 @@
+import { tanstackConfig } from '@tanstack/config/eslint'
+import pluginQuery from '@tanstack/eslint-plugin-query'
+import pluginReact from '@eslint-react/eslint-plugin'
+import pluginReactHooks from 'eslint-plugin-react-hooks'
+
+export default [
+  ...tanstackConfig,
+  ...pluginQuery.configs['flat/recommended'],
+  pluginReact.configs.recommended,
+  {
+    plugins: {
+      'react-hooks': pluginReactHooks,
+    },
+    rules: {
+      'react-hooks/exhaustive-deps': 'error',
+      'react-hooks/rules-of-hooks': 'error',
+    },
+  },
+]

--- a/packages/eslint-plugin-query/src/index.ts
+++ b/packages/eslint-plugin-query/src/index.ts
@@ -23,7 +23,7 @@ const plugin: Plugin = {
 // Assign configs here so we can reference `plugin`
 Object.assign(plugin.configs, {
   recommended: {
-    plugins: ['@tanstack/eslint-plugin-query'],
+    plugins: ['@tanstack/query'],
     rules: {
       '@tanstack/query/exhaustive-deps': 'error',
       '@tanstack/query/no-rest-destructuring': 'warn',


### PR DESCRIPTION
Reference: https://eslint.org/docs/latest/use/configure/configuration-files-deprecated#using-a-configuration-from-a-plugin

The current config does work, but this is more consistent with the setup used by other eslint plugins