### PR TITLE
feat(react-query): remove `.Provider` for new React 19 syntax

### DIFF
--- a/packages/react-query/src/QueryClientProvider.tsx
+++ b/packages/react-query/src/QueryClientProvider.tsx
@@ -37,9 +37,5 @@ export const QueryClientProvider = ({
     }
   }, [client])
 
-  return (
-    <QueryClientContext.Provider value={client}>
-      {children}
-    </QueryClientContext.Provider>
-  )
+  return <QueryClientContext value={client}>{children}</QueryClientContext>
 }

--- a/packages/react-query/src/QueryErrorResetBoundary.tsx
+++ b/packages/react-query/src/QueryErrorResetBoundary.tsx
@@ -49,8 +49,8 @@ export const QueryErrorResetBoundary = ({
 }: QueryErrorResetBoundaryProps) => {
   const [value] = React.useState(() => createValue())
   return (
-    <QueryErrorResetBoundaryContext.Provider value={value}>
+    <QueryErrorResetBoundaryContext value={value}>
       {typeof children === 'function' ? children(value) : children}
-    </QueryErrorResetBoundaryContext.Provider>
+    </QueryErrorResetBoundaryContext>
   )
 }


### PR DESCRIPTION
Hi @TkDodo , 

In React 19, we can use `<Context>` instead of `<Context.Provider>`.

In fact, I found the following warning in `packages/react-query/` :

<img width="488" alt="스크린샷 2025-01-27 오후 7 46 46" src="https://github.com/user-attachments/assets/1b28822a-466b-41b5-a526-362752221c73" />

React documentation here: https://react.dev/blog/2024/12/05/react-19#context-as-a-provider

So I suggest we remove the `.Provider` that are causing the warning