### PR TITLE
fix(query-core): prevent circular and confused error in hashKey

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   addToEnd,
   addToStart,
+  hashKey,
   isPlainArray,
   isPlainObject,
   matchMutation,
@@ -463,6 +464,62 @@ describe('core/utils', () => {
       const max = 0
       const newItems = addToStart(items, item, max)
       expect(newItems).toEqual([4, 1, 2, 3])
+    })
+  })
+
+  describe('hashKey', () => {
+    it('should hash primitives correctly', () => {
+      expect(hashKey(['test'])).toEqual(JSON.stringify(['test']))
+      expect(hashKey([123])).toEqual(JSON.stringify([123]))
+      expect(hashKey([null])).toEqual(JSON.stringify([null]))
+    })
+
+    it('should hash objects with sorted keys consistently', () => {
+      const key1 = [{ b: 2, a: 1 }]
+      const key2 = [{ a: 1, b: 2 }]
+
+      const hash1 = hashKey(key1)
+      const hash2 = hashKey(key2)
+
+      expect(hash1).toEqual(hash2)
+      expect(hash1).toEqual(JSON.stringify([{ a: 1, b: 2 }]))
+    })
+
+    it('should hash arrays consistently', () => {
+      const arr1 = [{ b: 2, a: 1 }, 'test', 123]
+      const arr2 = [{ a: 1, b: 2 }, 'test', 123]
+
+      expect(hashKey(arr1)).toEqual(hashKey(arr2))
+    })
+
+    it('should handle nested objects with sorted keys', () => {
+      const nested1 = [{ a: { d: 4, c: 3 }, b: 2 }]
+      const nested2 = [{ b: 2, a: { c: 3, d: 4 } }]
+
+      expect(hashKey(nested1)).toEqual(hashKey(nested2))
+    })
+
+    it('should skip circular references in objects', () => {
+      const obj: any = [{ a: 1 }]
+      obj.self = obj
+
+      expect(hashKey(obj)).toEqual(JSON.stringify([{ a: 1 }]))
+    })
+
+    it('should skip circular references in nested objects', () => {
+      const nested: any = { a: { b: 2 } }
+      nested.a.self = nested.a
+
+      expect(hashKey([nested])).toEqual(JSON.stringify([{ a: { b: 2 } }]))
+    })
+
+    it('should handle complex structures with circular references', () => {
+      const complex: any = { a: 1, b: { c: 2 } }
+      complex.b.d = complex
+
+      expect(hashKey([complex])).toEqual(
+        JSON.stringify([{ a: 1, b: { c: 2 } }]),
+      )
     })
   })
 })


### PR DESCRIPTION
Thank you for improving the `asynchronous state management for TS/JS` ecosystem with a greatest library.

I think it's good if the user becomes a more predictable `queryKey`.

related #8625 

## Problem Statement
When using query keys containing circular references or complex objects (e.g., React elements in `DEV`), `JSON.stringify` in query key serialization triggers maximum call stack errors due to:

1. Recursive object comparison in replacer functions
2. Circular dependencies in nested objects

This results in unpredictable behavior and debugging difficulties for developers using non-serializable query keys.

When,

```tsx
  const div = <div>asfd</div>;

  const {data} = useQuery({
    queryKey: [div],
    queryFn: // ...
  });
```

```ts
  const obj = {name: "root"};
  obj.self = obj;

  const {data} = useQuery({
    queryKey: [obj],
    queryFn: // ...
  });
```

Then,

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/72f5de75-a819-4e2d-927b-9c46c22d5838" />

<br/>

It took me quite some time to notice that the cause was in the `hashkey` of `queryKey`. I wish no one else would use this kind of time.

<br/>


## Solution Overview
Introduces a robust hashKey serializer that:

🛡️ **Circular Reference Handling**
Utilizes WeakSet to detect and prune circular dependencies during serialization

🧹 **Save Memories**
Memory Safety using WeakSet for temporary tracking


<br/>


I also wrote **test code** for `hashKey`