### PR TITLE
docs(react-query): fix broken links in QueryClient docs

### DIFF
--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -63,7 +63,7 @@ Its available methods are:
 - `defaultOptions?: DefaultOptions`
   - Optional
   - Define defaults for all queries and mutations using this queryClient.
-  - You can also define defaults to be used for [hydration](../../framework/react/reference/hydration)
+  - You can also define defaults to be used for [hydration](../framework/react/reference/hydration)
 
 ## `queryClient.fetchQuery`
 
@@ -95,7 +95,7 @@ try {
 
 **Options**
 
-The options for `fetchQuery` are exactly the same as those of [`useQuery`](../../framework/react/reference/useQuery), except the following: `enabled, refetchInterval, refetchIntervalInBackground, refetchOnWindowFocus, refetchOnReconnect, refetchOnMount, notifyOnChangeProps, throwOnError, select, suspense, placeholderData`; which are strictly for useQuery and useInfiniteQuery. You can check the [source code](https://github.com/TanStack/query/blob/7cd2d192e6da3df0b08e334ea1cf04cd70478827/packages/query-core/src/types.ts#L119) for more clarity.
+The options for `fetchQuery` are exactly the same as those of [`useQuery`](../framework/react/reference/useQuery), except the following: `enabled, refetchInterval, refetchIntervalInBackground, refetchOnWindowFocus, refetchOnReconnect, refetchOnMount, notifyOnChangeProps, throwOnError, select, suspense, placeholderData`; which are strictly for useQuery and useInfiniteQuery. You can check the [source code](https://github.com/TanStack/query/blob/7cd2d192e6da3df0b08e334ea1cf04cd70478827/packages/query-core/src/types.ts#L119) for more clarity.
 
 **Returns**
 
@@ -172,7 +172,7 @@ const data = queryClient.getQueryData(queryKey)
 
 **Options**
 
-- `queryKey: QueryKey`: [Query Keys](../../framework/react/guides/query-keys)
+- `queryKey: QueryKey`: [Query Keys](../framework/react/guides/query-keys)
 
 **Returns**
 
@@ -234,7 +234,7 @@ const data = queryClient.getQueriesData(filters)
 
 **Options**
 
-- `filters: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `filters: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
   - if a filter is passed, the data with queryKeys matching the filter will be returned
 
 **Returns**
@@ -260,7 +260,7 @@ queryClient.setQueryData(queryKey, updater)
 
 **Options**
 
-- `queryKey: QueryKey`: [Query Keys](../../framework/react/guides/query-keys)
+- `queryKey: QueryKey`: [Query Keys](../framework/react/guides/query-keys)
 - `updater: TQueryFnData | undefined | ((oldData: TQueryFnData | undefined) => TQueryFnData | undefined)`
   - If non-function is passed, the data will be updated to this value
   - If a function is passed, it will receive the old data value and be expected to return a new one.
@@ -298,7 +298,7 @@ console.log(state.dataUpdatedAt)
 
 **Options**
 
-- `queryKey: QueryKey`: [Query Keys](../../framework/react/guides/query-keys)
+- `queryKey: QueryKey`: [Query Keys](../framework/react/guides/query-keys)
 
 ## `queryClient.setQueriesData`
 
@@ -310,7 +310,7 @@ queryClient.setQueriesData(filters, updater)
 
 **Options**
 
-- `filters: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `filters: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
   - if a filter is passed, queryKeys matching the filter will be updated
 - `updater: TQueryFnData | (oldData: TQueryFnData | undefined) => TQueryFnData`
   - the [setQueryData](#queryclientsetquerydata) updater function or new data, will be called for each matching queryKey
@@ -335,8 +335,8 @@ await queryClient.invalidateQueries(
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
-  - `queryKey?: QueryKey`: [Query Keys](../../framework/react/guides/query-keys)
+- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
+  - `queryKey?: QueryKey`: [Query Keys](../framework/react/guides/query-keys)
   - `refetchType?: 'active' | 'inactive' | 'all' | 'none'`
     - Defaults to `'active'`
     - When set to `active`, only queries that match the refetch predicate and are actively being rendered via `useQuery` and friends will be refetched in the background.
@@ -377,7 +377,7 @@ await queryClient.refetchQueries({
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
 - `options?: RefetchOptions`:
   - `throwOnError?: boolean`
     - When set to `true`, this method will throw if any of the query refetch tasks fail.
@@ -402,7 +402,7 @@ await queryClient.cancelQueries({ queryKey: ['posts'], exact: true })
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
 
 **Returns**
 
@@ -418,7 +418,7 @@ queryClient.removeQueries({ queryKey, exact: true })
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
 
 **Returns**
 
@@ -441,7 +441,7 @@ queryClient.resetQueries({ queryKey, exact: true })
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
 - `options?: ResetOptions`:
   - `throwOnError?: boolean`
     - When set to `true`, this method will throw if any of the query refetch tasks fail.
@@ -464,11 +464,11 @@ if (queryClient.isFetching()) {
 }
 ```
 
-TanStack Query also exports a handy [`useIsFetching`](../../framework/react/reference/useIsFetching) hook that will let you subscribe to this state in your components without creating a manual subscription to the query cache.
+TanStack Query also exports a handy [`useIsFetching`](../framework/react/reference/useIsFetching) hook that will let you subscribe to this state in your components without creating a manual subscription to the query cache.
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
 
 **Returns**
 
@@ -484,11 +484,11 @@ if (queryClient.isMutating()) {
 }
 ```
 
-TanStack Query also exports a handy [`useIsMutating`](../../framework/react/reference/useIsMutating) hook that will let you subscribe to this state in your components without creating a manual subscription to the mutation cache.
+TanStack Query also exports a handy [`useIsMutating`](../framework/react/reference/useIsMutating) hook that will let you subscribe to this state in your components without creating a manual subscription to the mutation cache.
 
 **Options**
 
-- `filters: MutationFilters`: [Mutation Filters](../../framework/react/guides/filters#mutation-filters)
+- `filters: MutationFilters`: [Mutation Filters](../framework/react/guides/filters#mutation-filters)
 
 **Returns**
 
@@ -539,7 +539,7 @@ function Component() {
 
 **Options**
 
-- `queryKey: QueryKey`: [Query Keys](../../framework/react/guides/query-keys)
+- `queryKey: QueryKey`: [Query Keys](../framework/react/guides/query-keys)
 - `options: QueryOptions`
 
 > As stated in [`getQueryDefaults`](#queryclientgetquerydefaults), the order of registration of query defaults does matter.


### PR DESCRIPTION
This PR updates the QueryClient documentation by replacing broken URLs with the correct ones, ensuring that users are directed to the right resources.