### PR TITLE
docs: fix missing closing quote in networkMode option

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -75,7 +75,7 @@ const {
 - `enabled: boolean | (query: Query) => boolean`
   - Set this to `false` to disable this query from automatically running.
   - Can be used for [Dependent Queries](../guides/dependent-queries.md).
-- `networkMode: 'online' | 'always' | 'offlineFirst`
+- `networkMode: 'online' | 'always' | 'offlineFirst'`
   - optional
   - defaults to `'online'`
   - see [Network Mode](../guides/network-mode.md) for more information.


### PR DESCRIPTION
Description

This PR corrects a small typo in the documentation for the networkMode field. Specifically, the closing quote was missing in the 'offlineFirst' option.

Before

`networkMode: 'online' | 'always' | 'offlineFirst`

After

`networkMode: 'online' | 'always' | 'offlineFirst'`

