### PR TITLE
fix(angular-query): fix injectInfiniteQuery to narrow type after isSuccess

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test-d.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing'
+import { afterEach } from 'vitest'
+import { provideExperimentalZonelessChangeDetection } from '@angular/core'
+import { QueryClient, injectInfiniteQuery, provideTanStackQuery } from '..'
+import { infiniteFetcher } from './test-utils'
+import type { InfiniteData } from '@tanstack/query-core'
+
+describe('injectInfiniteQuery', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient()
+    vi.useFakeTimers()
+    TestBed.configureTestingModule({
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        provideTanStackQuery(queryClient),
+      ],
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('should narrow type after isSuccess', async () => {
+    const query = TestBed.runInInjectionContext(() => {
+      return injectInfiniteQuery(() => ({
+        queryKey: ['infiniteQuery'],
+        queryFn: infiniteFetcher,
+        initialPageParam: 0,
+        getNextPageParam: () => 12,
+      }))
+    })
+
+    if (query.isSuccess()) {
+      const data = query.data()
+      expectTypeOf(data).toEqualTypeOf<InfiniteData<string, unknown>>()
+    }
+  })
+})

--- a/packages/angular-query-experimental/src/types.ts
+++ b/packages/angular-query-experimental/src/types.ts
@@ -145,7 +145,8 @@ export type DefinedCreateQueryResult<
 export type CreateInfiniteQueryResult<
   TData = unknown,
   TError = DefaultError,
-> = MapToSignals<InfiniteQueryObserverResult<TData, TError>>
+> = BaseQueryNarrowing<TData, TError> &
+  MapToSignals<InfiniteQueryObserverResult<TData, TError>>
 
 /**
  * @public


### PR DESCRIPTION
closes #8984 

I fixed injectInfiniteQuery to narrow type after isSuccess.
Also, I wrote a test for this case.


```typescript
const infiniteQuery = injectInfiniteQuery(() => ({
  queryKey: ["projects"],
  queryFn: ({ pageParam }) => {
    return Promise.resolve(5);
  },
  initialPageParam: 2,
  getPreviousPageParam: (firstPage) => 1,
  getNextPageParam: (lastPage) => 3,
}));

if (infiniteQuery.isSuccess()) {
  // ✅ after checking isSuccess data signal is not possibly undefined
  const data = infiniteQuery.data();
}
```

