### PR TITLE
test(react-query): fix async to promise to match TypeScript requirements in ssr.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -94,7 +94,7 @@ describe('Server Side Rendering', () => {
       const [page, setPage] = React.useState(1)
       const { data } = useQuery({
         queryKey: [key, page],
-        queryFn: async () => page,
+        queryFn: () => Promise.resolve(page),
         initialData: 1,
       })
 


### PR DESCRIPTION
I noticed this ESLint warning in the react-query ssr test.

**"Async method 'queryFn' has no 'await' expression.eslint[@typescript-eslint/require-await](https://typescript-eslint.io/rules/require-await)"**
