### PR TITLE
fix(react-query): fix inferring data as | undefined when using initialData without queryFn

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -105,6 +105,15 @@ describe('initialData', () => {
         expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
       }
     })
+
+    it('data should not have undefined when initialData is provided', () => {
+      const { data } = useQuery({
+        queryKey: ['query-key'],
+        initialData: 42,
+      })
+
+      expectTypeOf(data).toEqualTypeOf<number>()
+    })
   })
 
   describe('custom hook', () => {

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -47,7 +47,7 @@ export type DefinedInitialDataOptions<
   initialData:
     | NonUndefinedGuard<TQueryFnData>
     | (() => NonUndefinedGuard<TQueryFnData>)
-  queryFn: QueryFunction<TQueryFnData, TQueryKey>
+  queryFn?: QueryFunction<TQueryFnData, TQueryKey>
 }
 
 export function queryOptions<


### PR DESCRIPTION
closes #8672 
```typescript
const { data } = useQuery({ queryKey: ['query-key'], initialData: 42 })
```
data should be inferred as `number`. However, previously it was inferred as `number | undefined`.

By this PR, the data is inferred as `number`.