### PR TITLE
refactor(query-async-storage-persister): remove unnecessary export "AsyncThrottleOptions"

### DIFF
--- a/packages/query-async-storage-persister/src/asyncThrottle.ts
+++ b/packages/query-async-storage-persister/src/asyncThrottle.ts
@@ -1,6 +1,6 @@
 import { noop } from './utils'
 
-export interface AsyncThrottleOptions {
+interface AsyncThrottleOptions {
   interval?: number
   onError?: (error: unknown) => void
 }


### PR DESCRIPTION
AsyncThrottleOptions are only used within `asyncThrottle.ts`, so I decided that it would be better not to export them.
