### PR TITLE
fix: import fixes for svelte query persist client

### DIFF
--- a/packages/svelte-query-persist-client/tests/AwaitOnSuccess/AwaitOnSuccess.svelte
+++ b/packages/svelte-query-persist-client/tests/AwaitOnSuccess/AwaitOnSuccess.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
   import { sleep } from '@tanstack/query-test-utils'
-  import { sleep, StatelessRef } from '../utils.svelte.js'
+  import { StatelessRef } from '../utils.svelte.js'
 
   let { states }: { states: StatelessRef<Array<string>> } = $props()
 

--- a/packages/svelte-query-persist-client/tests/PersistQueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query-persist-client/tests/PersistQueryClientProvider.svelte.test.ts
@@ -9,12 +9,13 @@ import InitialData from './InitialData/Provider.svelte'
 import RemoveCache from './RemoveCache/Provider.svelte'
 import RestoreCache from './RestoreCache/Provider.svelte'
 import UseQueries from './UseQueries/Provider.svelte'
-import { StatelessRef, createQueryClient } from './utils.svelte.js'
+import { StatelessRef } from './utils.svelte.js'
 import type {
   PersistedClient,
   Persister,
 } from '@tanstack/query-persist-client-core'
 import type { StatusResult } from './utils.svelte.js'
+import { QueryClient } from '../../query-core/src'
 
 const createMockPersister = (): Persister => {
   let storedState: PersistedClient | undefined


### PR DESCRIPTION
Probably during the merge conflict resolution, some imports were not updated correctly. This commit fixes these imports in order to make all tests pass again.