### PR TITLE
fix(react-query): allow null type for result ref in useMutationState

### DIFF
--- a/packages/react-query/src/useMutationState.ts
+++ b/packages/react-query/src/useMutationState.ts
@@ -47,7 +47,7 @@ export function useMutationState<TResult = MutationState>(
 ): Array<TResult> {
   const mutationCache = useQueryClient(queryClient).getMutationCache()
   const optionsRef = React.useRef(options)
-  const result = React.useRef<Array<TResult>>(null)
+  const result = React.useRef<Array<TResult | null>>(null)
   if (!result.current) {
     result.current = getResult(mutationCache, options)
   }


### PR DESCRIPTION
The result ref is initialized with null, but its type does not reflect null, causing issues in TypeScript projects with --strictNullChecks enabled. This commit updates the type to resolve the problem.