### PR TITLE
fix: make queryFn optional again

### DIFF
--- a/packages/react-query/src/infiniteQueryOptions.ts
+++ b/packages/react-query/src/infiniteQueryOptions.ts
@@ -48,7 +48,7 @@ export type UnusedSkipTokenInfiniteOptions<
   >,
   'queryFn'
 > & {
-  queryFn: Exclude<
+  queryFn?: Exclude<
     UseInfiniteQueryOptions<
       TQueryFnData,
       TError,

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -29,7 +29,7 @@ export type UnusedSkipTokenOptions<
   UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   'queryFn'
 > & {
-  queryFn: Exclude<
+  queryFn?: Exclude<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>['queryFn'],
     SkipToken
   >

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -50,7 +50,7 @@ export interface UseSuspenseQueryOptions<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
     'queryFn' | 'enabled' | 'throwOnError' | 'placeholderData'
   > {
-  queryFn: Exclude<
+  queryFn?: Exclude<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>['queryFn'],
     SkipToken
   >
@@ -93,7 +93,7 @@ export interface UseSuspenseInfiniteQueryOptions<
     >,
     'queryFn' | 'enabled' | 'throwOnError' | 'placeholderData'
   > {
-  queryFn: Exclude<
+  queryFn?: Exclude<
     UseInfiniteQueryOptions<
       TQueryFnData,
       TError,


### PR DESCRIPTION
fixes #8180

https://github.com/TanStack/query/pull/8082 broke trpc's `useSuspenseQueries` as it made `queryFn` required. `queryFn` is optional in all other types and should remain so. We set this param internally and the users should not provide it themselves.

For example, this should be possible:

```ts
   const [posts] = client.useSuspenseQueries((t) => [
      t.post.byId(
        { id: '1' },
        {
          select(data) {
            return "bar" as const;
          },
        },
      ),
    ]);
```

most notably `options` doesn't have a `queryFn` specified since that's set by trpc internally.

this PR fixes the issue by making the override still optional, as it is in the base type

PR on trpc: https://github.com/trpc/trpc/pull/6118 (see patch here: https://github.com/trpc/trpc/pull/6118/files#diff-996d92a63ec784c3182c4cfccc74574ce428ba741562b83cffa4fed1999539e1)

--

not sure how i should add tests in RQ for this