### PR TITLE
refactor: integration should throw error

### DIFF
--- a/packages/angular-query-experimental/src/create-base-query.ts
+++ b/packages/angular-query-experimental/src/create-base-query.ts
@@ -7,9 +7,12 @@ import {
   signal,
   untracked,
 } from '@angular/core'
-import { QueryClient, notifyManager } from '@tanstack/query-core'
+import {
+  QueryClient,
+  notifyManager,
+  shouldThrowError,
+} from '@tanstack/query-core'
 import { signalProxy } from './signal-proxy'
-import { shouldThrowError } from './util'
 import { injectIsRestoring } from './inject-is-restoring'
 import type {
   QueryKey,

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -13,9 +13,10 @@ import {
   MutationObserver,
   QueryClient,
   notifyManager,
+  shouldThrowError,
 } from '@tanstack/query-core'
 import { signalProxy } from './signal-proxy'
-import { noop, shouldThrowError } from './util'
+import { noop } from './util'
 import type { DefaultError, MutationObserverResult } from '@tanstack/query-core'
 import type { CreateMutateFunction, CreateMutationResult } from './types'
 import type { CreateMutationOptions } from './mutation-options'

--- a/packages/angular-query-experimental/src/util/index.ts
+++ b/packages/angular-query-experimental/src/util/index.ts
@@ -1,13 +1,1 @@
-export function shouldThrowError<T extends (...args: Array<any>) => boolean>(
-  throwError: boolean | T | undefined,
-  params: Parameters<T>,
-): boolean {
-  // Allow throwError function to override throwing behavior on a per-error basis
-  if (typeof throwError === 'function') {
-    return throwError(...params)
-  }
-
-  return !!throwError
-}
-
 export function noop(): void {}

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -12,6 +12,7 @@ import {
   partialMatchKey,
   replaceEqualDeep,
   shallowEqualObjects,
+  shouldThrowError,
 } from '../utils'
 import { Mutation } from '../mutation'
 
@@ -528,6 +529,24 @@ describe('core/utils', () => {
       const nested2 = [{ b: 2, a: { c: 3, d: 4 } }]
 
       expect(hashKey(nested1)).toEqual(hashKey(nested2))
+    })
+  })
+
+  describe('shouldThrowError', () => {
+    it('should return the result of executing throwOnError if throwOnError parameter is a function', () => {
+      const throwOnError = (error: Error) => error.message === 'test error'
+      expect(shouldThrowError(throwOnError, [new Error('test error')])).toBe(
+        true,
+      )
+      expect(shouldThrowError(throwOnError, [new Error('other error')])).toBe(
+        false,
+      )
+    })
+
+    it('should return throwOnError parameter itself if throwOnError is not a function', () => {
+      expect(shouldThrowError(true, [new Error('test error')])).toBe(true)
+      expect(shouldThrowError(false, [new Error('test error')])).toBe(false)
+      expect(shouldThrowError(undefined, [new Error('test error')])).toBe(false)
     })
   })
 })

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -21,6 +21,7 @@ export {
   matchMutation,
   keepPreviousData,
   skipToken,
+  shouldThrowError,
 } from './utils'
 export type { MutationFilters, QueryFilters, Updater, SkipToken } from './utils'
 export { isCancelledError } from './retryer'

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -430,3 +430,15 @@ export function ensureQueryFn<
 
   return options.queryFn
 }
+
+export function shouldThrowError<T extends (...args: Array<any>) => boolean>(
+  throwOnError: boolean | T | undefined,
+  params: Parameters<T>,
+): boolean {
+  // Allow throwOnError function to override throwing behavior on a per-error basis
+  if (typeof throwOnError === 'function') {
+    return throwOnError(...params)
+  }
+
+  return !!throwOnError
+}

--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -1,6 +1,6 @@
 'use client'
 import * as React from 'react'
-import { shouldThrowError } from './utils'
+import { shouldThrowError } from '@tanstack/query-core'
 import type {
   DefaultedQueryObserverOptions,
   Query,

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -1,8 +1,12 @@
 'use client'
 import * as React from 'react'
-import { MutationObserver, notifyManager } from '@tanstack/query-core'
+import {
+  MutationObserver,
+  notifyManager,
+  shouldThrowError,
+} from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
-import { noop, shouldThrowError } from './utils'
+import { noop } from './utils'
 import type {
   UseMutateFunction,
   UseMutationOptions,

--- a/packages/react-query/src/utils.ts
+++ b/packages/react-query/src/utils.ts
@@ -1,13 +1,1 @@
-export function shouldThrowError<T extends (...args: Array<any>) => boolean>(
-  throwError: boolean | T | undefined,
-  params: Parameters<T>,
-): boolean {
-  // Allow throwError function to override throwing behavior on a per-error basis
-  if (typeof throwError === 'function') {
-    return throwError(...params)
-  }
-
-  return !!throwError
-}
-
 export function noop(): void {}

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -1,7 +1,7 @@
 // Had to disable the lint rule because isServer type is defined as false
 // in solid-js/web package. I'll create a GitHub issue with them to see
 // why that happens.
-import { hydrate, notifyManager } from '@tanstack/query-core'
+import { hydrate, notifyManager, shouldThrowError } from '@tanstack/query-core'
 import { isServer } from 'solid-js/web'
 import {
   createComputed,
@@ -13,7 +13,6 @@ import {
 } from 'solid-js'
 import { createStore, reconcile, unwrap } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
-import { shouldThrowError } from './utils'
 import { useIsRestoring } from './isRestoring'
 import type { UseBaseQueryOptions } from './types'
 import type { Accessor, Signal } from 'solid-js'
@@ -230,7 +229,7 @@ export function useBaseQuery<
     Fixes #7275
     In a few cases, the observer could unmount before the resource is loaded.
     This leads to Suspense boundaries to be suspended indefinitely.
-    This resolver will be called when the observer is unmounting 
+    This resolver will be called when the observer is unmounting
     but the resource is still in a loading state
   */
   let resolver: ((value: ResourceData) => void) | null = null

--- a/packages/solid-query/src/useMutation.ts
+++ b/packages/solid-query/src/useMutation.ts
@@ -1,8 +1,8 @@
-import { MutationObserver } from '@tanstack/query-core'
+import { MutationObserver, shouldThrowError } from '@tanstack/query-core'
 import { createComputed, createMemo, on, onCleanup } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { useQueryClient } from './QueryClientProvider'
-import { noop, shouldThrowError } from './utils'
+import { noop } from './utils'
 import type { DefaultError } from '@tanstack/query-core'
 import type { QueryClient } from './QueryClient'
 import type {

--- a/packages/solid-query/src/utils.ts
+++ b/packages/solid-query/src/utils.ts
@@ -1,13 +1,1 @@
-export function shouldThrowError<T extends (...args: Array<any>) => boolean>(
-  throwError: boolean | T | undefined,
-  params: Parameters<T>,
-): boolean {
-  // Allow throwError function to override throwing behavior on a per-error basis
-  if (typeof throwError === 'function') {
-    return throwError(...params)
-  }
-
-  return !!throwError
-}
-
 export function noop(): void {}

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -9,8 +9,9 @@ import {
   toRefs,
   watch,
 } from 'vue-demi'
+import { shouldThrowError } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient'
-import { cloneDeepUnref, shouldThrowError, updateState } from './utils'
+import { cloneDeepUnref, updateState } from './utils'
 import type { Ref } from 'vue-demi'
 import type {
   DefaultedQueryObserverOptions,

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -9,8 +9,8 @@ import {
   toRefs,
   watch,
 } from 'vue-demi'
-import { MutationObserver } from '@tanstack/query-core'
-import { cloneDeepUnref, shouldThrowError, updateState } from './utils'
+import { MutationObserver, shouldThrowError } from '@tanstack/query-core'
+import { cloneDeepUnref, updateState } from './utils'
 import { useQueryClient } from './useQueryClient'
 import type { ToRefs } from 'vue-demi'
 import type {

--- a/packages/vue-query/src/utils.ts
+++ b/packages/vue-query/src/utils.ts
@@ -109,15 +109,3 @@ function isPlainObject(value: unknown): value is Object {
 function isFunction(value: unknown): value is Function {
   return typeof value === 'function'
 }
-
-export function shouldThrowError<T extends (...args: Array<any>) => boolean>(
-  throwOnError: boolean | T | undefined,
-  params: Parameters<T>,
-): boolean {
-  // Allow throwOnError function to override throwing behavior on a per-error basis
-  if (typeof throwOnError === 'function') {
-    return throwOnError(...params)
-  }
-
-  return !!throwOnError
-}


### PR DESCRIPTION
In each packages, there was a same util function "shouldThrowError". So, I integrated those in common query-core package. 