### PR TITLE
fix(useInfiniteQuery): prevent error when pages is undefined

### DIFF
--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -132,14 +132,13 @@ function getNextPageParam(
   options: InfiniteQueryPageParamsOptions<any>,
   { pages, pageParams }: InfiniteData<unknown>,
 ): unknown | undefined {
-  if (!pages || pages.length === 0 || !pageParams || pageParams.length === 0) {
-    return undefined;
+  if (!pages?.length || !pageParams?.length) {
+    return undefined
   }
-
   const lastIndex = pages.length - 1
 
   if (lastIndex >= pageParams.length) {
-    return undefined;
+    return undefined
   }
 
   return pages.length > 0

--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -132,7 +132,16 @@ function getNextPageParam(
   options: InfiniteQueryPageParamsOptions<any>,
   { pages, pageParams }: InfiniteData<unknown>,
 ): unknown | undefined {
+  if (!pages || pages.length === 0 || !pageParams || pageParams.length === 0) {
+    return undefined;
+  }
+
   const lastIndex = pages.length - 1
+
+  if (lastIndex >= pageParams.length) {
+    return undefined;
+  }
+
   return pages.length > 0
     ? options.getNextPageParam(
         pages[lastIndex],


### PR DESCRIPTION
This address a very rare bug that happened few times to my users with useInfiniteQuery, where the pages was undefined in getNextPageParam function
should not break anything
![image](https://github.com/user-attachments/assets/039f5610-0d5e-4f9c-a1ea-8f071a09840d)
