### PR TITLE
fix(react-query): add missing subscribed option to UseInfiniteQueryOp…

### DIFF
--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -102,12 +102,12 @@ export interface UseInfiniteQueryOptions<
     >,
     'suspense'
   > {
-    /**
-     * Set this to `false` to unsubscribe this observer from updates to the query cache.
-     * Defaults to `true`.
-     */
-    subscribed?: boolean
-  }
+  /**
+   * Set this to `false` to unsubscribe this observer from updates to the query cache.
+   * Defaults to `true`.
+   */
+  subscribed?: boolean
+}
 
 export type AnyUseSuspenseInfiniteQueryOptions =
   UseSuspenseInfiniteQueryOptions<any, any, any, any, any, any>

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -101,7 +101,13 @@ export interface UseInfiniteQueryOptions<
       TPageParam
     >,
     'suspense'
-  > {}
+  > {
+    /**
+     * Set this to `false` to unsubscribe this observer from updates to the query cache.
+     * Defaults to `true`.
+     */
+    subscribed?: boolean
+  }
 
 export type AnyUseSuspenseInfiniteQueryOptions =
   UseSuspenseInfiniteQueryOptions<any, any, any, any, any, any>


### PR DESCRIPTION
This pull request adds the missing `subscribed` option to the `UseInfiniteQueryOptions` type, as discussed in [#8538](https://github.com/TanStack/query/discussions/8538).

## Context

Both `useQuery` and `useInfiniteQuery` rely on `useBaseQuery` under the hood, and the subscription logic resides in `useBaseQuery`. However, the options type for `useInfiniteQuery` does not currently extend `UseBaseQueryOptions`, which would seem logical given their shared base.

## Approach

Initially, I attempted to make `UseInfiniteQueryOptions` extend `UseBaseQueryOptions`. To achieve this, I broadened `UseBaseQueryOptions` to accept an additional generic parameter, `TPageParam`, required for infinite queries. However, this caused a lot of type breaks throughout the codebase, as `UseBaseQueryOptions` appears to have been designed specifically for `useQuery`.

To avoid widespread changes and potential compatibility issues, I decided to stick with the existing approach. Instead, I directly added the `subscribed` field to `UseInfiniteQueryOptions`. This resolves the issue for now without disrupting other parts of the type system.