### PR TITLE
fix(core): don't consider queries as enabled if they have no observers and have never fetched (successfully or erroneously)

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -3,6 +3,7 @@ import {
   noop,
   replaceData,
   resolveEnabled,
+  skipToken,
   timeUntilStale,
 } from './utils'
 import { notifyManager } from './notifyManager'
@@ -256,7 +257,14 @@ export class Query<
   }
 
   isDisabled(): boolean {
-    return this.getObserversCount() > 0 && !this.isActive()
+    if (this.getObserversCount() > 0) {
+      return !this.isActive()
+    }
+    // if a query has no observers, it should still be considered disabled if it never attempted a fetch
+    return (
+      this.options.queryFn === skipToken ||
+      this.state.dataUpdateCount + this.state.errorUpdateCount === 0
+    )
   }
 
   isStale(): boolean {


### PR DESCRIPTION
it's very likely that this used to be a disabled observer; one other case would be canceling a query while you were initially fetching it, but this is a weird corner case that brings all sorts of troubles

additionally, we can check for the queryFn being a skipToken; even if we have data in the cache, when the queryFn is currently set to skipToken, this is means we never want to see this query fetch

fixes #8118