### PR TITLE
docs: Clarify that `useQuery` results are immutable

### DIFF
--- a/docs/framework/vue/reactivity.md
+++ b/docs/framework/vue/reactivity.md
@@ -157,6 +157,12 @@ export function useUserProjects(userId: MaybeRef<string>) {
 
 More details on this option can be found on the [useQuery reference](./reference/useQuery.md) page.
 
+## Immutability
+
+Results from `useQuery` are always immutable. This is necessary for performance and caching purposes. If you need to mutate a value returned from `useQuery`, you must create a copy of the data.
+
+One implication of this design is that passing values from `useQuery` to a two-way binding such as `v-model` will not work. You must create a mutable copy of the data before attempting to update it in place.
+
 # Key Takeaways
 
 - `enabled` and `queryKey` are the two query options that can accept reactive values.
@@ -164,3 +170,4 @@ More details on this option can be found on the [useQuery reference](./reference
 - If you expect a query to react to changes based on the values it consumes, ensure that the values are reactive. (i.e. pass in refs directly to the query, or use reactive getters)
 - If you don't need a query to be reactive pass in a plain value.
 - For trivial derived state such as property access consider using a reactive getter in place of a `computed`.
+- Results from `useQuery` are always immutable.


### PR DESCRIPTION
This PR probably feels unnecessary to the maintainers, but it caused some confusion for me and seems to come up from time to time in various discussions and issue reports, e.g.

- https://github.com/TanStack/query/issues/7361
- https://github.com/TanStack/query/issues/4750
- https://github.com/TanStack/query/discussions/1304

In React, immutability is a core design choice baked into most operations. For React, immutable data should be intuitive for most developers.

In contrast, Vue treats mutability as a feature, even highlighting [deep reactivity](https://vuejs.org/guide/essentials/reactivity-fundamentals#deep-reactivity) in their documentation and providing recommendations on [two-way bindings with v-model](https://vuejs.org/guide/components/v-model.html). For the average Vue developer, I would wager that the default assumption is that data is mutable.

`useQuery` properly annotates the data as `readonly` in TypeScript. However, the TypeScript compiler (at least as of 5.8.3) does not protect against all operations on `readonly` objects. For example, [this is valid and compiles just fine](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBAlgWwQVygQwEYBsCmAuGAJRzQBNwsBPAHmNACdTrp64wBzAGhgxBFzRgA2gF0AfGJgBeGAG8YWONAJCo9ZDhEwAvgChEKdNhwA6RdBMAHZBAAWACgBmaLBBwBKXbtCRYB1Ji4AEwExGQUNHQgjMxqbFw8fALC4pIy8uZQKmoaWnr+RsFmSrAyquqaQA):

```ts
const immutable: Readonly<Record<string, boolean[]>> = { list: [true] }
immutable.list.push(false)
```

(Of course, assignment is forbidden):

```ts
const immutable: Readonly<Record<string, boolean[]>> = { list: [true] }
immutable.list = [false]
^^^^^^^^^^^^^^
Index signature in type 'Readonly<Record<string, boolean[]>>' only permits reading.
```

In addition Vue provides a warning when immutable object mutations are attempted. However, warnings can be easy to overlook and this can lead to bugs.

Therefore, I believe being explicit about immutability is a useful contribution for the Vue framework docs.