### PR TITLE
fix(vue-query): update `initialData` type to allow `InitialDataFunction` and `NonUndefinedGuard`, similar to react-query

### DIFF
--- a/packages/vue-query/src/__tests__/useQueries.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test-d.ts
@@ -35,7 +35,7 @@ describe('UseQueries config object overload', () => {
     })
 
     expectTypeOf(queriesState[0].data).toEqualTypeOf<{ wow: boolean }>()
-    expectTypeOf(queriesState[1].data).toEqualTypeOf<string>()
+    expectTypeOf(queriesState[1].data).toEqualTypeOf<string | undefined>()
     expectTypeOf(queriesState[2].data).toEqualTypeOf<string | undefined>()
   })
 
@@ -54,7 +54,7 @@ describe('UseQueries config object overload', () => {
 
     const { value: queriesState } = useQueries({ queries: [options] })
 
-    expectTypeOf(queriesState[0].data).toEqualTypeOf<{ wow: boolean }>()
+    expectTypeOf(queriesState[0].data).toEqualTypeOf<{ wow: boolean } | undefined>()
   })
 
   it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQueries', () => {

--- a/packages/vue-query/src/__tests__/useQueries.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test-d.ts
@@ -54,7 +54,9 @@ describe('UseQueries config object overload', () => {
 
     const { value: queriesState } = useQueries({ queries: [options] })
 
-    expectTypeOf(queriesState[0].data).toEqualTypeOf<{ wow: boolean } | undefined>()
+    expectTypeOf(queriesState[0].data).toEqualTypeOf<
+      { wow: boolean } | undefined
+    >()
   })
 
   it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQueries', () => {

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -23,7 +23,7 @@ describe('useQuery', () => {
         }),
       )
 
-      expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
+      expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
     })
 
     it('TData should be defined when passed through queryOptions', () => {
@@ -40,7 +40,7 @@ describe('useQuery', () => {
       })
       const { data } = reactive(useQuery(options))
 
-      expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
+      expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
     })
 
     it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQuery', () => {
@@ -74,7 +74,7 @@ describe('useQuery', () => {
         }),
       )
 
-      expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
+      expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
     })
 
     it('TData should have undefined in the union when initialData is NOT provided', () => {

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -66,9 +66,9 @@ export type UndefinedInitialQueryOptions<
   TQueryKey extends QueryKey = QueryKey,
 > = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
   initialData?:
-  | undefined
-  | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
-  | NonUndefinedGuard<TQueryFnData>
+    | undefined
+    | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
+    | NonUndefinedGuard<TQueryFnData>
 }
 
 export type DefinedInitialQueryOptions<

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -3,6 +3,7 @@ import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
+  InitialDataFunction,
   QueryKey,
   QueryObserverOptions,
 } from '@tanstack/query-core'
@@ -64,7 +65,10 @@ export type UndefinedInitialQueryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData?: undefined
+  initialData?:
+  | undefined
+  | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
+  | NonUndefinedGuard<TQueryFnData>
 }
 
 export type DefinedInitialQueryOptions<


### PR DESCRIPTION
Suggesting fix for https://github.com/TanStack/query/issues/9069