### PR TITLE
feat(angular-query): add mutationOptions

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -523,6 +523,10 @@
               "to": "framework/angular/guides/mutations"
             },
             {
+              "label": "Mutation Options",
+              "to": "framework/angular/guides/mutation-options"
+            },
+            {
               "label": "Query Invalidation",
               "to": "framework/angular/guides/query-invalidation"
             },

--- a/docs/framework/angular/guides/mutation-options.md
+++ b/docs/framework/angular/guides/mutation-options.md
@@ -1,0 +1,27 @@
+---
+id: query-options
+title: Mutation Options
+---
+
+One of the best ways to share mutation options between multiple places,
+is to use the `mutationOptions` helper. At runtime, this helper just returns whatever you pass into it,
+but it has a lot of advantages when using it [with TypeScript](../../typescript#typing-query-options).
+You can define all possible options for a mutation in one place,
+and you'll also get type inference and type safety for all of them.
+
+```ts
+export class QueriesService {
+  private http = inject(HttpClient)
+
+  updatePost(id: number) {
+    return mutationOptions({
+      mutationFn: (post: Post) => Promise.resolve(post),
+      mutationKey: ['updatePost', id],
+      onSuccess: (newPost) => {
+        //           ^? newPost: Post
+        this.queryClient.setQueryData(['posts', id], newPost)
+      },
+    })
+  }
+}
+```

--- a/packages/angular-query-experimental/src/__tests__/mutation-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/mutation-options.test-d.ts
@@ -1,0 +1,22 @@
+import { mutationOptions } from '../mutation-options'
+
+describe('mutationOptions', () => {
+  test('should not allow excess properties', () => {
+    return mutationOptions({
+      mutationFn: () => Promise.resolve(5),
+      mutationKey: ['key'],
+      // @ts-expect-error this is a good error, because onMutates does not exist!
+      onMutates: 1000,
+    })
+  })
+
+  test('should infer types for callbacks', () => {
+    return mutationOptions({
+      mutationFn: () => Promise.resolve(5),
+      mutationKey: ['key'],
+      onSuccess: (data) => {
+        expectTypeOf(data).toEqualTypeOf<number>()
+      },
+    })
+  })
+})

--- a/packages/angular-query-experimental/src/index.ts
+++ b/packages/angular-query-experimental/src/index.ts
@@ -10,6 +10,7 @@ export type {
   UndefinedInitialDataOptions,
 } from './query-options'
 export { queryOptions } from './query-options'
+export { mutationOptions } from './mutation-options'
 
 export type {
   DefinedInitialDataInfiniteOptions,

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -19,11 +19,8 @@ import { noop, shouldThrowError } from './util'
 
 import { lazyInit } from './util/lazy-init/lazy-init'
 import type { DefaultError, MutationObserverResult } from '@tanstack/query-core'
-import type {
-  CreateMutateFunction,
-  CreateMutationOptions,
-  CreateMutationResult,
-} from './types'
+import type { CreateMutateFunction, CreateMutationResult } from './types'
+import type { CreateMutationOptions } from './mutation-options'
 
 /**
  * Injects a mutation: an imperative function that can be invoked which typically performs server side effects.

--- a/packages/angular-query-experimental/src/mutation-options.ts
+++ b/packages/angular-query-experimental/src/mutation-options.ts
@@ -1,0 +1,60 @@
+import type {
+  DefaultError,
+  MutationObserverOptions,
+  OmitKeyof,
+} from '@tanstack/query-core'
+
+/**
+ * Allows to share and re-use mutation options in a type-safe way.
+ *
+ * **Example**
+ *
+ * ```ts
+ * export class QueriesService {
+ *   private http = inject(HttpClient);
+ *
+ *   updatePost(id: number) {
+ *     return mutationOptions({
+ *       mutationFn: (post: Post) => Promise.resolve(post),
+ *       mutationKey: ["updatePost", id],
+ *       onSuccess: (newPost) => {
+ *         //           ^? newPost: Post
+ *         this.queryClient.setQueryData(["posts", id], newPost);
+ *       },
+ *     });
+ *   }
+ * }
+ *
+ * queries = inject(QueriesService)
+ * idSignal = new Signal(0);
+ * mutation = injectMutation(() => this.queries.updatePost(this.idSignal()))
+ *
+ * mutation.mutate({ title: 'New Title' })
+ * ```
+ * @param options - The mutation options.
+ * @returns Mutation options.
+ * @public
+ */
+export function mutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TContext = unknown,
+>(
+  options: MutationObserverOptions<TData, TError, TVariables, TContext>,
+): CreateMutationOptions<TData, TError, TVariables, TContext> {
+  return options
+}
+
+/**
+ * @public
+ */
+export interface CreateMutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TContext = unknown,
+> extends OmitKeyof<
+    MutationObserverOptions<TData, TError, TVariables, TContext>,
+    '_defaulted'
+  > {}

--- a/packages/angular-query-experimental/src/types.ts
+++ b/packages/angular-query-experimental/src/types.ts
@@ -7,7 +7,6 @@ import type {
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
   MutateFunction,
-  MutationObserverOptions,
   MutationObserverResult,
   OmitKeyof,
   Override,
@@ -158,19 +157,6 @@ export type DefinedCreateInfiniteQueryResult<
     TError
   >,
 > = MapToSignals<TDefinedInfiniteQueryObserver>
-
-/**
- * @public
- */
-export interface CreateMutationOptions<
-  TData = unknown,
-  TError = DefaultError,
-  TVariables = void,
-  TContext = unknown,
-> extends OmitKeyof<
-    MutationObserverOptions<TData, TError, TVariables, TContext>,
-    '_defaulted'
-  > {}
 
 /**
  * @public


### PR DESCRIPTION
`mutationOptions` helps extracting mutation options into separate functions, signals and Angular services.