### PR TITLE
chore: prefer using satisfies instead of type cast

### DIFF
--- a/docs/framework/react/plugins/persistQueryClient.md
+++ b/docs/framework/react/plugins/persistQueryClient.md
@@ -283,6 +283,6 @@ export function createIDBPersister(idbValidKey: IDBValidKey = 'reactQuery') {
     removeClient: async () => {
       await del(idbValidKey)
     },
-  } as Persister
+  } satisfies Persister
 }
 ```


### PR DESCRIPTION
Better to use satisfies in case of future API changes, such that we're not accidentally type casting.