### PR TITLE
docs: fix `variables` obtaining path in the `predicate` example

### DIFF
--- a/docs/framework/react/guides/filters.md
+++ b/docs/framework/react/guides/filters.md
@@ -56,7 +56,7 @@ await queryClient.isMutating({ mutationKey: ['post'] })
 
 // Filter mutations using a predicate function
 await queryClient.isMutating({
-  predicate: (mutation) => mutation.options.variables?.id === 1,
+  predicate: (mutation) => mutation.state.variables?.id === 1,
 })
 ```
 


### PR DESCRIPTION
## Issue
See - https://github.com/TanStack/query/issues/8578#issuecomment-2614037228

## Changes Made
Fixed `variables` prop obtaining path in the `predicate` example to address the TS error.