### PR TITLE
fix(QueriesObserver): include default options on duplicate query, queryHash check

### DIFF
--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -92,7 +92,9 @@ export class QueriesObserver<
     this.#options = options
 
     if (process.env.NODE_ENV !== 'production') {
-      const queryHashes = queries.map((query) => query.queryHash)
+      const queryHashes = queries.map(
+        (query) => this.#client.defaultQueryOptions(query).queryHash,
+      )
       if (new Set(queryHashes).size !== queryHashes.length) {
         console.warn(
           '[QueriesObserver]: Duplicate Queries found. This might result in unexpected behavior.',


### PR DESCRIPTION
This commit fixes the issue logged here 
https://github.com/TanStack/query/issues/8431

The duplicate keys check occurs prior to default options being set on the queries which generates the queryHash.

The below contains 2 unique query key's. However the duplicate keys warning logs since these queries are checked as-is and they do not yet have a queryHash.

`const observer = new QueriesObserver(queryClient, [ { queryKey: [ 'Hippo', 'Layout', 'detail', 'id1', ], }, { queryKey: [ 'Hippo', 'Layout', 'detail', 'id2', ], }, ])`
