### PR TITLE
fix(angular-query): forward queryFn errors to the NgZone

### DIFF
--- a/packages/angular-query-experimental/src/create-base-query.ts
+++ b/packages/angular-query-experimental/src/create-base-query.ts
@@ -108,23 +108,19 @@ export function createBaseQuery<
         observer.subscribe(
           notifyManager.batchCalls((state) => {
             ngZone.run(() => {
-              try {
-                if (
-                  state.isError &&
-                  !state.isFetching &&
-                  // !isRestoring() && // todo: enable when client persistence is implemented
-                  shouldThrowError(observer.options.throwOnError, [
-                    state.error,
-                    observer.getCurrentQuery(),
-                  ])
-                ) {
-                  throw state.error
-                }
-                resultFromSubscriberSignal.set(state)
-              } catch (error) {
-                ngZone.onError.next(error)
-                throw error
+              if (
+                state.isError &&
+                !state.isFetching &&
+                // !isRestoring() && // todo: enable when client persistence is implemented
+                shouldThrowError(observer.options.throwOnError, [
+                  state.error,
+                  observer.getCurrentQuery(),
+                ])
+              ) {
+                ngZone.onError.emit(state.error)
+                throw state.error
               }
+              resultFromSubscriberSignal.set(state)
             })
           }),
         ),

--- a/packages/angular-query-experimental/src/create-base-query.ts
+++ b/packages/angular-query-experimental/src/create-base-query.ts
@@ -108,18 +108,23 @@ export function createBaseQuery<
         observer.subscribe(
           notifyManager.batchCalls((state) => {
             ngZone.run(() => {
-              if (
-                state.isError &&
-                !state.isFetching &&
-                // !isRestoring() && // todo: enable when client persistence is implemented
-                shouldThrowError(observer.options.throwOnError, [
-                  state.error,
-                  observer.getCurrentQuery(),
-                ])
-              ) {
-                throw state.error
+              try {
+                if (
+                  state.isError &&
+                  !state.isFetching &&
+                  // !isRestoring() && // todo: enable when client persistence is implemented
+                  shouldThrowError(observer.options.throwOnError, [
+                    state.error,
+                    observer.getCurrentQuery(),
+                  ])
+                ) {
+                  throw state.error
+                }
+                resultFromSubscriberSignal.set(state)
+              } catch (error) {
+                ngZone.onError.next(error)
+                throw error
               }
-              resultFromSubscriberSignal.set(state)
             })
           }),
         ),

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -114,16 +114,21 @@ export function injectMutation<
             observer.subscribe(
               notifyManager.batchCalls((state) => {
                 ngZone.run(() => {
-                  if (
-                    state.isError &&
-                    shouldThrowError(observer.options.throwOnError, [
-                      state.error,
-                    ])
-                  ) {
-                    throw state.error
+                  try {
+                    if (
+                      state.isError &&
+                      shouldThrowError(observer.options.throwOnError, [
+                        state.error,
+                      ])
+                    ) {
+                      throw state.error
+                    }
+  
+                    resultFromSubscriberSignal.set(state)
+                  } catch (error) {
+                    ngZone.onError.next(error)
+                    throw error
                   }
-
-                  resultFromSubscriberSignal.set(state)
                 })
               }),
             ),

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -114,21 +114,17 @@ export function injectMutation<
             observer.subscribe(
               notifyManager.batchCalls((state) => {
                 ngZone.run(() => {
-                  try {
-                    if (
-                      state.isError &&
-                      shouldThrowError(observer.options.throwOnError, [
-                        state.error,
-                      ])
-                    ) {
-                      throw state.error
-                    }
-  
-                    resultFromSubscriberSignal.set(state)
-                  } catch (error) {
-                    ngZone.onError.next(error)
-                    throw error
+                  if (
+                    state.isError &&
+                    shouldThrowError(observer.options.throwOnError, [
+                      state.error,
+                    ])
+                  ) {
+                    ngZone.onError.emit(state.error)
+                    throw state.error
                   }
+
+                  resultFromSubscriberSignal.set(state)
                 })
               }),
             ),


### PR DESCRIPTION
Any errors that occur in the queryFn or mutationnFn that should be thrown in case of `throwOnError: true` should run in the `NgZone`, or else the Angular [`ErrorHandler`](https://angular.dev/api/core/ErrorHandler) will not pick them up. A manual try...catch is needed because any errors that occur inside of [`ngZone.run`](https://angular.dev/api/core/NgZone#run) are not automatically reported in the zone:

> If a synchronous error happens it will be rethrown and not reported via onError.

This fixes #8839.