### PR TITLE
refactor(react-query-devtools): remove unnecessary export "DevtoolsOptions" and "DevtoolsPanelOptions"

### DIFF
--- a/packages/react-query-devtools/src/ReactQueryDevtools.tsx
+++ b/packages/react-query-devtools/src/ReactQueryDevtools.tsx
@@ -9,7 +9,7 @@ import type {
 } from '@tanstack/query-devtools'
 import type { QueryClient } from '@tanstack/react-query'
 
-export interface DevtoolsOptions {
+interface DevtoolsOptions {
   /**
    * Set this true if you want the dev tools to default to being open
    */

--- a/packages/react-query-devtools/src/ReactQueryDevtoolsPanel.tsx
+++ b/packages/react-query-devtools/src/ReactQueryDevtoolsPanel.tsx
@@ -5,7 +5,7 @@ import { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
 import type { DevtoolsErrorType } from '@tanstack/query-devtools'
 import type { QueryClient } from '@tanstack/react-query'
 
-export interface DevtoolsPanelOptions {
+interface DevtoolsPanelOptions {
   /**
    * Custom instance of QueryClient
    */


### PR DESCRIPTION


`DevtoolsOptions` is only used within `ReactQueryDevtools.tsx` and `DevtoolsPanelOptions` is only used within `ReactQueryDevtoolsPanel.tsx`. so I decided that it would be better not to export them.