### PR TITLE
refactor(query-core): remove double negative

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -241,7 +241,7 @@ export function partialMatchKey(a: any, b: any): boolean {
   }
 
   if (a && b && typeof a === 'object' && typeof b === 'object') {
-    return !Object.keys(b).some((key) => !partialMatchKey(a[key], b[key]))
+    return Object.keys(b).every((key) => partialMatchKey(a[key], b[key]))
   }
 
   return false


### PR DESCRIPTION
Refactored the partialMatchKey function to improve readability by replacing a double negation with the more intuitive every() method. This change makes the logic easier to understand at a glance, as it clearly expresses that all keys in object b must match corresponding keys in object a.