### PR TITLE
fix(solid-query): use `DefaultError` type on error in`queryOptions` 

### DIFF
--- a/packages/solid-query/src/queryOptions.ts
+++ b/packages/solid-query/src/queryOptions.ts
@@ -25,7 +25,7 @@ export type DefinedInitialDataOptions<
 
 export function queryOptions<
   TQueryFnData = unknown,
-  TError = unknown,
+  TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TOptions extends ReturnType<
@@ -45,7 +45,7 @@ export function queryOptions<
 
 export function queryOptions<
   TQueryFnData = unknown,
-  TError = unknown,
+  TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TOptions extends ReturnType<


### PR DESCRIPTION
Fix #8460 

Resolve the erased error type when using `queryOptions` by changing the default `TError` to `DefaultError` instead of `unknown` 