### PR TITLE
docs: Fix broken link some example path 

### DIFF
--- a/docs/framework/react/guides/advanced-ssr.md
+++ b/docs/framework/react/guides/advanced-ssr.md
@@ -532,7 +532,7 @@ export default function Posts() {
 
 Now, your `getPosts` function can return e.g. `Temporal` datetime objects and the data will be serialized and deserialized on the client, assuming your transformer can serialize and deserialize those data types.
 
-For more information, check out the [Next.js App with Prefetching Example](../../examples/nextjs-app-prefetching).
+For more information, check out the [Next.js App with Prefetching Example](../../../../examples/react//nextjs-app-prefetching).
 
 ## Experimental streaming without prefetching in Next.js
 
@@ -599,7 +599,7 @@ export function Providers(props: { children: React.ReactNode }) {
 }
 ```
 
-For more information, check out the [NextJs Suspense Streaming Example](../../examples/nextjs-suspense-streaming).
+For more information, check out the [NextJs Suspense Streaming Example](../../../../examples/react/nextjs-suspense-streaming).
 
 The big upside is that you no longer need to prefetch queries manually to have SSR work, and it even still streams in the result! This gives you phenomenal DX and lower code complexity.
 

--- a/docs/framework/react/guides/mutations.md
+++ b/docs/framework/react/guides/mutations.md
@@ -386,7 +386,7 @@ export default function App() {
 
 [//]: # 'Example11'
 
-We also have an extensive [offline example](../../examples/offline) that covers both queries and mutations.
+We also have an extensive [offline example](../../../../examples/react/offline) that covers both queries and mutations.
 
 ## Mutation Scopes
 

--- a/docs/framework/react/guides/prefetching.md
+++ b/docs/framework/react/guides/prefetching.md
@@ -412,7 +412,7 @@ const articleRoute = new Route({
 })
 ```
 
-Integration with other routers is also possible, see the [React Router example](../../examples/react-router) for another demonstration.
+Integration with other routers is also possible, see the [React Router example](../../../../examples/react/react-router) for another demonstration.
 
 [//]: # 'Router'
 

--- a/docs/framework/react/guides/suspense.md
+++ b/docs/framework/react/guides/suspense.md
@@ -172,7 +172,7 @@ export function Providers(props: { children: React.ReactNode }) {
 }
 ```
 
-For more information, check out the [NextJs Suspense Streaming Example](../../examples/nextjs-suspense-streaming) and the [Advanced Rendering & Hydration](../advanced-ssr) guide.
+For more information, check out the [NextJs Suspense Streaming Example](../../../../examples/react/nextjs-suspense-streaming) and the [Advanced Rendering & Hydration](../advanced-ssr) guide.
 
 ## Using `useQuery().promise` and `React.use()` (Experimental)
 


### PR DESCRIPTION
This PR updates the example path in docs by replacing broken URLs with the correct ones