### PR TITLE
style: disable the ESLint rule that removes Context.Provider

### DIFF
--- a/packages/react-query/eslint.config.js
+++ b/packages/react-query/eslint.config.js
@@ -11,6 +11,7 @@ export default [
   {
     files: ['**/*.{ts,tsx}'],
     ...pluginReact.configs.recommended,
+    '@eslint-react/no-context-provider': 'off',
   },
   {
     plugins: {


### PR DESCRIPTION
With the update to React version 19, we can now use Context without needing Context.Provider.

And the @eslint-react/eslint-plugin added a rule called @eslint-react/no-context-provider.

When this ESLint rule is enabled, auto-formatting in files like `react-query/src/QueryClientProvider.tsx` that use Provider will remove Context.Provider.

However, this behavior can negatively impact users on React versions below 19.

Therefore, in this PR, the rule has been turned off.