### PR TITLE
fix(react-query): fix "no-unnecessary-type-assertion" eslint error

### DIFF
--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -7,7 +7,6 @@ import type {
   InfiniteQueryObserverOptions,
   QueryClient,
   QueryKey,
-  QueryObserver,
 } from '@tanstack/query-core'
 import type {
   DefinedUseInfiniteQueryResult,

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -4,6 +4,7 @@ import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
   InfiniteData,
+  InfiniteQueryObserverOptions,
   QueryClient,
   QueryKey,
   QueryObserver,
@@ -70,13 +71,44 @@ export function useInfiniteQuery<
   queryClient?: QueryClient,
 ): UseInfiniteQueryResult<TData, TError>
 
-export function useInfiniteQuery(
-  options: UseInfiniteQueryOptions,
+export function useInfiniteQuery<
+  TQueryFnData,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+>(
+  options: UseInfiniteQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey,
+    TPageParam
+  >,
   queryClient?: QueryClient,
 ) {
-  return useBaseQuery(
-    options,
-    InfiniteQueryObserver as typeof QueryObserver,
-    queryClient,
-  )
+  return useBaseQuery<
+    TQueryFnData,
+    TError,
+    TData,
+    InfiniteData<TQueryFnData, TPageParam>,
+    TQueryKey,
+    InfiniteQueryObserver<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey,
+      TPageParam
+    >,
+    InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey,
+      TPageParam
+    >
+  >(options, InfiniteQueryObserver, queryClient)
 }

--- a/packages/react-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/react-query/src/useSuspenseInfiniteQuery.ts
@@ -9,7 +9,6 @@ import type {
   InfiniteQueryObserverSuccessResult,
   QueryClient,
   QueryKey,
-  QueryObserver,
 } from '@tanstack/query-core'
 import type {
   UseSuspenseInfiniteQueryOptions,

--- a/packages/react-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/react-query/src/useSuspenseInfiniteQuery.ts
@@ -5,6 +5,7 @@ import { defaultThrowOnError } from './suspense'
 import type {
   DefaultError,
   InfiniteData,
+  InfiniteQueryObserverOptions,
   InfiniteQueryObserverSuccessResult,
   QueryClient,
   QueryKey,
@@ -38,14 +39,36 @@ export function useSuspenseInfiniteQuery<
     }
   }
 
-  return useBaseQuery(
+  return useBaseQuery<
+    TQueryFnData,
+    TError,
+    TData,
+    InfiniteData<TQueryFnData, TPageParam>,
+    TQueryKey,
+    InfiniteQueryObserver<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey,
+      TPageParam
+    >,
+    InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey,
+      TPageParam
+    >
+  >(
     {
       ...options,
       enabled: true,
       suspense: true,
       throwOnError: defaultThrowOnError,
     },
-    InfiniteQueryObserver as typeof QueryObserver,
+    InfiniteQueryObserver,
     queryClient,
   ) as InfiniteQueryObserverSuccessResult<TData, TError>
 }


### PR DESCRIPTION
#8620 

ESLint flagged "no-unnecessary-type-assertion" error in useInfiniteQuery.ts and useSuspenseInfiniteQuery.ts.
Removing it led to type errors, which have now been resolved by updating the related type definitions.