### PR TITLE
Removed unused notifyOnChangeProps prop

### DIFF
--- a/docs/framework/react/react-native.md
+++ b/docs/framework/react/react-native.md
@@ -165,7 +165,7 @@ Enabled can also be set to a callback to support disabling queries on out of foc
 import React from 'react'
 import { useFocusEffect } from '@react-navigation/native'
 
-export function useQueryFocusAware(notifyOnChangeProps?: NotifyOnChangeProps) {
+export function useQueryFocusAware() {
   const focusedRef = React.useRef(true)
 
   useFocusEffect(


### PR DESCRIPTION
This will remove the notifyOnChangeProps from the example as this is not used within the hook.
