### PR TITLE
fix(query-core): unpause restored mutations

### DIFF
--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -290,7 +290,7 @@ describe('mutations', () => {
       submittedAt: 1,
     })
 
-    queryClient.resumePausedMutations()
+    void queryClient.resumePausedMutations()
     await vi.advanceTimersByTimeAsync(0)
 
     // check that the mutation is correctly resumed

--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -252,7 +252,7 @@ describe('mutations', () => {
     const onSettled = vi.fn()
 
     queryClient.setMutationDefaults(key, {
-      mutationFn: (text: string) => Promise.resolve(text),
+      mutationFn: (text: string) => sleep(10).then(() => text),
       onMutate,
       onSuccess,
       onSettled,
@@ -290,7 +290,23 @@ describe('mutations', () => {
       submittedAt: 1,
     })
 
-    await queryClient.resumePausedMutations()
+    queryClient.resumePausedMutations()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // check that the mutation is correctly resumed
+    expect(mutation.state).toEqual({
+      context: 'todo',
+      data: undefined,
+      error: null,
+      failureCount: 1,
+      failureReason: 'err',
+      isPaused: false,
+      status: 'pending',
+      variables: 'todo',
+      submittedAt: 1,
+    })
+
+    await vi.advanceTimersByTimeAsync(20)
 
     expect(mutation.state).toEqual({
       context: 'todo',


### PR DESCRIPTION
ensure that restored mutations have their isPaused state set to false when continued.

Resolves #8999