### PR TITLE
fix(eslint-plugin-query): change naming for `text` variables

### DIFF
--- a/packages/eslint-plugin-query/src/rules/infinite-query-property-order/infinite-query-property-order.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/infinite-query-property-order/infinite-query-property-order.rule.ts
@@ -86,11 +86,11 @@ export const rule = createRule({
           fix(fixer) {
             const sourceCode = context.sourceCode
 
-            const text = sortedProperties.reduce(
+            const reorderedText = sortedProperties.reduce(
               (sourceText, specifier, index) => {
-                let text = ''
+                let textBetweenProperties = ''
                 if (index < allProperties.length - 1) {
-                  text = sourceCode
+                  textBetweenProperties = sourceCode
                     .getText()
                     .slice(
                       allProperties[index]!.range[1],
@@ -98,14 +98,16 @@ export const rule = createRule({
                     )
                 }
                 return (
-                  sourceText + sourceCode.getText(specifier.property) + text
+                  sourceText +
+                  sourceCode.getText(specifier.property) +
+                  textBetweenProperties
                 )
               },
               '',
             )
             return fixer.replaceTextRange(
               [allProperties[0]!.range[0], allProperties.at(-1)!.range[1]],
-              text,
+              reorderedText,
             )
           },
         })


### PR DESCRIPTION
Currently, we have a linter warning for having the same name "`text`" for inner and outer scope:
<img width="682" alt="Captura de pantalla 2024-10-06 a las 6 04 46 p  m" src="https://github.com/user-attachments/assets/73c10ab8-f59d-44c2-8935-0c9133852e5a">

This PR fixes this warning by refactoring their naming. I chose these names for the following reasons:
- `reorderedText`: it holds the final source code after the properties are reordered
- `textBetweenProperties`: it holds the characters between the properties. For example, 
   - ```
       const query = useInfiniteQuery({
          queryKey: 'todos',   // Property 1
          queryFn: fetchTodos, // Property 2
       })
      ```
      Between `queryKey: 'todos'`, and `queryFn: fetchTodos`, there is a **comma, space, and comment**.