### PR TITLE
feature(angular-query): support providing QueryClient via InjectionToken

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/provide-query-client.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/provide-query-client.test.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing'
+import { describe, expect, test } from 'vitest'
+import {
+  InjectionToken,
+  provideExperimentalZonelessChangeDetection,
+} from '@angular/core'
+import { QueryClient } from '@tanstack/query-core'
+import { provideQueryClient } from '../providers'
+
+describe('provideQueryClient', () => {
+  test('should provide a QueryClient instance directly', () => {
+    const queryClient = new QueryClient()
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        provideQueryClient(queryClient),
+      ],
+    })
+
+    const providedQueryClient = TestBed.inject(QueryClient)
+    expect(providedQueryClient).toBe(queryClient)
+  })
+
+  test('should provide a QueryClient instance using an InjectionToken', () => {
+    const queryClient = new QueryClient()
+    const CUSTOM_QUERY_CLIENT = new InjectionToken<QueryClient>('', {
+      factory: () => queryClient,
+    })
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        provideQueryClient(CUSTOM_QUERY_CLIENT),
+      ],
+    })
+
+    const providedQueryClient = TestBed.inject(QueryClient)
+    expect(providedQueryClient).toBe(queryClient)
+  })
+})

--- a/packages/angular-query-experimental/src/__tests__/provide-tanstack-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/provide-tanstack-query.test.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing'
+import { describe, expect, test } from 'vitest'
+import {
+  InjectionToken,
+  provideExperimentalZonelessChangeDetection,
+} from '@angular/core'
+import { QueryClient } from '@tanstack/query-core'
+import { provideTanStackQuery } from '../providers'
+
+describe('provideTanStackQuery', () => {
+  test('should provide a QueryClient instance directly', () => {
+    const queryClient = new QueryClient()
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        provideTanStackQuery(queryClient),
+      ],
+    })
+
+    const providedQueryClient = TestBed.inject(QueryClient)
+    expect(providedQueryClient).toBe(queryClient)
+  })
+
+  test('should provide a QueryClient instance using an InjectionToken', () => {
+    const queryClient = new QueryClient()
+    const CUSTOM_QUERY_CLIENT = new InjectionToken<QueryClient>('', {
+      factory: () => queryClient,
+    })
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        provideTanStackQuery(CUSTOM_QUERY_CLIENT),
+      ],
+    })
+
+    const providedQueryClient = TestBed.inject(QueryClient)
+    expect(providedQueryClient).toBe(queryClient)
+  })
+})


### PR DESCRIPTION
This is useful for example in thin app shell applications where feature teams provide their dependencies on lazy loaded route providers while still allowing to easily share a QueryClient.

This way the main bundle for the app shell does not include TanStack Query.