### PR TITLE
fix: handle non-null at then end of var  in exhaustive-deps

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/exhaustive-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/exhaustive-deps.test.ts
@@ -497,6 +497,18 @@ ruleTester.run('exhaustive-deps', rule, {
         }
       `,
     },
+    {
+      name: 'should pass with optional chaining as key and non-null assertion at the end of the variable in queryFn',
+      code: `
+        function useTest(data?: any) {
+          return useQuery({
+            queryKey: ['query-name', data?.address],
+            queryFn: async () => sendQuery(data!.address!),
+            enabled: !!data?.address,
+          })
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-query/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-query/src/utils/ast-utils.ts
@@ -234,8 +234,8 @@ export const ASTUtils = {
     sourceCode: Readonly<TSESLint.SourceCode>,
   ) {
     return ASTUtils.mapKeyNodeToText(node, sourceCode).replace(
-      /(\?\.|!\.)/g,
-      '.',
+      /(?:\?(\.)|!)/g,
+      '$1',
     )
   },
   isValidReactComponentOrHookName(


### PR DESCRIPTION
followup of #8365

This pr also allows adding `!` at the end of var name