### PR TITLE
Fix broken links in persistQueryClient.md

### DIFF
--- a/docs/framework/react/plugins/persistQueryClient.md
+++ b/docs/framework/react/plugins/persistQueryClient.md
@@ -7,8 +7,8 @@ This is set of utilities for interacting with "persisters" which save your query
 
 ## Build Persisters
 
-- [createSyncStoragePersister](../createSyncStoragePersister)
-- [createAsyncStoragePersister](../createAsyncStoragePersister)
+- [createSyncStoragePersister](./createSyncStoragePersister)
+- [createAsyncStoragePersister](./createAsyncStoragePersister)
 - [create a custom persister](#persisters)
 
 ## How It Works


### PR DESCRIPTION
Fixes broken links for createSyncStoragePersistor and createAsyncStoragePersistor on the persistQueryClient page.  I'm honestly not sure how to test that this will work, but the links that end up on the docs pages just need to keep the "/plugins/" directory in the path.  I'm pretty sure this will work.