### PR TITLE
docs(react-query): highlight per component select pattern for query options

### DIFF
--- a/docs/framework/react/guides/query-options.md
+++ b/docs/framework/react/guides/query-options.md
@@ -35,6 +35,8 @@ For Infinite Queries, a separate [`infiniteQueryOptions`](../reference/infiniteQ
 
 You can still override some options at the component level. A very common and useful pattern is to create per-component [`select`](../guides/render-optimizations.md#select) functions:
 
+[//]: # 'Example2'
+
 ```ts
 // Type inference still works, so query.data will be the return type of select instead of queryFn
 

--- a/docs/framework/react/guides/query-options.md
+++ b/docs/framework/react/guides/query-options.md
@@ -32,3 +32,16 @@ queryClient.setQueryData(groupOptions(42).queryKey, newGroups)
 [//]: # 'Example1'
 
 For Infinite Queries, a separate [`infiniteQueryOptions`](../reference/infiniteQueryOptions.md) helper is available.
+
+You can still override some options at the component level. A very common and useful pattern is to create per-component [`select`](../guides/render-optimizations.md#select) functions:
+
+```ts
+// Type inference still works, so query.data will be the return type of select instead of queryFn
+
+const query = useQuery({
+  ...groupOptions(1),
+  select: (data) => data.groupName,
+})
+```
+
+[//]: # 'Example2'


### PR DESCRIPTION
Per discord conversation here https://discord.com/channels/719702312431386674/1327028649278312469

Per component select overrides are fairly common with the `queryOptions` API and have there own test [here](
https://github.com/TanStack/query/blob/ab1a353ae4645905b5ed89ab7c7bb1d643e7b75d/packages/react-query/src/__tests__/useQuery.test-d.tsx#L36-L48). Adding a few lines to make it more obvious as an useful pattern.