### PR TITLE
feat(query-core): add MutationFunctionContext argument to mutateFn

### DIFF
--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -48,10 +48,11 @@ mutate(variables, {
 
 **Parameter1 (Options)**
 
-- `mutationFn: (variables: TVariables) => Promise<TData>`
+- `mutationFn: (variables: TVariables, context: MutationFunctionContext) => Promise<TData>`
   - **Required, but only if no default mutation function has been defined**
   - A function that performs an asynchronous task and returns a promise.
   - `variables` is an object that `mutate` will pass to your `mutationFn`
+  - `context` is an object that `mutate` will pass to your `mutationFn`. Contains reference to `QueryClient` and optional `meta` object.
 - `gcTime: number | Infinity`
   - The time in milliseconds that unused/inactive cache data remains in memory. When a mutation's cache becomes unused or inactive, that cache data will be garbage collected after this duration. When different cache times are specified, the longest one will be used.
   - If set to `Infinity`, will disable garbage collection

--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -50,8 +50,36 @@ describe('mutations', () => {
       'vars',
     )
 
+    const args = fn.mock.calls[0]!
+
     expect(fn).toHaveBeenCalledTimes(1)
-    expect(fn).toHaveBeenCalledWith('vars')
+    expect(args[0]).toEqual('vars')
+  })
+
+  test('should provide MutationFunctionContext to mutateFn', async () => {
+    const key = queryKey()
+    const fn = vi.fn()
+    const meta = { hello: 'world' }
+
+    await executeMutation(
+      queryClient,
+      {
+        mutationKey: key,
+        mutationFn: fn,
+        meta: meta,
+      },
+      'vars',
+    )
+
+    const args = fn.mock.calls[0]!
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(args).toBeDefined()
+
+    const vars = args[0]
+    const mutationFnContext = args[1]
+    expect(vars).toEqual('vars')
+    expect(mutationFnContext.client).toEqual(queryClient)
+    expect(mutationFnContext.meta).toEqual(meta)
   })
 
   test('mutation should set correct success states', async () => {

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -423,6 +423,7 @@ describe('core/utils', () => {
       const filters = { mutationKey: ['key1'] }
       const queryClient = new QueryClient()
       const mutation = new Mutation({
+        client: queryClient,
         mutationId: 1,
         mutationCache: queryClient.getMutationCache(),
         options: {},

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -99,6 +99,7 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
     state?: MutationState<TData, TError, TVariables, TContext>,
   ): Mutation<TData, TError, TVariables, TContext> {
     const mutation = new Mutation({
+      client: client,
       mutationCache: this,
       mutationId: ++this.#mutationId,
       options: client.defaultMutationOptions(options),

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1086,8 +1086,14 @@ export type MutationMeta = Register extends {
     : Record<string, unknown>
   : Record<string, unknown>
 
+export type MutationFunctionContext = {
+  client: QueryClient
+  meta: MutationMeta | undefined
+}
+
 export type MutationFunction<TData = unknown, TVariables = unknown> = (
   variables: TVariables,
+  mutationFnContext: MutationFunctionContext,
 ) => Promise<TData>
 
 export interface MutationOptions<


### PR DESCRIPTION
This PR adds new argument to `mutateFn` allowing for access to `queryClient` as well as `meta` object.

This feature should make it easier to attach authentication headers from within `mutateFn`, that would typically live in `QueryCache`. Currently that's made very difficult and requires either having singleton context in the codebase or requiring consumers of mutations to pass auth token each time.

This PR also makes it more similar to how `queryFn` behaves, in that it accepts `QueryFunctionContext`.

**Note**: I wasn't entirely sure about the name of `MutateFunctionContext`, but ultimately I decided to go ahead with that name to mirror the way `queryFn` behaves. I realise this might be suboptimal, due to there already existing a `TContext` for mutations. Happy to discuss and take direction here.