### PR TITLE
Add `NoInfer` to `useQuery` return types

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -128,10 +128,8 @@ describe('initialData', () => {
   })
 
   describe('TData type inference', () => {
-
     it('no inference of TData from return annotations', () => {
-
-      const _testFn = (): UseQueryResult<string, unknown> =>  {
+      const _testFn = (): UseQueryResult<string, unknown> => {
         // @ts-expect-error expect number to be un-assignable to string
         return useQuery({
           queryKey: [],
@@ -147,39 +145,37 @@ describe('initialData', () => {
     })
 
     it('correct or superset type annotations produce no type errors', () => {
-
-      const _testFn = (): UseQueryResult<number | string, unknown> =>  {
+      const _testFn = (): UseQueryResult<number | string, unknown> => {
         return useQuery({
           queryKey: [],
           queryFn: () => 5,
         })
       }
 
-      expectTypeOf(_testFn()["data"]).toEqualTypeOf<string | number>()
+      expectTypeOf(_testFn()['data']).toEqualTypeOf<string | number>()
 
       const _val: UseQueryResult<string | number, unknown> = useQuery({
         queryKey: [],
         queryFn: () => 5,
       })
 
-      expectTypeOf(_val["data"]).toEqualTypeOf<string | number | undefined>()
+      expectTypeOf(_val['data']).toEqualTypeOf<string | number | undefined>()
     })
 
     it('usage of select function still changes generic inference', () => {
-
       const result = useQuery({
         queryKey: [],
         queryFn: () => 5,
-        select: () => "foo"
+        select: () => 'foo',
       })
 
-      expectTypeOf(result["data"]).toEqualTypeOf<string | undefined>()
+      expectTypeOf(result['data']).toEqualTypeOf<string | undefined>()
 
       const _result2 = useQuery<number, unknown, string, unknown[]>({
         queryKey: [],
         queryFn: () => 5,
         // @ts-expect-error select fn differs from generic (when provided), so correctly type errors)
-        select: () => 5
+        select: () => 5,
       })
     })
   })

--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from 'vitest'
 import { useQuery } from '../useQuery'
 import { queryOptions } from '../queryOptions'
 import type { OmitKeyof } from '..'
-import type { UseQueryOptions } from '../types'
+import type { UseQueryOptions, UseQueryResult } from '../types'
 
 describe('initialData', () => {
   describe('Config object overload', () => {
@@ -124,6 +124,63 @@ describe('initialData', () => {
       const { data } = useCustomQuery()
 
       expectTypeOf(data).toEqualTypeOf<Data | undefined>()
+    })
+  })
+
+  describe('TData type inference', () => {
+
+    it('no inference of TData from return annotations', () => {
+
+      const _testFn = (): UseQueryResult<string, unknown> =>  {
+        // @ts-expect-error expect number to be un-assignable to string
+        return useQuery({
+          queryKey: [],
+          queryFn: () => 5,
+        })
+      }
+
+      // @ts-expect-error expect number to be un-assignable to string
+      const _val: UseQueryResult<string, unknown> = useQuery({
+        queryKey: [],
+        queryFn: () => 5,
+      })
+    })
+
+    it('correct or superset type annotations produce no type errors', () => {
+
+      const _testFn = (): UseQueryResult<number | string, unknown> =>  {
+        return useQuery({
+          queryKey: [],
+          queryFn: () => 5,
+        })
+      }
+
+      expectTypeOf(_testFn()["data"]).toEqualTypeOf<string | number>()
+
+      const _val: UseQueryResult<string | number, unknown> = useQuery({
+        queryKey: [],
+        queryFn: () => 5,
+      })
+
+      expectTypeOf(_val["data"]).toEqualTypeOf<string | number | undefined>()
+    })
+
+    it('usage of select function still changes generic inference', () => {
+
+      const result = useQuery({
+        queryKey: [],
+        queryFn: () => 5,
+        select: () => "foo"
+      })
+
+      expectTypeOf(result["data"]).toEqualTypeOf<string | undefined>()
+
+      const _result2 = useQuery<number, unknown, string, unknown[]>({
+        queryKey: [],
+        queryFn: () => 5,
+        // @ts-expect-error select fn differs from generic (when provided), so correctly type errors)
+        select: () => 5
+      })
     })
   })
 

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -1,7 +1,12 @@
 'use client'
 import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type { DefaultError, NoInfer, QueryClient, QueryKey } from '@tanstack/query-core'
+import type {
+  DefaultError,
+  NoInfer,
+  QueryClient,
+  QueryKey,
+} from '@tanstack/query-core'
 import type {
   DefinedUseQueryResult,
   UseQueryOptions,

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -1,7 +1,7 @@
 'use client'
 import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type { DefaultError, QueryClient, QueryKey } from '@tanstack/query-core'
+import type { DefaultError, NoInfer, QueryClient, QueryKey } from '@tanstack/query-core'
 import type {
   DefinedUseQueryResult,
   UseQueryOptions,
@@ -20,7 +20,7 @@ export function useQuery<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError>
+): DefinedUseQueryResult<NoInfer<TData>, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -30,7 +30,7 @@ export function useQuery<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<TData, TError>
+): UseQueryResult<NoInfer<TData>, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -40,7 +40,7 @@ export function useQuery<
 >(
   options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<TData, TError>
+): UseQueryResult<NoInfer<TData>, TError>
 
 export function useQuery(options: UseQueryOptions, queryClient?: QueryClient) {
   return useBaseQuery(options, QueryObserver, queryClient)


### PR DESCRIPTION
## Partially fixes https://github.com/TanStack/query/issues/8639

## TODOs:
- We should try to push `NoInfer` upstream into the `query-core` types (eg. `QueryObserverResult`)
  - I didn't have extensive time, but didn't have any luck w/o pushing this as _close_ to the usage as possible
  - If ^ doesn't work, I'd probably need some assistance to enumerate other (non-react) codepaths to change similarly.
- We should try to use native `NoInfer` from TS (https://devblogs.microsoft.com/typescript/announcing-typescript-5-4-beta/#the-noinfer-utility-type) instead of our own utility -- not 100% what our TS compatibility story is (eg what if a project doesn't have a "native" feature like `NoInfer` when we publish `d.ts` files)
