### PR TITLE
Support `Map` and `Set` as query keys

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -210,16 +210,21 @@ export function hashQueryKeyByOptions<TQueryKey extends QueryKey = QueryKey>(
  * Hashes the value into a stable hash.
  */
 export function hashKey(queryKey: QueryKey | MutationKey): string {
-  return JSON.stringify(queryKey, (_, val) =>
-    isPlainObject(val)
-      ? Object.keys(val)
+  return JSON.stringify(queryKey, (_, val) => {
+    const thingToHash =
+      val instanceof Map || val instanceof Set
+        ? Object.fromEntries([...val.entries()])
+        : val;
+
+    return isPlainObject(thingToHash)
+      ? Object.keys(thingToHash)
           .sort()
           .reduce((result, key) => {
-            result[key] = val[key]
-            return result
+            result[key] = thingToHash[key];
+            return result;
           }, {} as any)
-      : val,
-  )
+      : thingToHash;
+  });
 }
 
 /**


### PR DESCRIPTION
I'm not sure if this is intended to be supported but I figured it wouldn't hurt to open this pr. Feel free to close if we don't want to support `Map` and `Set` instances as query keys. But I found this useful for me.

JSON.stringify doesn't properly support instances of these types and will just return "{}". xref https://github.com/TanStack/query/discussions/6444