### PR TITLE
fix(react-query): ensure suspense example fallback renders correctly

### DIFF
--- a/examples/react/suspense/src/index.tsx
+++ b/examples/react/suspense/src/index.tsx
@@ -70,18 +70,18 @@ function Example() {
             )}
             onReset={reset}
           >
-            <React.Suspense fallback={<h1>Loading projects...</h1>}>
-              {showProjects ? (
-                activeProject ? (
+            {showProjects ? (
+              <React.Suspense fallback={<h1>Loading projects...</h1>}>
+                {activeProject ? (
                   <Project
                     activeProject={activeProject}
                     setActiveProject={setActiveProject}
                   />
                 ) : (
                   <Projects setActiveProject={setActiveProject} />
-                )
-              ) : null}
-            </React.Suspense>
+                )}
+              </React.Suspense>
+            ) : null}
           </ErrorBoundary>
         )}
       </QueryErrorResetBoundary>


### PR DESCRIPTION
The previous suspense example incorrectly rendered null instead of the fallback UI. This change moves the null check outside the Suspense component to ensure the fallback is displayed as expected.

Fixes #9019