### PR TITLE
Fix: Prevent redundant function call error

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -373,6 +373,9 @@ export function replaceData<
         console.error(
           `Structural sharing requires data to be JSON serializable. To fix this, turn off structuralSharing or return JSON-serializable data from your queryFn. [${options.queryHash}]: ${error}`,
         )
+
+        // Prevent the replaceEqualDeep from being called again down below.
+        throw error
       }
     }
     // Structurally share data between prev and new data if needed


### PR DESCRIPTION
Fix for issue: #8876 

In order to prevent a redundant call to the `replaceEqualDeep` function while in development mode, we should just throw the error that it previously threw.