### PR TITLE
fix(useQuery): don't retryOnMount when prefetchInRender is used

### DIFF
--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -26,7 +26,11 @@ export const ensurePreventErrorBoundaryRetry = <
   >,
   errorResetBoundary: QueryErrorResetBoundaryValue,
 ) => {
-  if (options.suspense || options.throwOnError) {
+  if (
+    options.suspense ||
+    options.throwOnError ||
+    options.experimental_prefetchInRender
+  ) {
     // Prevent retrying failed query if the error boundary has not been reset yet
     if (!errorResetBoundary.isReset()) {
       options.retryOnMount = false


### PR DESCRIPTION
otherwise, queries will not stay in error state, but immediately go into pending + fetching again; this is also shown by the fact that an additional test now failed, because it didn't reset the error boundary correctly

fixes #8219