### PR TITLE
fix(query-core): don't finalizeThenable of different queries

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -598,10 +598,12 @@ export class QueryObserver<
 
     if (this.options.experimental_prefetchInRender) {
       const finalizeThenableIfPossible = (thenable: PendingThenable<TData>) => {
-        if (nextResult.status === 'error') {
-          thenable.reject(nextResult.error)
-        } else if (nextResult.data !== undefined) {
-          thenable.resolve(nextResult.data)
+        if (query.queryHash === prevQuery.queryHash) {
+          if (nextResult.status === 'error') {
+            thenable.reject(nextResult.error)
+          } else if (nextResult.data !== undefined) {
+            thenable.resolve(nextResult.data)
+          }
         }
       }
 

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -7467,7 +7467,6 @@ describe('useQuery', () => {
 
       await waitFor(() => rendered.getByText('test1'))
 
-      console.log('---------dec------------')
       fireEvent.click(rendered.getByText('dec'))
 
       await waitFor(() => rendered.getByText('test0'))


### PR DESCRIPTION
if we have multiple promises in-flight, once they resolve, we need to make sure to not finalize with data / error from a different key; otherwise, we might see intermediate data of non-matching keys