### PR TITLE
fix documentation on status for suspense hooks

### DIFF
--- a/docs/framework/react/reference/useSuspenseInfiniteQuery.md
+++ b/docs/framework/react/reference/useSuspenseInfiniteQuery.md
@@ -22,7 +22,7 @@ Same object as [useInfiniteQuery](../reference/useInfiniteQuery.md), except that
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing
-- `status` is either  `success` or `error`
+- `status` is either `success` or `error`
   - the derived flags are set accordingly.
 
 **Caveat**

--- a/docs/framework/react/reference/useSuspenseInfiniteQuery.md
+++ b/docs/framework/react/reference/useSuspenseInfiniteQuery.md
@@ -22,7 +22,7 @@ Same object as [useInfiniteQuery](../reference/useInfiniteQuery.md), except that
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing
-- `status` is always `success`
+- `status` is either  `success` or `error`
   - the derived flags are set accordingly.
 
 **Caveat**

--- a/docs/framework/react/reference/useSuspenseQueries.md
+++ b/docs/framework/react/reference/useSuspenseQueries.md
@@ -22,7 +22,7 @@ Same structure as [useQueries](../reference/useQueries.md), except that for each
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing
-- `status` is always `success`
+- `status` is either `success` or `error`
   - the derived flags are set accordingly.
 
 **Caveats**

--- a/docs/framework/react/reference/useSuspenseQuery.md
+++ b/docs/framework/react/reference/useSuspenseQuery.md
@@ -21,7 +21,7 @@ Same object as [useQuery](../reference/useQuery.md), except that:
 
 - `data` is guaranteed to be defined
 - `isPlaceholderData` is missing
-- `status` is always `success`
+- `status` is either `success` or `error`
   - the derived flags are set accordingly.
 
 **Caveat**


### PR DESCRIPTION
Following the discussion on https://github.com/TanStack/query/issues/9001 this PR updates the reference documentation for `useSuspenseQuery`, `useSuspenseQueries` and `useSuspenseInfiniteQuery` to reflect the fact that `status` can also be `"error"`.

More info on when this can happen is already in the documentation here: https://github.com/TanStack/query/blob/main/docs/framework/react/guides/suspense.md#throwonerror-default