### PR TITLE
refactor(query-core): remove unused common type 

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -430,13 +430,8 @@ export interface QueryObserverOptions<
 }
 
 export type WithRequired<TTarget, TKey extends keyof TTarget> = TTarget & {
-  [_ in TKey]: {}
+  [K in TKey]-?: TTarget[K]
 }
-export type Optional<TTarget, TKey extends keyof TTarget> = Pick<
-  Partial<TTarget>,
-  TKey
-> &
-  Omit<TTarget, TKey>
 
 export type DefaultedQueryObserverOptions<
   TQueryFnData = unknown,

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -430,7 +430,7 @@ export interface QueryObserverOptions<
 }
 
 export type WithRequired<TTarget, TKey extends keyof TTarget> = TTarget & {
-  [K in TKey]-?: TTarget[K]
+  [_ in TKey]: {}
 }
 
 export type DefaultedQueryObserverOptions<

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -432,12 +432,11 @@ export interface QueryObserverOptions<
 export type WithRequired<TTarget, TKey extends keyof TTarget> = TTarget & {
   [_ in TKey]: {}
 }
-
 export type Optional<TTarget, TKey extends keyof TTarget> = Pick<
   Partial<TTarget>,
   TKey
 > &
-  Omit<TTarget, TKey>
+  OmitKeyof<TTarget, TKey>
 
 export type DefaultedQueryObserverOptions<
   TQueryFnData = unknown,

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -429,11 +429,9 @@ export interface QueryObserverOptions<
   experimental_prefetchInRender?: boolean
 }
 
-export type WithRequired<TTarget, TKey extends keyof TTarget> = Pick<
-  Required<TTarget>,
-  TKey
-> &
-  Omit<TTarget, TKey>
+export type WithRequired<TTarget, TKey extends keyof TTarget> = TTarget & {
+  [_ in TKey]: {}
+}
 
 export type Optional<TTarget, TKey extends keyof TTarget> = Pick<
   Partial<TTarget>,

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -436,7 +436,7 @@ export type Optional<TTarget, TKey extends keyof TTarget> = Pick<
   Partial<TTarget>,
   TKey
 > &
-  OmitKeyof<TTarget, TKey>
+  Omit<TTarget, TKey>
 
 export type DefaultedQueryObserverOptions<
   TQueryFnData = unknown,

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -429,14 +429,17 @@ export interface QueryObserverOptions<
   experimental_prefetchInRender?: boolean
 }
 
-export type WithRequired<TTarget, TKey extends keyof TTarget> = TTarget & {
-  [_ in TKey]: {}
-}
+export type WithRequired<TTarget, TKey extends keyof TTarget> = Pick<
+  Required<TTarget>,
+  TKey
+> &
+  Omit<TTarget, TKey>
+
 export type Optional<TTarget, TKey extends keyof TTarget> = Pick<
   Partial<TTarget>,
   TKey
 > &
-  OmitKeyof<TTarget, TKey>
+  Omit<TTarget, TKey>
 
 export type DefaultedQueryObserverOptions<
   TQueryFnData = unknown,


### PR DESCRIPTION
I change a type a little. 

# Optional

I change `OmitKeyof` to `Omit`. Since the third parameter TStrictly in OmitKeyof is always fixed, there's no need to use OmitKeyof in this case.