### PR TITLE
fix(solid-query): add `useQuery`, `useInfiniteQuery`, `useQueries`, `useMutation` as alternative (primary) syntax to align with react and ease maintenance

### DIFF
--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { render, screen, waitFor } from '@solidjs/testing-library'
-import { QueryClient, createQueries, createQuery } from '@tanstack/solid-query'
+import { QueryClient, useQueries, useQuery } from '@tanstack/solid-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
 import { createEffect, createSignal, onMount } from 'solid-js'
 
@@ -69,7 +69,7 @@ describe('PersistQueryClientProvider', () => {
     queryClient.clear()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -147,7 +147,7 @@ describe('PersistQueryClientProvider', () => {
     queryClient.clear()
 
     function Page() {
-      const [state] = createQueries(() => ({
+      const [state] = useQueries(() => ({
         queries: [
           {
             queryKey: key,
@@ -230,7 +230,7 @@ describe('PersistQueryClientProvider', () => {
     queryClient.clear()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -315,7 +315,7 @@ describe('PersistQueryClientProvider', () => {
     let fetched = false
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           fetched = true
@@ -386,7 +386,7 @@ describe('PersistQueryClientProvider', () => {
     queryClient.clear()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -432,7 +432,7 @@ describe('PersistQueryClientProvider', () => {
     const [error, persister] = createMockErrorPersister(removeClient)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -530,7 +530,7 @@ describe('PersistQueryClientProvider', () => {
     }
 
     function Page() {
-      const state = createQuery(() => ({ queryKey: key }))
+      const state = useQuery(() => ({ queryKey: key }))
 
       createEffect(() =>
         states.push({

--- a/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, waitFor } from '@solidjs/testing-library'
 import { QueryCache } from '@tanstack/query-core'
-import { QueryClientProvider, createQuery, useQueryClient } from '..'
+import { QueryClientProvider, useQuery, useQueryClient } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 
 describe('QueryClientProvider', () => {
@@ -12,7 +12,7 @@ describe('QueryClientProvider', () => {
     const queryClient = createQueryClient({ queryCache })
 
     function Page() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -51,7 +51,7 @@ describe('QueryClientProvider', () => {
     const queryClient2 = createQueryClient({ queryCache: queryCache2 })
 
     function Page1() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key1,
         queryFn: async () => {
           await sleep(10)
@@ -66,7 +66,7 @@ describe('QueryClientProvider', () => {
       )
     }
     function Page2() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key2,
         queryFn: async () => {
           await sleep(10)
@@ -115,7 +115,7 @@ describe('QueryClientProvider', () => {
     })
 
     function Page() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)

--- a/packages/solid-query/src/__tests__/createQueries.test-d.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test-d.tsx
@@ -25,10 +25,7 @@ describe('useQueries', () => {
     }))
 
     expectTypeOf(result).toEqualTypeOf<
-      [
-        ...Array<UseQueryResult<number, Error>>,
-        UseQueryResult<boolean, Error>,
-      ]
+      [...Array<UseQueryResult<number, Error>>, UseQueryResult<boolean, Error>]
     >()
   })
 })

--- a/packages/solid-query/src/__tests__/createQueries.test-d.tsx
+++ b/packages/solid-query/src/__tests__/createQueries.test-d.tsx
@@ -1,8 +1,8 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { createQueries, queryOptions } from '..'
-import type { CreateQueryResult } from '..'
+import { queryOptions, useQueries } from '..'
+import type { UseQueryResult } from '..'
 
-describe('createQueries', () => {
+describe('useQueries', () => {
   it('should return correct data for dynamic queries with mixed result types', () => {
     const Queries1 = {
       get: () =>
@@ -20,14 +20,14 @@ describe('createQueries', () => {
     }
 
     const queries1List = [1, 2, 3].map(() => ({ ...Queries1.get() }))
-    const result = createQueries(() => ({
+    const result = useQueries(() => ({
       queries: [...queries1List, { ...Queries2.get() }],
     }))
 
     expectTypeOf(result).toEqualTypeOf<
       [
-        ...Array<CreateQueryResult<number, Error>>,
-        CreateQueryResult<boolean, Error>,
+        ...Array<UseQueryResult<number, Error>>,
+        UseQueryResult<boolean, Error>,
       ]
     >()
   })

--- a/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { QueryClient, dataTagSymbol, skipToken } from '@tanstack/query-core'
-import { createQuery } from '../createQuery'
+import { useQuery } from '../useQuery'
 import { queryOptions } from '../queryOptions'
 
 describe('queryOptions', () => {
@@ -22,13 +22,13 @@ describe('queryOptions', () => {
       },
     })
   })
-  it('should work when passed to createQuery', () => {
+  it('should work when passed to useQuery', () => {
     const options = queryOptions({
       queryKey: ['key'],
       queryFn: () => Promise.resolve(5),
     })
 
-    const { data } = createQuery(() => options)
+    const { data } = useQuery(() => options)
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
   it('should work when passed to fetchQuery', async () => {

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -12,14 +12,14 @@ import {
 import {
   QueryCache,
   QueryClientProvider,
-  createInfiniteQuery,
-  createQuery,
+  useInfiniteQuery,
+  useQuery,
 } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type {
-  CreateInfiniteQueryResult,
-  CreateQueryResult,
   InfiniteData,
+  UseInfiniteQueryResult,
+  UseQueryResult,
 } from '..'
 
 describe("useQuery's in Suspense mode", () => {
@@ -28,7 +28,7 @@ describe("useQuery's in Suspense mode", () => {
 
   it('should render the correct amount of times in Suspense mode', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
 
     let count = 0
     let renders = 0
@@ -36,7 +36,7 @@ describe("useQuery's in Suspense mode", () => {
     function Page() {
       const [stateKey, setStateKey] = createSignal(key)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: stateKey(),
         queryFn: async () => {
           count++
@@ -84,11 +84,11 @@ describe("useQuery's in Suspense mode", () => {
 
   it('should return the correct states for a successful infinite query', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<number>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<number>>> = []
 
     function Page() {
       const [multiplier, setMultiplier] = createSignal(1)
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: [`${key}_${multiplier()}`],
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -152,7 +152,7 @@ describe("useQuery's in Suspense mode", () => {
     })
 
     function Page() {
-      createQuery(() => ({ queryKey: [key], queryFn, suspense: true }))
+      useQuery(() => ({ queryKey: [key], queryFn, suspense: true }))
 
       return <>rendered</>
     }
@@ -174,7 +174,7 @@ describe("useQuery's in Suspense mode", () => {
     const key = queryKey()
 
     function Page() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key,
         queryFn: () => {
           sleep(10)
@@ -226,7 +226,7 @@ describe("useQuery's in Suspense mode", () => {
     let succeed = false
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -289,7 +289,7 @@ describe("useQuery's in Suspense mode", () => {
     let succeed = false
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -350,7 +350,7 @@ describe("useQuery's in Suspense mode", () => {
     let count = 0
 
     function Component() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(100)
@@ -409,7 +409,7 @@ describe("useQuery's in Suspense mode", () => {
     const key2 = queryKey()
 
     function Component(props: { queryKey: Array<string> }) {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: props.queryKey,
         queryFn: async () => {
           await sleep(100)
@@ -460,7 +460,7 @@ describe("useQuery's in Suspense mode", () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async (): Promise<unknown> => {
           await sleep(10)
@@ -510,7 +510,7 @@ describe("useQuery's in Suspense mode", () => {
     const key = queryKey()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async (): Promise<unknown> => {
           await sleep(10)
@@ -562,7 +562,7 @@ describe("useQuery's in Suspense mode", () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async (): Promise<unknown> => {
           await sleep(10)
@@ -612,7 +612,7 @@ describe("useQuery's in Suspense mode", () => {
     const key = queryKey()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async (): Promise<unknown> => {
           await sleep(10)
@@ -669,7 +669,7 @@ describe("useQuery's in Suspense mode", () => {
 
     function Page() {
       const [enabled, setEnabled] = createSignal(false)
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: [key],
         queryFn,
         suspense: true,
@@ -715,7 +715,7 @@ describe("useQuery's in Suspense mode", () => {
     function Page() {
       const [nonce] = createSignal(0)
       const queryKeys = [`${key}-${succeed}`]
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: queryKeys,
         queryFn: async () => {
           await sleep(10)
@@ -784,7 +784,7 @@ describe("useQuery's in Suspense mode", () => {
     function Page() {
       const [key, setKey] = createSignal(0)
 
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: [`${key()}-${succeed}`],
         queryFn: async () => {
           await sleep(10)
@@ -847,7 +847,7 @@ describe("useQuery's in Suspense mode", () => {
       const queryKeys = '1'
       const [enabled, setEnabled] = createSignal(false)
 
-      const result = createQuery<string>(() => ({
+      const result = useQuery<string>(() => ({
         queryKey: [queryKeys],
         queryFn: async () => {
           await sleep(10)
@@ -906,13 +906,13 @@ describe("useQuery's in Suspense mode", () => {
 
   it('should render the correct amount of times in Suspense mode when gcTime is set to 0', async () => {
     const key = queryKey()
-    let state: CreateQueryResult<number> | null = null
+    let state: UseQueryResult<number> | null = null
 
     let count = 0
     let renders = 0
 
     function Page() {
-      state = createQuery(() => ({
+      state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           count++

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -9,18 +9,9 @@ import {
   createSignal,
   on,
 } from 'solid-js'
-import {
-  QueryCache,
-  QueryClientProvider,
-  useInfiniteQuery,
-  useQuery,
-} from '..'
+import { QueryCache, QueryClientProvider, useInfiniteQuery, useQuery } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
-import type {
-  InfiniteData,
-  UseInfiniteQueryResult,
-  UseQueryResult,
-} from '..'
+import type { InfiniteData, UseInfiniteQueryResult, UseQueryResult } from '..'
 
 describe("useQuery's in Suspense mode", () => {
   const queryCache = new QueryCache()

--- a/packages/solid-query/src/__tests__/transition.test.tsx
+++ b/packages/solid-query/src/__tests__/transition.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it } from 'vitest'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { Show, Suspense, createSignal, startTransition } from 'solid-js'
-import { QueryCache, QueryClientProvider, createQuery } from '..'
+import { QueryCache, QueryClientProvider, useQuery } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 
-describe("createQuery's in Suspense mode with transitions", () => {
+describe("useQuery's in Suspense mode with transitions", () => {
   const queryCache = new QueryCache()
   const queryClient = createQueryClient({ queryCache })
 
@@ -12,7 +12,7 @@ describe("createQuery's in Suspense mode with transitions", () => {
     const key = queryKey()
 
     function Suspended() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)

--- a/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -206,9 +206,8 @@ describe('useInfiniteQuery', () => {
 
   it('should keep the previous data when placeholderData is set', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<string>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<string>>>> =
+      []
 
     function Page() {
       const [order, setOrder] = createSignal('desc')
@@ -393,9 +392,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to reverse the data', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const state = useInfiniteQuery(() => ({
@@ -469,9 +467,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to fetch a previous page', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const start = 10
@@ -558,9 +555,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to refetch when providing page params automatically', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const state = useInfiniteQuery(() => ({
@@ -682,9 +678,8 @@ describe('useInfiniteQuery', () => {
 
   it('should return the correct states when refetch fails', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     let isRefetch = false
 
@@ -795,9 +790,8 @@ describe('useInfiniteQuery', () => {
 
   it('should return the correct states when fetchNextPage fails', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const state = useInfiniteQuery(() => ({
@@ -899,9 +893,8 @@ describe('useInfiniteQuery', () => {
 
   it('should return the correct states when fetchPreviousPage fails', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const state = useInfiniteQuery(() => ({
@@ -1007,9 +1000,8 @@ describe('useInfiniteQuery', () => {
 
   it('should silently cancel any ongoing fetch when fetching more', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const start = 10
@@ -1359,9 +1351,8 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to set new pages with the query client', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const [firstPage, setFirstPage] = createSignal(0)
@@ -1455,9 +1446,8 @@ describe('useInfiniteQuery', () => {
 
   it('should only refetch the first page when initialData is provided', async () => {
     const key = queryKey()
-    const states: Array<
-      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
-    > = []
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
 
     function Page() {
       const state = useInfiniteQuery(() => ({

--- a/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -14,9 +14,9 @@ import {
 import {
   QueryCache,
   QueryClientProvider,
-  createInfiniteQuery,
   infiniteQueryOptions,
   keepPreviousData,
+  useInfiniteQuery,
 } from '..'
 import {
   Blink,
@@ -27,9 +27,9 @@ import {
 } from './utils'
 
 import type {
-  CreateInfiniteQueryResult,
   InfiniteData,
   QueryFunctionContext,
+  UseInfiniteQueryResult,
 } from '..'
 import type { Mock } from 'vitest'
 
@@ -63,10 +63,10 @@ describe('useInfiniteQuery', () => {
 
   it('should return the correct states for a successful query', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<number>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<number>>> = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }) => Number(pageParam),
         getNextPageParam: (lastPage) => lastPage + 1,
@@ -166,7 +166,7 @@ describe('useInfiniteQuery', () => {
 
     function Page() {
       const start = 1
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }) => {
           if (pageParam === 2) {
@@ -207,13 +207,13 @@ describe('useInfiniteQuery', () => {
   it('should keep the previous data when placeholderData is set', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<string>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<string>>>
     > = []
 
     function Page() {
       const [order, setOrder] = createSignal('desc')
 
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: [key, order()],
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -306,10 +306,10 @@ describe('useInfiniteQuery', () => {
 
   it('should be able to select a part of the data', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<string>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<string>>> = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: () => ({ count: 1 }),
         select: (data) => ({
@@ -347,12 +347,12 @@ describe('useInfiniteQuery', () => {
   it('should be able to select a new result and not cause infinite renders', async () => {
     const key = queryKey()
     const states: Array<
-      CreateInfiniteQueryResult<InfiniteData<{ count: number; id: number }>>
+      UseInfiniteQueryResult<InfiniteData<{ count: number; id: number }>>
     > = []
     let selectCalled = 0
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: () => ({ count: 1 }),
         select: (data: InfiniteData<{ count: number }>) => {
@@ -394,11 +394,11 @@ describe('useInfiniteQuery', () => {
   it('should be able to reverse the data', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -470,12 +470,12 @@ describe('useInfiniteQuery', () => {
   it('should be able to fetch a previous page', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
       const start = 10
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -559,11 +559,11 @@ describe('useInfiniteQuery', () => {
   it('should be able to refetch when providing page params automatically', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -683,13 +683,13 @@ describe('useInfiniteQuery', () => {
   it('should return the correct states when refetch fails', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     let isRefetch = false
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -796,11 +796,11 @@ describe('useInfiniteQuery', () => {
   it('should return the correct states when fetchNextPage fails', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -900,11 +900,11 @@ describe('useInfiniteQuery', () => {
   it('should return the correct states when fetchPreviousPage fails', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -1008,12 +1008,12 @@ describe('useInfiniteQuery', () => {
   it('should silently cancel any ongoing fetch when fetching more', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
       const start = 10
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(50)
@@ -1114,7 +1114,7 @@ describe('useInfiniteQuery', () => {
     })
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: fetchPage,
         getNextPageParam: (lastPage) => lastPage + 1,
@@ -1195,7 +1195,7 @@ describe('useInfiniteQuery', () => {
     })
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: fetchPage,
         getNextPageParam: (lastPage) => lastPage + 1,
@@ -1249,11 +1249,11 @@ describe('useInfiniteQuery', () => {
 
   it('should keep fetching first page when not loaded yet and triggering fetch more', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<number>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<number>>> = []
 
     function Page() {
       const start = 10
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(50)
@@ -1311,7 +1311,7 @@ describe('useInfiniteQuery', () => {
     const initialData = { pages: [1, 2, 3, 4], pageParams: [0, 1, 2, 3] }
 
     function List() {
-      createInfiniteQuery(() => ({
+      useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam, signal: _ }) => {
           fetches++
@@ -1360,13 +1360,13 @@ describe('useInfiniteQuery', () => {
   it('should be able to set new pages with the query client', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
       const [firstPage, setFirstPage] = createSignal(0)
 
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }) => {
           await sleep(10)
@@ -1456,11 +1456,11 @@ describe('useInfiniteQuery', () => {
   it('should only refetch the first page when initialData is provided', async () => {
     const key = queryKey()
     const states: Array<
-      Partial<CreateInfiniteQueryResult<InfiniteData<number>>>
+      Partial<UseInfiniteQueryResult<InfiniteData<number>>>
     > = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: async ({ pageParam }): Promise<number> => {
           await sleep(10)
@@ -1534,10 +1534,10 @@ describe('useInfiniteQuery', () => {
 
   it('should set hasNextPage to false if getNextPageParam returns undefined', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<number>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<number>>> = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }) => Number(pageParam),
         initialPageParam: 1,
@@ -1578,10 +1578,10 @@ describe('useInfiniteQuery', () => {
 
   it('should compute hasNextPage correctly using initialData', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<number>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<number>>> = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }): number => pageParam,
         initialPageParam: 10,
@@ -1622,10 +1622,10 @@ describe('useInfiniteQuery', () => {
 
   it('should compute hasNextPage correctly for falsy getFetchMore return value using initialData', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<number>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<number>>> = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }): number => pageParam,
         initialPageParam: 10,
@@ -1666,10 +1666,10 @@ describe('useInfiniteQuery', () => {
 
   it('should not use selected data when computing hasNextPage', async () => {
     const key = queryKey()
-    const states: Array<CreateInfiniteQueryResult<InfiniteData<string>>> = []
+    const states: Array<UseInfiniteQueryResult<InfiniteData<string>>> = []
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }) => Number(pageParam),
         initialPageParam: 1,
@@ -1731,7 +1731,7 @@ describe('useInfiniteQuery', () => {
 
     function Page() {
       let fetchCountRef = 0
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }) =>
           fetchItemsWithLimit(pageParam, fetchCountRef++),
@@ -1861,7 +1861,7 @@ describe('useInfiniteQuery', () => {
       let fetchCountRef = 0
       const [isRemovedLastPage, setIsRemovedLastPage] =
         createSignal<boolean>(false)
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }) =>
           fetchItems(
@@ -1999,7 +1999,7 @@ describe('useInfiniteQuery', () => {
     }
 
     function Page() {
-      const state = createInfiniteQuery(() => ({
+      const state = useInfiniteQuery(() => ({
         queryKey: key,
         queryFn,
         getNextPageParam: () => undefined,
@@ -2032,7 +2032,7 @@ describe('useInfiniteQuery', () => {
     }
 
     function Page() {
-      const state = createInfiniteQuery(
+      const state = useInfiniteQuery(
         () => ({
           queryKey: key,
           queryFn,
@@ -2066,7 +2066,7 @@ describe('useInfiniteQuery', () => {
     })
 
     function Page() {
-      const state = createInfiniteQuery(
+      const state = useInfiniteQuery(
         () => options,
         () => queryClient,
       )

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
-import { QueryCache, QueryClientProvider, createQuery, useIsFetching } from '..'
+import { QueryCache, QueryClientProvider, useIsFetching, useQuery } from '..'
 import { createQueryClient, queryKey, setActTimeout, sleep } from './utils'
 
 describe('useIsFetching', () => {
@@ -19,7 +19,7 @@ describe('useIsFetching', () => {
     function Query() {
       const [ready, setReady] = createSignal(false)
 
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(50)
@@ -70,7 +70,7 @@ describe('useIsFetching', () => {
     }
 
     function FirstQuery() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key1,
         queryFn: async () => {
           await sleep(150)
@@ -81,7 +81,7 @@ describe('useIsFetching', () => {
     }
 
     function SecondQuery() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key2,
         queryFn: async () => {
           await sleep(200)
@@ -128,7 +128,7 @@ describe('useIsFetching', () => {
     const isFetchingArray: Array<number> = []
 
     function One() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key1,
         queryFn: async () => {
           await sleep(10)
@@ -139,7 +139,7 @@ describe('useIsFetching', () => {
     }
 
     function Two() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key2,
         queryFn: async () => {
           await sleep(20)
@@ -192,7 +192,7 @@ describe('useIsFetching', () => {
     const key = queryKey()
 
     function Page() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -224,7 +224,7 @@ describe('useIsFetching', () => {
     const key = queryKey()
 
     function Page() {
-      createQuery(
+      useQuery(
         () => ({
           queryKey: key,
           queryFn: async () => {

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
 import * as QueryCore from '@tanstack/query-core'
-import { QueryClientProvider, createMutation, useIsMutating } from '..'
+import { QueryClientProvider, useIsMutating, useMutation } from '..'
 import { createQueryClient, setActTimeout, sleep } from './utils'
 
 describe('useIsMutating', () => {
@@ -19,14 +19,14 @@ describe('useIsMutating', () => {
     }
 
     function Mutations() {
-      const { mutate: mutate1 } = createMutation(() => ({
+      const { mutate: mutate1 } = useMutation(() => ({
         mutationKey: ['mutation1'],
         mutationFn: async () => {
           await sleep(150)
           return 'data'
         },
       }))
-      const { mutate: mutate2 } = createMutation(() => ({
+      const { mutate: mutate2 } = useMutation(() => ({
         mutationKey: ['mutation2'],
         mutationFn: async () => {
           await sleep(50)
@@ -74,14 +74,14 @@ describe('useIsMutating', () => {
     }
 
     function Page() {
-      const { mutate: mutate1 } = createMutation(() => ({
+      const { mutate: mutate1 } = useMutation(() => ({
         mutationKey: ['mutation1'],
         mutationFn: async () => {
           await sleep(100)
           return 'data'
         },
       }))
-      const { mutate: mutate2 } = createMutation(() => ({
+      const { mutate: mutate2 } = useMutation(() => ({
         mutationKey: ['mutation2'],
         mutationFn: async () => {
           await sleep(100)
@@ -122,14 +122,14 @@ describe('useIsMutating', () => {
     }
 
     function Page() {
-      const { mutate: mutate1 } = createMutation(() => ({
+      const { mutate: mutate1 } = useMutation(() => ({
         mutationKey: ['mutation1'],
         mutationFn: async () => {
           await sleep(100)
           return 'data'
         },
       }))
-      const { mutate: mutate2 } = createMutation(() => ({
+      const { mutate: mutate2 } = useMutation(() => ({
         mutationKey: ['mutation2'],
         mutationFn: async () => {
           await sleep(100)
@@ -160,7 +160,7 @@ describe('useIsMutating', () => {
 
     function Page() {
       const isMutating = useIsMutating(undefined, () => queryClient)
-      const { mutate } = createMutation(
+      const { mutate } = useMutation(
         () => ({
           mutationKey: ['mutation1'],
           mutationFn: async () => {
@@ -210,7 +210,7 @@ describe('useIsMutating', () => {
 
     function Page() {
       const [mounted, setMounted] = createSignal(true)
-      const { mutate: mutate1 } = createMutation(() => ({
+      const { mutate: mutate1 } = useMutation(() => ({
         mutationKey: ['mutation1'],
         mutationFn: async () => {
           await sleep(10)

--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -6,12 +6,7 @@ import {
   createSignal,
 } from 'solid-js'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
-import {
-  MutationCache,
-  QueryCache,
-  QueryClientProvider,
-  useMutation,
-} from '..'
+import { MutationCache, QueryCache, QueryClientProvider, useMutation } from '..'
 import {
   createQueryClient,
   mockOnlineManagerIsOnline,

--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -10,7 +10,7 @@ import {
   MutationCache,
   QueryCache,
   QueryClientProvider,
-  createMutation,
+  useMutation,
 } from '..'
 import {
   createQueryClient,
@@ -19,16 +19,16 @@ import {
   setActTimeout,
   sleep,
 } from './utils'
-import type { CreateMutationResult } from '../types'
+import type { UseMutationResult } from '../types'
 
-describe('createMutation', () => {
+describe('useMutation', () => {
   const queryCache = new QueryCache()
   const mutationCache = new MutationCache()
   const queryClient = createQueryClient({ queryCache, mutationCache })
 
   it('should be able to reset `data`', async () => {
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: () => Promise.resolve('mutation'),
       }))
 
@@ -68,7 +68,7 @@ describe('createMutation', () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const mutation = createMutation<string, Error>(() => ({
+      const mutation = useMutation<string, Error>(() => ({
         mutationFn: () => {
           const err = new Error('Expected mock error. All is well!')
           err.stack = ''
@@ -118,7 +118,7 @@ describe('createMutation', () => {
     const onSettledMock = vi.fn()
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: (vars: { count: number }) => Promise.resolve(vars.count),
         onSuccess: (data) => {
           onSuccessMock(data)
@@ -192,7 +192,7 @@ describe('createMutation', () => {
     })
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: mutateFn,
       }))
 
@@ -242,7 +242,7 @@ describe('createMutation', () => {
     const [count, setCount] = createSignal(0)
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: (vars: { count: number }) => {
           const error = new Error(
             `Expected mock error. All is well! ${vars.count}`,
@@ -320,7 +320,7 @@ describe('createMutation', () => {
     const callbacks: Array<string> = []
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (text: string) => text,
         onSuccess: async () => {
           callbacks.push('useMutation.onSuccess')
@@ -371,7 +371,7 @@ describe('createMutation', () => {
     const callbacks: Array<string> = []
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => Promise.reject(new Error('oops')),
 
         onError: async () => {
@@ -430,10 +430,10 @@ describe('createMutation', () => {
       },
     })
 
-    const states: Array<CreateMutationResult<any, any, any, any>> = []
+    const states: Array<UseMutationResult<any, any, any, any>> = []
 
     function Page() {
-      const mutation = createMutation<string, unknown, string>(() => ({
+      const mutation = useMutation<string, unknown, string>(() => ({
         mutationKey: key,
       }))
 
@@ -469,7 +469,7 @@ describe('createMutation', () => {
     let count = 0
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: (_text: string) => {
           count++
           return Promise.reject(new Error('oops'))
@@ -505,7 +505,7 @@ describe('createMutation', () => {
     let count = 0
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: (_text: string) => {
           count++
           return Promise.reject(new Error('oops'))
@@ -572,7 +572,7 @@ describe('createMutation', () => {
     let count = 0
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           count++
           await sleep(10)
@@ -624,7 +624,7 @@ describe('createMutation', () => {
     const states: Array<string> = []
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           count++
           await sleep(10)
@@ -675,10 +675,10 @@ describe('createMutation', () => {
     const onlineMock = mockOnlineManagerIsOnline(false)
 
     let count = 0
-    const states: Array<CreateMutationResult<any, any, any, any>> = []
+    const states: Array<UseMutationResult<any, any, any, any>> = []
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           await sleep(1)
           count++
@@ -763,7 +763,7 @@ describe('createMutation', () => {
 
   it('should not change state if unmounted', async () => {
     function Mutates() {
-      const mutation = createMutation(() => ({ mutationFn: () => sleep(10) }))
+      const mutation = useMutation(() => ({ mutationFn: () => sleep(10) }))
       return <button onClick={() => mutation.mutate()}>mutate</button>
     }
     function Page() {
@@ -791,7 +791,7 @@ describe('createMutation', () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const mutation = createMutation<string, Error>(() => ({
+      const mutation = useMutation<string, Error>(() => ({
         mutationFn: () => {
           const err = new Error('Expected mock error. All is well!')
           err.stack = ''
@@ -837,7 +837,7 @@ describe('createMutation', () => {
 
     let boundary = false
     function Page() {
-      const mutation = createMutation<string, Error>(() => ({
+      const mutation = useMutation<string, Error>(() => ({
         mutationFn: () => {
           const err = new Error('mock error')
           err.stack = ''
@@ -905,11 +905,11 @@ describe('createMutation', () => {
     const metaErrorMessage = 'mutation failed'
 
     function Page() {
-      const mutationSucceed = createMutation(() => ({
+      const mutationSucceed = useMutation(() => ({
         mutationFn: async () => '',
         meta: { metaSuccessMessage },
       }))
-      const mutationError = createMutation(() => ({
+      const mutationError = useMutation(() => ({
         mutationFn: async () => {
           throw new Error('')
         },
@@ -965,7 +965,7 @@ describe('createMutation', () => {
     }
 
     function Component() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           count++
           await sleep(10)
@@ -1030,7 +1030,7 @@ describe('createMutation', () => {
     let count = 0
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           count++
           await sleep(10)
@@ -1092,7 +1092,7 @@ describe('createMutation', () => {
     const onError = vi.fn()
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           await sleep(10)
           return 'result'
@@ -1129,7 +1129,7 @@ describe('createMutation', () => {
     const mutateFnError = new Error('mutateFnError')
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           await sleep(10)
           throw mutateFnError
@@ -1168,7 +1168,7 @@ describe('createMutation', () => {
     const onError = vi.fn()
 
     function Page() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationFn: async (_text: string) => {
           await sleep(10)
           throw mutateFnError
@@ -1206,7 +1206,7 @@ describe('createMutation', () => {
 
   it('should use provided custom queryClient', async () => {
     function Page() {
-      const mutation = createMutation(
+      const mutation = useMutation(
         () => ({
           mutationFn: async (text: string) => {
             return Promise.resolve(text)

--- a/packages/solid-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutationState.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { createEffect } from 'solid-js'
 import { useMutationState } from '../useMutationState'
-import { createMutation } from '../createMutation'
+import { useMutation } from '../useMutation'
 import { QueryClientProvider } from '../QueryClientProvider'
 import { createQueryClient, sleep } from './utils'
 
@@ -26,7 +26,7 @@ describe('useMutationState', () => {
     }
 
     function Mutate() {
-      const mutation = createMutation(() => ({
+      const mutation = useMutation(() => ({
         mutationKey,
         mutationFn: async (input: number) => {
           await sleep(150)

--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -127,12 +127,8 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result2[0]).toEqualTypeOf<
-        UseQueryResult<string, unknown>
-      >()
-      expectTypeOf(result2[1]).toEqualTypeOf<
-        UseQueryResult<number, unknown>
-      >()
+      expectTypeOf(result2[0]).toEqualTypeOf<UseQueryResult<string, unknown>>()
+      expectTypeOf(result2[1]).toEqualTypeOf<UseQueryResult<number, unknown>>()
       expectTypeOf(result2[0].data).toEqualTypeOf<string | undefined>()
       expectTypeOf(result2[1].data).toEqualTypeOf<number | undefined>()
 
@@ -207,12 +203,8 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result1[0]).toEqualTypeOf<
-        UseQueryResult<number, unknown>
-      >()
-      expectTypeOf(result1[1]).toEqualTypeOf<
-        UseQueryResult<string, unknown>
-      >()
+      expectTypeOf(result1[0]).toEqualTypeOf<UseQueryResult<number, unknown>>()
+      expectTypeOf(result1[1]).toEqualTypeOf<UseQueryResult<string, unknown>>()
       expectTypeOf(result1[2]).toEqualTypeOf<
         UseQueryResult<Array<string>, boolean>
       >()
@@ -247,44 +239,34 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result2[0]).toEqualTypeOf<
-        UseQueryResult<string, unknown>
-      >()
-      expectTypeOf(result2[1]).toEqualTypeOf<
-        UseQueryResult<number, unknown>
-      >()
+      expectTypeOf(result2[0]).toEqualTypeOf<UseQueryResult<string, unknown>>()
+      expectTypeOf(result2[1]).toEqualTypeOf<UseQueryResult<number, unknown>>()
       expectTypeOf(result2[0].data).toEqualTypeOf<string | undefined>()
       expectTypeOf(result2[1].data).toEqualTypeOf<number | undefined>()
 
       // can pass only TData (data prop) although TQueryFnData will be left unknown
-      const result3 = useQueries<[{ data: string }, { data: number }]>(
-        () => ({
-          queries: [
-            {
-              queryKey: key1,
-              queryFn: () => 'string',
-              select: (a) => {
-                expectTypeOf(a).toEqualTypeOf<unknown>()
-                return a as string
-              },
+      const result3 = useQueries<[{ data: string }, { data: number }]>(() => ({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => 'string',
+            select: (a) => {
+              expectTypeOf(a).toEqualTypeOf<unknown>()
+              return a as string
             },
-            {
-              queryKey: key2,
-              queryFn: () => 'string',
-              select: (a) => {
-                expectTypeOf(a).toEqualTypeOf<unknown>()
-                return a as number
-              },
+          },
+          {
+            queryKey: key2,
+            queryFn: () => 'string',
+            select: (a) => {
+              expectTypeOf(a).toEqualTypeOf<unknown>()
+              return a as number
             },
-          ],
-        }),
-      )
-      expectTypeOf(result3[0]).toEqualTypeOf<
-        UseQueryResult<string, unknown>
-      >()
-      expectTypeOf(result3[1]).toEqualTypeOf<
-        UseQueryResult<number, unknown>
-      >()
+          },
+        ],
+      }))
+      expectTypeOf(result3[0]).toEqualTypeOf<UseQueryResult<string, unknown>>()
+      expectTypeOf(result3[1]).toEqualTypeOf<UseQueryResult<number, unknown>>()
       expectTypeOf(result3[0].data).toEqualTypeOf<string | undefined>()
       expectTypeOf(result3[1].data).toEqualTypeOf<number | undefined>()
 

--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -6,11 +6,11 @@ import {
   QueriesObserver,
   QueryCache,
   QueryClientProvider,
-  createQueries,
+  useQueries,
 } from '..'
 import { createQueryClient, queryKey, sleep } from './utils'
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
-import type { CreateQueryResult, QueryFunction, SolidQueryOptions } from '..'
+import type { QueryFunction, SolidQueryOptions, UseQueryResult } from '..'
 
 describe('useQueries', () => {
   const queryCache = new QueryCache()
@@ -19,10 +19,10 @@ describe('useQueries', () => {
   it('should return the correct states', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
-    const results: Array<Array<CreateQueryResult>> = []
+    const results: Array<Array<UseQueryResult>> = []
 
     function Page() {
-      const result = createQueries(() => ({
+      const result = useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -76,7 +76,7 @@ describe('useQueries', () => {
 
     // @ts-expect-error (Page component is not rendered)
     function Page() {
-      const result1 = createQueries<
+      const result1 = useQueries<
         [[number], [string], [Array<string>, boolean]]
       >(() => ({
         queries: [
@@ -94,10 +94,10 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result1[0]).toEqualTypeOf<CreateQueryResult<number>>()
-      expectTypeOf(result1[1]).toEqualTypeOf<CreateQueryResult<string>>()
+      expectTypeOf(result1[0]).toEqualTypeOf<UseQueryResult<number>>()
+      expectTypeOf(result1[1]).toEqualTypeOf<UseQueryResult<string>>()
       expectTypeOf(result1[2]).toEqualTypeOf<
-        CreateQueryResult<Array<string>, boolean>
+        UseQueryResult<Array<string>, boolean>
       >()
       expectTypeOf(result1[0].data).toEqualTypeOf<number | undefined>()
       expectTypeOf(result1[1].data).toEqualTypeOf<string | undefined>()
@@ -105,7 +105,7 @@ describe('useQueries', () => {
       expectTypeOf(result1[2].error).toEqualTypeOf<boolean | null>()
 
       // TData (3rd element) takes precedence over TQueryFnData (1st element)
-      const result2 = createQueries<
+      const result2 = useQueries<
         [[string, unknown, string], [string, unknown, number]]
       >(() => ({
         queries: [
@@ -128,16 +128,16 @@ describe('useQueries', () => {
         ],
       }))
       expectTypeOf(result2[0]).toEqualTypeOf<
-        CreateQueryResult<string, unknown>
+        UseQueryResult<string, unknown>
       >()
       expectTypeOf(result2[1]).toEqualTypeOf<
-        CreateQueryResult<number, unknown>
+        UseQueryResult<number, unknown>
       >()
       expectTypeOf(result2[0].data).toEqualTypeOf<string | undefined>()
       expectTypeOf(result2[1].data).toEqualTypeOf<number | undefined>()
 
       // types should be enforced
-      createQueries<[[string, unknown, string], [string, boolean, number]]>(
+      useQueries<[[string, unknown, string], [string, boolean, number]]>(
         () => ({
           queries: [
             {
@@ -167,7 +167,7 @@ describe('useQueries', () => {
       )
 
       // field names should be enforced
-      createQueries<[[string]]>(() => ({
+      useQueries<[[string]]>(() => ({
         queries: [
           {
             queryKey: key1,
@@ -185,7 +185,7 @@ describe('useQueries', () => {
 
     // @ts-expect-error (Page component is not rendered)
     function Page() {
-      const result1 = createQueries<
+      const result1 = useQueries<
         [
           { queryFnData: number },
           { queryFnData: string },
@@ -208,13 +208,13 @@ describe('useQueries', () => {
         ],
       }))
       expectTypeOf(result1[0]).toEqualTypeOf<
-        CreateQueryResult<number, unknown>
+        UseQueryResult<number, unknown>
       >()
       expectTypeOf(result1[1]).toEqualTypeOf<
-        CreateQueryResult<string, unknown>
+        UseQueryResult<string, unknown>
       >()
       expectTypeOf(result1[2]).toEqualTypeOf<
-        CreateQueryResult<Array<string>, boolean>
+        UseQueryResult<Array<string>, boolean>
       >()
       expectTypeOf(result1[0].data).toEqualTypeOf<number | undefined>()
       expectTypeOf(result1[1].data).toEqualTypeOf<string | undefined>()
@@ -222,7 +222,7 @@ describe('useQueries', () => {
       expectTypeOf(result1[2].error).toEqualTypeOf<boolean | null>()
 
       // TData (data prop) takes precedence over TQueryFnData (queryFnData prop)
-      const result2 = createQueries<
+      const result2 = useQueries<
         [
           { queryFnData: string; data: string },
           { queryFnData: string; data: number },
@@ -248,16 +248,16 @@ describe('useQueries', () => {
         ],
       }))
       expectTypeOf(result2[0]).toEqualTypeOf<
-        CreateQueryResult<string, unknown>
+        UseQueryResult<string, unknown>
       >()
       expectTypeOf(result2[1]).toEqualTypeOf<
-        CreateQueryResult<number, unknown>
+        UseQueryResult<number, unknown>
       >()
       expectTypeOf(result2[0].data).toEqualTypeOf<string | undefined>()
       expectTypeOf(result2[1].data).toEqualTypeOf<number | undefined>()
 
       // can pass only TData (data prop) although TQueryFnData will be left unknown
-      const result3 = createQueries<[{ data: string }, { data: number }]>(
+      const result3 = useQueries<[{ data: string }, { data: number }]>(
         () => ({
           queries: [
             {
@@ -280,16 +280,16 @@ describe('useQueries', () => {
         }),
       )
       expectTypeOf(result3[0]).toEqualTypeOf<
-        CreateQueryResult<string, unknown>
+        UseQueryResult<string, unknown>
       >()
       expectTypeOf(result3[1]).toEqualTypeOf<
-        CreateQueryResult<number, unknown>
+        UseQueryResult<number, unknown>
       >()
       expectTypeOf(result3[0].data).toEqualTypeOf<string | undefined>()
       expectTypeOf(result3[1].data).toEqualTypeOf<number | undefined>()
 
       // types should be enforced
-      createQueries<
+      useQueries<
         [
           { queryFnData: string; data: string },
           { queryFnData: string; data: number; error: boolean },
@@ -322,7 +322,7 @@ describe('useQueries', () => {
       }))
 
       // field names should be enforced
-      createQueries<[{ queryFnData: string }]>(() => ({
+      useQueries<[{ queryFnData: string }]>(() => ({
         queries: [
           {
             queryKey: key1,
@@ -342,21 +342,21 @@ describe('useQueries', () => {
     // @ts-expect-error (Page component is not rendered)
     function Page() {
       // Array.map preserves TQueryFnData
-      const result1 = createQueries(() => ({
+      const result1 = useQueries(() => ({
         queries: Array(50).map((_, i) => ({
           queryKey: ['key', i] as const,
           queryFn: () => i + 10,
         })),
       }))
       expectTypeOf(result1).toEqualTypeOf<
-        Array<CreateQueryResult<number, Error>>
+        Array<UseQueryResult<number, Error>>
       >()
       if (result1[0]) {
         expectTypeOf(result1[0].data).toEqualTypeOf<number | undefined>()
       }
 
       // Array.map preserves TData
-      const result2 = createQueries(() => ({
+      const result2 = useQueries(() => ({
         queries: Array(50).map((_, i) => ({
           queryKey: ['key', i] as const,
           queryFn: () => i + 10,
@@ -364,10 +364,10 @@ describe('useQueries', () => {
         })),
       }))
       expectTypeOf(result2).toEqualTypeOf<
-        Array<CreateQueryResult<string, Error>>
+        Array<UseQueryResult<string, Error>>
       >()
 
-      const result3 = createQueries(() => ({
+      const result3 = useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -384,16 +384,16 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result3[0]).toEqualTypeOf<CreateQueryResult<number, Error>>()
-      expectTypeOf(result3[1]).toEqualTypeOf<CreateQueryResult<string, Error>>()
-      expectTypeOf(result3[2]).toEqualTypeOf<CreateQueryResult<number, Error>>()
+      expectTypeOf(result3[0]).toEqualTypeOf<UseQueryResult<number, Error>>()
+      expectTypeOf(result3[1]).toEqualTypeOf<UseQueryResult<string, Error>>()
+      expectTypeOf(result3[2]).toEqualTypeOf<UseQueryResult<number, Error>>()
       expectTypeOf(result3[0].data).toEqualTypeOf<number | undefined>()
       expectTypeOf(result3[1].data).toEqualTypeOf<string | undefined>()
       // select takes precedence over queryFn
       expectTypeOf(result3[2].data).toEqualTypeOf<number | undefined>()
 
       // initialData/placeholderData are enforced
-      createQueries(() => ({
+      useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -413,7 +413,7 @@ describe('useQueries', () => {
       }))
 
       // select params are "indirectly" enforced
-      createQueries(() => ({
+      useQueries(() => ({
         queries: [
           // unfortunately TS will not suggest the type for you
           {
@@ -439,7 +439,7 @@ describe('useQueries', () => {
       }))
 
       // callbacks are also indirectly enforced with Array.map
-      createQueries(() => ({
+      useQueries(() => ({
         queries: Array(50).map((_, i) => ({
           queryKey: ['key', i] as const,
           queryFn: () => i + 10,
@@ -447,7 +447,7 @@ describe('useQueries', () => {
         })),
       }))
 
-      createQueries(() => ({
+      useQueries(() => ({
         queries: Array(50).map((_, i) => ({
           queryKey: ['key', i] as const,
           queryFn: () => i + 10,
@@ -456,7 +456,7 @@ describe('useQueries', () => {
       }))
 
       // results inference works when all the handlers are defined
-      const result4 = createQueries(() => ({
+      const result4 = useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -473,12 +473,12 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result4[0]).toEqualTypeOf<CreateQueryResult<string, Error>>()
-      expectTypeOf(result4[1]).toEqualTypeOf<CreateQueryResult<string, Error>>()
-      expectTypeOf(result4[2]).toEqualTypeOf<CreateQueryResult<number, Error>>()
+      expectTypeOf(result4[0]).toEqualTypeOf<UseQueryResult<string, Error>>()
+      expectTypeOf(result4[1]).toEqualTypeOf<UseQueryResult<string, Error>>()
+      expectTypeOf(result4[2]).toEqualTypeOf<UseQueryResult<number, Error>>()
 
       // handles when queryFn returns a Promise
-      const result5 = createQueries(() => ({
+      const result5 = useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -486,10 +486,10 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result5[0]).toEqualTypeOf<CreateQueryResult<string, Error>>()
+      expectTypeOf(result5[0]).toEqualTypeOf<UseQueryResult<string, Error>>()
 
       // Array as const does not throw error
-      const result6 = createQueries(
+      const result6 = useQueries(
         () =>
           ({
             queries: [
@@ -504,11 +504,11 @@ describe('useQueries', () => {
             ],
           }) as const,
       )
-      expectTypeOf(result6[0]).toEqualTypeOf<CreateQueryResult<string, Error>>()
-      expectTypeOf(result6[1]).toEqualTypeOf<CreateQueryResult<number, Error>>()
+      expectTypeOf(result6[0]).toEqualTypeOf<UseQueryResult<string, Error>>()
+      expectTypeOf(result6[1]).toEqualTypeOf<UseQueryResult<number, Error>>()
 
       // field names should be enforced - array literal
-      createQueries(() => ({
+      useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -518,7 +518,7 @@ describe('useQueries', () => {
       }))
 
       // field names should be enforced - Array.map() result
-      createQueries(() => ({
+      useQueries(() => ({
         // @ts-expect-error (invalidField)
         queries: Array(10).map(() => ({
           someInvalidField: '',
@@ -526,7 +526,7 @@ describe('useQueries', () => {
       }))
 
       // field names should be enforced - array literal
-      createQueries(() => ({
+      useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -536,7 +536,7 @@ describe('useQueries', () => {
       }))
 
       // supports queryFn using fetch() to return Promise<any> - Array.map() result
-      createQueries(() => ({
+      useQueries(() => ({
         queries: Array(50).map((_, i) => ({
           queryKey: ['key', i] as const,
           queryFn: () =>
@@ -545,7 +545,7 @@ describe('useQueries', () => {
       }))
 
       // supports queryFn using fetch() to return Promise<any> - array literal
-      createQueries(() => ({
+      useQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -586,7 +586,7 @@ describe('useQueries', () => {
     >(
       queries: Array<SolidQueryOptions<TQueryFnData, TError, TData, TQueryKey>>,
     ) {
-      return createQueries(() => ({
+      return useQueries(() => ({
         queries: queries.map(
           // no need to type the mapped query
           (query) => {
@@ -616,7 +616,7 @@ describe('useQueries', () => {
 
     // @ts-expect-error (Page component is not rendered)
     function Page() {
-      const result = createQueries(() => ({
+      const result = useQueries(() => ({
         queries: [
           {
             queryKey: getQueryKeyA(),
@@ -628,10 +628,10 @@ describe('useQueries', () => {
           },
         ],
       }))
-      expectTypeOf(result[0]).toEqualTypeOf<CreateQueryResult<number, Error>>()
-      expectTypeOf(result[1]).toEqualTypeOf<CreateQueryResult<string, Error>>()
+      expectTypeOf(result[0]).toEqualTypeOf<UseQueryResult<number, Error>>()
+      expectTypeOf(result[1]).toEqualTypeOf<UseQueryResult<string, Error>>()
 
-      const withSelector = createQueries(() => ({
+      const withSelector = useQueries(() => ({
         queries: [
           {
             queryKey: getQueryKeyA(),
@@ -646,10 +646,10 @@ describe('useQueries', () => {
         ],
       }))
       expectTypeOf(withSelector[0]).toEqualTypeOf<
-        CreateQueryResult<[number, string], Error>
+        UseQueryResult<[number, string], Error>
       >()
       expectTypeOf(withSelector[1]).toEqualTypeOf<
-        CreateQueryResult<[string, number], Error>
+        UseQueryResult<[string, number], Error>
       >()
 
       const withWrappedQueries = useWrappedQueries(
@@ -661,7 +661,7 @@ describe('useQueries', () => {
       )
 
       expectTypeOf(withWrappedQueries).toEqualTypeOf<
-        Array<CreateQueryResult<number, Error>>
+        Array<UseQueryResult<number, Error>>
       >()
     }
   })
@@ -685,7 +685,7 @@ describe('useQueries', () => {
       })
 
     function Queries() {
-      createQueries(() => ({
+      useQueries(() => ({
         queries: [
           {
             queryKey: key1,

--- a/packages/solid-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test-d.tsx
@@ -1,10 +1,10 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { createQuery, queryOptions } from '../index'
+import { queryOptions, useQuery } from '../index'
 
 describe('initialData', () => {
   describe('Config object overload', () => {
     it('TData should always be defined when initialData is provided as an object', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
         initialData: { wow: true },
@@ -19,13 +19,13 @@ describe('initialData', () => {
         queryFn: () => ({ wow: true }),
         initialData: { wow: true },
       })
-      const { data } = createQuery(() => options)
+      const { data } = useQuery(() => options)
 
       expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
     })
 
     it('TData should always be defined when initialData is provided as a function which ALWAYS returns the data', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
         initialData: () => ({ wow: true }),
@@ -35,7 +35,7 @@ describe('initialData', () => {
     })
 
     it('TData should have undefined in the union when initialData is NOT provided', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
       }))
@@ -44,7 +44,7 @@ describe('initialData', () => {
     })
 
     it('TData should have undefined in the union when initialData is provided as a function which can return undefined', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
         initialData: () => undefined as { wow: boolean } | undefined,
@@ -56,7 +56,7 @@ describe('initialData', () => {
 
   describe('Query key overload', () => {
     it('TData should always be defined when initialData is provided', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
         initialData: { wow: true },
@@ -66,7 +66,7 @@ describe('initialData', () => {
     })
 
     it('TData should have undefined in the union when initialData is NOT provided', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
       }))
@@ -77,7 +77,7 @@ describe('initialData', () => {
 
   describe('Query key and func', () => {
     it('TData should always be defined when initialData is provided', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
         initialData: { wow: true },
@@ -87,7 +87,7 @@ describe('initialData', () => {
     })
 
     it('TData should have undefined in the union when initialData is NOT provided', () => {
-      const { data } = createQuery(() => ({
+      const { data } = useQuery(() => ({
         queryKey: ['key'],
         queryFn: () => ({ wow: true }),
       }))

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -11,12 +11,7 @@ import {
 } from 'solid-js'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { reconcile } from 'solid-js/store'
-import {
-  QueryCache,
-  QueryClientProvider,
-  keepPreviousData,
-  useQuery,
-} from '..'
+import { QueryCache, QueryClientProvider, keepPreviousData, useQuery } from '..'
 import {
   Blink,
   createQueryClient,
@@ -2985,8 +2980,7 @@ describe('useQuery', () => {
 
   it('should keep initial data when the query key changes', async () => {
     const key = queryKey()
-    const states: Array<Partial<DefinedUseQueryResult<{ count: number }>>> =
-      []
+    const states: Array<Partial<DefinedUseQueryResult<{ count: number }>>> = []
 
     function Page() {
       const [count, setCount] = createSignal(0)
@@ -4193,8 +4187,7 @@ describe('useQuery', () => {
   it('should use placeholder data even for disabled queries', async () => {
     const key1 = queryKey()
 
-    const states: Array<{ state: UseQueryResult<string>; count: number }> =
-      []
+    const states: Array<{ state: UseQueryResult<string>; count: number }> = []
 
     function Page() {
       const [count, setCount] = createSignal(0)

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -14,8 +14,8 @@ import { reconcile } from 'solid-js/store'
 import {
   QueryCache,
   QueryClientProvider,
-  createQuery,
   keepPreviousData,
+  useQuery,
 } from '..'
 import {
   Blink,
@@ -27,16 +27,16 @@ import {
   sleep,
 } from './utils'
 import type {
-  CreateQueryOptions,
-  CreateQueryResult,
-  DefinedCreateQueryResult,
+  DefinedUseQueryResult,
   OmitKeyof,
   QueryFunction,
+  UseQueryOptions,
+  UseQueryResult,
 } from '..'
 import type { Mock } from 'vitest'
 import type { JSX } from 'solid-js'
 
-describe('createQuery', () => {
+describe('useQuery', () => {
   const queryCache = new QueryCache()
   const queryClient = createQueryClient({ queryCache })
 
@@ -46,12 +46,12 @@ describe('createQuery', () => {
     // @ts-expect-error
     function Page() {
       // unspecified query function should default to unknown
-      const noQueryFn = createQuery(() => ({ queryKey: key }))
+      const noQueryFn = useQuery(() => ({ queryKey: key }))
       expectTypeOf(noQueryFn.data).toEqualTypeOf<unknown>()
       expectTypeOf(noQueryFn.error).toEqualTypeOf<Error | null>()
 
       // it should infer the result type from the query function
-      const fromQueryFn = createQuery(() => ({
+      const fromQueryFn = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'test',
       }))
@@ -59,7 +59,7 @@ describe('createQuery', () => {
       expectTypeOf(fromQueryFn.error).toEqualTypeOf<Error | null>()
 
       // it should be possible to specify the result type
-      const withResult = createQuery<string>(() => ({
+      const withResult = useQuery<string>(() => ({
         queryKey: key,
         queryFn: () => 'test',
       }))
@@ -67,7 +67,7 @@ describe('createQuery', () => {
       expectTypeOf(withResult.error).toEqualTypeOf<Error | null>()
 
       // it should be possible to specify the error type
-      const withError = createQuery<string, Error>(() => ({
+      const withError = useQuery<string, Error>(() => ({
         queryKey: key,
         queryFn: () => 'test',
       }))
@@ -75,18 +75,18 @@ describe('createQuery', () => {
       expectTypeOf(withError.error).toEqualTypeOf<Error | null>()
 
       // it should provide the result type in the configuration
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: [key],
         queryFn: async () => true,
       }))
 
       // it should be possible to specify a union type as result type
-      const unionTypeSync = createQuery(() => ({
+      const unionTypeSync = useQuery(() => ({
         queryKey: key,
         queryFn: () => (Math.random() > 0.5 ? ('a' as const) : ('b' as const)),
       }))
       expectTypeOf(unionTypeSync.data).toEqualTypeOf<'a' | 'b' | undefined>()
-      const unionTypeAsync = createQuery<'a' | 'b'>(() => ({
+      const unionTypeAsync = useQuery<'a' | 'b'>(() => ({
         queryKey: key,
         queryFn: () => Promise.resolve(Math.random() > 0.5 ? 'a' : 'b'),
       }))
@@ -94,21 +94,21 @@ describe('createQuery', () => {
 
       // should error when the query function result does not match with the specified type
       // @ts-expect-error
-      createQuery<number>(() => ({ queryKey: key, queryFn: () => 'test' }))
+      useQuery<number>(() => ({ queryKey: key, queryFn: () => 'test' }))
 
       // it should infer the result type from a generic query function
       function queryFn<T = string>(): Promise<T> {
         return Promise.resolve({} as T)
       }
 
-      const fromGenericQueryFn = createQuery(() => ({
+      const fromGenericQueryFn = useQuery(() => ({
         queryKey: key,
         queryFn: () => queryFn(),
       }))
       expectTypeOf(fromGenericQueryFn.data).toEqualTypeOf<string | undefined>()
       expectTypeOf(fromGenericQueryFn.error).toEqualTypeOf<Error | null>()
 
-      const fromGenericOptionsQueryFn = createQuery(() => ({
+      const fromGenericOptionsQueryFn = useQuery(() => ({
         queryKey: key,
         queryFn: () => queryFn(),
       }))
@@ -128,7 +128,7 @@ describe('createQuery', () => {
         return n + 42
       }
 
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: ['my-data', 100] as const,
         queryFn: getMyDataArrayKey,
       }))
@@ -140,13 +140,13 @@ describe('createQuery', () => {
         return Number(context.queryKey[0]) + 42
       }
 
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: ['1'] as ['1'],
         queryFn: getMyDataStringKey,
       }))
 
       // it should handle query-functions that return Promise<any>
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key,
         queryFn: () => fetch('return Promise<any>').then((resp) => resp.json()),
       }))
@@ -165,12 +165,12 @@ describe('createQuery', () => {
           // return type must be wrapped with TQueryFnReturn
         ) => Promise<TQueryFnData>,
         options?: OmitKeyof<
-          CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+          UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
           'queryKey' | 'queryFn' | 'initialData',
           'safely'
         >,
       ) =>
-        createQuery(() => ({
+        useQuery(() => ({
           queryKey: qk,
           queryFn: () => fetcher(qk[1], 'token'),
           ...options,
@@ -178,7 +178,7 @@ describe('createQuery', () => {
       const test = useWrappedQuery([''], async () => '1')
       expectTypeOf(test.data).toEqualTypeOf<string | undefined>()
 
-      // handles wrapped queries with custom fetcher passed directly to createQuery
+      // handles wrapped queries with custom fetcher passed directly to useQuery
       const useWrappedFuncStyleQuery = <
         TQueryKey extends [string, Record<string, unknown>?],
         TQueryFnData,
@@ -188,11 +188,11 @@ describe('createQuery', () => {
         qk: TQueryKey,
         fetcher: () => Promise<TQueryFnData>,
         options?: OmitKeyof<
-          CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+          UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
           'queryKey' | 'queryFn' | 'initialData',
           'safely'
         >,
-      ) => createQuery(() => ({ queryKey: qk, queryFn: fetcher, ...options }))
+      ) => useQuery(() => ({ queryKey: qk, queryFn: fetcher, ...options }))
       const testFuncStyle = useWrappedFuncStyleQuery([''], async () => true)
       expectTypeOf(testFuncStyle.data).toEqualTypeOf<boolean | undefined>()
     }
@@ -203,7 +203,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -231,10 +231,10 @@ describe('createQuery', () => {
 
   it('should return the correct states for a successful query', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page(): JSX.Element {
-      const state = createQuery<string, Error>(() => ({
+      const state = useQuery<string, Error>(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -339,10 +339,10 @@ describe('createQuery', () => {
   it('should return the correct states for an unsuccessful query', async () => {
     const key = queryKey()
 
-    const states: Array<CreateQueryResult<unknown, Error>> = []
+    const states: Array<UseQueryResult<unknown, Error>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('rejected')),
         retry: 1,
@@ -457,7 +457,7 @@ describe('createQuery', () => {
 
   it('should set isFetchedAfterMount to true after a query has been fetched', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     await queryClient.prefetchQuery({
       queryKey: key,
@@ -465,7 +465,7 @@ describe('createQuery', () => {
     })
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
       }))
@@ -501,7 +501,7 @@ describe('createQuery', () => {
     let fetchCount = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           fetchCount++
@@ -540,7 +540,7 @@ describe('createQuery', () => {
     let fetchCount = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           fetchCount++
@@ -579,7 +579,7 @@ describe('createQuery', () => {
     let fetchCount = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           fetchCount++
@@ -614,12 +614,12 @@ describe('createQuery', () => {
 
   it('should be able to watch a query without providing a query function', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     queryClient.setQueryDefaults(key, { queryFn: () => 'data' })
 
     function Page() {
-      const state = createQuery<string>(() => ({ queryKey: key }))
+      const state = useQuery<string>(() => ({ queryKey: key }))
       createRenderEffect(() => {
         states.push({ ...state })
       })
@@ -641,7 +641,7 @@ describe('createQuery', () => {
 
   it('should pick up a query when re-mounting with gcTime 0', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
       const [toggle, setToggle] = createSignal(false)
@@ -662,7 +662,7 @@ describe('createQuery', () => {
     }
 
     function Component({ value }: { value: string }) {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -721,10 +721,10 @@ describe('createQuery', () => {
 
   it('should fetch when refetchOnMount is false and nothing has been fetched yet', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'test',
         refetchOnMount: false,
@@ -750,12 +750,12 @@ describe('createQuery', () => {
 
   it('should not fetch when refetchOnMount is false and data has been fetched already', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     queryClient.setQueryData(key, 'prefetched')
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'test',
         refetchOnMount: false,
@@ -780,10 +780,10 @@ describe('createQuery', () => {
 
   it('should be able to select a part of the data with select', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => ({ name: 'test' }),
         select: (data) => data.name,
@@ -809,10 +809,10 @@ describe('createQuery', () => {
 
   it('should be able to select a part of the data with select in object syntax 2', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => ({ name: 'test' }),
         select: (data) => data.name,
@@ -838,10 +838,10 @@ describe('createQuery', () => {
 
   it('should be able to select a part of the data with select in object syntax 1', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => ({ name: 'test' }),
         select: (data) => data.name,
@@ -867,10 +867,10 @@ describe('createQuery', () => {
 
   it('should not re-render when it should only re-render only data change and the selected data did not change', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -911,7 +911,7 @@ describe('createQuery', () => {
     const error = new Error('Select Error')
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => ({ name: 'test' }),
         select: () => {
@@ -943,10 +943,10 @@ describe('createQuery', () => {
 
   it('should track properties and only re-render when a tracked property changes', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -991,10 +991,10 @@ describe('createQuery', () => {
   it('should always re-render if we are tracking props but not using any', async () => {
     const key = queryKey()
     let renderCount = 0
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'test',
       }))
@@ -1044,12 +1044,12 @@ describe('createQuery', () => {
       { id: '2', done: true },
     ]
 
-    const states: Array<CreateQueryResult<typeof result1>> = []
+    const states: Array<UseQueryResult<typeof result1>> = []
 
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1106,12 +1106,12 @@ describe('createQuery', () => {
 
   it('should use query function from hook when the existing query does not have a query function', async () => {
     const key = queryKey()
-    const results: Array<CreateQueryResult<string>> = []
+    const results: Array<UseQueryResult<string>> = []
 
     queryClient.setQueryData(key, 'set')
 
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1155,11 +1155,11 @@ describe('createQuery', () => {
 
   it('should update query stale state and refetch when invalidated with invalidateQueries', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1229,11 +1229,11 @@ describe('createQuery', () => {
 
   it('should not update disabled query when refetch with refetchQueries', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1275,11 +1275,11 @@ describe('createQuery', () => {
 
   it('should not refetch disabled query when invalidated with invalidateQueries', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1321,12 +1321,12 @@ describe('createQuery', () => {
 
   it('should not fetch when switching to a disabled query', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
 
     function Page() {
       const [count, setCount] = createSignal(0)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [key, count()],
         queryFn: async () => {
           await sleep(5)
@@ -1378,12 +1378,12 @@ describe('createQuery', () => {
 
   it('should keep the previous data when placeholderData is set', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
 
     function Page() {
       const [count, setCount] = createSignal(0)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [key, count()],
         queryFn: async () => {
           await sleep(10)
@@ -1445,12 +1445,12 @@ describe('createQuery', () => {
 
   it('should not show initial data from next query if placeholderData is set', async () => {
     const key = queryKey()
-    const states: Array<DefinedCreateQueryResult<number>> = []
+    const states: Array<DefinedUseQueryResult<number>> = []
 
     function Page() {
       const [count, setCount] = createSignal(0)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [key, count()],
         queryFn: async () => {
           await sleep(10)
@@ -1525,7 +1525,7 @@ describe('createQuery', () => {
 
   it('should keep the previous data on disabled query when placeholderData is set and switching query key multiple times', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
 
     queryClient.setQueryData([key, 10], 10)
 
@@ -1534,7 +1534,7 @@ describe('createQuery', () => {
     function Page() {
       const [count, setCount] = createSignal(10)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [key, count()],
         queryFn: async () => {
           await sleep(10)
@@ -1607,10 +1607,10 @@ describe('createQuery', () => {
 
   it('should use the correct query function when components use different configurations', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
 
     function FirstComponent() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1631,7 +1631,7 @@ describe('createQuery', () => {
     }
 
     function SecondComponent() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key,
         queryFn: () => 2,
       }))
@@ -1675,8 +1675,8 @@ describe('createQuery', () => {
 
   it('should be able to set different stale times for a query', async () => {
     const key = queryKey()
-    const states1: Array<CreateQueryResult<string>> = []
-    const states2: Array<CreateQueryResult<string>> = []
+    const states1: Array<UseQueryResult<string>> = []
+    const states2: Array<UseQueryResult<string>> = []
 
     await queryClient.prefetchQuery({
       queryKey: key,
@@ -1689,7 +1689,7 @@ describe('createQuery', () => {
     await sleep(20)
 
     function FirstComponent() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1704,7 +1704,7 @@ describe('createQuery', () => {
     }
 
     function SecondComponent() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -1744,12 +1744,12 @@ describe('createQuery', () => {
         data: 'prefetch',
         isStale: false,
       },
-      // Second createQuery started fetching
+      // Second useQuery started fetching
       {
         data: 'prefetch',
         isStale: false,
       },
-      // Second createQuery data came in
+      // Second useQuery data came in
       {
         data: 'two',
         isStale: false,
@@ -1767,7 +1767,7 @@ describe('createQuery', () => {
         data: 'prefetch',
         isStale: true,
       },
-      // Second createQuery data came in
+      // Second useQuery data came in
       {
         data: 'two',
         isStale: false,
@@ -1782,10 +1782,10 @@ describe('createQuery', () => {
 
   it('should re-render when a query becomes stale', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'test',
         staleTime: 50,
@@ -1812,10 +1812,10 @@ describe('createQuery', () => {
 
   it('should not re-render when it should only re-render on data changes and the data did not change', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(5)
@@ -1864,14 +1864,14 @@ describe('createQuery', () => {
     const key2 = queryKey()
 
     function Page() {
-      const first = createQuery(() => ({
+      const first = useQuery(() => ({
         queryKey: key1,
         queryFn: () => 'data',
         enabled: false,
         initialData: 'init',
       }))
 
-      const second = createQuery(() => ({
+      const second = useQuery(() => ({
         queryKey: key2,
         queryFn: () => 'data',
         enabled: false,
@@ -1909,8 +1909,8 @@ describe('createQuery', () => {
     }
 
     function Page() {
-      createQuery(() => ({ queryKey: key, queryFn, retryDelay: 10 }))
-      createQuery(() => ({ queryKey: key, queryFn, retryDelay: 20 }))
+      useQuery(() => ({ queryKey: key, queryFn, retryDelay: 10 }))
+      useQuery(() => ({ queryKey: key, queryFn, retryDelay: 20 }))
       return null
     }
 
@@ -1934,8 +1934,8 @@ describe('createQuery', () => {
     }
 
     function Page() {
-      createQuery(() => ({ queryKey: key, queryFn }))
-      createQuery(() => ({ queryKey: key, queryFn }))
+      useQuery(() => ({ queryKey: key, queryFn }))
+      useQuery(() => ({ queryKey: key, queryFn }))
       renders++
       return null
     }
@@ -1958,7 +1958,7 @@ describe('createQuery', () => {
 
     function Page() {
       const [, setNewState] = createSignal('state')
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
       }))
@@ -1987,12 +1987,12 @@ describe('createQuery', () => {
     const key2 = queryKey()
 
     function Page() {
-      const first = createQuery(() => ({
+      const first = useQuery(() => ({
         queryKey: key1,
         queryFn: () => 'data',
         enabled: false,
       }))
-      const second = createQuery(() => ({
+      const second = useQuery(() => ({
         queryKey: key2,
         queryFn: () => 'data',
       }))
@@ -2027,7 +2027,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const { status } = createQuery(() => ({
+      const { status } = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -2054,7 +2054,7 @@ describe('createQuery', () => {
       .mockReturnValue('data')
 
     function Page() {
-      const { data = 'default' } = createQuery(() => ({
+      const { data = 'default' } = useQuery(() => ({
         queryKey: key,
         queryFn,
         enabled: false,
@@ -2082,11 +2082,11 @@ describe('createQuery', () => {
 
   it('should not refetch stale query on focus when `refetchOnWindowFocus` is set to `false`', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => count++,
         staleTime: 0,
@@ -2117,11 +2117,11 @@ describe('createQuery', () => {
 
   it('should not refetch stale query on focus when `refetchOnWindowFocus` is set to a function that returns `false`', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => count++,
         staleTime: 0,
@@ -2152,11 +2152,11 @@ describe('createQuery', () => {
 
   it('should not refetch fresh query on focus when `refetchOnWindowFocus` is set to `true`', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => count++,
         staleTime: Infinity,
@@ -2187,11 +2187,11 @@ describe('createQuery', () => {
 
   it('should refetch fresh query on focus when `refetchOnWindowFocus` is set to `always`', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -2227,11 +2227,11 @@ describe('createQuery', () => {
 
   it('should calculate focus behavior for refetchOnWindowFocus depending on function', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -2277,7 +2277,7 @@ describe('createQuery', () => {
 
   it('should refetch fresh query when refetchOnMount is set to always', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     await queryClient.prefetchQuery({
       queryKey: key,
@@ -2285,7 +2285,7 @@ describe('createQuery', () => {
     })
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         refetchOnMount: 'always',
@@ -2320,7 +2320,7 @@ describe('createQuery', () => {
 
   it('should refetch stale query when refetchOnMount is set to true', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     await queryClient.prefetchQuery({
       queryKey: key,
@@ -2330,7 +2330,7 @@ describe('createQuery', () => {
     await sleep(10)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         refetchOnMount: true,
@@ -2371,7 +2371,7 @@ describe('createQuery', () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => {
           return Promise.reject(new Error('Error test'))
@@ -2407,7 +2407,7 @@ describe('createQuery', () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('Error test')),
         retry: false,
@@ -2444,7 +2444,7 @@ describe('createQuery', () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('Error test')),
         retry: false,
@@ -2481,7 +2481,7 @@ describe('createQuery', () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('Error test')),
         retry: false,
@@ -2520,7 +2520,7 @@ describe('createQuery', () => {
       .mockImplementation(() => undefined)
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('Error test')),
         retry: false,
@@ -2557,10 +2557,10 @@ describe('createQuery', () => {
   it('should update with data if we observe no properties and throwOnError', async () => {
     const key = queryKey()
 
-    let result: CreateQueryResult<string> | undefined
+    let result: UseQueryResult<string> | undefined
 
     function Page() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.resolve('data'),
         throwOnError: true,
@@ -2588,7 +2588,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('Local Error')),
         retry: false,
@@ -2619,7 +2619,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('Remote Error')),
         retry: false,
@@ -2659,7 +2659,7 @@ describe('createQuery', () => {
     let count = 0
 
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           count++
@@ -2714,7 +2714,7 @@ describe('createQuery', () => {
     let count = 0
 
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           count++
@@ -2770,7 +2770,7 @@ describe('createQuery', () => {
 
   it('should always fetch if refetchOnMount is set to always', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     await queryClient.prefetchQuery({
       queryKey: key,
@@ -2778,7 +2778,7 @@ describe('createQuery', () => {
     })
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         refetchOnMount: 'always',
@@ -2824,10 +2824,10 @@ describe('createQuery', () => {
 
   it('should fetch if initial data is set', async () => {
     const key = queryKey()
-    const states: Array<DefinedCreateQueryResult<string>> = []
+    const states: Array<DefinedUseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         initialData: 'initial',
@@ -2862,10 +2862,10 @@ describe('createQuery', () => {
 
   it('should not fetch if initial data is set with a stale time', async () => {
     const key = queryKey()
-    const states: Array<DefinedCreateQueryResult<string>> = []
+    const states: Array<DefinedUseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         staleTime: 50,
@@ -2900,12 +2900,12 @@ describe('createQuery', () => {
 
   it('should fetch if initial data updated at is older than stale time', async () => {
     const key = queryKey()
-    const states: Array<DefinedCreateQueryResult<string>> = []
+    const states: Array<DefinedUseQueryResult<string>> = []
 
     const oneSecondAgo = Date.now() - 1000
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         staleTime: 50,
@@ -2946,10 +2946,10 @@ describe('createQuery', () => {
 
   it('should fetch if "initial data updated at" is exactly 0', async () => {
     const key = queryKey()
-    const states: Array<DefinedCreateQueryResult<string>> = []
+    const states: Array<DefinedUseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         staleTime: 10 * 1000, // 10 seconds
@@ -2985,12 +2985,12 @@ describe('createQuery', () => {
 
   it('should keep initial data when the query key changes', async () => {
     const key = queryKey()
-    const states: Array<Partial<DefinedCreateQueryResult<{ count: number }>>> =
+    const states: Array<Partial<DefinedUseQueryResult<{ count: number }>>> =
       []
 
     function Page() {
       const [count, setCount] = createSignal(0)
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [key, count()],
         queryFn: () => ({ count: 10 }),
         staleTime: Infinity,
@@ -3034,7 +3034,7 @@ describe('createQuery', () => {
     })
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn,
         retry: 1,
@@ -3080,7 +3080,7 @@ describe('createQuery', () => {
     })
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn,
         retryDelay: 1,
@@ -3123,7 +3123,7 @@ describe('createQuery', () => {
     })
 
     function Page() {
-      const state = createQuery<unknown, DelayError>(() => ({
+      const state = useQuery<unknown, DelayError>(() => ({
         queryKey: key,
         queryFn,
         retry: 1,
@@ -3165,7 +3165,7 @@ describe('createQuery', () => {
     let count = 0
 
     function Page() {
-      const query = createQuery<unknown, string>(() => ({
+      const query = useQuery<unknown, string>(() => ({
         queryKey: key,
         queryFn: () => {
           count++
@@ -3219,12 +3219,12 @@ describe('createQuery', () => {
 
   it('should fetch on mount when a query was already created with setQueryData', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     queryClient.setQueryData(key, 'prefetched')
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
       }))
@@ -3259,7 +3259,7 @@ describe('createQuery', () => {
 
   it('should refetch after focus regain', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     // make page unfocused
     const visibilityMock = mockVisibilityState('hidden')
@@ -3268,7 +3268,7 @@ describe('createQuery', () => {
     queryClient.setQueryData(key, 'prefetched')
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -3326,7 +3326,7 @@ describe('createQuery', () => {
   // See https://github.com/tannerlinsley/react-query/issues/195
   it('should refetch if stale after a prefetch', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     const queryFn = vi.fn<(...args: Array<unknown>) => string>()
     queryFn.mockImplementation(() => 'data')
@@ -3343,7 +3343,7 @@ describe('createQuery', () => {
     await sleep(11)
 
     function Page() {
-      const state = createQuery(() => ({ queryKey: key, queryFn }))
+      const state = useQuery(() => ({ queryKey: key, queryFn }))
       createRenderEffect(() => {
         states.push({ ...state })
       })
@@ -3384,7 +3384,7 @@ describe('createQuery', () => {
     await sleep(0)
 
     function Page() {
-      createQuery(() => ({ queryKey: key, queryFn, staleTime: 1000 }))
+      useQuery(() => ({ queryKey: key, queryFn, staleTime: 1000 }))
       return null
     }
 
@@ -3407,7 +3407,7 @@ describe('createQuery', () => {
     function Page() {
       let counter = 0
 
-      const query = createQuery<unknown, Error>(() => ({
+      const query = useQuery<unknown, Error>(() => ({
         queryKey: key,
         queryFn: async () => {
           if (counter < 2) {
@@ -3449,7 +3449,7 @@ describe('createQuery', () => {
       const [enabled, setEnabled] = createSignal(false)
       const [isPrefetched, setPrefetched] = createSignal(false)
 
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           count++
@@ -3498,7 +3498,7 @@ describe('createQuery', () => {
     function Page() {
       const [shouldFetch, setShouldFetch] = createSignal(false)
 
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         enabled: shouldFetch(),
@@ -3539,7 +3539,7 @@ describe('createQuery', () => {
 
     function Component() {
       let val = 1
-      const dataQuery = createQuery(() => ({
+      const dataQuery = useQuery(() => ({
         queryKey: [key],
         queryFn: () => {
           return val++
@@ -3598,7 +3598,7 @@ describe('createQuery', () => {
 
     function Component() {
       let val = 1
-      const dataQuery = createQuery(() => ({
+      const dataQuery = useQuery(() => ({
         queryKey: [key],
         queryFn: () => {
           return val++
@@ -3653,10 +3653,10 @@ describe('createQuery', () => {
 
   it('should mark query as fetching, when using initialData', async () => {
     const key = queryKey()
-    const results: Array<DefinedCreateQueryResult<string>> = []
+    const results: Array<DefinedUseQueryResult<string>> = []
 
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -3688,10 +3688,10 @@ describe('createQuery', () => {
 
   it('should initialize state properly, when initialData is falsy', async () => {
     const key = queryKey()
-    const results: Array<DefinedCreateQueryResult<number>> = []
+    const results: Array<DefinedUseQueryResult<number>> = []
 
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: () => 1,
         initialData: 0,
@@ -3720,12 +3720,12 @@ describe('createQuery', () => {
   // // See https://github.com/tannerlinsley/react-query/issues/214
   it('data should persist when enabled is changed to false', async () => {
     const key = queryKey()
-    const results: Array<DefinedCreateQueryResult<string>> = []
+    const results: Array<DefinedUseQueryResult<string>> = []
 
     function Page() {
       const [shouldFetch, setShouldFetch] = createSignal(true)
 
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'fetched data',
         enabled: shouldFetch(),
@@ -3765,7 +3765,7 @@ describe('createQuery', () => {
     queryFn.mockImplementation(() => 'data')
 
     function Page() {
-      const { fetchStatus } = createQuery(() => ({
+      const { fetchStatus } = useQuery(() => ({
         queryKey: key,
         queryFn,
         enabled: false,
@@ -3790,7 +3790,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
         enabled: false,
@@ -3818,7 +3818,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'fetched data',
         gcTime: Infinity,
@@ -3844,7 +3844,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const query = createQuery(() => ({
+      const query = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'fetched data',
         gcTime: 1000 * 60 * 10, // 10 Minutes
@@ -3877,7 +3877,7 @@ describe('createQuery', () => {
     const memoFn = vi.fn()
 
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -3926,7 +3926,7 @@ describe('createQuery', () => {
 
     function Page() {
       const [int, setInt] = createSignal(200)
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => count++,
         refetchInterval: int(),
@@ -3956,10 +3956,10 @@ describe('createQuery', () => {
   it('should refetch in an interval depending on function result', async () => {
     const key = queryKey()
     let count = 0
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -4028,10 +4028,10 @@ describe('createQuery', () => {
 
   it('should not interval fetch with a refetchInterval of 0', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 1,
         refetchInterval: 0,
@@ -4072,7 +4072,7 @@ describe('createQuery', () => {
 
   it('should accept an empty string as query key', async () => {
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: [''],
         queryFn: (ctx) => ctx.queryKey,
       }))
@@ -4090,7 +4090,7 @@ describe('createQuery', () => {
 
   it('should accept an object as query key', async () => {
     function Page() {
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: [{ a: 'a' }],
         queryFn: (ctx) => ctx.queryKey,
       }))
@@ -4114,13 +4114,13 @@ describe('createQuery', () => {
       .mockReturnValue('data')
 
     function Disabled() {
-      createQuery(() => ({ queryKey: key, queryFn, enabled: false }))
+      useQuery(() => ({ queryKey: key, queryFn, enabled: false }))
       return null
     }
 
     function Page() {
       const [enabled, setEnabled] = createSignal(false)
-      const result = createQuery(() => ({
+      const result = useQuery(() => ({
         queryKey: key,
         queryFn,
         enabled: enabled(),
@@ -4148,10 +4148,10 @@ describe('createQuery', () => {
   it('should use placeholder data while the query loads', async () => {
     const key1 = queryKey()
 
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key1,
         queryFn: () => 'data',
         placeholderData: 'placeholder',
@@ -4193,13 +4193,13 @@ describe('createQuery', () => {
   it('should use placeholder data even for disabled queries', async () => {
     const key1 = queryKey()
 
-    const states: Array<{ state: CreateQueryResult<string>; count: number }> =
+    const states: Array<{ state: UseQueryResult<string>; count: number }> =
       []
 
     function Page() {
       const [count, setCount] = createSignal(0)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key1,
         queryFn: () => 'data',
         placeholderData: 'placeholder',
@@ -4260,10 +4260,10 @@ describe('createQuery', () => {
   it('placeholder data should run through select', async () => {
     const key1 = queryKey()
 
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key1,
         queryFn: () => 1,
         placeholderData: 23,
@@ -4306,11 +4306,11 @@ describe('createQuery', () => {
   it('placeholder data function result should run through select', async () => {
     const key1 = queryKey()
 
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
     let placeholderFunctionRunCount = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key1,
         queryFn: () => 1,
         placeholderData: () => {
@@ -4370,7 +4370,7 @@ describe('createQuery', () => {
         setForceValue((prev) => prev + 1)
       }
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key1,
         queryFn: async () => {
           await sleep(10)
@@ -4420,7 +4420,7 @@ describe('createQuery', () => {
     function Page() {
       const [forceValue, setForceValue] = createSignal(1)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key1,
         queryFn: async () => {
           await sleep(10)
@@ -4472,7 +4472,7 @@ describe('createQuery', () => {
     function Page() {
       const [forceValue, setForceValue] = createSignal(1)
 
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key1,
         queryFn: async () => {
           await sleep(10)
@@ -4535,7 +4535,7 @@ describe('createQuery', () => {
     }
 
     function Page() {
-      const state = createQuery(() => ({ queryKey: key, queryFn }))
+      const state = useQuery(() => ({ queryKey: key, queryFn }))
       return (
         <div>
           <h1>Status: {state.status}</h1>
@@ -4558,7 +4558,7 @@ describe('createQuery', () => {
 
   it('should cancel the query if the signal was consumed and there are no more subscriptions', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     const queryFn: QueryFunction<
       string,
@@ -4572,7 +4572,7 @@ describe('createQuery', () => {
     }
 
     function Page(props: { limit: number }) {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [key, props.limit] as const,
         queryFn,
       }))
@@ -4628,7 +4628,7 @@ describe('createQuery', () => {
 
   it('should refetch when quickly switching to a failed query', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<string>> = []
+    const states: Array<UseQueryResult<string>> = []
 
     const queryFn = async () => {
       await sleep(50)
@@ -4639,7 +4639,7 @@ describe('createQuery', () => {
       const [id, setId] = createSignal(1)
       const [hasChanged, setHasChanged] = createSignal(false)
 
-      const state = createQuery(() => ({ queryKey: [key, id()], queryFn }))
+      const state = useQuery(() => ({ queryKey: [key, id()], queryFn }))
 
       createRenderEffect(() => {
         states.push({ ...state })
@@ -4678,11 +4678,11 @@ describe('createQuery', () => {
 
   it('should update query state and refetch when reset with resetQueries', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -4752,11 +4752,11 @@ describe('createQuery', () => {
 
   it('should update query state and not refetch when resetting a disabled query with resetQueries', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -4840,7 +4840,7 @@ describe('createQuery', () => {
     }
 
     function Page() {
-      createQuery(() => ({
+      useQuery(() => ({
         queryKey: key,
         queryFn: () => 'test',
         queryKeyHashFn,
@@ -4867,7 +4867,7 @@ describe('createQuery', () => {
     })
 
     function Page(props: { enabled: boolean }) {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: ['key'],
         queryFn,
         enabled: props.enabled,
@@ -4928,7 +4928,7 @@ describe('createQuery', () => {
 
   it('should refetch when query key changed when previous status is error', async () => {
     function Page(props: { id: number }) {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [props.id],
         queryFn: async () => {
           await sleep(10)
@@ -4993,7 +4993,7 @@ describe('createQuery', () => {
 
   it('should refetch when query key changed when switching between erroneous queries', async () => {
     function Page(props: { id: boolean }) {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: [props.id],
         queryFn: async () => {
           await sleep(10)
@@ -5055,13 +5055,13 @@ describe('createQuery', () => {
 
   it('should have no error in pending state when refetching after error occurred', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<number>> = []
+    const states: Array<UseQueryResult<number>> = []
     const error = new Error('oops')
 
     let count = 0
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async () => {
           await sleep(10)
@@ -5139,7 +5139,7 @@ describe('createQuery', () => {
       const states: Array<any> = []
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             await sleep(10)
@@ -5189,7 +5189,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery<unknown, string, string>(() => ({
+        const state = useQuery<unknown, string, string>(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5260,7 +5260,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5314,7 +5314,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5368,7 +5368,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5426,7 +5426,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5498,7 +5498,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery<unknown, Error>(() => ({
+        const state = useQuery<unknown, Error>(() => ({
           queryKey: key,
           queryFn: async (): Promise<unknown> => {
             count++
@@ -5563,7 +5563,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Component() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5627,7 +5627,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5691,7 +5691,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Component() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async ({ signal: _signal }) => {
             count++
@@ -5772,7 +5772,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async () => {
             count++
@@ -5816,7 +5816,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery(() => ({
+        const state = useQuery(() => ({
           queryKey: key,
           queryFn: async (): Promise<unknown> => {
             count++
@@ -5866,7 +5866,7 @@ describe('createQuery', () => {
       let count = 0
 
       function Page() {
-        const state = createQuery<unknown, Error>(() => ({
+        const state = useQuery<unknown, Error>(() => ({
           queryKey: key,
           queryFn: async (): Promise<unknown> => {
             count++
@@ -5920,7 +5920,7 @@ describe('createQuery', () => {
 
   it('should have status=error on mount when a query has failed', async () => {
     const key = queryKey()
-    const states: Array<CreateQueryResult<unknown>> = []
+    const states: Array<UseQueryResult<unknown>> = []
     const error = new Error('oops')
 
     const queryFn = async (): Promise<unknown> => {
@@ -5928,7 +5928,7 @@ describe('createQuery', () => {
     }
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn,
         retry: false,
@@ -5961,7 +5961,7 @@ describe('createQuery', () => {
     const key = queryKey()
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: () => 'data',
       }))
@@ -6001,7 +6001,7 @@ describe('createQuery', () => {
     const error = new Error('oops')
 
     function Page() {
-      const state = createQuery(() => ({
+      const state = useQuery(() => ({
         queryKey: key,
         queryFn: async (): Promise<unknown> => {
           throw error
@@ -6037,7 +6037,7 @@ describe('createQuery', () => {
     }
 
     function Page() {
-      const state = createQuery(
+      const state = useQuery(
         () => ({ queryKey: key, queryFn }),
         () => queryClient,
       )

--- a/packages/solid-query/src/__tests__/useQueryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useQueryOptions.test-d.tsx
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { dataTagSymbol } from '@tanstack/query-core'
-import { createInfiniteQuery } from '../createInfiniteQuery'
+import { useInfiniteQuery } from '../useInfiniteQuery'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
 import type { InfiniteData } from '@tanstack/query-core'
 import type {
@@ -24,7 +24,7 @@ describe('infiniteQueryOptions', () => {
     })
 
     doNotRun(() => {
-      expectTypeOf(createInfiniteQuery(() => options).data).toEqualTypeOf<
+      expectTypeOf(useInfiniteQuery(() => options).data).toEqualTypeOf<
         InfiniteData<{ wow: boolean }, unknown>
       >()
 
@@ -55,7 +55,7 @@ describe('infiniteQueryOptions', () => {
     })
 
     doNotRun(() => {
-      expectTypeOf(() => createInfiniteQuery(() => options).data).toEqualTypeOf<
+      expectTypeOf(() => useInfiniteQuery(() => options).data).toEqualTypeOf<
         () => InfiniteData<{ wow: boolean }, unknown> | undefined
       >()
 

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -12,7 +12,8 @@ export type {
   QueryClientConfig,
   InfiniteQueryObserverOptions,
 } from './QueryClient'
-export { createQuery } from './createQuery'
+export { useQuery } from './useQuery'
+export { useQuery as createQuery } from './useQuery'
 export { queryOptions } from './queryOptions'
 export type {
   DefinedInitialDataOptions,
@@ -25,14 +26,17 @@ export {
 } from './QueryClientProvider'
 export type { QueryClientProviderProps } from './QueryClientProvider'
 export { useIsFetching } from './useIsFetching'
-export { createInfiniteQuery } from './createInfiniteQuery'
+export { useInfiniteQuery } from './useInfiniteQuery'
+export { useInfiniteQuery as createInfiniteQuery } from './useInfiniteQuery'
 export { infiniteQueryOptions } from './infiniteQueryOptions'
 export type {
   DefinedInitialDataInfiniteOptions,
   UndefinedInitialDataInfiniteOptions,
 } from './infiniteQueryOptions'
-export { createMutation } from './createMutation'
+export { useMutation } from './useMutation'
+export { useMutation as createMutation } from './useMutation'
 export { useIsMutating } from './useIsMutating'
 export { useMutationState } from './useMutationState'
-export { createQueries } from './createQueries'
+export { useQueries } from './useQueries'
+export { useQueries as createQueries } from './useQueries'
 export { useIsRestoring, IsRestoringProvider } from './isRestoring'

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -19,7 +19,7 @@ import type {
 } from './QueryClient'
 import type { Accessor } from 'solid-js'
 
-export interface CreateBaseQueryOptions<
+export interface UseBaseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
@@ -38,7 +38,7 @@ export interface CreateBaseQueryOptions<
   deferStream?: boolean
   /**
    * @deprecated The `suspense` option has been deprecated in v5 and will be removed in the next major version.
-   * The `data` property on createQuery is a SolidJS resource and will automatically suspend when the data is loading.
+   * The `data` property on useQuery is a SolidJS resource and will automatically suspend when the data is loading.
    * Setting `suspense` to `false` will be a no-op.
    */
   suspense?: boolean
@@ -49,7 +49,7 @@ export interface SolidQueryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends CreateBaseQueryOptions<
+> extends UseBaseQueryOptions<
     TQueryFnData,
     TError,
     TData,
@@ -57,7 +57,7 @@ export interface SolidQueryOptions<
     TQueryKey
   > {}
 
-export type CreateQueryOptions<
+export type UseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
@@ -66,25 +66,25 @@ export type CreateQueryOptions<
 
 /* --- Create Query and Create Base Query  Types --- */
 
-export type CreateBaseQueryResult<
+export type UseBaseQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = QueryObserverResult<TData, TError>
 
-export type CreateQueryResult<
+export type UseQueryResult<
   TData = unknown,
   TError = DefaultError,
-> = CreateBaseQueryResult<TData, TError>
+> = UseBaseQueryResult<TData, TError>
 
-export type DefinedCreateBaseQueryResult<
+export type DefinedUseBaseQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = DefinedQueryObserverResult<TData, TError>
 
-export type DefinedCreateQueryResult<
+export type DefinedUseQueryResult<
   TData = unknown,
   TError = DefaultError,
-> = DefinedCreateBaseQueryResult<TData, TError>
+> = DefinedUseBaseQueryResult<TData, TError>
 
 /* --- Create Infinite Queries Types --- */
 export interface SolidInfiniteQueryOptions<
@@ -115,13 +115,13 @@ export interface SolidInfiniteQueryOptions<
   deferStream?: boolean
   /**
    * @deprecated The `suspense` option has been deprecated in v5 and will be removed in the next major version.
-   * The `data` property on createInfiniteQuery is a SolidJS resource and will automatically suspend when the data is loading.
+   * The `data` property on useInfiniteQuery is a SolidJS resource and will automatically suspend when the data is loading.
    * Setting `suspense` to `false` will be a no-op.
    */
   suspense?: boolean
 }
 
-export type CreateInfiniteQueryOptions<
+export type UseInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
@@ -138,12 +138,12 @@ export type CreateInfiniteQueryOptions<
   >
 >
 
-export type CreateInfiniteQueryResult<
+export type UseInfiniteQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = InfiniteQueryObserverResult<TData, TError>
 
-export type DefinedCreateInfiniteQueryResult<
+export type DefinedUseInfiniteQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = DefinedInfiniteQueryObserverResult<TData, TError>
@@ -159,14 +159,14 @@ export interface SolidMutationOptions<
     '_defaulted'
   > {}
 
-export type CreateMutationOptions<
+export type UseMutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
   TContext = unknown,
 > = Accessor<SolidMutationOptions<TData, TError, TVariables, TContext>>
 
-export type CreateMutateFunction<
+export type UseMutateFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
@@ -175,28 +175,28 @@ export type CreateMutateFunction<
   ...args: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
 ) => void
 
-export type CreateMutateAsyncFunction<
+export type UseMutateAsyncFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
   TContext = unknown,
 > = MutateFunction<TData, TError, TVariables, TContext>
 
-export type CreateBaseMutationResult<
+export type UseBaseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
   TContext = unknown,
 > = Override<
   MutationObserverResult<TData, TError, TVariables, TContext>,
-  { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+  { mutate: UseMutateFunction<TData, TError, TVariables, TContext> }
 > & {
-  mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
+  mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TContext>
 }
 
-export type CreateMutationResult<
+export type UseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
   TContext = unknown,
-> = CreateBaseMutationResult<TData, TError, TVariables, TContext>
+> = UseBaseMutationResult<TData, TError, TVariables, TContext>

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -15,7 +15,7 @@ import { createStore, reconcile, unwrap } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
 import { shouldThrowError } from './utils'
 import { useIsRestoring } from './isRestoring'
-import type { CreateBaseQueryOptions } from './types'
+import type { UseBaseQueryOptions } from './types'
 import type { Accessor, Signal } from 'solid-js'
 import type { QueryClient } from './QueryClient'
 import type {
@@ -101,7 +101,7 @@ const hydratableObserverResult = <
 }
 
 // Base Query Function that is used to create the query.
-export function createBaseQuery<
+export function useBaseQuery<
   TQueryFnData,
   TError,
   TData,
@@ -109,7 +109,7 @@ export function createBaseQuery<
   TQueryKey extends QueryKey,
 >(
   options: Accessor<
-    CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
+    UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   Observer: typeof QueryObserver,
   queryClient?: Accessor<QueryClient>,

--- a/packages/solid-query/src/useInfiniteQuery.ts
+++ b/packages/solid-query/src/useInfiniteQuery.ts
@@ -1,6 +1,6 @@
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { createMemo } from 'solid-js'
-import { createBaseQuery } from './createBaseQuery'
+import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
   InfiniteData,
@@ -9,9 +9,9 @@ import type {
 } from '@tanstack/query-core'
 import type { QueryClient } from './QueryClient'
 import type {
-  CreateInfiniteQueryOptions,
-  CreateInfiniteQueryResult,
-  DefinedCreateInfiniteQueryResult,
+  UseInfiniteQueryOptions,
+  UseInfiniteQueryResult,
+  DefinedUseInfiniteQueryResult,
 } from './types'
 import type { Accessor } from 'solid-js'
 import type {
@@ -19,7 +19,7 @@ import type {
   UndefinedInitialDataInfiniteOptions,
 } from './infiniteQueryOptions'
 
-export function createInfiniteQuery<
+export function useInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
   TData = InfiniteData<TQueryFnData>,
@@ -34,8 +34,8 @@ export function createInfiniteQuery<
     TPageParam
   >,
   queryClient?: Accessor<QueryClient>,
-): DefinedCreateInfiniteQueryResult<TData, TError>
-export function createInfiniteQuery<
+): DefinedUseInfiniteQueryResult<TData, TError>
+export function useInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
   TData = InfiniteData<TQueryFnData>,
@@ -50,16 +50,16 @@ export function createInfiniteQuery<
     TPageParam
   >,
   queryClient?: Accessor<QueryClient>,
-): CreateInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<TData, TError>
 
-export function createInfiniteQuery<
+export function useInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
   TData = InfiniteData<TQueryFnData>,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 >(
-  options: CreateInfiniteQueryOptions<
+  options: UseInfiniteQueryOptions<
     TQueryFnData,
     TError,
     TData,
@@ -67,10 +67,10 @@ export function createInfiniteQuery<
     TPageParam
   >,
   queryClient?: Accessor<QueryClient>,
-): CreateInfiniteQueryResult<TData, TError> {
-  return createBaseQuery(
+): UseInfiniteQueryResult<TData, TError> {
+  return useBaseQuery(
     createMemo(() => options()),
     InfiniteQueryObserver as typeof QueryObserver,
     queryClient,
-  ) as CreateInfiniteQueryResult<TData, TError>
+  ) as UseInfiniteQueryResult<TData, TError>
 }

--- a/packages/solid-query/src/useInfiniteQuery.ts
+++ b/packages/solid-query/src/useInfiniteQuery.ts
@@ -9,9 +9,9 @@ import type {
 } from '@tanstack/query-core'
 import type { QueryClient } from './QueryClient'
 import type {
+  DefinedUseInfiniteQueryResult,
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
-  DefinedUseInfiniteQueryResult,
 } from './types'
 import type { Accessor } from 'solid-js'
 import type {

--- a/packages/solid-query/src/useMutation.ts
+++ b/packages/solid-query/src/useMutation.ts
@@ -6,22 +6,22 @@ import { noop, shouldThrowError } from './utils'
 import type { DefaultError } from '@tanstack/query-core'
 import type { QueryClient } from './QueryClient'
 import type {
-  CreateMutateFunction,
-  CreateMutationOptions,
-  CreateMutationResult,
+  UseMutateFunction,
+  UseMutationOptions,
+  UseMutationResult,
 } from './types'
 import type { Accessor } from 'solid-js'
 
 // HOOK
-export function createMutation<
+export function useMutation<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
   TContext = unknown,
 >(
-  options: CreateMutationOptions<TData, TError, TVariables, TContext>,
+  options: UseMutationOptions<TData, TError, TVariables, TContext>,
   queryClient?: Accessor<QueryClient>,
-): CreateMutationResult<TData, TError, TVariables, TContext> {
+): UseMutationResult<TData, TError, TVariables, TContext> {
   const client = createMemo(() => useQueryClient(queryClient?.()))
 
   const observer = new MutationObserver<TData, TError, TVariables, TContext>(
@@ -29,7 +29,7 @@ export function createMutation<
     options(),
   )
 
-  const mutate: CreateMutateFunction<TData, TError, TVariables, TContext> = (
+  const mutate: UseMutateFunction<TData, TError, TVariables, TContext> = (
     variables,
     mutateOptions,
   ) => {
@@ -37,7 +37,7 @@ export function createMutation<
   }
 
   const [state, setState] = createStore<
-    CreateMutationResult<TData, TError, TVariables, TContext>
+    UseMutationResult<TData, TError, TVariables, TContext>
   >({
     ...observer.getCurrentResult(),
     mutate,

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -14,7 +14,7 @@ import {
 import { useQueryClient } from './QueryClientProvider'
 import { useIsRestoring } from './isRestoring'
 import { noop } from './utils'
-import type { CreateQueryResult, SolidQueryOptions } from './types'
+import type { UseQueryResult, SolidQueryOptions } from './types'
 import type { Accessor } from 'solid-js'
 import type { QueryClient } from './QueryClient'
 import type {
@@ -31,7 +31,7 @@ import type {
 
 // This defines the `UseQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
 // `placeholderData` function does not have a parameter
-type CreateQueryOptionsForCreateQueries<
+type UseQueryOptionsForUseQueries<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
@@ -43,7 +43,7 @@ type CreateQueryOptionsForCreateQueries<
   placeholderData?: TQueryFnData | QueriesPlaceholderDataFunction<TQueryFnData>
   /**
    * @deprecated The `suspense` option has been deprecated in v5 and will be removed in the next major version.
-   * The `data` property on createQueries is a plain object and not a SolidJS Resource.
+   * The `data` property on useQueries is a plain object and not a SolidJS Resource.
    * It will not suspend when the data is loading.
    * Setting `suspense` to `true` will be a no-op.
    */
@@ -63,18 +63,18 @@ type GetOptions<T> =
     error?: infer TError
     data: infer TData
   }
-    ? CreateQueryOptionsForCreateQueries<TQueryFnData, TError, TData>
+    ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
     : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-      ? CreateQueryOptionsForCreateQueries<TQueryFnData, TError>
+      ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
       : T extends { data: infer TData; error?: infer TError }
-        ? CreateQueryOptionsForCreateQueries<unknown, TError, TData>
+        ? UseQueryOptionsForUseQueries<unknown, TError, TData>
         : // Part 2: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
           T extends [infer TQueryFnData, infer TError, infer TData]
-          ? CreateQueryOptionsForCreateQueries<TQueryFnData, TError, TData>
+          ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
           : T extends [infer TQueryFnData, infer TError]
-            ? CreateQueryOptionsForCreateQueries<TQueryFnData, TError>
+            ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
             : T extends [infer TQueryFnData]
-              ? CreateQueryOptionsForCreateQueries<TQueryFnData>
+              ? UseQueryOptionsForUseQueries<TQueryFnData>
               : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
                 T extends {
                     queryFn?:
@@ -83,30 +83,30 @@ type GetOptions<T> =
                     select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
-                ? CreateQueryOptionsForCreateQueries<
+                ? UseQueryOptionsForUseQueries<
                     TQueryFnData,
                     unknown extends TError ? DefaultError : TError,
                     unknown extends TData ? TQueryFnData : TData,
                     TQueryKey
                   >
                 : // Fallback
-                  CreateQueryOptionsForCreateQueries
+                  UseQueryOptionsForUseQueries
 
 type GetResults<T> =
   // Part 1: responsible for mapping explicit type parameter to function result, if object
   T extends { queryFnData: any; error?: infer TError; data: infer TData }
-    ? CreateQueryResult<TData, TError>
+    ? UseQueryResult<TData, TError>
     : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-      ? CreateQueryResult<TQueryFnData, TError>
+      ? UseQueryResult<TQueryFnData, TError>
       : T extends { data: infer TData; error?: infer TError }
-        ? CreateQueryResult<TData, TError>
+        ? UseQueryResult<TData, TError>
         : // Part 2: responsible for mapping explicit type parameter to function result, if tuple
           T extends [any, infer TError, infer TData]
-          ? CreateQueryResult<TData, TError>
+          ? UseQueryResult<TData, TError>
           : T extends [infer TQueryFnData, infer TError]
-            ? CreateQueryResult<TQueryFnData, TError>
+            ? UseQueryResult<TQueryFnData, TError>
             : T extends [infer TQueryFnData]
-              ? CreateQueryResult<TQueryFnData>
+              ? UseQueryResult<TQueryFnData>
               : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
                 T extends {
                     queryFn?:
@@ -115,12 +115,12 @@ type GetResults<T> =
                     select?: (data: any) => infer TData
                     throwOnError?: ThrowOnError<any, infer TError, any, any>
                   }
-                ? CreateQueryResult<
+                ? UseQueryResult<
                     unknown extends TData ? TQueryFnData : TData,
                     unknown extends TError ? DefaultError : TError
                   >
                 : // Fallback
-                  CreateQueryResult
+                  UseQueryResult
 
 /**
  * QueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
@@ -130,7 +130,7 @@ type QueriesOptions<
   TResult extends Array<any> = [],
   TDepth extends ReadonlyArray<number> = [],
 > = TDepth['length'] extends MAXIMUM_DEPTH
-  ? Array<CreateQueryOptionsForCreateQueries>
+  ? Array<UseQueryOptionsForUseQueries>
   : T extends []
     ? []
     : T extends [infer Head]
@@ -146,7 +146,7 @@ type QueriesOptions<
           : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
-                CreateQueryOptionsForCreateQueries<
+                UseQueryOptionsForUseQueries<
                   infer TQueryFnData,
                   infer TError,
                   infer TData,
@@ -154,7 +154,7 @@ type QueriesOptions<
                 >
               >
             ? Array<
-                CreateQueryOptionsForCreateQueries<
+                UseQueryOptionsForUseQueries<
                   TQueryFnData,
                   TError,
                   TData,
@@ -162,7 +162,7 @@ type QueriesOptions<
                 >
               >
             : // Fallback
-              Array<CreateQueryOptionsForCreateQueries>
+              Array<UseQueryOptionsForUseQueries>
 
 /**
  * QueriesResults reducer recursively maps type param to results
@@ -172,7 +172,7 @@ type QueriesResults<
   TResult extends Array<any> = [],
   TDepth extends ReadonlyArray<number> = [],
 > = TDepth['length'] extends MAXIMUM_DEPTH
-  ? Array<CreateQueryResult>
+  ? Array<UseQueryResult>
   : T extends []
     ? []
     : T extends [infer Head]
@@ -185,7 +185,7 @@ type QueriesResults<
           >
         : { [K in keyof T]: GetResults<T[K]> }
 
-export function createQueries<
+export function useQueries<
   T extends Array<any>,
   TCombinedResult extends QueriesResults<T> = QueriesResults<T>,
 >(

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -14,7 +14,7 @@ import {
 import { useQueryClient } from './QueryClientProvider'
 import { useIsRestoring } from './isRestoring'
 import { noop } from './utils'
-import type { UseQueryResult, SolidQueryOptions } from './types'
+import type { SolidQueryOptions, UseQueryResult } from './types'
 import type { Accessor } from 'solid-js'
 import type { QueryClient } from './QueryClient'
 import type {

--- a/packages/solid-query/src/useQuery.ts
+++ b/packages/solid-query/src/useQuery.ts
@@ -1,20 +1,20 @@
 import { QueryObserver } from '@tanstack/query-core'
 import { createMemo } from 'solid-js'
-import { createBaseQuery } from './createBaseQuery'
+import { useBaseQuery } from './useBaseQuery'
 import type { DefaultError, QueryKey } from '@tanstack/query-core'
 import type { QueryClient } from './QueryClient'
 import type { Accessor } from 'solid-js'
 import type {
-  CreateQueryOptions,
-  CreateQueryResult,
-  DefinedCreateQueryResult,
+  UseQueryOptions,
+  UseQueryResult,
+  DefinedUseQueryResult,
 } from './types'
 import type {
   DefinedInitialDataOptions,
   UndefinedInitialDataOptions,
 } from './queryOptions'
 
-export function createQuery<
+export function useQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
@@ -22,9 +22,9 @@ export function createQuery<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: () => QueryClient,
-): CreateQueryResult<TData, TError>
+): UseQueryResult<TData, TError>
 
-export function createQuery<
+export function useQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
@@ -32,17 +32,17 @@ export function createQuery<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: () => QueryClient,
-): DefinedCreateQueryResult<TData, TError>
-export function createQuery<
+): DefinedUseQueryResult<TData, TError>
+export function useQuery<
   TQueryFnData,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: Accessor<QueryClient>,
 ) {
-  return createBaseQuery(
+  return useBaseQuery(
     createMemo(() => options()),
     QueryObserver,
     queryClient,

--- a/packages/solid-query/src/useQuery.ts
+++ b/packages/solid-query/src/useQuery.ts
@@ -5,9 +5,9 @@ import type { DefaultError, QueryKey } from '@tanstack/query-core'
 import type { QueryClient } from './QueryClient'
 import type { Accessor } from 'solid-js'
 import type {
+  DefinedUseQueryResult,
   UseQueryOptions,
   UseQueryResult,
-  DefinedUseQueryResult,
 } from './types'
 import type {
   DefinedInitialDataOptions,


### PR DESCRIPTION
Related to
- https://github.com/TanStack/query/discussions/8891

Rename (and add alias for backwards compat):
`createQuery` -> `useQuery`
`createInfiniteQuery` -> `useInfiniteQuery`
`createQueries` -> `useQueries`
`createMutation` -> `useMutation`

This is done, because having same API surface and file structure makes it much easier to sync the solid adapter to the react adapter, and it makes no difference to solid devs.