### PR TITLE
test(react-query): resolve ESLint typescript-eslint/require-await warnings for queryOptions.test-d.tsx

### DIFF
--- a/packages/react-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.test-d.tsx
@@ -225,7 +225,7 @@ describe('queryOptions', () => {
     const testFn = (id?: string) => {
       const options = queryOptions({
         queryKey: ['test'],
-        queryFn: async () => 'something string',
+        queryFn: () => Promise.resolve('something string'),
         initialData: id ? 'initial string' : undefined,
       })
       expectTypeOf(options.initialData).toMatchTypeOf<


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.

ref: https://github.com/TanStack/query/pull/8887#issuecomment-2765491556

