### PR TITLE
docs(framework): update Next.js and Svelte documentation links

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -554,6 +554,6 @@ Alternatively, you can set a smaller `gcTime`.
 
 ### Caveat for Next.js rewrites
 
-There's a catch if you're using [Next.js' rewrites feature](https://nextjs.org/docs/api-reference/next.config.js/rewrites) together with [Automatic Static Optimization](https://nextjs.org/docs/advanced-features/automatic-static-optimization) or `getStaticProps`: It will cause a second hydration by React Query. That's because [Next.js needs to ensure that they parse the rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites#rewrite-parameters) on the client and collect any params after hydration so that they can be provided in `router.query`.
+There's a catch if you're using [Next.js' rewrites feature](https://nextjs.org/docs/app/api-reference/next-config-js/rewrites) together with [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization) or `getStaticProps`: It will cause a second hydration by React Query. That's because [Next.js needs to ensure that they parse the rewrites](https://nextjs.org/docs/app/api-reference/next-config-js/rewrites#rewrite-parameters) on the client and collect any params after hydration so that they can be provided in `router.query`.
 
 The result is missing referential equality for all the hydration data, which for example triggers wherever your data is used as props of components or in the dependency array of `useEffect`s/`useMemo`s.

--- a/docs/framework/svelte/overview.md
+++ b/docs/framework/svelte/overview.md
@@ -70,5 +70,5 @@ Svelte Query offers useful functions and components that will make managing serv
 
 Svelte Query offers an API similar to React Query, but there are some key differences to be mindful of.
 
-- Many of the functions in Svelte Query return a Svelte store. To access values on these stores reactively, you need to prefix the store with a `$`. You can learn more about Svelte stores [here](https://svelte.dev/tutorial/writable-stores).
+- Many of the functions in Svelte Query return a Svelte store. To access values on these stores reactively, you need to prefix the store with a `$`. You can learn more about Svelte stores [here](https://learn.svelte.dev/tutorial/writable-stores).
 - If your query or mutation depends on variables, you must use a store for the options. You can read more about this [here](../reactivity).


### PR DESCRIPTION
Updates external documentation links across framework guides that were previously 
returning 404 errors:

Next.js:
- Update rewrites feature link to point to /app directory docs
- Update automatic static optimization link to latest path
- Update rewrite parameters link to /app directory docs

Svelte:
- Update stores tutorial link to latest version at learn.svelte.dev

MOTIVATION:
The previous documentation links were broken and returning 404 errors. These updates 
ensure users are directed to the most current and relevant external documentation, 
improving the developer experience when following our guides.