### PR TITLE
test(react-query): ensure HydrationBoundary does not hydrate when state is truthy and non-object

### DIFF
--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -331,12 +331,8 @@ describe('React hydration', () => {
       </QueryClientProvider>,
     )
 
-    await Promise.all(
-      Array.from({ length: 1000 }).map(async (_, index) => {
-        await vi.advanceTimersByTimeAsync(index)
-        expect(hydrateSpy).toHaveBeenCalledTimes(0)
-      }),
-    )
+    await vi.runAllTimersAsync()
+    expect(hydrateSpy).toHaveBeenCalledTimes(0)
 
     hydrateSpy.mockRestore()
     queryClient.clear()
@@ -365,4 +361,27 @@ describe('React hydration', () => {
     hydrateSpy.mockRestore()
     queryClient.clear()
   })
+
+  test('should not hydrate queries if state is truthy and non-object', async () => {
+    const queryClient = createQueryClient()
+    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
+  
+    function Page() {
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HydrationBoundary state='state'>
+          <Page />
+        </HydrationBoundary>
+      </QueryClientProvider>,
+    )
+
+    await vi.runAllTimersAsync()
+    expect(hydrateSpy).toHaveBeenCalledTimes(0)
+  
+    hydrateSpy.mockRestore()
+    queryClient.clear()
+  })  
 })


### PR DESCRIPTION
Coverage improves **0.43%** and Modify the code that was missed in [PR](https://github.com/TanStack/query/pull/8774)

```js
await vi.runAllTimersAsync()
expect(hydrateSpy).toHaveBeenCalledTimes(0)
```