### PR TITLE
Fix broken links in SSR documentation

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -5,7 +5,7 @@ title: Server Rendering & Hydration
 
 In this guide you'll learn how to use React Query with server rendering.
 
-See the guide on [Prefetching & Router Integration](../prefetching) for some background. You might also want to check out the [Performance & Request Waterfalls guide](../request-waterfalls) before that.
+See the guide on [Prefetching & Router Integration](./prefetching) for some background. You might also want to check out the [Performance & Request Waterfalls guide](./request-waterfalls) before that.
 
 For advanced server rendering patterns, such as streaming, Server Components and the new Next.js app router, see the [Advanced Server Rendering guide](./advanced-ssr).
 
@@ -386,7 +386,7 @@ With Remix, this is a little bit more involved, we recommend checking out the [u
 
 ## Prefetching dependent queries
 
-Over in the Prefetching guide we learned how to [prefetch dependent queries](../prefetching#dependent-queries--code-splitting), but how do we do this in framework loaders? Consider the following code, taken from the [Dependent Queries guide](../dependent-queries):
+Over in the Prefetching guide we learned how to [prefetch dependent queries](./prefetching#dependent-queries--code-splitting), but how do we do this in framework loaders? Consider the following code, taken from the [Dependent Queries guide](./dependent-queries):
 
 ```tsx
 // Get the user


### PR DESCRIPTION
This PR fixes several broken links in the SSR documentation (ssr.md) that were preventing proper navigation between related concepts.

- Fixed link to "prefetching" documentation
- Fixed link to "request-waterfalls" documentation
- Fixed link to "dependent-queries" documentation
- Fixed section-specific link to "prefetching#dependent-queries--code-splitting"