### PR TITLE
docs(react-query): fix incorrect link in documentation

### DIFF
--- a/docs/framework/react/reference/infiniteQueryOptions.md
+++ b/docs/framework/react/reference/infiniteQueryOptions.md
@@ -12,7 +12,7 @@ infiniteQueryOptions({
 
 **Options**
 
-You can generally pass everything to `infiniteQueryOptions` that you can also pass to [`useInfiniteQuery`](../useInfiniteQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchInfiniteQuery`, but TypeScript will still be fine with those excess properties.
+You can generally pass everything to `infiniteQueryOptions` that you can also pass to [`useInfiniteQuery`](./useInfiniteQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchInfiniteQuery`, but TypeScript will still be fine with those excess properties.
 
 - `queryKey: QueryKey`
   - **Required**

--- a/docs/framework/react/reference/infiniteQueryOptions.md
+++ b/docs/framework/react/reference/infiniteQueryOptions.md
@@ -12,7 +12,7 @@ infiniteQueryOptions({
 
 **Options**
 
-You can generally pass everything to `infiniteQueryOptions` that you can also pass to [`useInfiniteQuery`](./useInfiniteQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchInfiniteQuery`, but TypeScript will still be fine with those excess properties.
+You can generally pass everything to `infiniteQueryOptions` that you can also pass to [`useInfiniteQuery`](../reference/useInfiniteQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchInfiniteQuery`, but TypeScript will still be fine with those excess properties.
 
 - `queryKey: QueryKey`
   - **Required**

--- a/docs/framework/react/reference/queryOptions.md
+++ b/docs/framework/react/reference/queryOptions.md
@@ -12,7 +12,7 @@ queryOptions({
 
 **Options**
 
-You can generally pass everything to `queryOptions` that you can also pass to [`useQuery`](../useQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchQuery`, but TypeScript will still be fine with those excess properties.
+You can generally pass everything to `queryOptions` that you can also pass to [`useQuery`](./useQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchQuery`, but TypeScript will still be fine with those excess properties.
 
 - `queryKey: QueryKey`
   - **Required**

--- a/docs/framework/react/reference/queryOptions.md
+++ b/docs/framework/react/reference/queryOptions.md
@@ -12,7 +12,7 @@ queryOptions({
 
 **Options**
 
-You can generally pass everything to `queryOptions` that you can also pass to [`useQuery`](./useQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchQuery`, but TypeScript will still be fine with those excess properties.
+You can generally pass everything to `queryOptions` that you can also pass to [`useQuery`](../reference/useQuery). Some options will have no effect when then forwarded to a function like `queryClient.prefetchQuery`, but TypeScript will still be fine with those excess properties.
 
 - `queryKey: QueryKey`
   - **Required**

--- a/docs/framework/react/reference/useInfiniteQuery.md
+++ b/docs/framework/react/reference/useInfiniteQuery.md
@@ -27,7 +27,7 @@ const {
 
 **Options**
 
-The options for `useInfiniteQuery` are identical to the [`useQuery` hook](./useQuery) with the addition of the following:
+The options for `useInfiniteQuery` are identical to the [`useQuery` hook](../reference/useQuery) with the addition of the following:
 
 - `queryFn: (context: QueryFunctionContext) => Promise<TData>`
   - **Required, but only if no default query function has been defined** [`defaultQueryFn`](../guides/default-query-function)
@@ -55,7 +55,7 @@ The options for `useInfiniteQuery` are identical to the [`useQuery` hook](./useQ
 
 **Returns**
 
-The returned properties for `useInfiniteQuery` are identical to the [`useQuery` hook](./useQuery), with the addition of the following properties and a small difference in `isRefetching` and `isRefetchError`:
+The returned properties for `useInfiniteQuery` are identical to the [`useQuery` hook](../reference/useQuery), with the addition of the following properties and a small difference in `isRefetching` and `isRefetchError`:
 
 - `data.pages: TData[]`
   - Array containing all pages.

--- a/docs/framework/react/reference/useInfiniteQuery.md
+++ b/docs/framework/react/reference/useInfiniteQuery.md
@@ -27,12 +27,12 @@ const {
 
 **Options**
 
-The options for `useInfiniteQuery` are identical to the [`useQuery` hook](../useQuery) with the addition of the following:
+The options for `useInfiniteQuery` are identical to the [`useQuery` hook](./useQuery) with the addition of the following:
 
 - `queryFn: (context: QueryFunctionContext) => Promise<TData>`
-  - **Required, but only if no default query function has been defined** [`defaultQueryFn`](../../guides/default-query-function)
+  - **Required, but only if no default query function has been defined** [`defaultQueryFn`](../guides/default-query-function)
   - The function that the query will use to request data.
-  - Receives a [QueryFunctionContext](../../guides/query-functions#queryfunctioncontext)
+  - Receives a [QueryFunctionContext](../guides/query-functions#queryfunctioncontext)
   - Must return a promise that will either resolve data or throw an error.
 - `initialPageParam: TPageParam`
   - **Required**
@@ -55,7 +55,7 @@ The options for `useInfiniteQuery` are identical to the [`useQuery` hook](../use
 
 **Returns**
 
-The returned properties for `useInfiniteQuery` are identical to the [`useQuery` hook](../useQuery), with the addition of the following properties and a small difference in `isRefetching` and `isRefetchError`:
+The returned properties for `useInfiniteQuery` are identical to the [`useQuery` hook](./useQuery), with the addition of the following properties and a small difference in `isRefetching` and `isRefetchError`:
 
 - `data.pages: TData[]`
   - Array containing all pages.

--- a/docs/framework/react/reference/useIsFetching.md
+++ b/docs/framework/react/reference/useIsFetching.md
@@ -15,7 +15,7 @@ const isFetchingPosts = useIsFetching({ queryKey: ['posts'] })
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../../guides/filters#query-filters)
+- `filters?: QueryFilters`: [Query Filters](../guides/filters#query-filters)
 - `queryClient?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 

--- a/docs/framework/react/reference/useIsMutating.md
+++ b/docs/framework/react/reference/useIsMutating.md
@@ -15,7 +15,7 @@ const isMutatingPosts = useIsMutating({ mutationKey: ['posts'] })
 
 **Options**
 
-- `filters?: MutationFilters`: [Mutation Filters](../../guides/filters#mutation-filters)
+- `filters?: MutationFilters`: [Mutation Filters](../guides/filters#mutation-filters)
 - `queryClient?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 

--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -62,7 +62,7 @@ mutate(variables, {
 - `networkMode: 'online' | 'always' | 'offlineFirst'`
   - Optional
   - defaults to `'online'`
-  - see [Network Mode](../../guides/network-mode) for more information.
+  - see [Network Mode](../guides/network-mode) for more information.
 - `onMutate: (variables: TVariables) => Promise<TContext | void> | TContext | void`
   - Optional
   - This function will fire before the mutation function is fired and is passed the same variables the mutation function would receive
@@ -137,7 +137,7 @@ mutate(variables, {
 - `isIdle`, `isPending`, `isSuccess`, `isError`: boolean variables derived from `status`
 - `isPaused: boolean`
   - will be `true` if the mutation has been `paused`
-  - see [Network Mode](../../guides/network-mode) for more information.
+  - see [Network Mode](../guides/network-mode) for more information.
 - `data: undefined | unknown`
   - Defaults to `undefined`
   - The last successfully resolved data for the mutation.

--- a/docs/framework/react/reference/useMutationState.md
+++ b/docs/framework/react/reference/useMutationState.md
@@ -69,7 +69,7 @@ const latest = data[data.length - 1]
 **Options**
 
 - `options`
-  - `filters?: MutationFilters`: [Mutation Filters](../../guides/filters#mutation-filters)
+  - `filters?: MutationFilters`: [Mutation Filters](../guides/filters#mutation-filters)
   - `select?: (mutation: Mutation) => TResult`
     - Use this to transform the mutation state.
 - `queryClient?: QueryClient`,

--- a/docs/framework/react/reference/usePrefetchInfiniteQuery.md
+++ b/docs/framework/react/reference/usePrefetchInfiniteQuery.md
@@ -34,4 +34,4 @@ You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`que
 
 - **Returns**
 
-The `usePrefetchInfiniteQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseInfiniteQuery`](./useSuspenseInfiniteQuery)
+The `usePrefetchInfiniteQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseInfiniteQuery`](../reference/useSuspenseInfiniteQuery)

--- a/docs/framework/react/reference/usePrefetchInfiniteQuery.md
+++ b/docs/framework/react/reference/usePrefetchInfiniteQuery.md
@@ -9,7 +9,7 @@ usePrefetchInfiniteQuery(options)
 
 **Options**
 
-You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`queryClient.prefetchInfiniteQuery`](../../../../reference/QueryClient#queryclientprefetchinfinitequery). Remember that some of them are required as below:
+You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`queryClient.prefetchInfiniteQuery`](../../../reference/QueryClient#queryclientprefetchinfinitequery). Remember that some of them are required as below:
 
 - `queryKey: QueryKey`
 
@@ -18,7 +18,7 @@ You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`que
 
 - `queryFn: (context: QueryFunctionContext) => Promise<TData>`
 
-  - **Required, but only if no default query function has been defined** See [Default Query Function](../../guides/default-query-function) for more information.
+  - **Required, but only if no default query function has been defined** See [Default Query Function](../guides/default-query-function) for more information.
 
 - `initialPageParam: TPageParam`
 
@@ -34,4 +34,4 @@ You can pass everything to `usePrefetchInfiniteQuery` that you can pass to [`que
 
 - **Returns**
 
-The `usePrefetchInfiniteQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseInfiniteQuery`](../useSuspenseInfiniteQuery)
+The `usePrefetchInfiniteQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseInfiniteQuery`](./useSuspenseInfiniteQuery)

--- a/docs/framework/react/reference/usePrefetchQuery.md
+++ b/docs/framework/react/reference/usePrefetchQuery.md
@@ -9,7 +9,7 @@ usePrefetchQuery(options)
 
 **Options**
 
-You can pass everything to `usePrefetchQuery` that you can pass to [`queryClient.prefetchQuery`](../../../../reference/QueryClient#queryclientprefetchquery). Remember that some of them are required as below:
+You can pass everything to `usePrefetchQuery` that you can pass to [`queryClient.prefetchQuery`](../../../reference/QueryClient#queryclientprefetchquery). Remember that some of them are required as below:
 
 - `queryKey: QueryKey`
 
@@ -17,8 +17,8 @@ You can pass everything to `usePrefetchQuery` that you can pass to [`queryClient
   - The query key to prefetch during render
 
 - `queryFn: (context: QueryFunctionContext) => Promise<TData>`
-  - **Required, but only if no default query function has been defined** See [Default Query Function](../../guides/default-query-function) for more information.
+  - **Required, but only if no default query function has been defined** See [Default Query Function](../guides/default-query-function) for more information.
 
 **Returns**
 
-The `usePrefetchQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseQuery`](../useSuspenseQuery).
+The `usePrefetchQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseQuery`](./useSuspenseQuery).

--- a/docs/framework/react/reference/usePrefetchQuery.md
+++ b/docs/framework/react/reference/usePrefetchQuery.md
@@ -21,4 +21,4 @@ You can pass everything to `usePrefetchQuery` that you can pass to [`queryClient
 
 **Returns**
 
-The `usePrefetchQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseQuery`](./useSuspenseQuery).
+The `usePrefetchQuery` does not return anything, it should be used just to fire a prefetch during render, before a suspense boundary that wraps a component that uses [`useSuspenseQuery`](../reference/useSuspenseQuery).

--- a/docs/framework/react/reference/useQueries.md
+++ b/docs/framework/react/reference/useQueries.md
@@ -18,7 +18,7 @@ const results = useQueries({
 
 **Options**
 
-The `useQueries` hook accepts an options object with a **queries** key whose value is an array with query option objects identical to the [`useQuery` hook](./useQuery) (excluding the `queryClient` option - because the `QueryClient` can be passed in on the top level).
+The `useQueries` hook accepts an options object with a **queries** key whose value is an array with query option objects identical to the [`useQuery` hook](../reference/useQuery) (excluding the `queryClient` option - because the `QueryClient` can be passed in on the top level).
 
 - `queryClient?: QueryClient`
   - Use this to provide a custom QueryClient. Otherwise, the one from the nearest context will be used.

--- a/docs/framework/react/reference/useQueries.md
+++ b/docs/framework/react/reference/useQueries.md
@@ -18,7 +18,7 @@ const results = useQueries({
 
 **Options**
 
-The `useQueries` hook accepts an options object with a **queries** key whose value is an array with query option objects identical to the [`useQuery` hook](../useQuery) (excluding the `queryClient` option - because the `QueryClient` can be passed in on the top level).
+The `useQueries` hook accepts an options object with a **queries** key whose value is an array with query option objects identical to the [`useQuery` hook](./useQuery) (excluding the `queryClient` option - because the `QueryClient` can be passed in on the top level).
 
 - `queryClient?: QueryClient`
   - Use this to provide a custom QueryClient. Otherwise, the one from the nearest context will be used.

--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -65,20 +65,20 @@ const {
 - `queryKey: unknown[]`
   - **Required**
   - The query key to use for this query.
-  - The query key will be hashed into a stable hash. See [Query Keys](../../guides/query-keys) for more information.
+  - The query key will be hashed into a stable hash. See [Query Keys](../guides/query-keys) for more information.
   - The query will automatically update when this key changes (as long as `enabled` is not set to `false`).
 - `queryFn: (context: QueryFunctionContext) => Promise<TData>`
-  - **Required, but only if no default query function has been defined** See [Default Query Function](../../guides/default-query-function) for more information.
+  - **Required, but only if no default query function has been defined** See [Default Query Function](../guides/default-query-function) for more information.
   - The function that the query will use to request data.
-  - Receives a [QueryFunctionContext](../../guides/query-functions#queryfunctioncontext)
+  - Receives a [QueryFunctionContext](../guides/query-functions#queryfunctioncontext)
   - Must return a promise that will either resolve data or throw an error. The data cannot be `undefined`.
 - `enabled: boolean | (query: Query) => boolean`
   - Set this to `false` to disable this query from automatically running.
-  - Can be used for [Dependent Queries](../../guides/dependent-queries).
+  - Can be used for [Dependent Queries](../guides/dependent-queries).
 - `networkMode: 'online' | 'always' | 'offlineFirst`
   - optional
   - defaults to `'online'`
-  - see [Network Mode](../../guides/network-mode) for more information.
+  - see [Network Mode](../guides/network-mode) for more information.
 - `retry: boolean | number | (failureCount: number, error: TError) => boolean`
   - If `false`, failed queries will not retry by default.
   - If `true`, failed queries will retry infinitely.
@@ -219,7 +219,7 @@ const {
   - `fetching`: Is `true` whenever the queryFn is executing, which includes initial `pending` as well as background refetches.
   - `paused`: The query wanted to fetch, but has been `paused`.
   - `idle`: The query is not fetching.
-  - see [Network Mode](../../guides/network-mode) for more information.
+  - see [Network Mode](../guides/network-mode) for more information.
 - `isFetching: boolean`
   - A derived boolean from the `fetchStatus` variable above, provided for convenience.
 - `isPaused: boolean`

--- a/docs/framework/react/reference/useSuspenseInfiniteQuery.md
+++ b/docs/framework/react/reference/useSuspenseInfiniteQuery.md
@@ -9,7 +9,7 @@ const result = useSuspenseInfiniteQuery(options)
 
 **Options**
 
-The same as for [useInfiniteQuery](./useInfiniteQuery), except for:
+The same as for [useInfiniteQuery](../reference/useInfiniteQuery), except for:
 
 - `suspense`
 - `throwOnError`
@@ -18,7 +18,7 @@ The same as for [useInfiniteQuery](./useInfiniteQuery), except for:
 
 **Returns**
 
-Same object as [useInfiniteQuery](./useInfiniteQuery), except that:
+Same object as [useInfiniteQuery](../reference/useInfiniteQuery), except that:
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing

--- a/docs/framework/react/reference/useSuspenseInfiniteQuery.md
+++ b/docs/framework/react/reference/useSuspenseInfiniteQuery.md
@@ -9,7 +9,7 @@ const result = useSuspenseInfiniteQuery(options)
 
 **Options**
 
-The same as for [useInfiniteQuery](../useInfiniteQuery), except for:
+The same as for [useInfiniteQuery](./useInfiniteQuery), except for:
 
 - `suspense`
 - `throwOnError`
@@ -18,7 +18,7 @@ The same as for [useInfiniteQuery](../useInfiniteQuery), except for:
 
 **Returns**
 
-Same object as [useInfiniteQuery](../useInfiniteQuery), except that:
+Same object as [useInfiniteQuery](./useInfiniteQuery), except that:
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing

--- a/docs/framework/react/reference/useSuspenseQueries.md
+++ b/docs/framework/react/reference/useSuspenseQueries.md
@@ -9,7 +9,7 @@ const result = useSuspenseQueries(options)
 
 **Options**
 
-The same as for [useQueries](../useQueries), except that each `query` can't have:
+The same as for [useQueries](./useQueries), except that each `query` can't have:
 
 - `suspense`
 - `throwOnError`
@@ -18,7 +18,7 @@ The same as for [useQueries](../useQueries), except that each `query` can't have
 
 **Returns**
 
-Same structure as [useQueries](../useQueries), except that for each `query`:
+Same structure as [useQueries](./useQueries), except that for each `query`:
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing

--- a/docs/framework/react/reference/useSuspenseQueries.md
+++ b/docs/framework/react/reference/useSuspenseQueries.md
@@ -9,7 +9,7 @@ const result = useSuspenseQueries(options)
 
 **Options**
 
-The same as for [useQueries](./useQueries), except that each `query` can't have:
+The same as for [useQueries](../reference/useQueries), except that each `query` can't have:
 
 - `suspense`
 - `throwOnError`
@@ -18,7 +18,7 @@ The same as for [useQueries](./useQueries), except that each `query` can't have:
 
 **Returns**
 
-Same structure as [useQueries](./useQueries), except that for each `query`:
+Same structure as [useQueries](../reference/useQueries), except that for each `query`:
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing

--- a/docs/framework/react/reference/useSuspenseQuery.md
+++ b/docs/framework/react/reference/useSuspenseQuery.md
@@ -9,7 +9,7 @@ const result = useSuspenseQuery(options)
 
 **Options**
 
-The same as for [useQuery](./useQuery.md), except for:
+The same as for [useQuery](../reference/useQuery), except for:
 
 - `throwOnError`
 - `enabled`
@@ -17,7 +17,7 @@ The same as for [useQuery](./useQuery.md), except for:
 
 **Returns**
 
-Same object as [useQuery](./useQuery), except that:
+Same object as [useQuery](../reference/useQuery), except that:
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing

--- a/docs/framework/react/reference/useSuspenseQuery.md
+++ b/docs/framework/react/reference/useSuspenseQuery.md
@@ -9,7 +9,7 @@ const result = useSuspenseQuery(options)
 
 **Options**
 
-The same as for [useQuery](../useQuery), except for:
+The same as for [useQuery](./useQuery.md), except for:
 
 - `throwOnError`
 - `enabled`
@@ -17,7 +17,7 @@ The same as for [useQuery](../useQuery), except for:
 
 **Returns**
 
-Same object as [useQuery](../useQuery), except that:
+Same object as [useQuery](./useQuery), except that:
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing


### PR DESCRIPTION
The documentation contained incorrect file paths at reference section.
Fixed the incorrect paths to match the actual directory structure.