### PR TITLE
feat(vue-query): useInfiniteQuery options support maybe ref type

### DIFF
--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { reactive } from 'vue-demi'
+import { computed, reactive } from 'vue-demi'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { simpleFetcher } from './test-utils'
 import type { InfiniteData } from '@tanstack/query-core'
@@ -79,6 +79,20 @@ describe('Discriminated union return type', () => {
 
     if (query.isError) {
       expectTypeOf(query.error).toEqualTypeOf<Error>()
+    }
+  })
+
+  it('should accept computed options', () => {
+    const options = computed(() => ({
+      queryKey: ['infiniteQuery'],
+      queryFn: simpleFetcher,
+      getNextPageParam: () => undefined,
+      initialPageParam: 0,
+    }))
+    const query = reactive(useInfiniteQuery(options))
+
+    if (query.isSuccess) {
+      expectTypeOf(query.data).toEqualTypeOf<InfiniteData<string, unknown>>()
     }
   })
 })

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -49,7 +49,7 @@ type UseQueryOptionsGeneric<
       TQueryFnData,
       TError,
       TData,
-      TQueryFnData,
+      TQueryData,
       TQueryKey,
       TPageParam
     >

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -49,7 +49,7 @@ type UseQueryOptionsGeneric<
       TQueryFnData,
       TError,
       TData,
-      TQueryData,
+      TQueryFnData,
       TQueryKey,
       TPageParam
     >

--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -1,6 +1,9 @@
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type { DefinedInitialDataInfiniteOptions, UndefinedInitialDataInfiniteOptions } from './infiniteQueryOptions'
+import type {
+  DefinedInitialDataInfiniteOptions,
+  UndefinedInitialDataInfiniteOptions,
+} from './infiniteQueryOptions'
 import type {
   DefaultError,
   InfiniteData,
@@ -12,7 +15,12 @@ import type {
 
 import type { UseBaseQueryReturnType } from './useBaseQuery'
 
-import type { DeepUnwrapRef, MaybeRef, MaybeRefDeep, MaybeRefOrGetter } from './types'
+import type {
+  DeepUnwrapRef,
+  MaybeRef,
+  MaybeRefDeep,
+  MaybeRefOrGetter,
+} from './types'
 import type { QueryClient } from './queryClient'
 
 export type UseInfiniteQueryOptions<

--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -1,5 +1,6 @@
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
+import type { DefinedInitialDataInfiniteOptions, UndefinedInitialDataInfiniteOptions } from './infiniteQueryOptions'
 import type {
   DefaultError,
   InfiniteData,
@@ -11,7 +12,7 @@ import type {
 
 import type { UseBaseQueryReturnType } from './useBaseQuery'
 
-import type { DeepUnwrapRef, MaybeRefDeep, MaybeRefOrGetter } from './types'
+import type { DeepUnwrapRef, MaybeRef, MaybeRefDeep, MaybeRefOrGetter } from './types'
 import type { QueryClient } from './queryClient'
 
 export type UseInfiniteQueryOptions<
@@ -21,43 +22,79 @@ export type UseInfiniteQueryOptions<
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
-> = {
-  [Property in keyof InfiniteQueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey,
-    TPageParam
-  >]: Property extends 'enabled'
-    ? MaybeRefOrGetter<
-        InfiniteQueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          DeepUnwrapRef<TQueryKey>
-        >[Property]
-      >
-    : MaybeRefDeep<
-        InfiniteQueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          DeepUnwrapRef<TQueryKey>,
-          TPageParam
-        >[Property]
-      >
-} & {
-  shallow?: boolean
-}
+> = MaybeRef<
+  {
+    [Property in keyof InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey,
+      TPageParam
+    >]: Property extends 'enabled'
+      ? MaybeRefOrGetter<
+          InfiniteQueryObserverOptions<
+            TQueryFnData,
+            TError,
+            TData,
+            TQueryData,
+            DeepUnwrapRef<TQueryKey>
+          >[Property]
+        >
+      : MaybeRefDeep<
+          InfiniteQueryObserverOptions<
+            TQueryFnData,
+            TError,
+            TData,
+            TQueryData,
+            DeepUnwrapRef<TQueryKey>,
+            TPageParam
+          >[Property]
+        >
+  } & {
+    shallow?: boolean
+  }
+>
 
 export type UseInfiniteQueryReturnType<TData, TError> = UseBaseQueryReturnType<
   TData,
   TError,
   InfiniteQueryObserverResult<TData, TError>
 >
+
+export function useInfiniteQuery<
+  TQueryFnData,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+>(
+  options: DefinedInitialDataInfiniteOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey,
+    TPageParam
+  >,
+  queryClient?: QueryClient,
+): UseInfiniteQueryReturnType<TData, TError>
+
+export function useInfiniteQuery<
+  TQueryFnData,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+>(
+  options: UndefinedInitialDataInfiniteOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey,
+    TPageParam
+  >,
+  queryClient?: QueryClient,
+): UseInfiniteQueryReturnType<TData, TError>
 
 export function useInfiniteQuery<
   TQueryFnData,
@@ -75,10 +112,16 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseInfiniteQueryReturnType<TData, TError> {
+): UseInfiniteQueryReturnType<TData, TError>
+
+export function useInfiniteQuery(
+  options: UseInfiniteQueryOptions,
+  queryClient?: QueryClient,
+) {
   return useBaseQuery(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     InfiniteQueryObserver as typeof QueryObserver,
     options,
     queryClient,
-  ) as UseInfiniteQueryReturnType<TData, TError>
+  )
 }


### PR DESCRIPTION
The useInfiniteQuery can directly use Ref in the runtime, but it's not supported at the Type level.