### PR TITLE
add ability to warn when suspense queries aren't prefetched

### DIFF
--- a/integrations/react-next-15/app/client-component.tsx
+++ b/integrations/react-next-15/app/client-component.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import React from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { Temporal } from '@js-temporal/polyfill'
 
 export function ClientComponent() {
-  const query = useQuery({
+  const query = useSuspenseQuery({
     queryKey: ['data'],
     queryFn: async () => {
       await new Promise((r) => setTimeout(r, 1000))
@@ -16,13 +16,13 @@ export function ClientComponent() {
     },
   })
 
-  if (query.isPending) {
-    return <div>Loading...</div>
-  }
+  // if (query.isPending) {
+  //   return <div>Loading...</div>
+  // }
 
-  if (query.isError) {
-    return <div>An error has occurred!</div>
-  }
+  // if (query.isError) {
+  //   return <div>An error has occurred!</div>
+  // }
 
   return (
     <div>

--- a/integrations/react-next-15/app/make-query-client.ts
+++ b/integrations/react-next-15/app/make-query-client.ts
@@ -26,6 +26,7 @@ export function makeQueryClient() {
       },
       queries: {
         staleTime: 60 * 1000,
+        warnOnServerFetches: true,
       },
       dehydrate: {
         serializeData: tson.serialize,

--- a/integrations/react-next-15/app/page.tsx
+++ b/integrations/react-next-15/app/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { Temporal } from '@js-temporal/polyfill'
 import { ClientComponent } from './client-component'
@@ -9,21 +9,23 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 export default async function Home() {
   const queryClient = makeQueryClient()
 
-  void queryClient.prefetchQuery({
-    queryKey: ['data'],
-    queryFn: async () => {
-      await sleep(2000)
-      return {
-        text: 'data from server',
-        date: Temporal.PlainDate.from('2024-01-01'),
-      }
-    },
-  })
+  // void queryClient.prefetchQuery({
+  //   queryKey: ['data'],
+  //   queryFn: async () => {
+  //     await sleep(2000)
+  //     return {
+  //       text: 'data from server',
+  //       date: Temporal.PlainDate.from('2024-01-01'),
+  //     }
+  //   },
+  // })
 
   return (
     <main>
       <HydrationBoundary state={dehydrate(queryClient)}>
-        <ClientComponent />
+        <Suspense fallback={<div>Loading...</div>}>
+          <ClientComponent />
+        </Suspense>
       </HydrationBoundary>
     </main>
   )

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -223,6 +223,12 @@ export interface QueryOptions<
    * Maximum number of pages to store in the data of an infinite query.
    */
   maxPages?: number
+  /**
+   * If set to `true`, the query will warn if it is fetched on the server.
+   * Use this if you intend to only consume prefetched queries.
+   * Defaults to `false`.
+   */
+  warnOnServerFetches?: boolean
 }
 
 export interface InitialPageParam<TPageParam = unknown> {

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -111,6 +111,11 @@ export function useBaseQuery<
 
   // Handle suspense
   if (shouldSuspend(defaultedOptions, result)) {
+    if (defaultedOptions.warnOnServerFetches && isNewCacheEntry) {
+      console.warn(
+        'A new query suspended on the server without any cache entry.',
+      )
+    }
     throw fetchOptimistic(defaultedOptions, observer, errorResetBoundary)
   }
 


### PR DESCRIPTION
When using the promise-rsc-hydration thingy we aim to prefetch all queries in the RSCs and just consume the streamed promises in our components. 

This can be a bit fragile since forgetting to prefetch may not be obvious to find. This PR adds a new option that, when enabled, will log at warning level when `useSuspenseQuery` is called on a new query that's not already observed.

as with all options, this can be set globally when constructing the QueryClient and overridden locally cause you may have queries 

### Questions

- naming? idk, just went with the first thing that came to mind. as a matter of fact it's not even bound to being on the server as you may wanna use this with a `usePrefetchQuery -> useSuspenseQuery` pattern in a SPA as well
- given @TkDodo's [recent talk](https://youtu.be/QB-S6UU5YEU?si=RVi8kdV4jablIH4K&t=936), this should probably also accept a callback that gets the query(?) and not just a static boolean flag
- warning log might be too specific, would it be better for this to be a function and allow the developer to control what should happen? Perhaps they want to log more/less info about the query to help track down the query that's missing a prefetch