### PR TITLE
fix(devtools): force LTR direction for DevTools panel

### DIFF
--- a/packages/react-query-devtools/src/ReactQueryDevtools.tsx
+++ b/packages/react-query-devtools/src/ReactQueryDevtools.tsx
@@ -106,5 +106,5 @@ export function ReactQueryDevtools(
     }
   }, [devtools])
 
-  return <div className="tsqd-parent-container" ref={ref}></div>
+  return <div dir='ltr' className="tsqd-parent-container" ref={ref}></div>
 }


### PR DESCRIPTION
### Description  
Fixes the **React Query DevTools** layout issue in RTL pages by adding `dir="ltr"` to the `<div className="tsqd-parent-container">` in **ReactQueryDevtools.tsx**, ensuring it always renders in LTR mode.  

### Changes  
- Added `dir="ltr"` to the `tsqd-parent-container` `<div>` in **ReactQueryDevtools.tsx**.  

### Related Issue  
Closes #7563  

### Testing  
- Verified in RTL pages—DevTools now stays in LTR.  
- No impact on LTR pages.  

✅ Ready for review! 🚀