### PR TITLE
docs(react-native): partial revert online manager usage

### DIFF
--- a/docs/framework/react/react-native.md
+++ b/docs/framework/react/react-native.md
@@ -23,10 +23,9 @@ import NetInfo from '@react-native-community/netinfo'
 import { onlineManager } from '@tanstack/react-query'
 
 onlineManager.setEventListener((setOnline) => {
-  const eventSubscribtion = NetInfo.addEventListener((state) => {
+  return NetInfo.addEventListener((state) => {
     setOnline(!!state.isConnected)
   })
-  return eventSubscribtion.remove
 })
 ```
 


### PR DESCRIPTION
introduced a regression in the doc with PR #8633
only expo network returns an object
NetInfo returns a function
mea culpa