### PR TITLE
chore(eslint-plugin-query): ignore `combinate` spell check lint warning

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default [
           cspell: {
             words: [
               'codemod', // We support our codemod
+              'combinate', // Library name
               'extralight', // Our public interface
               'jscodeshift',
               'Promisable', // Our public interface

--- a/packages/eslint-plugin-query/eslint.config.js
+++ b/packages/eslint-plugin-query/eslint.config.js
@@ -14,6 +14,12 @@ export default [
           assertFunctionNames: ['expect', 'expectArrayEqualIgnoreOrder'],
         },
       ],
+      'cspell/spell-checker': [
+        'warn',
+        {
+          ignoreWords: ['combinate'],
+        },
+      ],
     },
   },
 ]

--- a/packages/eslint-plugin-query/eslint.config.js
+++ b/packages/eslint-plugin-query/eslint.config.js
@@ -14,7 +14,7 @@ export default [
           assertFunctionNames: ['expect', 'expectArrayEqualIgnoreOrder'],
         },
       ],
-      'cspell/spell-checker': [
+      'cspell/spellchecker': [
         'warn',
         {
           ignoreWords: ['combinate'],

--- a/packages/eslint-plugin-query/eslint.config.js
+++ b/packages/eslint-plugin-query/eslint.config.js
@@ -14,12 +14,6 @@ export default [
           assertFunctionNames: ['expect', 'expectArrayEqualIgnoreOrder'],
         },
       ],
-      'cspell/spellchecker': [
-        'warn',
-        {
-          ignoreWords: ['combinate'],
-        },
-      ],
     },
   },
 ]


### PR DESCRIPTION
<img width="455" alt="Captura de pantalla 2024-11-09 a las 8 35 06 p  m" src="https://github.com/user-attachments/assets/de9c6af2-78c3-4ec5-b7c4-3bdbfc625fd0">

This PR removes this warning by ignoring spelling check of the word `combinate`