### PR TITLE
test(react-query): resolve ESLint typescript-eslint/require-await warnings for fine-grained-persister.test.tsx

### DIFF
--- a/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
+++ b/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
@@ -21,11 +21,13 @@ describe('fine grained persister', () => {
     const mapStorage = new Map()
     const storage = {
       getItem: (itemKey: string) => Promise.resolve(mapStorage.get(itemKey)),
-      setItem: async (itemKey: string, value: unknown) => {
+      setItem: (itemKey: string, value: unknown) => {
         mapStorage.set(itemKey, value)
+        return Promise.resolve()
       },
-      removeItem: async (itemKey: string) => {
+      removeItem: (itemKey: string) => {
         mapStorage.delete(itemKey)
+        return Promise.resolve()
       },
     }
 
@@ -75,11 +77,13 @@ describe('fine grained persister', () => {
     const mapStorage = new Map()
     const storage = {
       getItem: (itemKey: string) => Promise.resolve(mapStorage.get(itemKey)),
-      setItem: async (itemKey: string, value: unknown) => {
+      setItem: (itemKey: string, value: unknown) => {
         mapStorage.set(itemKey, value)
+        return Promise.resolve()
       },
-      removeItem: async (itemKey: string) => {
+      removeItem: (itemKey: string) => {
         mapStorage.delete(itemKey)
+        return Promise.resolve()
       },
     }
 
@@ -125,11 +129,13 @@ describe('fine grained persister', () => {
     const mapStorage = new Map()
     const storage = {
       getItem: (itemKey: string) => Promise.resolve(mapStorage.get(itemKey)),
-      setItem: async (itemKey: string, value: unknown) => {
+      setItem: (itemKey: string, value: unknown) => {
         mapStorage.set(itemKey, value)
+        return Promise.resolve()
       },
-      removeItem: async (itemKey: string) => {
+      removeItem: (itemKey: string) => {
         mapStorage.delete(itemKey)
+        return Promise.resolve()
       },
     }
 


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.

ref: https://github.com/TanStack/query/pull/8887#issuecomment-2765491556

