### PR TITLE
test(react-query): fix async to promise to match TypeScript requirements  in useSuspenseQueries.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -554,9 +554,9 @@ describe('useSuspenseQueries 2', () => {
     function Page() {
       useSuspenseQuery({
         queryKey: key,
-        queryFn: async () => {
+        queryFn: () => {
           count++
-          throw new Error('Query failed')
+          return Promise.reject(new Error('Query failed'))
         },
         gcTime: 0,
         retry: false,


### PR DESCRIPTION
Address ESLint warnings by refactoring async functions that don't use await:
- Replace async error throwing functions with Promise.reject()

This maintains the same behavior while satisfying linter requirements.