### PR TITLE
fix: new cache entry check

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -4971,6 +4971,29 @@ describe('useQuery', () => {
     expect(renders).toBe(hashes)
   })
 
+  it('should hash query keys that contain bigints given a supported query hash function', async () => {
+    const key = [queryKey(), 1n]
+
+    function queryKeyHashFn(x: any) {
+      return JSON.stringify(x, (_, value) => {
+        if (typeof value === 'bigint') return value.toString()
+        return value
+      })
+    }
+
+    function Page() {
+      useQuery({ queryKey: key, queryFn: () => 'test', queryKeyHashFn })
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await sleep(10)
+
+    const query = queryClient.getQueryCache().get(queryKeyHashFn(key))
+    expect(query?.state.data).toBe('test')
+  })
+
   it('should refetch when changed enabled to true in error state', async () => {
     const queryFn = vi.fn<(...args: Array<unknown>) => unknown>()
     queryFn.mockImplementation(async () => {

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -70,7 +70,7 @@ export function useBaseQuery<
   useClearResetErrorBoundary(errorResetBoundary)
 
   // this needs to be invoked before creating the Observer because that can create a cache entry
-  const isNewCacheEntry = !client.getQueryState(options.queryKey)
+  const isNewCacheEntry = !client.getQueryCache().get(defaultedOptions.queryHash)
 
   const [observer] = React.useState(
     () =>

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -70,7 +70,9 @@ export function useBaseQuery<
   useClearResetErrorBoundary(errorResetBoundary)
 
   // this needs to be invoked before creating the Observer because that can create a cache entry
-  const isNewCacheEntry = !client.getQueryCache().get(defaultedOptions.queryHash)
+  const isNewCacheEntry = !client
+    .getQueryCache()
+    .get(defaultedOptions.queryHash)
 
   const [observer] = React.useState(
     () =>


### PR DESCRIPTION
Fixes https://github.com/wevm/wagmi/issues/4322

Seems that https://github.com/TanStack/query/pull/7988 introduced a subtle breaking change whereby the check for `isNewCacheEntry` would not account for a custom `queryKeyHashFn`. This is because the implementation of `getQueryState` does not pass custom options from the query to `defaultQueryOptions`. As a result, this broke consumer code that relyed on `queryKeyHashFn` to serialize bigints. This PR aims to access the cache directly with `getQueryCache` instead.