### PR TITLE
test(react-query): initialise `queryClient` in `beforeEach`

### DIFF
--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -14,8 +14,13 @@ import { setIsServer } from './utils'
 describe('Server Side Rendering', () => {
   setIsServer(true)
 
+  let queryCache: QueryCache
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryCache = new QueryCache()
+    queryClient = new QueryClient({ queryCache })
   })
 
   afterEach(() => {
@@ -23,8 +28,6 @@ describe('Server Side Rendering', () => {
   })
 
   it('should not trigger fetch', () => {
-    const queryCache = new QueryCache()
-    const queryClient = new QueryClient({ queryCache })
     const key = queryKey()
     const queryFn = vi.fn().mockReturnValue('data')
 
@@ -52,8 +55,6 @@ describe('Server Side Rendering', () => {
   })
 
   it('should add prefetched data to cache', async () => {
-    const queryCache = new QueryCache()
-    const queryClient = new QueryClient({ queryCache })
     const key = queryKey()
     const fetchFn = () => Promise.resolve('data')
     const data = await queryClient.fetchQuery({
@@ -66,8 +67,6 @@ describe('Server Side Rendering', () => {
   })
 
   it('should return existing data from the cache', async () => {
-    const queryCache = new QueryCache()
-    const queryClient = new QueryClient({ queryCache })
     const key = queryKey()
     const queryFn = vi.fn(async () => {
       await vi.advanceTimersByTimeAsync(10)
@@ -102,9 +101,6 @@ describe('Server Side Rendering', () => {
   it('should add initialData to the cache', () => {
     const key = queryKey()
 
-    const queryCache = new QueryCache()
-    const queryClient = new QueryClient({ queryCache })
-
     function Page() {
       const [page, setPage] = React.useState(1)
       const { data } = useQuery({
@@ -134,8 +130,6 @@ describe('Server Side Rendering', () => {
   })
 
   it('useInfiniteQuery should return the correct state', async () => {
-    const queryCache = new QueryCache()
-    const queryClient = new QueryClient({ queryCache })
     const key = queryKey()
     const queryFn = vi.fn(async () => {
       await vi.advanceTimersByTimeAsync(5)

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -14,18 +14,16 @@ import {
 import type { UseMutationResult } from '../types'
 
 describe('useMutation', () => {
-  let queryCache = new QueryCache()
-  let mutationCache = new MutationCache()
-  let queryClient = new QueryClient({
-    queryCache,
-    mutationCache,
-  })
+  let queryCache: QueryCache
+  let mutationCache: MutationCache
+  let queryClient: QueryClient
 
   beforeEach(() => {
     queryCache = new QueryCache()
     mutationCache = new MutationCache()
     queryClient = new QueryClient({
       queryCache,
+      mutationCache,
     })
     vi.useFakeTimers()
   })

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -26,10 +26,8 @@ import type { DefinedUseQueryResult, QueryFunction, UseQueryResult } from '..'
 import type { Mock } from 'vitest'
 
 describe('useQuery', () => {
-  let queryCache = new QueryCache()
-  let queryClient = new QueryClient({
-    queryCache,
-  })
+  let queryCache: QueryCache
+  let queryClient: QueryClient
 
   beforeEach(() => {
     queryCache = new QueryCache()


### PR DESCRIPTION
When porting `useMutation` tests to `svelte-query`, I noticed that the `beforeEach` function for `useMutation` did not re-initialise the mutationCache. This doesn't seem to have caused any bugs, but should be fixed. The other package tests use a slightly different initialisation format which is less prone to this issue, so I've tidied it up a little.