### PR TITLE
fix(vue-query): move `queryOptions` and `useQuery` function overloads 

### DIFF
--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -125,17 +125,19 @@ describe('queryOptions', () => {
 
   it('TData should always be defined when initialData is provided as a function which ALWAYS returns the data', () => {
     const { data } = reactive(
-      useQuery(queryOptions({
-        queryKey: ['key'],
-        queryFn: () => {
-          return {
+      useQuery(
+        queryOptions({
+          queryKey: ['key'],
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          initialData: () => ({
             wow: true,
-          }
-        },
-        initialData: () => ({
-          wow: true,
+          }),
         }),
-      })),
+      ),
     )
 
     expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
@@ -143,14 +145,16 @@ describe('queryOptions', () => {
 
   it('TData should have undefined in the union when initialData is NOT provided', () => {
     const { data } = reactive(
-      useQuery(queryOptions({
-        queryKey: ['key'],
-        queryFn: () => {
-          return {
-            wow: true,
-          }
-        },
-      })),
+      useQuery(
+        queryOptions({
+          queryKey: ['key'],
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+        }),
+      ),
     )
 
     expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
@@ -158,23 +162,8 @@ describe('queryOptions', () => {
 
   it('TData should have undefined in the union when initialData is provided as a function which can return undefined', () => {
     const { data } = reactive(
-      useQuery(queryOptions({
-        queryKey: ['key'],
-        queryFn: () => {
-          return {
-            wow: true,
-          }
-        },
-        initialData: () => undefined as { wow: boolean } | undefined,
-      })),
-    )
-
-    expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
-  })
-
-  it('TData should be narrowed after an isSuccess check when initialData is provided as a function which can return undefined', () => {
-    const { data, isSuccess } = reactive(
-      useQuery(queryOptions({
+      useQuery(
+        queryOptions({
           queryKey: ['key'],
           queryFn: () => {
             return {
@@ -182,8 +171,26 @@ describe('queryOptions', () => {
             }
           },
           initialData: () => undefined as { wow: boolean } | undefined,
-        }
-      )),
+        }),
+      ),
+    )
+
+    expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
+  })
+
+  it('TData should be narrowed after an isSuccess check when initialData is provided as a function which can return undefined', () => {
+    const { data, isSuccess } = reactive(
+      useQuery(
+        queryOptions({
+          queryKey: ['key'],
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          initialData: () => undefined as { wow: boolean } | undefined,
+        }),
+      ),
     )
 
     if (isSuccess) {
@@ -193,10 +200,13 @@ describe('queryOptions', () => {
 
   it('data should not have undefined when initialData is provided', () => {
     const { data } = reactive(
-      useQuery(queryOptions({
-        queryKey: ['query-key'],
-        initialData: 42,
-    })))
+      useQuery(
+        queryOptions({
+          queryKey: ['query-key'],
+          initialData: 42,
+        }),
+      ),
+    )
 
     expectTypeOf(data).toEqualTypeOf<number>()
   })

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -122,4 +122,82 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<Promise<void>>()
     expectTypeOf(data2).toEqualTypeOf<Promise<number>>()
   })
+
+  it('TData should always be defined when initialData is provided as a function which ALWAYS returns the data', () => {
+    const { data } = reactive(
+      useQuery(queryOptions({
+        queryKey: ['key'],
+        queryFn: () => {
+          return {
+            wow: true,
+          }
+        },
+        initialData: () => ({
+          wow: true,
+        }),
+      })),
+    )
+
+    expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
+  })
+
+  it('TData should have undefined in the union when initialData is NOT provided', () => {
+    const { data } = reactive(
+      useQuery(queryOptions({
+        queryKey: ['key'],
+        queryFn: () => {
+          return {
+            wow: true,
+          }
+        },
+      })),
+    )
+
+    expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
+  })
+
+  it('TData should have undefined in the union when initialData is provided as a function which can return undefined', () => {
+    const { data } = reactive(
+      useQuery(queryOptions({
+        queryKey: ['key'],
+        queryFn: () => {
+          return {
+            wow: true,
+          }
+        },
+        initialData: () => undefined as { wow: boolean } | undefined,
+      })),
+    )
+
+    expectTypeOf(data).toEqualTypeOf<{ wow: boolean } | undefined>()
+  })
+
+  it('TData should be narrowed after an isSuccess check when initialData is provided as a function which can return undefined', () => {
+    const { data, isSuccess } = reactive(
+      useQuery(queryOptions({
+          queryKey: ['key'],
+          queryFn: () => {
+            return {
+              wow: true,
+            }
+          },
+          initialData: () => undefined as { wow: boolean } | undefined,
+        }
+      )),
+    )
+
+    if (isSuccess) {
+      expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
+    }
+  })
+
+  it('data should not have undefined when initialData is provided', () => {
+    const { data } = reactive(
+      useQuery(queryOptions({
+        queryKey: ['query-key'],
+        initialData: 42,
+    })))
+
+    expectTypeOf(data).toEqualTypeOf<number>()
+  })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -125,6 +125,16 @@ describe('useQuery', () => {
         expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
       }
     })
+
+    it('data should not have undefined when initialData is provided', () => {
+      const { data } = reactive(
+        useQuery({
+          queryKey: ['query-key'],
+          initialData: 42,
+      }))
+
+      expectTypeOf(data).toEqualTypeOf<number>()
+    })
   })
 
   describe('custom composable', () => {

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -131,7 +131,8 @@ describe('useQuery', () => {
         useQuery({
           queryKey: ['query-key'],
           initialData: 42,
-      }))
+        }),
+      )
 
       expectTypeOf(data).toEqualTypeOf<number>()
     })

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -10,8 +10,8 @@ export function queryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+): DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 
@@ -21,8 +21,8 @@ export function queryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -3,6 +3,7 @@ import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
+  InitialDataFunction,
   QueryKey,
   QueryObserverOptions,
 } from '@tanstack/query-core'
@@ -64,7 +65,10 @@ export type UndefinedInitialQueryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData?: undefined | (() => undefined)
+  initialData?:
+    | undefined
+    | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
+    | NonUndefinedGuard<TQueryFnData>
 }
 
 export type DefinedInitialQueryOptions<
@@ -95,9 +99,9 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryReturnType<TData, TError>
+): UseQueryDefinedReturnType<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -105,9 +109,9 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryDefinedReturnType<TData, TError>
+): UseQueryReturnType<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,


### PR DESCRIPTION
Fixes #9069. Unfortunately solutions from #9073 and #9077 didn't fully resolve the original issue.

I looked at what `react-query` does to ensure correct type safety for 4 different cases of `initialData`. These are: `undefined`, `T`, `() => T`, `() => T | undefined` and how come we're seeing troubles with type inference in `vue-query`.

So what I noticed is that react version declares overloads of `useQuery` and `queryOptions` where `initialData` is defined **_before_** the ones where `initialData` is undefined. [But overload ordering matters](https://github.com/microsoft/TypeScript/issues/1860#issuecomment-72154737). In a nutshell, more specific overload should come before a more general one. Vue was doing the opposite where defined `initialData` overloads are declared later which caused TypeScript to pick the wrong overload instead. That was causing both forbidding of `undefined` in function returns and leaving `undefined` in type union for `data`.

So I changed type declarations to align with `react-query` types. And it looks to be working as expected now.

I also copied `initialData` type test cases from `useQuery` into `queryOptions` to verify that when query is using `queryOptions` API then `data` types are still inferred correctly.