### PR TITLE
chore(react-query): add warning when useSuspenseQuery is used without queryFn

### DIFF
--- a/packages/react-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/react-query/src/useSuspenseInfiniteQuery.ts
@@ -36,6 +36,9 @@ export function useSuspenseInfiniteQuery<
     if ((options.queryFn as any) === skipToken) {
       console.error('skipToken is not allowed for useSuspenseInfiniteQuery')
     }
+    if (!options.queryFn && !options.initialData) {
+      console.error('useSuspenseInfiniteQuery requires either `queryFn` or `initialData`')
+    }
   }
 
   return useBaseQuery(

--- a/packages/react-query/src/useSuspenseQueries.ts
+++ b/packages/react-query/src/useSuspenseQueries.ts
@@ -182,6 +182,9 @@ export function useSuspenseQueries<
           if (query.queryFn === skipToken) {
             console.error('skipToken is not allowed for useSuspenseQueries')
           }
+          if (!query.queryFn && !query.initialData) {
+            console.error('useSuspenseQueries requires either `queryFn` or `initialData`')
+          }
         }
 
         return {

--- a/packages/react-query/src/useSuspenseQuery.ts
+++ b/packages/react-query/src/useSuspenseQuery.ts
@@ -18,6 +18,9 @@ export function useSuspenseQuery<
     if ((options.queryFn as any) === skipToken) {
       console.error('skipToken is not allowed for useSuspenseQuery')
     }
+    if (!options.queryFn && !options.initialData) {
+      console.error('useSuspenseQuery requires either `queryFn` or `initialData`')
+    }
   }
 
   return useBaseQuery(


### PR DESCRIPTION
`useSuspenseQuery` is designed to accept queryFn as an optional parameter. (related https://github.com/TanStack/query/pull/8176)

However, when I built my Next.js app using `useSuspenseQuery` without `queryFn`, I encountered the following error.

`Error: Missing queryFn:`

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/023be41e-abce-4aa1-ac2c-0eb191f6cbab" />

(This Picture is `@tanstack/query-example-react-nextjs`)

The reason my Next.js app was **able to run without queryFn or initialData** was that I had already received the data on the **Server-Side using HydrationBoundary**.

To prevent this situation, I have added a warning message.

Alternatively, this could be addressed by modifying the implementation like the example below, but I don’t think this would be the best approach:

```tsx
initialData: options.initialData ?? queryClient?.getQueryData(options.queryKey),
```