### PR TITLE
fix(react-query): Allow optional initialData object in infiniteQueryOptions

### DIFF
--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -153,7 +153,7 @@ describe('queryOptions', () => {
     queryClient.prefetchQuery(options)
   })
 
-  test('allow optional initialData', () => {
+  test('allow optional initialData function', () => {
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
       queryKey: ['example'],
@@ -168,6 +168,27 @@ describe('queryOptions', () => {
     queryOptions.initialData
     expectTypeOf(queryOptions.initialData).toMatchTypeOf<
       | InitialDataFunction<InfiniteData<{ example: boolean }, number>>
+      | InfiniteData<{ example: boolean }, number>
+      | undefined
+    >()
+  })
+
+  test('allow optional initialData object', () => {
+    const initialData: { example: boolean } | undefined = { example: true }
+    const queryOptions = infiniteQueryOptions({
+      queryKey: ['example'],
+      queryFn: async () => initialData,
+      // initialData below errors
+      initialData: initialData
+        ? { pages: [initialData], pageParams: [] }
+        : undefined,
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+    })
+    queryOptions.initialData
+    expectTypeOf(queryOptions.initialData).toMatchTypeOf<
+      | InitialDataFunction<InfiniteData<{ example: boolean }, number>>
+      | InfiniteData<{ example: boolean }, number>
       | undefined
     >()
   })

--- a/packages/react-query/src/infiniteQueryOptions.ts
+++ b/packages/react-query/src/infiniteQueryOptions.ts
@@ -23,6 +23,7 @@ export type UndefinedInitialDataInfiniteOptions<
 > & {
   initialData?:
     | undefined
+    | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
     | InitialDataFunction<
         NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
       >


### PR DESCRIPTION
This is a follow-up on https://github.com/TanStack/query/pull/8154 and the post-merge discussion. 

This resolves a TS issue where you cannot pass an optional initialData object to the infiniteQueryOptions function. The previous referred solution only handled initialData callback functions.