### PR TITLE
fix(angular-query): ensure initial mutation pending state is emitted

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -62,8 +62,6 @@ describe('injectMutation', () => {
       }))
     })
 
-    TestBed.flushEffects()
-
     mutation.mutate(result)
     vi.advanceTimersByTime(1)
 

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -84,14 +84,6 @@ export function injectMutation<
   })
 
   /**
-   * Computed signal that gets result from mutation cache based on passed options
-   */
-  const resultFromInitialOptionsSignal = computed(() => {
-    const observer = observerSignal()
-    return observer.getCurrentResult()
-  })
-
-  /**
    * Signal that contains result set by subscriber
    */
   const resultFromSubscriberSignal = signal<MutationObserverResult<
@@ -101,6 +93,37 @@ export function injectMutation<
     TContext
   > | null>(null)
 
+  /**
+   * Computed signal that gets result from mutation cache based on passed options
+   */
+  const resultFromInitialOptionsSignal = computed(() => {
+    const observer = observerSignal()
+
+    untracked(() => {
+      const unsubscribe = ngZone.runOutsideAngular(() =>
+        // observer.trackResult is not used as this optimization is not needed for Angular
+        observer.subscribe(
+          notifyManager.batchCalls((state) => {
+            ngZone.run(() => {
+              if (
+                state.isError &&
+                shouldThrowError(observer.options.throwOnError, [state.error])
+              ) {
+                ngZone.onError.emit(state.error)
+                throw state.error
+              }
+
+              resultFromSubscriberSignal.set(state)
+            })
+          }),
+        ),
+      )
+      destroyRef.onDestroy(unsubscribe)
+    })
+
+    return observer.getCurrentResult()
+  })
+
   effect(
     () => {
       const observer = observerSignal()
@@ -108,37 +131,6 @@ export function injectMutation<
 
       untracked(() => {
         observer.setOptions(observerOptions)
-      })
-    },
-    {
-      injector,
-    },
-  )
-
-  effect(
-    () => {
-      // observer.trackResult is not used as this optimization is not needed for Angular
-      const observer = observerSignal()
-
-      untracked(() => {
-        const unsubscribe = ngZone.runOutsideAngular(() =>
-          observer.subscribe(
-            notifyManager.batchCalls((state) => {
-              ngZone.run(() => {
-                if (
-                  state.isError &&
-                  shouldThrowError(observer.options.throwOnError, [state.error])
-                ) {
-                  ngZone.onError.emit(state.error)
-                  throw state.error
-                }
-
-                resultFromSubscriberSignal.set(state)
-              })
-            }),
-          ),
-        )
-        destroyRef.onDestroy(unsubscribe)
       })
     },
     {


### PR DESCRIPTION
Fixes https://github.com/TanStack/query/issues/9020

The issue was that the effect that subscribes to the observer runs after the observer emits the first state change if the mutation is triggered in the `constructor` of a component or `ngOnInit`. This is fixed by immediately subscribing when the initial result is computed.

One could also consider combining `resultFromSubscriberSignal` and `resultFromInitialOptionsSignal` into a single `linkedSignal`, but this would require dropping support for Angular 18.