### PR TITLE
fix(query-core, vue-query): fix type inference in `setQueryData` when used in functions with explicit return types

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -113,6 +113,19 @@ describe('setQueryData', () => {
 
     expectTypeOf(data).toEqualTypeOf<string | undefined>()
   })
+
+  it('should preserve updater parameter type inference when used in functions with explicit return types', () => {
+    const queryKey = ['key'] as DataTag<Array<string>, number>
+    const queryClient = new QueryClient()
+
+    // Simulate usage inside a function with explicit return type
+    // The outer function returns 'unknown' but this shouldn't affect the updater's type inference
+    ;(() =>
+      queryClient.setQueryData(queryKey, (data) => {
+        expectTypeOf(data).toEqualTypeOf<number | undefined>()
+        return data
+      })) satisfies () => unknown
+  })
 })
 
 describe('getQueryState', () => {
@@ -589,4 +602,29 @@ describe('resetQueries', () => {
       },
     })
   })
+})
+type SuccessCallback = () => unknown
+it('should infer types correctly with expression body arrow functions', () => {
+  const queryKey = ['key'] as DataTag<Array<string>, number>
+  const queryClient = new QueryClient()
+
+  // @ts-expect-error
+  const callbackTest: SuccessCallback = () =>
+    queryClient.setQueryData(queryKey, (data) => {
+      expectTypeOf(data).toEqualTypeOf<number | undefined>()
+      return data
+    })
+})
+
+it('should infer types correctly with block body arrow functions', () => {
+  const queryKey = ['key'] as DataTag<Array<string>, number>
+  const queryClient = new QueryClient()
+
+  // @ts-expect-error
+  const callbackTest2: SuccessCallback = () => {
+    queryClient.setQueryData(queryKey, (data) => {
+      expectTypeOf(data).toEqualTypeOf<number | undefined>()
+      return data
+    })
+  }
 })

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -185,7 +185,7 @@ export class QueryClient {
       NoInfer<TInferredQueryFnData> | undefined
     >,
     options?: SetDataOptions,
-  ): TInferredQueryFnData | undefined {
+  ): NoInfer<TInferredQueryFnData> | undefined {
     const defaultedOptions = this.defaultQueryOptions<
       any,
       any,

--- a/packages/vue-query/src/__tests__/queryClient.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test-d.ts
@@ -96,6 +96,19 @@ describe('setQueryData', () => {
 
     expectTypeOf(data).toEqualTypeOf<string | undefined>()
   })
+
+  it('should preserve updater parameter type inference when used in functions with explicit return types', () => {
+    const queryKey = ['key'] as DataTag<Array<string>, number>
+    const queryClient = new QueryClient()
+
+    // Simulate usage inside a function with explicit return type
+    // The outer function returns 'unknown' but this shouldn't affect the updater's type inference
+    ;(() =>
+      queryClient.setQueryData(queryKey, (data) => {
+        expectTypeOf(data).toEqualTypeOf<number | undefined>()
+        return data
+      })) satisfies () => unknown
+  })
 })
 
 describe('fetchInfiniteQuery', () => {

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -114,17 +114,17 @@ export class QueryClient extends QC {
       NoInfer<TInferredQueryFnData> | undefined
     >,
     options?: MaybeRefDeep<SetDataOptions>,
-  ): TInferredQueryFnData | undefined
+  ): NoInfer<TInferredQueryFnData> | undefined
   setQueryData<TQueryFnData, TData = NoUnknown<TQueryFnData>>(
     queryKey: MaybeRefDeep<QueryKey>,
     updater: Updater<NoInfer<TData> | undefined, NoInfer<TData> | undefined>,
     options?: MaybeRefDeep<SetDataOptions>,
-  ): TData | undefined
+  ): NoInfer<TData> | undefined
   setQueryData<TData>(
     queryKey: MaybeRefDeep<QueryKey>,
     updater: Updater<TData | undefined, TData | undefined>,
     options: MaybeRefDeep<SetDataOptions> = {},
-  ): TData | undefined {
+  ): NoInfer<TData> | undefined {
     return super.setQueryData(
       cloneDeepUnref(queryKey),
       updater,


### PR DESCRIPTION
Applied the `NoInfer` utility type to the return type of `setQueryData` to prevent the outer function's return type from affecting the updater function's type inference.

closes #9024