### PR TITLE
docs(react-query): Fix broken route on eslint-plugin-query.md

### DIFF
--- a/docs/eslint/eslint-plugin-query.md
+++ b/docs/eslint/eslint-plugin-query.md
@@ -96,4 +96,4 @@ Alternatively, add `@tanstack/query` to the plugins section, and configure the r
 - [@tanstack/query/exhaustive-deps](../exhaustive-deps)
 - [@tanstack/query/no-rest-destructuring](../no-rest-destructuring)
 - [@tanstack/query/stable-query-client](../stable-query-client)
-- [@tanstack/query/no-unstable-deps](../no-unstable-deps.md)
+- [@tanstack/query/no-unstable-deps](../no-unstable-deps)


### PR DESCRIPTION
Hi, I was reading docs and noticed that `@tanstack/query/no-unstable-deps` route was broken on ESLint Plugin Query page.

This PR fixes that broken route.