### PR TITLE
refactor: restore missing readonly

### DIFF
--- a/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
@@ -223,7 +223,7 @@ describe('UseSuspenseQueries config object overload', () => {
     useSuspenseQueries({ queries: [query2] })
   })
 
-  it('test', () => {
+  it('should not show type error when using spreaded queryOptions', () => {
     function myQueryOptions() {
       return queryOptions({
         queryKey: ['key1'],

--- a/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test-d.tsx
@@ -173,7 +173,15 @@ describe('UseSuspenseQueries config object overload', () => {
 
     const queries1List = [1, 2, 3].map(() => ({ ...Queries1.get() }))
     const result = useSuspenseQueries({
-      queries: [...queries1List, { ...Queries2.get() }],
+      queries: [
+        ...queries1List,
+        {
+          ...Queries2.get(),
+          select(data: boolean) {
+            return data
+          },
+        },
+      ],
     })
 
     expectTypeOf(result).toEqualTypeOf<
@@ -213,5 +221,24 @@ describe('UseSuspenseQueries config object overload', () => {
     useSuspenseQueries({ queries: [query1] })
     // @ts-expect-error
     useSuspenseQueries({ queries: [query2] })
+  })
+
+  it('test', () => {
+    function myQueryOptions() {
+      return queryOptions({
+        queryKey: ['key1'],
+        queryFn: () => 'Query Data',
+      })
+    }
+    useSuspenseQueries({
+      queries: [
+        {
+          ...myQueryOptions(),
+          select(data: string) {
+            return data
+          },
+        },
+      ],
+    })
   })
 })

--- a/packages/react-query/src/useSuspenseQueries.ts
+++ b/packages/react-query/src/useSuspenseQueries.ts
@@ -169,7 +169,7 @@ export function useSuspenseQueries<
   options: {
     queries:
       | readonly [...SuspenseQueriesOptions<T>]
-      | [...{ [K in keyof T]: GetUseSuspenseQueryOptions<T[K]> }]
+      | readonly [...{ [K in keyof T]: GetUseSuspenseQueryOptions<T[K]> }]
     combine?: (result: SuspenseQueriesResults<T>) => TCombinedResult
   },
   queryClient?: QueryClient,

--- a/packages/react-query/src/useSuspenseQueries.ts
+++ b/packages/react-query/src/useSuspenseQueries.ts
@@ -169,15 +169,28 @@ export function useSuspenseQueries<
   options: {
     queries:
       | readonly [...SuspenseQueriesOptions<T>]
-      | readonly [...{ [K in keyof T]: GetUseSuspenseQueryOptions<T[K]> }]
+      | [...{ [K in keyof T]: GetUseSuspenseQueryOptions<T[K]> }]
     combine?: (result: SuspenseQueriesResults<T>) => TCombinedResult
   },
   queryClient?: QueryClient,
-): TCombinedResult {
+): TCombinedResult
+
+export function useSuspenseQueries<
+  T extends Array<any>,
+  TCombinedResult = SuspenseQueriesResults<T>,
+>(
+  options: {
+    queries: readonly [...SuspenseQueriesOptions<T>]
+    combine?: (result: SuspenseQueriesResults<T>) => TCombinedResult
+  },
+  queryClient?: QueryClient,
+): TCombinedResult
+
+export function useSuspenseQueries(options: any, queryClient?: QueryClient) {
   return useQueries(
     {
       ...options,
-      queries: options.queries.map((query) => {
+      queries: options.queries.map((query: any) => {
         if (process.env.NODE_ENV !== 'production') {
           if (query.queryFn === skipToken) {
             console.error('skipToken is not allowed for useSuspenseQueries')
@@ -192,7 +205,7 @@ export function useSuspenseQueries<
           placeholderData: undefined,
         }
       }),
-    } as any,
+    },
     queryClient,
   )
 }


### PR DESCRIPTION
Previously, `readonly` was removed by mistake.
I restored it again.