### PR TITLE
📝 docs(query): add link to infiniteQueryOptions reference

### DIFF
--- a/docs/framework/react/guides/query-options.md
+++ b/docs/framework/react/guides/query-options.md
@@ -31,4 +31,4 @@ queryClient.setQueryData(groupOptions(42).queryKey, newGroups)
 
 [//]: # 'Example1'
 
-For Infinite Queries, a separate `infiniteQueryOptions` helper is available.
+For Infinite Queries, a separate [`infiniteQueryOptions`](../reference/infiniteQueryOptions.md) helper is available.


### PR DESCRIPTION

This pull request includes a small change to the `docs/framework/react/guides/query-options.md` file. The change updates a reference to the `infiniteQueryOptions` helper to link to its documentation.

Documentation update:

* [`docs/framework/react/guides/query-options.md`](diffhunk://#diff-fde8eec3471b86abbcbc7582d1d74763a12a1664ef1dd253b23480e59b88ca7cL34-R34): Updated the reference for `infiniteQueryOptions` to link to its documentation.