### PR TITLE
test(react-query): remove `async` from queryFn

### DIFF
--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -169,7 +169,7 @@ describe('infiniteQueryOptions', () => {
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
       queryKey: ['example'],
-      queryFn: async () => initialData,
+      queryFn: () => initialData,
       initialData: initialData
         ? () => ({ pages: [initialData], pageParams: [] })
         : undefined,
@@ -187,7 +187,7 @@ describe('infiniteQueryOptions', () => {
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
       queryKey: ['example'],
-      queryFn: async () => initialData,
+      queryFn: () => initialData,
       initialData: initialData
         ? { pages: [initialData], pageParams: [] }
         : undefined,


### PR DESCRIPTION
![Captura de pantalla 2024-10-29 a las 8 58 08 p  m](https://github.com/user-attachments/assets/a86ba4c4-3c97-4840-a160-41fb790d8aa5)

This PR removes the `async` keyword from `queryFn` which is raising above warning. 

**Explanation**
I traced back to its original type:
https://github.com/TanStack/query/blob/c61ff1e2f8036afa3f60ed434866e95175a3421c/packages/query-core/src/types.ts#L50-L54
The `QueryFunction` type allows return type of `T` or `Promise<T>`. In our case `T` is the type of `initialData`, which is`{ example: boolean } | undefined`. No Promise, no async..