### PR TITLE
test(react-query-devtools): resolve ESLint typescript-eslint/require-await warnings for devtools.test.tsx 

### DIFF
--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 describe('ReactQueryDevtools', () => {
-  it('should be able to open and close devtools', async () => {
+  it('should be able to open and close devtools', () => {
     expect(1).toBe(1)
   })
 })


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used

These changes don't affect functionality but make the linter happy and improve code clarity.