### PR TITLE
fix(react-query): remove redundant `setIsRestoring(true)` to fix lint warning

### DIFF
--- a/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
+++ b/packages/react-query-persist-client/src/PersistQueryClientProvider.tsx
@@ -36,7 +36,6 @@ export const PersistQueryClientProvider = ({
     }
     if (!didRestore.current) {
       didRestore.current = true
-      setIsRestoring(true)
       persistQueryClientRestore(options).then(async () => {
         try {
           await refs.current.onSuccess?.()


### PR DESCRIPTION
<img width="591" alt="Captura de pantalla 2024-10-24 a las 12 11 37 p  m" src="https://github.com/user-attachments/assets/dcf3294d-9352-4296-8275-72b63e544ba2">

Since `isRestoring`'s initial value is `true`, I think we can remove this `setIsRestoring(true)` that is warning not to use it directly in a `useEffect`. 