### PR TITLE
fix(react-query): resolve overload matches error with exactOptionalPropertyTypes in query options

### DIFF
--- a/packages/react-query/src/infiniteQueryOptions.ts
+++ b/packages/react-query/src/infiniteQueryOptions.ts
@@ -57,7 +57,7 @@ export type UnusedSkipTokenInfiniteOptions<
       TQueryKey,
       TPageParam
     >['queryFn'],
-    SkipToken
+    SkipToken | undefined
   >
 }
 

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -31,7 +31,7 @@ export type UnusedSkipTokenOptions<
 > & {
   queryFn?: Exclude<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>['queryFn'],
-    SkipToken
+    SkipToken | undefined
   >
 }
 


### PR DESCRIPTION
fixed: https://github.com/TanStack/query/issues/8184

Resolve overload matches error in `queryOptions`, `infiniteQueryOptions` when exactOptionalPropertyTypes in typescript is enabled.