### PR TITLE
Fix community resource links in important Defaults page.

### DIFF
--- a/docs/framework/react/guides/important-defaults.md
+++ b/docs/framework/react/guides/important-defaults.md
@@ -36,7 +36,7 @@ Out of the box, TanStack Query is configured with **aggressive but sane** defaul
 
 Have a look at the following articles from our Community Resources for further explanations of the defaults:
 
-- [Practical React Query](../../community/tkdodos-blog#1-practical-react-query)
-- [React Query as a State Manager](../../community/tkdodos-blog#10-react-query-as-a-state-manager)
+- [Practical React Query](../community/tkdodos-blog#1-practical-react-query)
+- [React Query as a State Manager](../community/tkdodos-blog#10-react-query-as-a-state-manager)
 
 [//]: # 'Materials'

--- a/docs/framework/react/guides/initial-query-data.md
+++ b/docs/framework/react/guides/initial-query-data.md
@@ -170,6 +170,6 @@ const result = useQuery({
 
 ## Further reading
 
-For a comparison between `Initial Data` and `Placeholder Data`, have a look at the [Community Resources](../../community/tkdodos-blog#9-placeholder-and-initial-data-in-react-query).
+For a comparison between `Initial Data` and `Placeholder Data`, have a look at the [Community Resources](../community/tkdodos-blog#9-placeholder-and-initial-data-in-react-query).
 
 [//]: # 'Materials'

--- a/docs/framework/react/guides/mutations.md
+++ b/docs/framework/react/guides/mutations.md
@@ -408,7 +408,7 @@ const mutation = useMutation({
 
 ## Further reading
 
-For more information about mutations, have a look at [#12: Mastering Mutations in React Query](../../community/tkdodos-blog#12-mastering-mutations-in-react-query) from
+For more information about mutations, have a look at [#12: Mastering Mutations in React Query](../community/tkdodos-blog#12-mastering-mutations-in-react-query) from
 the Community Resources.
 
 [//]: # 'Materials'

--- a/docs/framework/react/guides/placeholder-query-data.md
+++ b/docs/framework/react/guides/placeholder-query-data.md
@@ -96,6 +96,6 @@ function Todo({ blogPostId }) {
 
 ## Further reading
 
-For a comparison between `Placeholder Data` and `Initial Data`, have a look at the [Community Resources](../../community/tkdodos-blog#9-placeholder-and-initial-data-in-react-query).
+For a comparison between `Placeholder Data` and `Initial Data`, have a look at the [Community Resources](../community/tkdodos-blog#9-placeholder-and-initial-data-in-react-query).
 
 [//]: # 'Materials'

--- a/docs/framework/react/guides/prefetching.md
+++ b/docs/framework/react/guides/prefetching.md
@@ -431,7 +431,7 @@ queryClient.setQueryData(['todos'], todos)
 
 ## Further reading
 
-For a deep-dive on how to get data into your Query Cache before you fetch, have a look at [#17: Seeding the Query Cache](../../community/tkdodos-blog#17-seeding-the-query-cache) from the Community Resources.
+For a deep-dive on how to get data into your Query Cache before you fetch, have a look at [#17: Seeding the Query Cache](../community/tkdodos-blog#17-seeding-the-query-cache) from the Community Resources.
 
 Integrating with Server Side routers and frameworks is very similar to what we just saw, with the addition that the data has to passed from the server to the client to be hydrated into the cache there. To learn how, continue on to the [Server Rendering & Hydration guide](../ssr).
 

--- a/docs/framework/react/guides/queries.md
+++ b/docs/framework/react/guides/queries.md
@@ -140,6 +140,6 @@ So keep in mind that a query can be in `pending` state without actually fetching
 
 ## Further Reading
 
-For an alternative way of performing status checks, have a look at the [Community Resources](../../community/tkdodos-blog#4-status-checks-in-react-query).
+For an alternative way of performing status checks, have a look at the [Community Resources](../community/tkdodos-blog#4-status-checks-in-react-query).
 
 [//]: # 'Materials'

--- a/docs/framework/react/guides/query-keys.md
+++ b/docs/framework/react/guides/query-keys.md
@@ -91,13 +91,13 @@ function Todos({ todoId }) {
 
 [//]: # 'Example5'
 
-Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, _queries will be refetched automatically_ (depending on your `staleTime` settings). See the [exhaustive-deps](../../../../eslint/exhaustive-deps) section for more information and examples.
+Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, _queries will be refetched automatically_ (depending on your `staleTime` settings). See the [exhaustive-deps](../../../eslint/exhaustive-deps) section for more information and examples.
 
 [//]: # 'Materials'
 
 ## Further reading
 
-For tips on organizing Query Keys in larger applications, have a look at [Effective React Query Keys](../../community/tkdodos-blog#8-effective-react-query-keys) and check the [Query Key Factory Package](../../community/community-projects#query-key-factory) from
+For tips on organizing Query Keys in larger applications, have a look at [Effective React Query Keys](../community/tkdodos-blog#8-effective-react-query-keys) and check the [Query Key Factory Package](../community/community-projects#query-key-factory) from
 the Community Resources.
 
 [//]: # 'Materials'

--- a/docs/framework/react/guides/render-optimizations.md
+++ b/docs/framework/react/guides/render-optimizations.md
@@ -72,5 +72,5 @@ export const useTodoCount = () => {
 
 ## Further Reading
 
-For an in-depth guide about these topics, read [React Query Render Optimizations](../../community/tkdodos-blog#3-react-query-render-optimizations) from
+For an in-depth guide about these topics, read [React Query Render Optimizations](../community/tkdodos-blog#3-react-query-render-optimizations) from
 the Community Resources.

--- a/docs/framework/react/guides/testing.md
+++ b/docs/framework/react/guides/testing.md
@@ -179,5 +179,5 @@ _Note_: when using React 18, the semantics of `waitFor` have changed as noted ab
 
 ## Further reading
 
-For additional tips and an alternative setup using `mock-service-worker`, have a look at [Testing React Query](../../community/tkdodos-blog#5-testing-react-query) from
+For additional tips and an alternative setup using `mock-service-worker`, have a look at [Testing React Query](../community/tkdodos-blog#5-testing-react-query) from
 the Community Resources.


### PR DESCRIPTION
In [Important Defaults](https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults), resources in [Further reading](https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults#further-reading) point to the wrong URL (404).