### PR TITLE
fix: handle nullish coalescing operator in exhaustive-deps rule

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/exhaustive-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/exhaustive-deps.test.ts
@@ -413,6 +413,15 @@ ruleTester.run('exhaustive-deps', rule, {
         }
       `,
     },
+    {
+      name: "should not fail when queryFn uses nullish coalescing operator",
+      code: normalizeIndent`
+        useQuery({
+          queryKey: ["foo", options],
+          queryFn: () => options?.params ?? options
+        });
+      `
+    }
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/exhaustive-deps/exhaustive-deps.rule.ts
@@ -115,7 +115,7 @@ export const rule = createRule({
               !ref.isTypeReference &&
               !ASTUtils.isAncestorIsCallee(ref.identifier) &&
               !existingKeys.some((existingKey) => existingKey === text) &&
-              !existingKeys.includes(text.split('.')[0] ?? '')
+              !existingKeys.includes(text.split(/[?.]/)[0] ?? '')
             )
           })
           .map(({ ref, text }) => ({


### PR DESCRIPTION
fixes https://github.com/TanStack/query/issues/8131

Ensure that the exhaustive-deps rule correctly handles cases where the nullish coalescing operator (??) is used in query functions.

Example test case:

```js
useQuery({
  queryKey: ["foo", options],
  queryFn: () => options?.params ?? options
});
```