### PR TITLE
docs(react-query): fix prefetch with suspense example

### DIFF
--- a/docs/framework/react/guides/prefetching.md
+++ b/docs/framework/react/guides/prefetching.md
@@ -201,35 +201,28 @@ If you want to prefetch together with Suspense, you will have to do things a bit
 You can now use `useSuspenseQuery` in the component that actually needs the data. You _might_ want to wrap this later component in its own `<Suspense>` boundary so the "secondary" query we are prefetching does not block rendering of the "primary" data.
 
 ```tsx
-function App() {
+function ArticleLayout({ id }) {
   usePrefetchQuery({
-    queryKey: ['articles'],
-    queryFn: (...args) => {
-      return getArticles(...args)
-    },
+    queryKey: ['article-comments', id],
+    queryFn: getArticleCommentsById,
+    // Optional optimization to avoid rerenders when this query changes:
+    notifyOnChangeProps: [],
   })
 
   return (
-    <Suspense fallback="Loading articles...">
-      <Articles />
+    <Suspense fallback="Loading article">
+      <Article id={id} />
     </Suspense>
   )
 }
 
-function Articles() {
-  const { data: articles } = useSuspenseQuery({
-    queryKey: ['articles'],
-    queryFn: (...args) => {
-      return getArticles(...args)
-    },
+function Article({ id }) {
+  const { data: articleData, isPending } = useSuspenseQuery({
+    queryKey: ['article', id],
+    queryFn: getArticleById,
   })
 
-  return articles.map((article) => (
-    <div key={articleData.id}>
-      <ArticleHeader article={article} />
-      <ArticleBody article={article} />
-    </div>
-  ))
+  ...
 }
 ```
 

--- a/docs/framework/react/guides/prefetching.md
+++ b/docs/framework/react/guides/prefetching.md
@@ -205,8 +205,6 @@ function ArticleLayout({ id }) {
   usePrefetchQuery({
     queryKey: ['article-comments', id],
     queryFn: getArticleCommentsById,
-    // Optional optimization to avoid rerenders when this query changes:
-    notifyOnChangeProps: [],
   })
 
   return (


### PR DESCRIPTION
In the [docs](https://tanstack.com/query/latest/docs/framework/react/guides/prefetching#prefetch-in-components), the current code example for prefetching with suspense queries is 

```tsx
function App() {
  usePrefetchQuery({
    queryKey: ['articles'],
    queryFn: (...args) => {
      return getArticles(...args)
    },
  })

  return (
    <Suspense fallback="Loading articles...">
      <Articles />
    </Suspense>
  )
}

function Articles() {
  const { data: articles } = useSuspenseQuery({
    queryKey: ['articles'],
    queryFn: (...args) => {
      return getArticles(...args)
    },
  })

  return articles.map((article) => (
    <div key={articleData.id}>
      <ArticleHeader article={article} />
      <ArticleBody article={article} />
    </div>
  ))
}
```

This might be a poor example: 

- the prefetch is followed directly by the suspense query, which does not bring much performance benefit,

-  all previous examples are dealing with the article item (primary data) and its comments (secondary data), the example is using a single query of the article list, which seems disconnected 

-  I think what we want to demonstrate is prefetching the article comments while the article suspense component is pending, i.e.

```tsx
function ArticleLayout({ id }) {
  usePrefetchQuery({
    queryKey: ['article-comments', id],
    queryFn: getArticleCommentsById,
  })

  return (
    <Suspense fallback="Loading article">
      <Article id={id} />
    </Suspense>
  )
}

function Article({ id }) {
  const { data: articleData, isPending } = useSuspenseQuery({
    queryKey: ['article', id],
    queryFn: getArticleById,
  })

  ...
}
```