### PR TITLE
test(react-query): fix async to promise and remove unnecessary await  to match TypeScript requirements in useMutation.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -271,12 +271,14 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (text: string) => text,
-        onSuccess: async () => {
+        mutationFn: (text: string) => Promise.resolve(text),
+        onSuccess: () => {
           callbacks.push('useMutation.onSuccess')
+          return Promise.resolve()
         },
-        onSettled: async () => {
+        onSettled: () => {
           callbacks.push('useMutation.onSettled')
+          return Promise.resolve()
         },
       })
 
@@ -284,11 +286,13 @@ describe('useMutation', () => {
         setActTimeout(async () => {
           try {
             const result = await mutateAsync('todo', {
-              onSuccess: async () => {
+              onSuccess: () => {
                 callbacks.push('mutateAsync.onSuccess')
+                return Promise.resolve()
               },
-              onSettled: async () => {
+              onSettled: () => {
                 callbacks.push('mutateAsync.onSettled')
+                return Promise.resolve()
               },
             })
             callbacks.push(`mutateAsync.result:${result}`)
@@ -318,11 +322,13 @@ describe('useMutation', () => {
     function Page() {
       const { mutateAsync } = useMutation({
         mutationFn: async (_text: string) => Promise.reject(new Error('oops')),
-        onError: async () => {
+        onError: () => {
           callbacks.push('useMutation.onError')
+          return Promise.resolve()
         },
-        onSettled: async () => {
+        onSettled: () => {
           callbacks.push('useMutation.onSettled')
+          return Promise.resolve()
         },
       })
 
@@ -330,11 +336,13 @@ describe('useMutation', () => {
         setActTimeout(async () => {
           try {
             await mutateAsync('todo', {
-              onError: async () => {
+              onError: () => {
                 callbacks.push('mutateAsync.onError')
+                return Promise.resolve()
               },
-              onSettled: async () => {
+              onSettled: () => {
                 callbacks.push('mutateAsync.onSettled')
+                return Promise.resolve()
               },
             })
           } catch (error) {
@@ -787,12 +795,12 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutate: succeed, isSuccess } = useMutation({
-        mutationFn: async () => '',
+        mutationFn: () => Promise.resolve(''),
         meta: { metaSuccessMessage },
       })
       const { mutate: error, isError } = useMutation({
-        mutationFn: async () => {
-          throw new Error('')
+        mutationFn: () => {
+          return Promise.reject(new Error(''))
         },
         meta: { metaErrorMessage },
       })


### PR DESCRIPTION
Address ESLint warnings by refactoring async functions that don't use await:
- Convert async callback functions to return Promise.resolve() directly
- Replace async error throwing functions with Promise.reject()

This maintains the same behavior while satisfying linter requirements.