### PR TITLE
docs(react-query): Add import statement with skipToken to the docs

### DIFF
--- a/docs/framework/react/guides/disabling-queries.md
+++ b/docs/framework/react/guides/disabling-queries.md
@@ -104,6 +104,8 @@ If you are using TypeScript, you can use the `skipToken` to disable a query. Thi
 [//]: # 'Example3'
 
 ```tsx
+import { skipToken, useQuery } from '@tanstack/react-query';
+
 function Todos() {
   const [filter, setFilter] = React.useState<string | undefined>()
 

--- a/docs/framework/react/guides/disabling-queries.md
+++ b/docs/framework/react/guides/disabling-queries.md
@@ -104,7 +104,7 @@ If you are using TypeScript, you can use the `skipToken` to disable a query. Thi
 [//]: # 'Example3'
 
 ```tsx
-import { skipToken, useQuery } from '@tanstack/react-query';
+import { skipToken, useQuery } from '@tanstack/react-query'
 
 function Todos() {
   const [filter, setFilter] = React.useState<string | undefined>()


### PR DESCRIPTION
It was not necessarily obvious enough from the docs where does the skipToken come from and how to use it. This makes it more obvious.