### PR TITLE
docs: Add Connect RPC to the list of community projects

### DIFF
--- a/docs/framework/react/community/community-projects.md
+++ b/docs/framework/react/community/community-projects.md
@@ -25,6 +25,12 @@ The Missing Fullstack Toolkit for Next.js
 
 Link: https://blitzjs.com/
 
+## Connect 
+
+A family of libraries for building building browser and gRPC-compatible HTTP APIs.
+
+Link: https://connectrpc.com/docs
+
 ## GraphQL Code Generator
 
 Generate React Query hooks from your GraphQL schema


### PR DESCRIPTION
Connect RPC has a native TanStack Query integration.

https://github.com/connectrpc/connect-query-es

I'm not affiliated with Connect or its authors, so the description is my paraphrasing of their introduction.