### PR TITLE
test(react-query): resolve ESLint typescript-eslint/require-await warnings for useMutation.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -656,7 +656,7 @@ describe('useMutation', () => {
     onlineMock.mockRestore()
   })
 
-  it('should not change state if unmounted', async () => {
+  it('should not change state if unmounted', () => {
     function Mutates() {
       const { mutate } = useMutation({ mutationFn: () => sleep(10) })
       return <button onClick={() => mutate()}>mutate</button>


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.

ref: https://github.com/TanStack/query/pull/8887#issuecomment-2765491556


