### PR TITLE
test(react-query): fix async to promise and remove unnecessary await to match TypeScript requirements in useQuery.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -64,7 +64,7 @@ describe('useQuery', () => {
       // it should provide the result type in the configuration
       useQuery({
         queryKey: [key],
-        queryFn: async () => true,
+        queryFn: () => Promise.resolve(true),
       })
 
       // it should be possible to specify a union type as result type
@@ -109,10 +109,10 @@ describe('useQuery', () => {
       type MyData = number
       type MyQueryKey = readonly ['my-data', number]
 
-      const getMyDataArrayKey: QueryFunction<MyData, MyQueryKey> = async ({
+      const getMyDataArrayKey: QueryFunction<MyData, MyQueryKey> = ({
         queryKey: [, n],
       }) => {
-        return n + 42
+        return Promise.resolve(n + 42)
       }
 
       useQuery({
@@ -120,11 +120,9 @@ describe('useQuery', () => {
         queryFn: getMyDataArrayKey,
       })
 
-      const getMyDataStringKey: QueryFunction<MyData, ['1']> = async (
-        context,
-      ) => {
+      const getMyDataStringKey: QueryFunction<MyData, ['1']> = (context) => {
         expectTypeOf(context.queryKey).toEqualTypeOf<['1']>()
-        return Number(context.queryKey[0]) + 42
+        return Promise.resolve(Number(context.queryKey[0]) + 42)
       }
 
       useQuery({
@@ -161,7 +159,7 @@ describe('useQuery', () => {
           queryFn: () => fetcher(qk[1], 'token'),
           ...options,
         })
-      const testQuery = useWrappedQuery([''], async () => '1')
+      const testQuery = useWrappedQuery([''], () => Promise.resolve('1'))
       expectTypeOf(testQuery.data).toEqualTypeOf<string | undefined>()
 
       // handles wrapped queries with custom fetcher passed directly to useQuery
@@ -178,7 +176,9 @@ describe('useQuery', () => {
           'queryKey' | 'queryFn' | 'initialData'
         >,
       ) => useQuery({ queryKey: qk, queryFn: fetcher, ...options })
-      const testFuncStyle = useWrappedFuncStyleQuery([''], async () => true)
+      const testFuncStyle = useWrappedFuncStyleQuery([''], () =>
+        Promise.resolve(true),
+      )
       expectTypeOf(testFuncStyle.data).toEqualTypeOf<boolean | undefined>()
     }
   })
@@ -2487,7 +2487,7 @@ describe('useQuery', () => {
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/137
-  it('should not override initial data in dependent queries', async () => {
+  it('should not override initial data in dependent queries', () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -2524,7 +2524,7 @@ describe('useQuery', () => {
     rendered.getByText('Second Status: success')
   })
 
-  it('should update query options', async () => {
+  it('should update query options', () => {
     const key = queryKey()
 
     const queryFn = async () => {
@@ -3777,12 +3777,12 @@ describe('useQuery', () => {
     function Page() {
       const query = useQuery({
         queryKey: key,
-        queryFn: async () => {
+        queryFn: () => {
           if (counter < 2) {
             counter++
-            throw new Error('error')
+            return Promise.reject(new Error('error'))
           } else {
-            return 'data'
+            return Promise.resolve('data')
           }
         },
         retryDelay: 10,
@@ -3955,9 +3955,11 @@ describe('useQuery', () => {
       const [filter, setFilter] = React.useState('')
       const { data: todos } = useQuery({
         queryKey: [...key, filter],
-        queryFn: async () => {
-          return ALL_TODOS.filter((todo) =>
-            filter ? todo.priority === filter : true,
+        queryFn: () => {
+          return Promise.resolve(
+            ALL_TODOS.filter((todo) =>
+              filter ? todo.priority === filter : true,
+            ),
           )
         },
         initialData() {
@@ -4047,7 +4049,7 @@ describe('useQuery', () => {
     expect(results[2]).toMatchObject({ data: 'fetched data', isStale: false })
   })
 
-  it('should support enabled:false in query object syntax', async () => {
+  it('should support enabled:false in query object syntax', () => {
     const key = queryKey()
     const queryFn = vi.fn<(...args: Array<unknown>) => string>()
     queryFn.mockImplementation(() => 'data')
@@ -6025,7 +6027,7 @@ describe('useQuery', () => {
   describe('subscribed', () => {
     it('should be able to toggle subscribed', async () => {
       const key = queryKey()
-      const queryFn = vi.fn(async () => 'data')
+      const queryFn = vi.fn(() => Promise.resolve('data'))
       function Page() {
         const [subscribed, setSubscribed] = React.useState(true)
         const { data } = useQuery({
@@ -6067,7 +6069,7 @@ describe('useQuery', () => {
 
     it('should not be attached to the query when subscribed is false', async () => {
       const key = queryKey()
-      const queryFn = vi.fn(async () => 'data')
+      const queryFn = vi.fn(() => Promise.resolve('data'))
       function Page() {
         const { data } = useQuery({
           queryKey: key,
@@ -6097,7 +6099,7 @@ describe('useQuery', () => {
       function Page() {
         const { data } = useQuery({
           queryKey: key,
-          queryFn: async () => 'data',
+          queryFn: () => Promise.resolve('data'),
           subscribed: false,
         })
         renders++
@@ -6131,8 +6133,8 @@ describe('useQuery', () => {
     const states: Array<UseQueryResult<unknown>> = []
     const error = new Error('oops')
 
-    const queryFn = async (): Promise<unknown> => {
-      throw error
+    const queryFn = (): Promise<unknown> => {
+      return Promise.reject(error)
     }
 
     function Page() {
@@ -6198,8 +6200,8 @@ describe('useQuery', () => {
     function Page() {
       const { refetch, errorUpdateCount } = useQuery({
         queryKey: key,
-        queryFn: async (): Promise<unknown> => {
-          throw error
+        queryFn: (): Promise<unknown> => {
+          return Promise.reject(error)
         },
         retry: false,
       })
@@ -6517,7 +6519,7 @@ describe('useQuery', () => {
   })
 
   // For Project without TS, when migrating from v4 to v5, make sure invalid calls due to bad parameters are tracked.
-  it('should throw in case of bad arguments to enhance DevX', async () => {
+  it('should throw in case of bad arguments to enhance DevX', () => {
     // Mock console error to avoid noise when test is run
     const consoleMock = vi
       .spyOn(console, 'error')


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:

- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.