### PR TITLE
refactor(svelte-query): rename FunctionedParams<T> to Accessor<T> for improved semantics and consistency, use in function return types

### DIFF
--- a/packages/svelte-query/src/context.ts
+++ b/packages/svelte-query/src/context.ts
@@ -1,5 +1,6 @@
 import { getContext, setContext } from 'svelte'
 import type { QueryClient } from '@tanstack/query-core'
+import type { Accessor } from './types.js'
 
 const _contextKey = '$$_queryClient'
 
@@ -23,9 +24,9 @@ export const setQueryClientContext = (client: QueryClient): void => {
 const _isRestoringContextKey = '$$_isRestoring'
 
 /** Retrieves a `isRestoring` from Svelte's context */
-export const getIsRestoringContext = (): (() => boolean) => {
+export const getIsRestoringContext = (): Accessor<boolean> => {
   try {
-    const isRestoring = getContext<(() => boolean) | undefined>(
+    const isRestoring = getContext<(Accessor<boolean>) | undefined>(
       _isRestoringContextKey,
     )
     return isRestoring ?? (() => false)
@@ -35,6 +36,6 @@ export const getIsRestoringContext = (): (() => boolean) => {
 }
 
 /** Sets a `isRestoring` on Svelte's context */
-export const setIsRestoringContext = (isRestoring: () => boolean): void => {
+export const setIsRestoringContext = (isRestoring: Accessor<boolean>): void => {
   setContext(_isRestoringContextKey, isRestoring)
 }

--- a/packages/svelte-query/src/createBaseQuery.svelte.ts
+++ b/packages/svelte-query/src/createBaseQuery.svelte.ts
@@ -4,7 +4,7 @@ import { useQueryClient } from './useQueryClient.js'
 import type {
   CreateBaseQueryOptions,
   CreateBaseQueryResult,
-  FunctionedParams,
+  Accessor,
 } from './types.js'
 import type {
   QueryClient,
@@ -20,7 +20,7 @@ export function createBaseQuery<
   TQueryData,
   TQueryKey extends QueryKey,
 >(
-  options: FunctionedParams<
+  options: Accessor<
     CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   Observer: typeof QueryObserver,

--- a/packages/svelte-query/src/createInfiniteQuery.ts
+++ b/packages/svelte-query/src/createInfiniteQuery.ts
@@ -10,7 +10,7 @@ import type {
 import type {
   CreateInfiniteQueryOptions,
   CreateInfiniteQueryResult,
-  FunctionedParams,
+  Accessor,
 } from './types.js'
 
 export function createInfiniteQuery<
@@ -20,7 +20,7 @@ export function createInfiniteQuery<
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 >(
-  options: FunctionedParams<
+  options: Accessor<
     CreateInfiniteQueryOptions<
       TQueryFnData,
       TError,

--- a/packages/svelte-query/src/createMutation.svelte.ts
+++ b/packages/svelte-query/src/createMutation.svelte.ts
@@ -6,7 +6,7 @@ import type {
   CreateMutateFunction,
   CreateMutationOptions,
   CreateMutationResult,
-  FunctionedParams,
+  Accessor,
 } from './types.js'
 
 import type { DefaultError, QueryClient } from '@tanstack/query-core'
@@ -17,7 +17,7 @@ export function createMutation<
   TVariables = void,
   TContext = unknown,
 >(
-  options: FunctionedParams<
+  options: Accessor<
     CreateMutationOptions<TData, TError, TVariables, TContext>
   >,
   queryClient?: QueryClient,

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -2,7 +2,7 @@ import { untrack } from 'svelte'
 import { QueriesObserver, notifyManager } from '@tanstack/query-core'
 import { useIsRestoring } from './useIsRestoring.js'
 import { useQueryClient } from './useQueryClient.js'
-import type { FunctionedParams } from './types.js'
+import type { Accessor } from './types.js'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
@@ -208,7 +208,7 @@ export function createQueries<
     queries,
     ...options
   }: {
-    queries: FunctionedParams<[...QueriesOptions<T>]>
+    queries: Accessor<[...QueriesOptions<T>]>
     combine?: (result: QueriesResults<T>) => TCombinedResult
   },
   queryClient?: QueryClient,

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -5,7 +5,7 @@ import type {
   CreateQueryOptions,
   CreateQueryResult,
   DefinedCreateQueryResult,
-  FunctionedParams,
+  Accessor,
 } from './types.js'
 import type {
   DefinedInitialDataOptions,
@@ -18,7 +18,7 @@ export function createQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: FunctionedParams<
+  options: Accessor<
     DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
   >,
   queryClient?: QueryClient,
@@ -30,7 +30,7 @@ export function createQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: FunctionedParams<
+  options: Accessor<
     UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
   >,
   queryClient?: QueryClient,
@@ -42,14 +42,14 @@ export function createQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: FunctionedParams<
+  options: Accessor<
     CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>
   >,
   queryClient?: QueryClient,
 ): CreateQueryResult<TData, TError>
 
 export function createQuery(
-  options: FunctionedParams<CreateQueryOptions>,
+  options: Accessor<CreateQueryOptions>,
   queryClient?: QueryClient,
 ) {
   return createBaseQuery(options, QueryObserver, queryClient)

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -17,7 +17,7 @@ import type {
   QueryObserverResult,
 } from '@tanstack/query-core'
 
-export type FunctionedParams<T> = () => T
+export type Accessor<T> = () => T
 
 /** Options for createBaseQuery */
 export type CreateBaseQueryOptions<

--- a/packages/svelte-query/src/useIsFetching.svelte.ts
+++ b/packages/svelte-query/src/useIsFetching.svelte.ts
@@ -1,11 +1,12 @@
 import { onDestroy } from 'svelte'
 import { useQueryClient } from './useQueryClient.js'
 import type { QueryClient, QueryFilters } from '@tanstack/query-core'
+import type { Accessor } from './types.js'
 
 export function useIsFetching(
   filters?: QueryFilters,
   queryClient?: QueryClient,
-): () => number {
+): Accessor<number> {
   const client = useQueryClient(queryClient)
   const queryCache = client.getQueryCache()
 

--- a/packages/svelte-query/src/useIsMutating.svelte.ts
+++ b/packages/svelte-query/src/useIsMutating.svelte.ts
@@ -1,11 +1,12 @@
 import { notifyManager } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient.js'
 import type { MutationFilters, QueryClient } from '@tanstack/query-core'
+import type { Accessor } from './types.js'
 
 export function useIsMutating(
   filters?: MutationFilters,
   queryClient?: QueryClient,
-): () => number {
+): Accessor<number> {
   const client = useQueryClient(queryClient)
   const cache = client.getMutationCache()
   // isMutating is the prev value initialized on mount *

--- a/packages/svelte-query/src/useIsRestoring.ts
+++ b/packages/svelte-query/src/useIsRestoring.ts
@@ -1,5 +1,6 @@
 import { getIsRestoringContext } from './context.js'
+import type { Accessor } from './types.js'
 
-export function useIsRestoring(): () => boolean {
+export function useIsRestoring(): Accessor<boolean> {
   return getIsRestoringContext()
 }

--- a/packages/svelte-query/tests/createQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createQuery/BaseExample.svelte
@@ -3,10 +3,10 @@
   import { createQuery } from '../../src/index.js'
   import type { QueryClient, QueryObserverResult } from '@tanstack/query-core'
   import type { CreateQueryOptions, FunctionedParams } from '../../src/index.js'
-
+Accessor
   let {
     options,
-    queryClient,
+    queryClient,Accessor
     states,
   }: {
     options: FunctionedParams<CreateQueryOptions<any>>

--- a/packages/svelte-query/tests/useMutationState/BaseExample.svelte
+++ b/packages/svelte-query/tests/useMutationState/BaseExample.svelte
@@ -6,14 +6,15 @@
   import type {
     CreateMutationOptions,
     FunctionedParams,
-    MutationStateOptions,
+    AccessorteOptions,
   } from '../../src/index.js'
 
   let {
     successMutationOpts,
     errorMutationOpts,
-    mutationStateOpts,
+    mutationAccessor,
   }: {
+    Accessor
     successMutationOpts: FunctionedParams<CreateMutationOptions>
     errorMutationOpts: FunctionedParams<CreateMutationOptions>
     mutationStateOpts?: MutationStateOptions | undefined


### PR DESCRIPTION
This change renames `FunctionedParams<T>` to `Accessor<T>` to improve code clarity and align with established patterns in the ecosystem. The change brings several key benefits:

1. **Alignment with Established Standards**: The name `Accessor<T>` aligns with established patterns, particularly SolidJS's `Accessor` utility type.

For example, you can already see this same pattern is used in `solid-query`'s [createQuery.ts](https://github.com/TanStack/query/blob/main/packages/solid-query/src/createQuery.ts), [createQueries.ts](https://github.com/TanStack/query/blob/main/packages/solid-query/src/createQueries.ts), [isRestoring.ts](https://github.com/tanstack/query/blob/main/packages/solid-query/src/isRestoring.ts)

2. **Semantic Clarity**: The term "Accessor" better describes the type's purpose - a function that provides access to a value. The previous name `FunctionedParams` was ambiguous and could be misinterpreted as parameters that have been "functioned" or transformed.

3. **Removal of Redundancy**: The word "Params" in `FunctionedParams<T>` was redundant since this type is already used in parameter positions. For example:

```typescript
export function createQuery<T>(
  options: Accessor<CreateQueryOptions<T>>,  // Clearer than FunctionedParams
  queryClient?: QueryClient
)
```

4. **Broader Type Utility**: The Accessor<T> type can be consistently used to type function return types across the codebase, particularly in utility hooks like `useIsFetching`, `useIsMutating`, `useIsRestoring`, and `context` functions. This creates a unified type pattern for functions that provide access to reactive values.

