### PR TITLE
fix(eslint-plugin-query): `expect-expect` warning for `expectArrayEqualIgnoreOrder`

### DIFF
--- a/packages/eslint-plugin-query/eslint.config.js
+++ b/packages/eslint-plugin-query/eslint.config.js
@@ -2,4 +2,16 @@
 
 import rootConfig from '../../eslint.config.js'
 
-export default [...rootConfig]
+export default [
+  ...rootConfig,
+  {
+    rules: {
+      'vitest/expect-expect': [
+        'error',
+        {
+          assertFunctionNames: ['expect', 'expectArrayEqualIgnoreOrder'],
+        },
+      ],
+    },
+  },
+]

--- a/packages/eslint-plugin-query/eslint.config.js
+++ b/packages/eslint-plugin-query/eslint.config.js
@@ -1,13 +1,15 @@
 // @ts-check
 
 import rootConfig from '../../eslint.config.js'
+import vitest from '@vitest/eslint-plugin'
 
 export default [
   ...rootConfig,
   {
+    plugins: { vitest },
     rules: {
       'vitest/expect-expect': [
-        'error',
+        'warn',
         {
           assertFunctionNames: ['expect', 'expectArrayEqualIgnoreOrder'],
         },


### PR DESCRIPTION
![Captura de pantalla 2024-10-08 a las 11 30 58 a  m](https://github.com/user-attachments/assets/50eca835-46f9-4af7-8e82-6e02b599a198)

ESLint's `expect-expect` rule doesn't recognize that the `expect` function is being used indirectly via `expectArrayEqualIgnoreOrder`. This PR adds a global config to fix it.