### PR TITLE
fix(docs): fix Advanced Server Rendering guide link

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -7,7 +7,7 @@ In this guide you'll learn how to use React Query with server rendering.
 
 See the guide on [Prefetching & Router Integration](../prefetching) for some background. You might also want to check out the [Performance & Request Waterfalls guide](../request-waterfalls) before that.
 
-For advanced server rendering patterns, such as streaming, Server Components and the new Next.js app router, see the [Advanced Server Rendering guide](../advanced-ssr).
+For advanced server rendering patterns, such as streaming, Server Components and the new Next.js app router, see the [Advanced Server Rendering guide](./advanced-ssr).
 
 If you just want to see some code, you can skip ahead to the [Full Next.js pages router example](#full-nextjs-pages-router-example) or the [Full Remix example](#full-remix-example) below.
 
@@ -181,7 +181,7 @@ With just a little more setup, you can use a `queryClient` to prefetch queries d
 
 ### Full Next.js pages router example
 
-> For app router documentation, see the [Advanced Server Rendering guide](../advanced-ssr).
+> For app router documentation, see the [Advanced Server Rendering guide](./advanced-ssr).
 
 Initial setup:
 


### PR DESCRIPTION
close #8739

I changed the link `../` to `./` 


current
https://tanstack.com/query/latest/docs/framework/react/advanced-ssr 

changed
https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr
