### PR TITLE
test(query-core): fix mutationFn to use Promise.resolve to match TypeScript requirements

### DIFF
--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -799,8 +799,8 @@ describe('dehydration and rehydration', () => {
       queryClient,
       {
         mutationKey: ['mutation'],
-        mutationFn: async () => {
-          return 'mutation'
+        mutationFn: () => {
+          return Promise.resolve('mutation')
         },
         scope: {
           id: 'scope',


### PR DESCRIPTION
I noticed this ESLint warning in the query-core hydration test.

**"Async method 'mutationFn' has no 'await' expression.eslint[@typescript-eslint/require-await](https://typescript-eslint.io/rules/require-await)"**

The problem was in the mutation scope test where we had an async function without any await expressions. Instead of adding a pointless await, I simply removed the async keyword and made it return `Promise.resolve()` directly. This keeps the code clean while still satisfying both TypeScript's MutationFunction type and the ESLint rule.
