### PR TITLE
fix(query-core): respect initialData for queryClient.ensureQueryData

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -477,6 +477,21 @@ describe('queryClient', () => {
         }),
       ).resolves.toEqual('new')
     })
+
+    test('should not fetch with initialDat', async () => {
+      const key = queryKey()
+      const queryFn = vi.fn().mockImplementation(() => Promise.resolve('data'))
+
+      await expect(
+        queryClient.ensureQueryData({
+          queryKey: [key, 'id'],
+          queryFn,
+          initialData: 'initial',
+        }),
+      ).resolves.toEqual('initial')
+
+      expect(queryFn).toHaveBeenCalledTimes(0)
+    })
   })
 
   describe('ensureInfiniteQueryData', () => {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -151,16 +151,16 @@ export class QueryClient {
 
     if (cachedData === undefined) {
       return this.fetchQuery(options)
-    } else {
-      if (
-        options.revalidateIfStale &&
-        query.isStaleByTime(resolveStaleTime(defaultedOptions.staleTime, query))
-      ) {
-        void this.prefetchQuery(defaultedOptions)
-      }
-
-      return Promise.resolve(cachedData)
     }
+
+    if (
+      options.revalidateIfStale &&
+      query.isStaleByTime(resolveStaleTime(defaultedOptions.staleTime, query))
+    ) {
+      void this.prefetchQuery(defaultedOptions)
+    }
+
+    return Promise.resolve(cachedData)
   }
 
   getQueriesData<

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -145,14 +145,13 @@ export class QueryClient {
   >(
     options: EnsureQueryDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   ): Promise<TData> {
-    const cachedData = this.getQueryData<TData>(options.queryKey)
+    const defaultedOptions = this.defaultQueryOptions(options)
+    const query = this.#queryCache.build(this, defaultedOptions)
+    const cachedData = query.state.data
 
     if (cachedData === undefined) {
       return this.fetchQuery(options)
     } else {
-      const defaultedOptions = this.defaultQueryOptions(options)
-      const query = this.#queryCache.build(this, defaultedOptions)
-
       if (
         options.revalidateIfStale &&
         query.isStaleByTime(resolveStaleTime(defaultedOptions.staleTime, query))


### PR DESCRIPTION
we used to call `getQueryData` before queryCache.build(), but building is what creates the query and potentially adds initialData. I tried to make that more obvious by reading directly from `query.state.data`

fixes #8418