### PR TITLE
fix(deps): Add react-native field to package.json for Metro resolutions

### DIFF
--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -36,6 +36,7 @@
   "types": "build/legacy/index.d.ts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -36,6 +36,7 @@
   "types": "build/legacy/index.d.ts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -36,6 +36,7 @@
   "types": "build/legacy/index.d.ts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -36,6 +36,7 @@
   "types": "build/legacy/index.d.ts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -36,6 +36,7 @@
   "types": "build/legacy/index.d.ts",
   "main": "build/legacy/index.cjs",
   "module": "build/legacy/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
This PR adds the `react-native` field to other `react-query` packages. `@tanstack/react-query` includes this field, but it's internal dependencies (like `query-core`) do not - which breaks Metro module resolution in (some) contexts. 

I'm surprised that seemingly no one else has encountered this - in our monorepo setup, this missing field led to some confusing runtime errors after upgrading from v4 to v5.

 I validated this fixed the issue by manually applying the field to all relevant packages, however as a temporary workaround we've also manually resolved this in our `metro.config.js` :

```

// Custom resolve to handle exports in our package.json
config.resolver.resolveRequest = (ctx, moduleName, platform) => {
  if (moduleName === '@tanstack/query-core') {
    return {
      type: 'sourceFile',
      filePath: path.join(
        __dirname,
        `./node_modules/@tanstack/query-core/src/index.ts`
      ),
    }
  }

  if (moduleName === '@tanstack/query-sync-storage-persister') {
    return {
      type: 'sourceFile',
      filePath: path.join(
        __dirname,
        `./node_modules/@tanstack/query-sync-storage-persister/src/index.ts`
      ),
    }
  }

  if (moduleName === '@tanstack/react-query-persist-client') {
    return {
      type: 'sourceFile',
      filePath: path.join(
        __dirname,
        `./node_modules/@tanstack/react-query-persist-client/src/index.ts`
      ),
    }
  }

  if (moduleName === '@tanstack/query-persist-client-core') {
    return {
      type: 'sourceFile',
      filePath: path.join(
        __dirname,
        `./node_modules/@tanstack/query-persist-client-core/src/index.ts`
      ),
    }
  }

// ...rest
}
```