### PR TITLE
bump @vitejs/plugin-react to 4.3.4

### DIFF
--- a/examples/react/algolia/package.json
+++ b/examples/react/algolia/package.json
@@ -18,7 +18,7 @@
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/basic-graphql-request/package.json
+++ b/examples/react/basic-graphql-request/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "vite": "^5.3.5"
   }
 }

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -19,7 +19,7 @@
     "@tanstack/eslint-plugin-query": "^5.68.0",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/chat/package.json
+++ b/examples/react/chat/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.14",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "tailwindcss": "^4.0.14",
     "typescript": "5.8.2",
     "vite": "^5.3.5"

--- a/examples/react/default-query-function/package.json
+++ b/examples/react/default-query-function/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/devtools-panel/package.json
+++ b/examples/react/devtools-panel/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/offline/package.json
+++ b/examples/react/offline/package.json
@@ -19,7 +19,7 @@
     "react-hot-toast": "^2.4.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   },

--- a/examples/react/playground/package.json
+++ b/examples/react/playground/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/react-router/package.json
+++ b/examples/react/react-router/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
     "@types/sort-by": "^1.2.3",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/rick-morty/package.json
+++ b/examples/react/rick-morty/package.json
@@ -20,7 +20,7 @@
     "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/shadow-dom/package.json
+++ b/examples/react/shadow-dom/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/simple/package.json
+++ b/examples/react/simple/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/star-wars/package.json
+++ b/examples/react/star-wars/package.json
@@ -20,7 +20,7 @@
     "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/examples/react/suspense/package.json
+++ b/examples/react/suspense/package.json
@@ -16,7 +16,7 @@
     "react-error-boundary": "^4.1.2"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "5.8.2",
     "vite": "^5.3.5"
   }

--- a/integrations/react-vite/package.json
+++ b/integrations/react-vite/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@tanstack/react-query": "workspace:*",
     "@tanstack/react-query-devtools": "workspace:*",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "vite": "^5.3.5"

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -84,7 +84,7 @@
     "@tanstack/react-query": "workspace:*",
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.0.1",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "npm-run-all": "^4.1.5",
     "react": "^19.0.0"
   },

--- a/packages/react-query-next-experimental/package.json
+++ b/packages/react-query-next-experimental/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@tanstack/react-query": "workspace:*",
     "@types/react": "^19.0.1",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "next": "^14.2.20",
     "npm-run-all": "^4.1.5",
     "react": "^19.0.0"

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -64,7 +64,7 @@
     "@tanstack/react-query": "workspace:*",
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.0.1",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "npm-run-all": "^4.1.5",
     "react": "^19.0.0"
   },

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -72,7 +72,7 @@
     "@testing-library/react-render-stream": "^2.0.0",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "eslint-plugin-react-compiler": "19.0.0-beta-df7b47d-20241124",
     "npm-run-all": "^4.1.5",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,8 +604,8 @@ importers:
         specifier: ^19.0.2
         version: 19.0.2(@types/react@19.0.1)
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -672,8 +672,8 @@ importers:
         specifier: ^19.0.2
         version: 19.0.2(@types/react@19.0.1)
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -703,8 +703,8 @@ importers:
         version: 19.0.0(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       vite:
         specifier: ^5.3.5
         version: 5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6)
@@ -728,8 +728,8 @@ importers:
         specifier: ^4.0.14
         version: 4.0.14(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       tailwindcss:
         specifier: ^4.0.14
         version: 4.0.14
@@ -756,8 +756,8 @@ importers:
         version: 19.0.0(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -781,8 +781,8 @@ importers:
         version: 19.0.0(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -964,8 +964,8 @@ importers:
         version: 2.4.1(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1073,8 +1073,8 @@ importers:
         version: 19.0.0(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1214,8 +1214,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1257,8 +1257,8 @@ importers:
         version: 6.25.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1288,8 +1288,8 @@ importers:
         specifier: ^19.0.2
         version: 19.0.2(@types/react@19.0.1)
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1313,8 +1313,8 @@ importers:
         version: 19.0.0(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1356,8 +1356,8 @@ importers:
         version: 6.25.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1387,8 +1387,8 @@ importers:
         version: 4.1.2(react@19.0.0)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -2015,8 +2015,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react-query-devtools
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -2368,8 +2368,8 @@ importers:
         specifier: ^19.0.2
         version: 19.0.2(@types/react@19.0.1)
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       eslint-plugin-react-compiler:
         specifier: 19.0.0-beta-df7b47d-20241124
         version: 19.0.0-beta-df7b47d-20241124(eslint@9.15.0(jiti@2.4.2))
@@ -2402,8 +2402,8 @@ importers:
         specifier: ^19.0.1
         version: 19.0.1
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -2420,8 +2420,8 @@ importers:
         specifier: ^19.0.1
         version: 19.0.1
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       next:
         specifier: ^14.2.20
         version: 14.2.21(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.86.0)
@@ -2448,8 +2448,8 @@ importers:
         specifier: ^19.0.1
         version: 19.0.1
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -3639,8 +3639,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-self@7.25.9':
+    resolution: {integrity: sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-source@7.24.7':
     resolution: {integrity: sha512-J2z+MWzZHVOemyLweMqngXrgGC42jQ//R0KdxqkIz/OrbVIIlhFI3WigZ5fO+nwFvBlncr4MGapd8vTyc7RPNQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9':
+    resolution: {integrity: sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -7170,11 +7182,11 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
 
-  '@vitejs/plugin-react@4.3.3':
-    resolution: {integrity: sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==}
+  '@vitejs/plugin-react@4.3.4':
+    resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
   '@vitejs/plugin-vue@5.2.1':
     resolution: {integrity: sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==}
@@ -17996,7 +18008,17 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.26.5
+
   '@babel/plugin-transform-react-jsx-source@7.24.7(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.26.5
@@ -22088,11 +22110,11 @@ snapshots:
     dependencies:
       vite: 5.4.11(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.80.7)(terser@5.31.6)
 
-  '@vitejs/plugin-react@4.3.3(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))':
+  '@vitejs/plugin-react@4.3.4(vite@5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6))':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
       vite: 5.4.16(@types/node@22.13.14)(less@4.2.2)(lightningcss@1.29.2)(sass@1.86.0)(terser@5.31.6)


### PR DESCRIPTION
this is a dev dependency. The newer version has vite 6 added to the allowed list in peerDeps