### PR TITLE
feat(eslint-plugin-query): add Suspense query hooks to no-rest-destructuring rule

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/no-rest-destructuring.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-rest-destructuring.test.ts
@@ -147,6 +147,144 @@ ruleTester.run('no-rest-destructuring', rule, {
           }
         `,
     },
+    {
+      name: 'useSuspenseQuery is not captured',
+      code: normalizeIndent`
+        import { useSuspenseQuery } from '@tanstack/react-query'
+
+        function Component() {
+          useSuspenseQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseQuery is not destructured',
+      code: normalizeIndent`
+        import { useSuspenseQuery } from '@tanstack/react-query'
+
+        function Component() {
+          const query = useSuspenseQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseQuery is destructured without rest',
+      code: normalizeIndent`
+        import { useSuspenseQuery } from '@tanstack/react-query'
+
+        function Component() {
+          const { data, isLoading, isError } = useSuspenseQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseInfiniteQuery is not captured',
+      code: normalizeIndent`
+        import { useSuspenseInfiniteQuery } from '@tanstack/react-query'
+
+        function Component() {
+          useSuspenseInfiniteQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseInfiniteQuery is not destructured',
+      code: normalizeIndent`
+        import { useSuspenseInfiniteQuery } from '@tanstack/react-query'
+
+        function Component() {
+          const query = useSuspenseInfiniteQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseInfiniteQuery is destructured without rest',
+      code: normalizeIndent`
+        import { useSuspenseInfiniteQuery } from '@tanstack/react-query'
+
+        function Component() {
+          const { data, isLoading, isError } = useSuspenseInfiniteQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseQueries is not captured',
+      code: normalizeIndent`
+        import { useSuspenseQueries } from '@tanstack/react-query'
+
+        function Component() {
+          useSuspenseQueries([])
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseQueries is not destructured',
+      code: normalizeIndent`
+        import { useSuspenseQueries } from '@tanstack/react-query'
+
+        function Component() {
+          const queries = useSuspenseQueries([])
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseQueries array has no rest destructured element',
+      code: normalizeIndent`
+        import { useSuspenseQueries } from '@tanstack/react-query'
+
+        function Component() {
+          const [query1, { data, isLoading }] = useSuspenseQueries([
+            { queryKey: ['key1'], queryFn: () => {} },
+            { queryKey: ['key2'], queryFn: () => {} },
+          ])
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseQuery is destructured with rest but not from tanstack query',
+      code: normalizeIndent`
+        import { useSuspenseQuery } from 'other-package'
+
+        function Component() {
+          const { data, ...rest } = useSuspenseQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseInfiniteQuery is destructured with rest but not from tanstack query',
+      code: normalizeIndent`
+        import { useSuspenseInfiniteQuery } from 'other-package'
+
+        function Component() {
+          const { data, ...rest } = useSuspenseInfiniteQuery()
+          return
+        }
+      `,
+    },
+    {
+      name: 'useSuspenseQueries array has rest destructured element but not from tanstack query',
+      code: normalizeIndent`
+        import { useSuspenseQueries } from 'other-package'
+
+        function Component() {
+          const [query1, { data, ...rest }] = useSuspenseQueries([
+            { queryKey: ['key1'], queryFn: () => {} },
+            { queryKey: ['key2'], queryFn: () => {} },
+          ])
+          return
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -186,6 +324,45 @@ ruleTester.run('no-rest-destructuring', rule, {
             return
           }
         `,
+      errors: [{ messageId: 'objectRestDestructure' }],
+    },
+    {
+      name: 'useSuspenseQuery is destructured with rest',
+      code: normalizeIndent`
+        import { useSuspenseQuery } from '@tanstack/react-query'
+
+        function Component() {
+          const { data, ...rest } = useSuspenseQuery()
+          return
+        }
+      `,
+      errors: [{ messageId: 'objectRestDestructure' }],
+    },
+    {
+      name: 'useSuspenseInfiniteQuery is destructured with rest',
+      code: normalizeIndent`
+        import { useSuspenseInfiniteQuery } from '@tanstack/react-query'
+
+        function Component() {
+          const { data, ...rest } = useSuspenseInfiniteQuery()
+          return
+        }
+      `,
+      errors: [{ messageId: 'objectRestDestructure' }],
+    },
+    {
+      name: 'useSuspenseQueries is destructured with rest',
+      code: normalizeIndent`
+        import { useSuspenseQueries } from '@tanstack/react-query'
+
+        function Component() {
+          const [query1, { data, ...rest }] = useSuspenseQueries([
+            { queryKey: ['key1'], queryFn: () => {} },
+            { queryKey: ['key2'], queryFn: () => {} },
+          ])
+          return
+        }
+      `,
       errors: [{ messageId: 'objectRestDestructure' }],
     },
   ],

--- a/packages/eslint-plugin-query/src/rules/no-rest-destructuring/no-rest-destructuring.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-rest-destructuring/no-rest-destructuring.rule.ts
@@ -7,7 +7,14 @@ import type { ExtraRuleDocs } from '../../types'
 
 export const name = 'no-rest-destructuring'
 
-const queryHooks = ['useQuery', 'useQueries', 'useInfiniteQuery']
+const queryHooks = [
+  'useQuery',
+  'useQueries',
+  'useInfiniteQuery',
+  'useSuspenseQuery',
+  'useSuspenseQueries',
+  'useSuspenseInfiniteQuery',
+]
 
 const createRule = ESLintUtils.RuleCreator<ExtraRuleDocs>(getDocsUrl)
 
@@ -38,7 +45,10 @@ export const rule = createRule({
         }
 
         const returnValue = node.parent.id
-        if (node.callee.name !== 'useQueries') {
+        if (
+          node.callee.name !== 'useQueries' &&
+          node.callee.name !== 'useSuspenseQueries'
+        ) {
           if (NoRestDestructuringUtils.isObjectRestDestructuring(returnValue)) {
             context.report({
               node: node.parent,


### PR DESCRIPTION

This PR adds 'useSuspenseQuery' , 'useSuspenseQueries' and 'useSuspenseInfiniteQuery' to the queryHooks array in the no-rest-destructuring ESLint rule. 

issue: #8231 