### PR TITLE
refactor(angular-query): use factory for IS_RESTORING injection token default value

### DIFF
--- a/packages/angular-query-experimental/src/inject-is-restoring.ts
+++ b/packages/angular-query-experimental/src/inject-is-restoring.ts
@@ -2,12 +2,20 @@ import {
   InjectionToken,
   Injector,
   assertInInjectionContext,
-  computed,
   inject,
+  signal,
 } from '@angular/core'
 import type { Provider, Signal } from '@angular/core'
 
-const IS_RESTORING = new InjectionToken<Signal<boolean>>('')
+const IS_RESTORING = new InjectionToken(
+  typeof ngDevMode === 'undefined' || ngDevMode
+    ? 'TANSTACK_QUERY_IS_RESTORING'
+    : '',
+  {
+    // Default value when not provided
+    factory: () => signal(false).asReadonly(),
+  },
+)
 
 /**
  * The `Injector` in which to create the isRestoring signal.
@@ -19,21 +27,15 @@ interface InjectIsRestoringOptions {
 }
 
 /**
- * Injects a signal that tracks whether a restore is currently in progress. {@link injectQuery} and friends also check this internally to avoid race conditions between the restore and mounting queries.
+ * Injects a signal that tracks whether a restore is currently in progress. {@link injectQuery} and friends also check this internally to avoid race conditions between the restore and initializing queries.
  * @param options - Options for injectIsRestoring.
  * @returns signal with boolean that indicates whether a restore is in progress.
  * @public
  */
-export function injectIsRestoring(
-  options?: InjectIsRestoringOptions,
-): Signal<boolean> {
+export function injectIsRestoring(options?: InjectIsRestoringOptions) {
   !options?.injector && assertInInjectionContext(injectIsRestoring)
   const injector = options?.injector ?? inject(Injector)
-  return injector.get(
-    IS_RESTORING,
-    computed(() => false),
-    { optional: true },
-  )
+  return injector.get(IS_RESTORING)
 }
 
 /**

--- a/packages/angular-query-persist-client/src/with-persist-query-client.ts
+++ b/packages/angular-query-persist-client/src/with-persist-query-client.ts
@@ -55,10 +55,11 @@ type PersistQueryClientOptions = {
 export function withPersistQueryClient(
   persistQueryClientOptions: PersistQueryClientOptions,
 ): PersistQueryClientFeature {
-  const isRestoring = signal(false)
+  const isRestoring = signal(true)
   const providers = [
     provideIsRestoring(isRestoring.asReadonly()),
     {
+      // Do not use provideEnvironmentInitializer while Angular < v19 is supported
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,
       useValue: () => {
@@ -66,7 +67,6 @@ export function withPersistQueryClient(
         const destroyRef = inject(DestroyRef)
         const queryClient = inject(QueryClient)
 
-        isRestoring.set(true)
         const { onSuccess, onError, persistOptions } = persistQueryClientOptions
         const options = { queryClient, ...persistOptions }
         persistQueryClientRestore(options)


### PR DESCRIPTION
This ensures IS_RESTORING always provides a valid signal.

Initializes the signal to true when using `withPersistQueryClient`.