### PR TITLE
New fix for hydration loop bug

### DIFF
--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -203,6 +203,7 @@ export function hydrate(
 
       let query = queryCache.get(queryHash)
       const existingQueryIsPending = query?.state.status === 'pending'
+      const existingQueryIsFetching = query?.state.fetchStatus === 'fetching'
 
       // Do not hydrate if an existing query exists with newer data
       if (query) {
@@ -249,6 +250,7 @@ export function hydrate(
       if (
         promise &&
         !existingQueryIsPending &&
+        !existingQueryIsFetching &&
         // Only hydrate if dehydration is newer than any existing data,
         // this is always true for new queries
         (dehydratedAt === undefined || dehydratedAt > query.state.dataUpdatedAt)

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -76,6 +76,7 @@ export const HydrationBoundary = ({
               existingQuery.state.dataUpdatedAt ||
             (dehydratedQuery.promise &&
               existingQuery.state.status !== 'pending' &&
+              existingQuery.state.fetchStatus !== 'fetching' &&
               dehydratedQuery.dehydratedAt !== undefined &&
               dehydratedQuery.dehydratedAt > existingQuery.state.dataUpdatedAt)
 
@@ -110,7 +111,6 @@ export const HydrationBoundary = ({
   React.useEffect(() => {
     if (hydrationQueue) {
       hydrate(client, { queries: hydrationQueue }, optionsRef.current)
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setHydrationQueue(undefined)
     }
   }, [client, hydrationQueue])

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -372,7 +372,6 @@ describe('React hydration', () => {
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
     let hydrationCount = 0
     hydrateSpy.mockImplementation((...args: Parameters<typeof hydrate>) => {
-      console.log('Hydrate spy')
       hydrationCount++
       // Arbitrary number
       if (hydrationCount > 10) {


### PR DESCRIPTION
This is a follow up from #9157

Closes #8677 (properly this time)

The original PR had faulty logic in the test, so it only fixed the loop bug under some very specific circumstances. The test was _also_ broken to start with, because the mock would call itself instead of the original unmocked function, very sloppy of me. 😞

The original PR checked for if the existing query was _pending_, but this in itself is not enough to fix the bug, so this PR also checks for if the original query is _fetching_. If it is, it does not hydrate the promise (again) and so breaks the loop.