### PR TITLE
fix(vue-query): fix initialData Type Inference Bug in useQuery

### DIFF
--- a/packages/vue-query/src/__tests__/useQueries.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test-d.ts
@@ -35,7 +35,7 @@ describe('UseQueries config object overload', () => {
     })
 
     expectTypeOf(queriesState[0].data).toEqualTypeOf<{ wow: boolean }>()
-    expectTypeOf(queriesState[1].data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(queriesState[1].data).toEqualTypeOf<string>()
     expectTypeOf(queriesState[2].data).toEqualTypeOf<string | undefined>()
   })
 
@@ -54,9 +54,7 @@ describe('UseQueries config object overload', () => {
 
     const { value: queriesState } = useQueries({ queries: [options] })
 
-    expectTypeOf(queriesState[0].data).toEqualTypeOf<
-      { wow: boolean } | undefined
-    >()
+    expectTypeOf(queriesState[0].data).toEqualTypeOf<{ wow: boolean }>()
   })
 
   it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQueries', () => {

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -23,7 +23,7 @@ describe('useQuery', () => {
         }),
       )
 
-      expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
+      expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
     })
 
     it('TData should be defined when passed through queryOptions', () => {
@@ -40,7 +40,7 @@ describe('useQuery', () => {
       })
       const { data } = reactive(useQuery(options))
 
-      expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
+      expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
     })
 
     it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQuery', () => {

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -74,7 +74,7 @@ describe('useQuery', () => {
         }),
       )
 
-      expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
+      expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
     })
 
     it('TData should have undefined in the union when initialData is NOT provided', () => {

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -3,7 +3,6 @@ import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
-  InitialDataFunction,
   QueryKey,
   QueryObserverOptions,
 } from '@tanstack/query-core'
@@ -65,7 +64,7 @@ export type UndefinedInitialQueryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData?: undefined | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
+  initialData?: undefined | (() => undefined)
 }
 
 export type DefinedInitialQueryOptions<

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -65,10 +65,7 @@ export type UndefinedInitialQueryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData?:
-    | undefined
-    | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
-    | NonUndefinedGuard<TQueryFnData>
+  initialData?: undefined | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
 }
 
 export type DefinedInitialQueryOptions<


### PR DESCRIPTION
Overview

In the previous PR(#9073), there was a bug where data was incorrectly inferred as undefined even when initialData was defined. This PR ensures that when initialData is TData, data is correctly inferred as TData, and adds tests to verify this behavior.

Changes

- Bug Fix: Improved type inference for non-undefined initialData
  - Modified to ensure data.value is accurately inferred as TData when initialData is provided with a non-undefined value.
  - Commit: 6e73779

- Test Addition: Type validation for defined initialData
  - Added tests to verify that data is returned as TData type only when initialData is defined.
  - Commit: 2ff92c5ebbc1331ea62a6222e70219c591078d0e, 7684df1

Related Files

- packages/vue-query/src/useQuery.ts
- packages/vue-query/src/__tests__/useQuery.test-d.ts
- packages/vue-query/src/__tests__/useQueries.test-d.ts

closes #9069