### PR TITLE
Update infinite-queries.md

### DIFF
--- a/docs/framework/react/guides/infinite-queries.md
+++ b/docs/framework/react/guides/infinite-queries.md
@@ -110,7 +110,7 @@ To ensure a seamless querying process without conflicts, it's highly recommended
 [//]: # 'Example1'
 
 ```jsx
-<List onEndReached={() => !isFetching && fetchNextPage()} />
+<List onEndReached={() => !isFetchingNextPage && fetchNextPage()} />
 ```
 
 [//]: # 'Example1'


### PR DESCRIPTION
The example indicates we should prevent fetching the next page if we are currently refetching. But fetching the next page of data would cancel any background re-fetches (as exepected).

I've updated the example to check we are not already fetching the next page instead as that makes more sense.