### PR TITLE
refactor(*): centralize NonUndefinedGuard type definition

### DIFF
--- a/packages/angular-query-experimental/src/infinite-query-options.ts
+++ b/packages/angular-query-experimental/src/infinite-query-options.ts
@@ -3,6 +3,7 @@ import type {
   DefaultError,
   InfiniteData,
   InitialDataFunction,
+  NonUndefinedGuard,
   OmitKeyof,
   QueryKey,
   SkipToken,
@@ -60,8 +61,6 @@ export type UnusedSkipTokenInfiniteOptions<
     SkipToken | undefined
   >
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type DefinedInitialDataInfiniteOptions<
   TQueryFnData,

--- a/packages/angular-query-experimental/src/query-options.ts
+++ b/packages/angular-query-experimental/src/query-options.ts
@@ -2,6 +2,7 @@ import type {
   DataTag,
   DefaultError,
   InitialDataFunction,
+  NonUndefinedGuard,
   OmitKeyof,
   QueryFunction,
   QueryKey,
@@ -35,8 +36,6 @@ export type UnusedSkipTokenOptions<
     SkipToken | undefined
   >
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -9,6 +9,8 @@ import type { QueryFilters, QueryTypeFilter, SkipToken } from './utils'
 import type { QueryCache } from './queryCache'
 import type { MutationCache } from './mutationCache'
 
+export type NonUndefinedGuard<T> = T extends undefined ? never : T
+
 export type DistributiveOmit<
   TObject,
   TKey extends keyof TObject,

--- a/packages/react-query/src/infiniteQueryOptions.ts
+++ b/packages/react-query/src/infiniteQueryOptions.ts
@@ -3,6 +3,7 @@ import type {
   DefaultError,
   InfiniteData,
   InitialDataFunction,
+  NonUndefinedGuard,
   OmitKeyof,
   QueryKey,
   SkipToken,
@@ -60,8 +61,6 @@ export type UnusedSkipTokenInfiniteOptions<
     SkipToken | undefined
   >
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type DefinedInitialDataInfiniteOptions<
   TQueryFnData,

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -2,6 +2,7 @@ import type {
   DataTag,
   DefaultError,
   InitialDataFunction,
+  NonUndefinedGuard,
   OmitKeyof,
   QueryFunction,
   QueryKey,
@@ -35,8 +36,6 @@ export type UnusedSkipTokenOptions<
     SkipToken | undefined
   >
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,

--- a/packages/solid-query/src/infiniteQueryOptions.ts
+++ b/packages/solid-query/src/infiniteQueryOptions.ts
@@ -2,6 +2,7 @@ import type {
   DataTag,
   DefaultError,
   InfiniteData,
+  NonUndefinedGuard,
   QueryKey,
 } from '@tanstack/query-core'
 import type { SolidInfiniteQueryOptions } from './types'
@@ -25,8 +26,6 @@ export type UndefinedInitialDataInfiniteOptions<
     initialData?: undefined
   }
 >
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type DefinedInitialDataInfiniteOptions<
   TQueryFnData,

--- a/packages/svelte-query/src/queryOptions.ts
+++ b/packages/svelte-query/src/queryOptions.ts
@@ -2,6 +2,7 @@ import type {
   DataTag,
   DefaultError,
   InitialDataFunction,
+  NonUndefinedGuard,
   QueryKey,
 } from '@tanstack/query-core'
 import type { CreateQueryOptions } from './types.js'
@@ -14,8 +15,6 @@ export type UndefinedInitialDataOptions<
 > = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
   initialData?: undefined | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,

--- a/packages/vue-query/src/infiniteQueryOptions.ts
+++ b/packages/vue-query/src/infiniteQueryOptions.ts
@@ -2,6 +2,7 @@ import type {
   DataTag,
   DefaultError,
   InfiniteData,
+  NonUndefinedGuard,
   QueryKey,
 } from '@tanstack/query-core'
 import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
@@ -22,8 +23,6 @@ export type UndefinedInitialDataInfiniteOptions<
 > & {
   initialData?: undefined
 }
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type DefinedInitialDataInfiniteOptions<
   TQueryFnData,

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -4,6 +4,7 @@ import type {
   DefaultError,
   DefinedQueryObserverResult,
   InitialDataFunction,
+  NonUndefinedGuard,
   QueryKey,
   QueryObserverOptions,
 } from '@tanstack/query-core'
@@ -15,8 +16,6 @@ import type {
   MaybeRefOrGetter,
 } from './types'
 import type { QueryClient } from './queryClient'
-
-type NonUndefinedGuard<T> = T extends undefined ? never : T
 
 export type UseQueryOptions<
   TQueryFnData = unknown,


### PR DESCRIPTION
Moved the `NonUndefinedGuard` type definition to the query-core package for better reusability across various query options files in angular, react, solid, svelte, and vue packages. Removed duplicate definitions from individual files.