### PR TITLE
fix(react-query): fix queryOptions with initialData to work on useSuspenseQueries

### DIFF
--- a/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
@@ -154,4 +154,17 @@ describe('UseSuspenseQueries config object overload', () => {
       expectTypeOf(data).toEqualTypeOf<Data>()
     })
   })
+
+  it('queryOptions with initialData works on useSuspenseQueries', () => {
+    const query1 = queryOptions({
+      queryKey: ['key1'],
+      queryFn: () => 'Query Data',
+      initialData: 'initial data',
+    })
+
+    const queryResults = useSuspenseQueries({ queries: [query1] })
+    const query1Data = queryResults[0].data
+
+    expectTypeOf(query1Data).toEqualTypeOf<string>()
+  })
 })

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -55,7 +55,14 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
+): Omit<
+  DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  'queryFn'
+> & {
+  queryFn?: Exclude<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>['queryFn'],
+    SkipToken | undefined
+  >
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 


### PR DESCRIPTION
closes #8657 

Previously, the error was shown when we used queryOptions with initialData inside useSuspenseQueries.

```typescript
const query1 = queryOptions({
  queryKey: ['key1'],
  queryFn: () => 'Query Data',
  initialData: 'initial data',
})

const queryResults = useSuspenseQueries({ queries: [query1] })
```

I fixed the overload of `queryOptions`.
Now, the error does not occur.