### PR TITLE
fix(react-query): make error to be shown when using queryOptions with initialData and skipToken in queryFn inside useSuspenseQueries

### DIFF
--- a/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
@@ -167,4 +167,15 @@ describe('UseSuspenseQueries config object overload', () => {
 
     expectTypeOf(query1Data).toEqualTypeOf<string>()
   })
+
+  it('queryOptions with initialData and skipToken in queryFn should not work on useSuspenseQueries', () => {
+    const query1 = queryOptions({
+      queryKey: ['key1'],
+      queryFn: skipToken,
+      initialData: 'initial data',
+    })
+
+    // @ts-expect-error
+    useSuspenseQueries({ queries: [query1] })
+  })
 })

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -3,6 +3,7 @@ import type {
   DefaultError,
   InitialDataFunction,
   OmitKeyof,
+  QueryFunction,
   QueryKey,
   SkipToken,
 } from '@tanstack/query-core'
@@ -42,10 +43,11 @@ export type DefinedInitialDataOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryFn'> & {
   initialData:
     | NonUndefinedGuard<TQueryFnData>
     | (() => NonUndefinedGuard<TQueryFnData>)
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>
 }
 
 export function queryOptions<
@@ -55,14 +57,7 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): Omit<
-  DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-  'queryFn'
-> & {
-  queryFn?: Exclude<
-    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>['queryFn'],
-    SkipToken | undefined
-  >
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 


### PR DESCRIPTION
closes #8664 

Previously, the error was not shown when we used queryOptions with initialData and skipToken in queryFn inside useSuspenseQueries.

```typescript
const query1 = queryOptions({
  queryKey: ['key1'],
  queryFn: skipToken,
  initialData: 'initial data',
})

useSuspenseQueries({ queries: [query1] })
```

Now the error occurs.