### PR TITLE
docs: update infinite query fetchNextPage examples

### DIFF
--- a/docs/framework/react/guides/infinite-queries.md
+++ b/docs/framework/react/guides/infinite-queries.md
@@ -82,7 +82,7 @@ function Projects() {
       <div>
         <button
           onClick={() => fetchNextPage()}
-          disabled={!hasNextPage || isFetchingNextPage}
+          disabled={!hasNextPage || isFetching}
         >
           {isFetchingNextPage
             ? 'Loading more...'
@@ -110,7 +110,7 @@ To ensure a seamless querying process without conflicts, it's highly recommended
 [//]: # 'Example1'
 
 ```jsx
-<List onEndReached={() => !isFetchingNextPage && fetchNextPage()} />
+<List onEndReached={() => hasNextPage && !isFetching && fetchNextPage()} />
 ```
 
 [//]: # 'Example1'


### PR DESCRIPTION
This PR updates the `fetchNextPage` examples of `useInfiniteQuery`. When used with a persister, checking `isFetchingNextPage` is not enough to control if the next page can be fetched as the initial `queryFn` might still be running while the cached data is displayed. Using `isFetching` instead of `isFetchingNextPage` prevents silently cancelling the request.

Related issues: https://github.com/TanStack/query/issues/5583, https://github.com/TanStack/query/discussions/6709, https://github.com/TanStack/query/discussions/9166