### PR TITLE
docs(react-guides): fixed typo 

### DIFF
--- a/docs/framework/react/guides/request-waterfalls.md
+++ b/docs/framework/react/guides/request-waterfalls.md
@@ -233,7 +233,7 @@ function GraphFeedItem({ feedItem }) {
 }
 ```
 
-The second query `getGraphDataById` is dependent on it's parent in two different ways. First of all, it doesn't ever happen unless the `feedItem` is a graph, and second, it needs an `id` from the parent.
+The second query `getGraphDataById` is dependent on its parent in two different ways. First of all, it doesn't ever happen unless the `feedItem` is a graph, and second, it needs an `id` from the parent.
 
 ```
 1. |> getFeed()

--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -165,7 +165,7 @@ Setting up the full hydration solution is straightforward and does not have thes
 
 ## Using the Hydration APIs
 
-With just a little more setup, you can use a `queryClient` to prefetch queries during a preload phase, pass a serialized version of that `queryClient` to the rendering part of the app and reuse it there. This avoid the drawbacks above. Feel free to skip ahead for full Next.js pages router and Remix examples, but at a general level these are the extra steps:
+With just a little more setup, you can use a `queryClient` to prefetch queries during a preload phase, pass a serialized version of that `queryClient` to the rendering part of the app and reuse it there. This avoids the drawbacks above. Feel free to skip ahead for full Next.js pages router and Remix examples, but at a general level these are the extra steps:
 
 - In the framework loader function, create a `const queryClient = new QueryClient(options)`
 - In the loader function, do `await queryClient.prefetchQuery(...)` for each query you want to prefetch

--- a/docs/framework/react/guides/suspense.md
+++ b/docs/framework/react/guides/suspense.md
@@ -3,7 +3,7 @@ id: suspense
 title: Suspense
 ---
 
-React Query can also be used with React's Suspense for Data Fetching API's. For this, we have dedicated hooks:
+React Query can also be used with React's Suspense for Data Fetching APIs. For this, we have dedicated hooks:
 
 - [useSuspenseQuery](../reference/useSuspenseQuery.md)
 - [useSuspenseInfiniteQuery](../reference/useSuspenseInfiniteQuery.md)

--- a/docs/reference/streamedQuery.md
+++ b/docs/reference/streamedQuery.md
@@ -23,5 +23,5 @@ const query = queryOptions({
 - `refetchMode?: 'append' | 'reset'`
   - optional
   - when set to `'reset'`, the query will erase all data and go back into `pending` state when a refetch occurs.
-  - when set ot `'append'`, data will be appended on a refetch.
+  - when set to `'append'`, data will be appended on a refetch.
   - defaults to `'reset'`


### PR DESCRIPTION
Found and fixed small typos in `request-waterfalls`, `ssr`, `suspense`, and `streamedQuery`—hope this helps! 😊