### PR TITLE
docs(react-query): update QueryClient example to useRef

### DIFF
--- a/docs/eslint/stable-query-client.md
+++ b/docs/eslint/stable-query-client.md
@@ -28,7 +28,7 @@ Examples of **correct** code for this rule:
 
 ```tsx
 function App() {
-  const [queryClient] = useState(() => new QueryClient())
+  const queryClient = useRef(new QueryClient()).current
   return (
     <QueryClientProvider client={queryClient}>
       <Home />


### PR DESCRIPTION
## Summary

This PR updates the QueryClient example in the ESLint docs to use `useRef` instead of `useState` for persisting the QueryClient instance.

## Motivation

Using `useRef` is more appropriate for this case because it:
- Avoids unnecessary re-renders that come with `useState`.
- Clearly indicates that the QueryClient is a stable, persistent reference that doesn’t change.
- Is slightly lighter weight than `useState` for holding non-reactive values.

This approach better aligns with the intent of maintaining a single QueryClient instance throughout the app lifecycle—an idea that resonates with the principles of React Query.

## Testing

There are no functional changes; this is purely a docs update. The updated example should work exactly as before.