### PR TITLE
docs(*): update md format with callouts for better visibility

### DIFF
--- a/docs/framework/react/guides/mutations.md
+++ b/docs/framework/react/guides/mutations.md
@@ -63,7 +63,8 @@ Even with just variables, mutations aren't all that special, but when used with 
 
 [//]: # 'Info1'
 
-> IMPORTANT: The `mutate` function is an asynchronous function, which means you cannot use it directly in an event callback in **React 16 and earlier**. If you need to access the event in `onSubmit` you need to wrap `mutate` in another function. This is due to [React event pooling](https://reactjs.org/docs/legacy-event-pooling.html).
+> [!IMPORTANT]
+> The `mutate` function is an asynchronous function, which means you cannot use it directly in an event callback in **React 16 and earlier**. If you need to access the event in `onSubmit` you need to wrap `mutate` in another function. This is due to [React event pooling](https://reactjs.org/docs/legacy-event-pooling.html).
 
 [//]: # 'Info1'
 [//]: # 'Example2'
@@ -219,6 +220,7 @@ mutate(todo, {
 
 There is a slight difference in handling `onSuccess`, `onError` and `onSettled` callbacks when it comes to consecutive mutations. When passed to the `mutate` function, they will be fired up only _once_ and only if the component is still mounted. This is due to the fact that mutation observer is removed and resubscribed every time when the `mutate` function is called. On the contrary, `useMutation` handlers execute for each `mutate` call.
 
+> [!Caution]
 > Be aware that most likely, `mutationFn` passed to `useMutation` is asynchronous. In that case, the order in which mutations are fulfilled may differ from the order of `mutate` function calls.
 
 [//]: # 'Example7'


### PR DESCRIPTION
… markdown format to include callouts, making important points stand out and easier for users to notice. Previously, critical details were not emphasized, potentially causing users to overlook them.