### PR TITLE
fix: move thenable-recreation into createResult

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -628,7 +628,6 @@ export class QueryObserver<
             nextResult.status === 'error' ||
             nextResult.data !== prevThenable.value
           ) {
-            console.log('recreating thenable')
             recreateThenable()
           }
           break

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -594,27 +594,7 @@ export class QueryObserver<
       promise: this.#currentThenable,
     }
 
-    return result as QueryObserverResult<TData, TError>
-  }
-
-  updateResult(notifyOptions?: NotifyOptions): void {
-    const prevResult = this.#currentResult as
-      | QueryObserverResult<TData, TError>
-      | undefined
-
-    const nextResult = this.createResult(this.#currentQuery, this.options)
-
-    this.#currentResultState = this.#currentQuery.state
-    this.#currentResultOptions = this.options
-
-    if (this.#currentResultState.data !== undefined) {
-      this.#lastQueryWithDefinedData = this.#currentQuery
-    }
-
-    // Only notify and update result if something has changed
-    if (shallowEqualObjects(nextResult, prevResult)) {
-      return
-    }
+    const nextResult = result as QueryObserverResult<TData, TError>
 
     if (this.options.experimental_prefetchInRender) {
       const finalizeThenableIfPossible = (thenable: PendingThenable<TData>) => {
@@ -648,6 +628,7 @@ export class QueryObserver<
             nextResult.status === 'error' ||
             nextResult.data !== prevThenable.value
           ) {
+            console.log('recreating thenable')
             recreateThenable()
           }
           break
@@ -660,6 +641,28 @@ export class QueryObserver<
           }
           break
       }
+    }
+
+    return nextResult
+  }
+
+  updateResult(notifyOptions?: NotifyOptions): void {
+    const prevResult = this.#currentResult as
+      | QueryObserverResult<TData, TError>
+      | undefined
+
+    const nextResult = this.createResult(this.#currentQuery, this.options)
+
+    this.#currentResultState = this.#currentQuery.state
+    this.#currentResultOptions = this.options
+
+    if (this.#currentResultState.data !== undefined) {
+      this.#lastQueryWithDefinedData = this.#currentQuery
+    }
+
+    // Only notify and update result if something has changed
+    if (shallowEqualObjects(nextResult, prevResult)) {
+      return
     }
 
     this.#currentResult = nextResult

--- a/packages/react-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/react-query/src/__tests__/useMutationState.test.tsx
@@ -59,7 +59,19 @@ describe('useIsMutating', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate1/i }))
     await sleep(10)
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
-    await waitFor(() => expect(isMutatingArray).toEqual([0, 1, 2, 1, 0]))
+
+    // we don't really care if this yields
+    // [ +0, 1, 2, +0 ]
+    // or
+    // [ +0, 1, 2, 1, +0 ]
+    // our batching strategy might yield different results
+
+    await waitFor(() => expect(isMutatingArray[0]).toEqual(0))
+    await waitFor(() => expect(isMutatingArray[1]).toEqual(1))
+    await waitFor(() => expect(isMutatingArray[2]).toEqual(2))
+    await waitFor(() =>
+      expect(isMutatingArray[isMutatingArray.length - 1]).toEqual(0),
+    )
   })
 
   it('should filter correctly by mutationKey', async () => {

--- a/packages/vue-query/src/useMutationState.ts
+++ b/packages/vue-query/src/useMutationState.ts
@@ -71,12 +71,9 @@ export function useMutationState<TResult = MutationState>(
 ): Readonly<Ref<Array<TResult>>> {
   const filters = computed(() => cloneDeepUnref(options.filters))
   const mutationCache = (queryClient || useQueryClient()).getMutationCache()
-  const state = shallowRef(getResult(mutationCache, options)) as Ref<
-    Array<TResult>
-  >
+  const state = shallowRef(getResult(mutationCache, options))
   const unsubscribe = mutationCache.subscribe(() => {
-    const result = getResult(mutationCache, options)
-    state.value = result
+    state.value = getResult(mutationCache, options)
   })
 
   watch(filters, () => {


### PR DESCRIPTION
`updateResult` will only be called after a fetch, but when we switch between caches without a fetch, we will only call `createResult`; this fix stops `data` from the queryResult and the `thenable` to go out-of-sync; it's backwards compatible because `updateResult` also invokes `createResult`

fixes #8120 