### PR TITLE
Fix broken links on QueryCache reference page

### DIFF
--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -118,6 +118,6 @@ queryCache.clear()
 ## Further reading
 
 To get a better understanding how the QueryCache works internally, have a look at [#18: Inside React Query
-](../../framework/react/community/tkdodos-blog#18-inside-react-query) from the Community Resources.
+](../framework/react/community/tkdodos-blog#18-inside-react-query) from the Community Resources.
 
 [//]: # 'Materials'

--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -75,8 +75,8 @@ const queries = queryCache.findAll(queryKey)
 
 **Options**
 
-- `queryKey?: QueryKey`: [Query Keys](../../framework/react/guides/query-keys)
-- `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters#query-filters)
+- `queryKey?: QueryKey`: [Query Keys](../framework/react/guides/query-keys.md)
+- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters.md#query-filters)
 
 **Returns**
 
@@ -118,6 +118,6 @@ queryCache.clear()
 ## Further reading
 
 To get a better understanding how the QueryCache works internally, have a look at [#18: Inside React Query
-](../framework/react/community/tkdodos-blog#18-inside-react-query) from the Community Resources.
+](../framework/react/community/tkdodos-blog.md#18-inside-react-query) from the Community Resources.
 
 [//]: # 'Materials'


### PR DESCRIPTION
It looks like the `docs` part of several urls was being removed, so this PR moves the relative link one level up by removing one `../` in those docs. As requested, this also adds `.md` extensions.