### PR TITLE
fix(useQueries): make sure we don't lose property tracking

### DIFF
--- a/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -556,7 +556,6 @@ describe('useSuspenseQueries 2', () => {
         queryKey: key,
         queryFn: async () => {
           count++
-          console.log('queryFn')
           throw new Error('Query failed')
         },
         gcTime: 0,


### PR DESCRIPTION
if we call `combine` with `#this.result`, we don't have a tracked version of it, as tracking happens in useQueries (to avoid tracking internal access)