### PR TITLE
Fix 404 link for Query Keys in useQuery.md

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -65,7 +65,7 @@ const {
 - `queryKey: unknown[]`
   - **Required**
   - The query key to use for this query.
-  - The query key will be hashed into a stable hash. See [Query Keys](../../guides/query-keys) for more information.
+  - The query key will be hashed into a stable hash. See [Query Keys](../guides/query-keys) for more information.
   - The query will automatically update when this key changes (as long as `enabled` is not set to `false`).
 - `queryFn: (context: QueryFunctionContext) => Promise<TData>`
   - **Required, but only if no default query function has been defined** See [Default Query Function](../../guides/default-query-function) for more information.


### PR DESCRIPTION
Current link takes to https://tanstack.com/query/latest/docs/framework/guides/query-keys which is a 404