### PR TITLE
fix(angular-query): improve compatibility with Jest

### DIFF
--- a/packages/angular-query-devtools-experimental/package.json
+++ b/packages/angular-query-devtools-experimental/package.json
@@ -31,13 +31,11 @@
   },
   "type": "module",
   "types": "build/index.d.ts",
-  "module": "build/index.js",
+  "module": "build/index.mjs",
   "exports": {
     ".": {
-      "import": {
-        "types": "./build/index.d.ts",
-        "default": "./build/index.js"
-      }
+      "types": "./build/index.d.ts",
+      "default": "./build/index.mjs"
     },
     "./package.json": {
       "default": "./package.json"

--- a/packages/angular-query-devtools-experimental/tsup.config.js
+++ b/packages/angular-query-devtools-experimental/tsup.config.js
@@ -7,4 +7,7 @@ export default defineConfig({
   format: ['esm'],
   dts: true,
   outDir: 'build',
+  outExtension({ format }) {
+    return format === 'esm' ? { js: '.mjs' } : { js: '.js' }
+  },
 })

--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -46,13 +46,11 @@
   },
   "type": "module",
   "types": "build/index.d.ts",
-  "module": "build/index.js",
+  "module": "build/index.mjs",
   "exports": {
     ".": {
-      "import": {
-        "types": "./build/index.d.ts",
-        "default": "./build/index.js"
-      }
+      "types": "./build/index.d.ts",
+      "default": "./build/index.mjs"
     },
     "./package.json": {
       "default": "./package.json"

--- a/packages/angular-query-experimental/tsup.config.js
+++ b/packages/angular-query-experimental/tsup.config.js
@@ -7,4 +7,7 @@ export default defineConfig({
   format: ['esm'],
   dts: true,
   outDir: 'build',
+  outExtension({ format }) {
+    return format === 'esm' ? { js: '.mjs' } : { js: '.js' }
+  },
 })


### PR DESCRIPTION
Changing file extension to .mjs helps Jest recognise the files as ESM