### PR TITLE
docs: add more info to description of `staleTime` field of query options

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -92,7 +92,7 @@ const {
 - `staleTime: number | ((query: Query) => number)`
   - Optional
   - Defaults to `0`
-  - The time in milliseconds after data is considered stale. This value only applies to the hook it is defined on.
+  - The time in milliseconds after which data is considered stale. This value only applies to the hook it is defined on.
   - If set to `Infinity`, the data will never be considered stale
   - If set to a function, the function will be executed with the query to compute a `staleTime`.
 - `gcTime: number | Infinity`


### PR DESCRIPTION
Add a missing word to the description of the `staleTime` option of `useQuery`