### PR TITLE
test(query-core): resolve ESLint typescript-eslint/require-await warnings for mutations.test.tsx

### DIFF
--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -22,9 +22,9 @@ describe('mutations', () => {
     let variables
 
     const mutation = new MutationObserver(queryClient, {
-      mutationFn: async (vars: unknown) => {
+      mutationFn: (vars: unknown) => {
         variables = vars
-        return vars
+        return Promise.resolve(vars)
       },
     })
 
@@ -252,7 +252,7 @@ describe('mutations', () => {
     const onSettled = vi.fn()
 
     queryClient.setMutationDefaults(key, {
-      mutationFn: async (text: string) => text,
+      mutationFn: (text: string) => Promise.resolve(text),
       onMutate,
       onSuccess,
       onSettled,
@@ -349,8 +349,8 @@ describe('mutations', () => {
     const onSettled = vi.fn()
 
     const mutation = new MutationObserver(queryClient, {
-      mutationFn: async () => {
-        return 'update'
+      mutationFn: () => {
+        return Promise.resolve('update')
       },
     })
 
@@ -365,8 +365,8 @@ describe('mutations', () => {
     const onSettled = vi.fn()
 
     const mutation = new MutationObserver(queryClient, {
-      mutationFn: async () => {
-        return 'update'
+      mutationFn: () => {
+        return Promise.resolve('update')
       },
     })
 
@@ -380,9 +380,9 @@ describe('mutations', () => {
     const onSuccess = vi.fn()
 
     const mutation = new MutationObserver(queryClient, {
-      mutationFn: async () => {
+      mutationFn: () => {
         sleep(100)
-        return 'update'
+        return Promise.resolve('update')
       },
       onSuccess: () => {
         onSuccess(1)
@@ -392,9 +392,9 @@ describe('mutations', () => {
     void mutation.mutate()
 
     mutation.setOptions({
-      mutationFn: async () => {
+      mutationFn: () => {
         sleep(100)
-        return 'update'
+        return Promise.resolve('update')
       },
       onSuccess: () => {
         onSuccess(2)


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.

ref: https://github.com/TanStack/query/pull/8887#issuecomment-2765491556