### PR TITLE
fix(query-core): fix to show type error when queryKey is a wrong type in invalidateQueries

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -496,4 +496,24 @@ describe('fully typed usage', () => {
     queryClient.setQueryDefaults(queryKey, {} as any)
     queryClient.getMutationDefaults(mutationKey)
   })
+
+  it('shows type error when queryKey is a wrong type in invalidateQueries', () => {
+    const queryClient = new QueryClient()
+
+    queryClient.invalidateQueries()
+
+    queryClient.invalidateQueries({
+      queryKey: ['1'],
+    })
+
+    queryClient.invalidateQueries({
+      // @ts-expect-error
+      queryKey: '1',
+    })
+
+    queryClient.invalidateQueries({
+      // @ts-expect-error
+      queryKey: {},
+    })
+  })
 })

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -336,25 +336,28 @@ export class QueryClient {
   }
 
   invalidateQueries<
-    TInvalidateQueryFilters extends InvalidateQueryFilters<
-      any,
-      any,
-      any,
-      any
-    > = InvalidateQueryFilters,
+    TQueryFnData = unknown,
+    TError = DefaultError,
+    TData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey,
   >(
-    filters?: TInvalidateQueryFilters,
+    filters?: InvalidateQueryFilters<TQueryFnData, TError, TData, TQueryKey>,
     options: InvalidateOptions = {},
   ): Promise<void> {
     return notifyManager.batch(() => {
-      this.#queryCache.findAll(filters).forEach((query) => {
+      this.#queryCache.findAll(filters as QueryFilters).forEach((query) => {
         query.invalidate()
       })
 
       if (filters?.refetchType === 'none') {
         return Promise.resolve()
       }
-      const refetchFilters: RefetchQueryFilters = {
+      const refetchFilters: RefetchQueryFilters<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryKey
+      > = {
         ...filters,
         type: filters?.refetchType ?? filters?.type ?? 'active',
       }

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -171,8 +171,37 @@ export class QueryClient extends QC {
     return super.cancelQueries(cloneDeepUnref(filters), cloneDeepUnref(options))
   }
 
-  invalidateQueries(
-    filters: MaybeRefDeep<InvalidateQueryFilters> = {},
+  invalidateQueries<
+    TQueryFnData = unknown,
+    TError = DefaultError,
+    TData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey,
+  >(
+    filters?: InvalidateQueryFilters<TQueryFnData, TError, TData, TQueryKey>,
+    options?: InvalidateOptions,
+  ): Promise<void>
+
+  invalidateQueries<
+    TQueryFnData = unknown,
+    TError = DefaultError,
+    TData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey,
+  >(
+    filters?: MaybeRefDeep<
+      InvalidateQueryFilters<TQueryFnData, TError, TData, TQueryKey>
+    >,
+    options?: MaybeRefDeep<InvalidateOptions>,
+  ): Promise<void>
+
+  invalidateQueries<
+    TQueryFnData = unknown,
+    TError = DefaultError,
+    TData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey,
+  >(
+    filters: MaybeRefDeep<
+      InvalidateQueryFilters<TQueryFnData, TError, TData, TQueryKey>
+    > = {},
     options: MaybeRefDeep<InvalidateOptions> = {},
   ): Promise<void> {
     const filtersCloned = cloneDeepUnref(filters)
@@ -187,7 +216,12 @@ export class QueryClient extends QC {
       return Promise.resolve()
     }
 
-    const refetchFilters: RefetchQueryFilters = {
+    const refetchFilters: RefetchQueryFilters<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryKey
+    > = {
       ...filtersCloned,
       type: filtersCloned.refetchType ?? filtersCloned.type ?? 'active',
     }


### PR DESCRIPTION
closes #8684 

Now, the type error is shown when queryKey is a wrong type in invalidateQueries.