### PR TITLE
fix(eslint-plugin-query): ignore all non-identifier properties in rule `infinite-query-property-order`

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/infinite-query-property-order.rule.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/infinite-query-property-order.rule.test.ts
@@ -24,6 +24,7 @@ const orderIndependentProps = [
   'queryKey',
   '...objectExpressionSpread',
   '...callExpressionSpread',
+  '...memberCallExpressionSpread',
 ] as const
 type OrderIndependentProps = (typeof orderIndependentProps)[number]
 
@@ -147,6 +148,8 @@ function getCode({
         return `...objectExpressionSpread`
       case '...callExpressionSpread':
         return callExpressionSpread
+      case '...memberCallExpressionSpread':
+        return '...myOptions.infiniteQueryOptions()'
       case 'queryKey':
         return `queryKey: ['projects']`
       case 'queryFn':

--- a/packages/eslint-plugin-query/src/rules/infinite-query-property-order/infinite-query-property-order.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/infinite-query-property-order/infinite-query-property-order.rule.ts
@@ -56,23 +56,13 @@ export const rule = createRule({
           return
         }
 
-        const properties = allProperties.flatMap((p) => {
+        const properties = allProperties.flatMap((p, index) => {
           if (
             p.type === AST_NODE_TYPES.Property &&
             p.key.type === AST_NODE_TYPES.Identifier
           ) {
             return { name: p.key.name, property: p }
-          } else if (p.type === AST_NODE_TYPES.SpreadElement) {
-            if (p.argument.type === AST_NODE_TYPES.Identifier) {
-              return { name: p.argument.name, property: p }
-            } else if (p.argument.type === AST_NODE_TYPES.CallExpression) {
-              if (p.argument.callee.type === AST_NODE_TYPES.Identifier) {
-                return { name: p.argument.callee.name, property: p }
-              }
-            }
-            throw new Error('Unsupported spread element')
-          }
-          return []
+          } else return { name: `_property_${index}`, property: p }
         })
 
         const sortedProperties = sortDataByOrder(properties, sortRules, 'name')


### PR DESCRIPTION
fixes #8156