### PR TITLE
chore(react-query): import `query-persist-client-core` into test as workspace dependency

### DIFF
--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -62,6 +62,7 @@
     "@tanstack/query-core": "workspace:*"
   },
   "devDependencies": {
+    "@tanstack/query-persist-client-core": "workspace:*",
     "@types/react": "npm:types-react@rc",
     "@types/react-dom": "npm:types-react-dom@rc",
     "@vitejs/plugin-react": "^4.3.1",

--- a/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
+++ b/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { QueryCache, hashKey } from '@tanstack/query-core'
-import { useQuery } from '..'
 import {
   PERSISTER_KEY_PREFIX,
   experimental_createPersister,
-} from '../../../query-persist-client-core/src'
+} from '@tanstack/query-persist-client-core'
+import { useQuery } from '..'
 import { createQueryClient, queryKey, renderWithClient, sleep } from './utils'
 
 describe('fine grained persister', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,7 +1223,7 @@ importers:
         version: 5.1.0(astro@4.12.3(@types/node@22.7.4)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)(typescript@5.3.3))(tailwindcss@3.4.7)
       '@astrojs/vercel':
         specifier: ^7.7.2
-        version: 7.7.2(astro@4.12.3(@types/node@22.7.4)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)(typescript@5.3.3))(encoding@0.1.13)(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522))(react@18.3.1)(sass@1.77.8))(react@18.3.1)
+        version: 7.7.2(astro@4.12.3(@types/node@22.7.4)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)(typescript@5.3.3))(encoding@0.1.13)(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@18.3.1))(react@18.3.1)(sass@1.77.8))(react@18.3.1)
       '@tanstack/solid-query':
         specifier: ^5.59.16
         version: link:../../../packages/solid-query
@@ -2119,6 +2119,9 @@ importers:
         specifier: workspace:*
         version: link:../query-core
     devDependencies:
+      '@tanstack/query-persist-client-core':
+        specifier: workspace:*
+        version: link:../query-persist-client-core
       '@types/react':
         specifier: npm:types-react@rc
         version: types-react@19.0.0-rc.1
@@ -17624,10 +17627,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@7.7.2(astro@4.12.3(@types/node@22.7.4)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)(typescript@5.3.3))(encoding@0.1.13)(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522))(react@18.3.1)(sass@1.77.8))(react@18.3.1)':
+  '@astrojs/vercel@7.7.2(astro@4.12.3(@types/node@22.7.4)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)(typescript@5.3.3))(encoding@0.1.13)(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@18.3.1))(react@18.3.1)(sass@1.77.8))(react@18.3.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.1
-      '@vercel/analytics': 1.3.1(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522))(react@18.3.1)(sass@1.77.8))(react@18.3.1)
+      '@vercel/analytics': 1.3.1(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@18.3.1))(react@18.3.1)(sass@1.77.8))(react@18.3.1)
       '@vercel/edge': 1.1.2
       '@vercel/nft': 0.27.3(encoding@0.1.13)
       astro: 4.12.3(@types/node@22.7.4)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)(typescript@5.3.3)
@@ -22887,11 +22890,11 @@ snapshots:
       graphql: 15.8.0
       wonka: 4.0.15
 
-  '@vercel/analytics@1.3.1(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522))(react@18.3.1)(sass@1.77.8))(react@18.3.1)':
+  '@vercel/analytics@1.3.1(next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@18.3.1))(react@18.3.1)(sass@1.77.8))(react@18.3.1)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522))(react@18.3.1)(sass@1.77.8)
+      next: 14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@18.3.1))(react@18.3.1)(sass@1.77.8)
       react: 18.3.1
 
   '@vercel/edge@1.1.2': {}
@@ -30006,7 +30009,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522))(react@18.3.1)(sass@1.77.8):
+  next@14.2.5(@babel/core@7.25.2)(react-dom@19.0.0-rc-4c2e457c7c-20240522(react@18.3.1))(react@18.3.1)(sass@1.77.8):
     dependencies:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5
@@ -30015,7 +30018,7 @@ snapshots:
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.3.1
-      react-dom: 19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522)
+      react-dom: 19.0.0-rc-4c2e457c7c-20240522(react@18.3.1)
       styled-jsx: 5.1.1(@babel/core@7.25.2)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.5
@@ -32312,6 +32315,12 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-dom@19.0.0-rc-4c2e457c7c-20240522(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      scheduler: 0.25.0-rc-4c2e457c7c-20240522
+    optional: true
 
   react-dom@19.0.0-rc-4c2e457c7c-20240522(react@19.0.0-rc-4c2e457c7c-20240522):
     dependencies:


### PR DESCRIPTION
Current import messes with some build tools (even though it's only in tests)

Replaces `'../../../query-persist-client-core/src'` with `'@tanstack/query-persist-client-core'`

Added `@tanstack/query-persist-client-core` as a _dev_ dependency (not installed for users)