### PR TITLE
fix(angular-query): fix error NG0600 on Angular v16-v18

### DIFF
--- a/packages/angular-query-experimental/src/create-base-query.ts
+++ b/packages/angular-query-experimental/src/create-base-query.ts
@@ -92,10 +92,12 @@ export function createBaseQuery<
         })
       })
       onCleanup(() => {
-        resultFromSubscriberSignal.set(null)
+        ngZone.run(() => resultFromSubscriberSignal.set(null))
       })
     },
     {
+      // Set allowSignalWrites to support Angular < v19
+      allowSignalWrites: true,
       injector,
     },
   )


### PR DESCRIPTION
Effect `onCleanup` sets a signal which throws an error on Angular < v19 unless `allowSignalWrites` is set.