### PR TITLE
test(react-query): resolve ESLint typescript-eslint/require-await warnings for useQuery.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -2631,7 +2631,7 @@ describe('useQuery', () => {
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/144
-  it('should be in "pending" state by default', async () => {
+  it('should be in "pending" state by default', () => {
     const key = queryKey()
 
     function Page() {


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.

ref: https://github.com/TanStack/query/pull/8887#issuecomment-2765491556

