### PR TITLE
fix(docs): update links to ESLint rules

### DIFF
--- a/docs/eslint/eslint-plugin-query.md
+++ b/docs/eslint/eslint-plugin-query.md
@@ -93,8 +93,8 @@ Alternatively, add `@tanstack/query` to the plugins section, and configure the r
 
 ## Rules
 
-- [@tanstack/query/exhaustive-deps](../exhaustive-deps)
-- [@tanstack/query/no-rest-destructuring](../no-rest-destructuring)
-- [@tanstack/query/stable-query-client](../stable-query-client)
-- [@tanstack/query/no-unstable-deps](../no-unstable-deps)
-- [@tanstack/query/infinite-query-property-order](../infinite-query-property-order)
+- [@tanstack/query/exhaustive-deps](./exhaustive-deps)
+- [@tanstack/query/no-rest-destructuring](./no-rest-destructuring)
+- [@tanstack/query/stable-query-client](./stable-query-client)
+- [@tanstack/query/no-unstable-deps](./no-unstable-deps)
+- [@tanstack/query/infinite-query-property-order](./infinite-query-property-order)


### PR DESCRIPTION
These links currently point to the `docs` folder instead of `docs/eslint`.