### PR TITLE
fix(vue-query): fix queryOptions return type

### DIFF
--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -1,8 +1,10 @@
 import type { DataTag, DefaultError, QueryKey } from '@tanstack/query-core'
 import type {
   DefinedInitialQueryOptions,
+  NonUndefinedGuard,
   UndefinedInitialQueryOptions,
 } from './useQuery'
+import type { UnwrapRef } from 'vue-demi'
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -11,7 +13,7 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+): UnwrapRef<UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>> & {
   queryKey: DataTag<TQueryKey, TQueryFnData>
 }
 
@@ -22,8 +24,10 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData>
+): UnwrapRef<DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>> & {
+    queryKey: DataTag<TQueryKey, TQueryFnData>;
+    initialData: | NonUndefinedGuard<TQueryFnData>
+    | (() => NonUndefinedGuard<TQueryFnData>);
 }
 
 export function queryOptions(options: unknown) {

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -15,7 +15,7 @@ import type {
 } from './types'
 import type { QueryClient } from './queryClient'
 
-type NonUndefinedGuard<T> = T extends undefined ? never : T
+export type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type UseQueryOptions<
   TQueryFnData = unknown,


### PR DESCRIPTION
I updated the return type of the queryOptions function with Vue's UnwrapRef.

[AS-IS]
<img width="546" alt="image" src="https://github.com/user-attachments/assets/06a14238-c08f-4914-8472-1f9c4d83db53">

[TO-BE]
<img width="541" alt="image" src="https://github.com/user-attachments/assets/621f1f71-ad7a-47a5-b821-e4f4690b7580">