### PR TITLE
fix(types): support both `Array` and `ReadonlyArray` for typed query and mutation keys

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -45,9 +45,9 @@ export type DefaultError = Register extends {
 export type QueryKey = Register extends {
   queryKey: infer TQueryKey
 }
-  ? TQueryKey extends Array<unknown>
+  ? TQueryKey extends ReadonlyArray<unknown>
     ? TQueryKey
-    : ReadonlyArray<unknown>
+    : TQueryKey extends Array<unknown> ? TQueryKey : ReadonlyArray<unknown>
   : ReadonlyArray<unknown>
 
 export const dataTagSymbol = Symbol('dataTagSymbol')
@@ -1009,7 +1009,7 @@ export type MutationKey = Register extends {
 }
   ? TMutationKey extends Array<unknown>
     ? TMutationKey
-    : ReadonlyArray<unknown>
+    : TMutationKey extends Array<unknown> ? TMutationKey : ReadonlyArray<unknown>
   : ReadonlyArray<unknown>
 
 export type MutationStatus = 'idle' | 'pending' | 'success' | 'error'


### PR DESCRIPTION
Follow-up to https://github.com/TanStack/query/pull/8521

When using this new feature I've realised that it currently doesn't support `ReadonlyArray`s, which some users may want to provide to `Register` for extra type safety. This PR updates the inference of `QueryKey` and `MutationKey` so that it will now support both.