### PR TITLE
fix(examples, docs): ignored promise from invalidate queries

### DIFF
--- a/docs/framework/react/guides/optimistic-updates.md
+++ b/docs/framework/react/guides/optimistic-updates.md
@@ -70,7 +70,7 @@ This approach works very well if the mutation and the query live in the same com
 // somewhere in your app
 const { mutate } = useMutation({
   mutationFn: (newTodo: string) => axios.post('/api/data', { text: newTodo }),
-  onSettled: async () => await queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   mutationKey: ['addTodo'],
 })
 

--- a/docs/framework/react/guides/optimistic-updates.md
+++ b/docs/framework/react/guides/optimistic-updates.md
@@ -16,7 +16,7 @@ const addTodoMutation = useMutation({
   mutationFn: (newTodo: string) => axios.post('/api/data', { text: newTodo }),
   // make sure to _return_ the Promise from the query invalidation
   // so that the mutation stays in `pending` state until the refetch is finished
-  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] })
+  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
 })
 
 const { isPending, submittedAt, variables, mutate, isError } = addTodoMutation
@@ -119,7 +119,7 @@ useMutation({
     queryClient.setQueryData(['todos'], context.previousTodos)
   },
   // Always refetch after error or success:
-  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] })
+  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
 })
 ```
 
@@ -155,7 +155,8 @@ useMutation({
     )
   },
   // Always refetch after error or success:
-  onSettled: (newTodo) => queryClient.invalidateQueries({ queryKey: ['todos', newTodo.id] })
+  onSettled: (newTodo) =>
+    queryClient.invalidateQueries({ queryKey: ['todos', newTodo.id] }),
 })
 ```
 

--- a/docs/framework/react/guides/optimistic-updates.md
+++ b/docs/framework/react/guides/optimistic-updates.md
@@ -16,9 +16,7 @@ const addTodoMutation = useMutation({
   mutationFn: (newTodo: string) => axios.post('/api/data', { text: newTodo }),
   // make sure to _return_ the Promise from the query invalidation
   // so that the mutation stays in `pending` state until the refetch is finished
-  onSettled: async () => {
-    return await queryClient.invalidateQueries({ queryKey: ['todos'] })
-  },
+  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] })
 })
 
 const { isPending, submittedAt, variables, mutate, isError } = addTodoMutation
@@ -121,9 +119,7 @@ useMutation({
     queryClient.setQueryData(['todos'], context.previousTodos)
   },
   // Always refetch after error or success:
-  onSettled: async () => {
-    return await queryClient.invalidateQueries({ queryKey: ['todos'] })
-  },
+  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] })
 })
 ```
 
@@ -159,9 +155,7 @@ useMutation({
     )
   },
   // Always refetch after error or success:
-  onSettled: async (newTodo) => {
-    return await queryClient.invalidateQueries({ queryKey: ['todos', newTodo.id] })
-  },
+  onSettled: (newTodo) => queryClient.invalidateQueries({ queryKey: ['todos', newTodo.id] })
 })
 ```
 

--- a/docs/framework/react/guides/optimistic-updates.md
+++ b/docs/framework/react/guides/optimistic-updates.md
@@ -70,7 +70,7 @@ This approach works very well if the mutation and the query live in the same com
 // somewhere in your app
 const { mutate } = useMutation({
   mutationFn: (newTodo: string) => axios.post('/api/data', { text: newTodo }),
-  onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  onSettled: async () => await queryClient.invalidateQueries({ queryKey: ['todos'] }),
   mutationKey: ['addTodo'],
 })
 
@@ -121,8 +121,8 @@ useMutation({
     queryClient.setQueryData(['todos'], context.previousTodos)
   },
   // Always refetch after error or success:
-  onSettled: () => {
-    queryClient.invalidateQueries({ queryKey: ['todos'] })
+  onSettled: async () => {
+    return await queryClient.invalidateQueries({ queryKey: ['todos'] })
   },
 })
 ```
@@ -159,8 +159,8 @@ useMutation({
     )
   },
   // Always refetch after error or success:
-  onSettled: (newTodo) => {
-    queryClient.invalidateQueries({ queryKey: ['todos', newTodo.id] })
+  onSettled: async (newTodo) => {
+    return await queryClient.invalidateQueries({ queryKey: ['todos', newTodo.id] })
   },
 })
 ```
@@ -175,7 +175,7 @@ You can also use the `onSettled` function in place of the separate `onError` and
 useMutation({
   mutationFn: updateTodo,
   // ...
-  onSettled: (newTodo, error, variables, context) => {
+  onSettled: async (newTodo, error, variables, context) => {
     if (error) {
       // do something
     }

--- a/examples/react/optimistic-updates-cache/src/pages/index.tsx
+++ b/examples/react/optimistic-updates-cache/src/pages/index.tsx
@@ -75,9 +75,7 @@ function Example() {
       }
     },
     // Always refetch after error or success:
-    onSettled: async () => {
-      return await queryClient.invalidateQueries({ queryKey: ['todos'] })
-    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] })
   })
 
   return (

--- a/examples/react/optimistic-updates-cache/src/pages/index.tsx
+++ b/examples/react/optimistic-updates-cache/src/pages/index.tsx
@@ -75,7 +75,7 @@ function Example() {
       }
     },
     // Always refetch after error or success:
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] })
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   })
 
   return (

--- a/examples/react/optimistic-updates-cache/src/pages/index.tsx
+++ b/examples/react/optimistic-updates-cache/src/pages/index.tsx
@@ -75,8 +75,8 @@ function Example() {
       }
     },
     // Always refetch after error or success:
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['todos'] })
+    onSettled: async () => {
+      return await queryClient.invalidateQueries({ queryKey: ['todos'] })
     },
   })
 

--- a/examples/react/optimistic-updates-ui/src/pages/index.tsx
+++ b/examples/react/optimistic-updates-ui/src/pages/index.tsx
@@ -44,7 +44,7 @@ function Example() {
       }
       return await response.json()
     },
-    onSettled: async () => await queryClient.invalidateQueries({ queryKey: ['todos'] }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   })
 
   return (

--- a/examples/react/optimistic-updates-ui/src/pages/index.tsx
+++ b/examples/react/optimistic-updates-ui/src/pages/index.tsx
@@ -44,7 +44,7 @@ function Example() {
       }
       return await response.json()
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+    onSettled: async () => await queryClient.invalidateQueries({ queryKey: ['todos'] }),
   })
 
   return (


### PR DESCRIPTION
This PR fixes the issue of Promise returned from invalidateQueries being ignored in documentation and examples