### PR TITLE
fix(angular-query): fix console warning on Angular 19

### DIFF
--- a/packages/angular-query-experimental/src/create-base-query.ts
+++ b/packages/angular-query-experimental/src/create-base-query.ts
@@ -2,6 +2,7 @@ import {
   DestroyRef,
   Injector,
   NgZone,
+  VERSION,
   computed,
   effect,
   inject,
@@ -97,7 +98,8 @@ export function createBaseQuery<
     },
     {
       // Set allowSignalWrites to support Angular < v19
-      allowSignalWrites: true,
+      // Set to undefined to avoid warning on newer versions
+      allowSignalWrites: VERSION.major < '19' || undefined,
       injector,
     },
   )


### PR DESCRIPTION
Although just a noop, Angular 19 gives a warning message when allowSignalWrites is set. Set it to true on Angular < 19, undefined otherwise.