### PR TITLE
test(react-query): resolve ESLint typescript-eslint/require-await warnings for QueryResetErrorBoundary.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -216,9 +216,7 @@ describe('QueryErrorResetBoundary', () => {
       function Page() {
         const { data, refetch, status, fetchStatus } = useQuery<string>({
           queryKey: key,
-          queryFn: async () => {
-            throw new Error('Error')
-          },
+          queryFn: () => Promise.reject(new Error('Error')),
           retry: false,
           enabled: false,
           throwOnError: true,
@@ -578,7 +576,7 @@ describe('QueryErrorResetBoundary', () => {
       consoleMock.mockRestore()
     })
 
-    it('should render children', async () => {
+    it('should render children', () => {
       const consoleMock = vi
         .spyOn(console, 'error')
         .mockImplementation(() => undefined)


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.

ref: https://github.com/TanStack/query/pull/8887#issuecomment-2765491556


