### PR TITLE
Update invalidations-from-mutations.md

### DIFF
--- a/docs/framework/angular/guides/invalidations-from-mutations.md
+++ b/docs/framework/angular/guides/invalidations-from-mutations.md
@@ -5,19 +5,6 @@ ref: docs/framework/react/guides/invalidations-from-mutations.md
 replace: { 'useMutation': 'injectMutation', 'hook': 'function' }
 ---
 
-[//]: # 'Example'
-
-```ts
-class TodoItemComponent {
-  mutation = injectMutation(() => ({
-    mutationFn: postTodo,
-  }))
-}
-```
-
-[//]: # 'Example'
-[//]: # 'Example2'
-
 ```ts
 import {
   injectMutation,
@@ -28,11 +15,11 @@ export class TodosComponent {
   queryClient = inject(QueryClient)
 
   // When this mutation succeeds, invalidate any queries with the `todos` or `reminders` query key
-  mutation = injectMutation(() => ({
+  mutation = injectMutation((queryClient) => ({
     mutationFn: addTodo,
     onSuccess: () => {
-      this.queryClient.invalidateQueries({ queryKey: ['todos'] })
-      this.queryClient.invalidateQueries({ queryKey: ['reminders'] })
+      queryClient.invalidateQueries({ queryKey: ['todos'] })
+      queryClient.invalidateQueries({ queryKey: ['reminders'] })
 
       // OR use the queryClient that is injected into the component
       // this.queryClient.invalidateQueries({ queryKey: ['todos'] })
@@ -41,6 +28,4 @@ export class TodosComponent {
 }
 ```
 
-[//]: # 'Example2'
-
-You can wire up your invalidations to happen using any of the callbacks available in the [`injectMutation` function](../mutations)
+You can wire up your invalidations to happen using any of the callbacks available in the [`injectMutation`](../mutations) function

--- a/docs/framework/angular/guides/invalidations-from-mutations.md
+++ b/docs/framework/angular/guides/invalidations-from-mutations.md
@@ -5,6 +5,17 @@ ref: docs/framework/react/guides/invalidations-from-mutations.md
 replace: { 'useMutation': 'injectMutation', 'hook': 'function' }
 ---
 
+[//]: # 'Example'
+
+```ts
+mutation = injectMutation(() => ({
+  mutationFn: postTodo,
+}))
+```
+
+[//]: # 'Example'
+[//]: # 'Example2'
+
 ```ts
 import {
   injectMutation,
@@ -25,4 +36,6 @@ export class TodosComponent {
 }
 ```
 
-You can wire up your invalidations to happen using any of the callbacks available in the [`injectMutation`](../mutations) function
+[//]: # 'Example2'
+
+You can wire up your invalidations to happen using any of the callbacks available in the [`injectMutation` function](../mutations)

--- a/docs/framework/angular/guides/invalidations-from-mutations.md
+++ b/docs/framework/angular/guides/invalidations-from-mutations.md
@@ -15,14 +15,11 @@ export class TodosComponent {
   queryClient = inject(QueryClient)
 
   // When this mutation succeeds, invalidate any queries with the `todos` or `reminders` query key
-  mutation = injectMutation((queryClient) => ({
+  mutation = injectMutation(() => ({
     mutationFn: addTodo,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['todos'] })
-      queryClient.invalidateQueries({ queryKey: ['reminders'] })
-
-      // OR use the queryClient that is injected into the component
-      // this.queryClient.invalidateQueries({ queryKey: ['todos'] })
+      this.queryClient.invalidateQueries({ queryKey: ['todos'] })
+      this.queryClient.invalidateQueries({ queryKey: ['reminders'] })
     },
   }))
 }


### PR DESCRIPTION
Updated the guide to show both ways of accessing `queryClient` inside a mutation, the comment earlier was wrong but now makes sense with the updated example.

There was also an irrelevant component code which I removed