### PR TITLE
test(query-persist-client-core): resolve ESLint typescript-eslint/require-await warnings for persist.test.tsx

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -20,7 +20,7 @@ describe('persistQueryClientSubscribe', () => {
     })
 
     queryClient.getMutationCache().build(queryClient, {
-      mutationFn: async (text: string) => text,
+      mutationFn: (text: string) => Promise.resolve(text),
     })
 
     const result = await persister.restoreClient()
@@ -32,7 +32,7 @@ describe('persistQueryClientSubscribe', () => {
 })
 
 describe('persistQueryClientSave', () => {
-  test('should not be triggered on observer type events', async () => {
+  test('should not be triggered on observer type events', () => {
     const queryClient = createQueryClient()
 
     const persister = createSpyPersister()


### PR DESCRIPTION
Fix ESLint warnings for async functions without await

Resolved ESLint "require-await" warnings throughout the test files by:
- Removing unnecessary async keywords where no await is used
- Using Promise.resolve() to explicitly return promises instead

These changes don't affect functionality but make the linter happy and improve code clarity.

ref: https://github.com/TanStack/query/pull/8887#issuecomment-2765491556