### PR TITLE
perf: improve performance of util function "difference" in quriesObserver.ts in query-core package

### DIFF
--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -10,7 +10,7 @@ import type {
 import type { QueryClient } from './queryClient'
 
 function difference<T>(array1: Array<T>, array2: Array<T>): Array<T> {
-  return array1.filter((x) => !array2.includes(x))
+  return array1.filter((x) => !new Set(array2).has(x))
 }
 
 function replaceAt<T>(array: Array<T>, index: number, value: T): Array<T> {

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -10,7 +10,8 @@ import type {
 import type { QueryClient } from './queryClient'
 
 function difference<T>(array1: Array<T>, array2: Array<T>): Array<T> {
-  return array1.filter((x) => !new Set(array2).has(x))
+  const excludeSet = new Set(array2)
+  return array1.filter((x) => !excludeSet.has(x))
 }
 
 function replaceAt<T>(array: Array<T>, index: number, value: T): Array<T> {


### PR DESCRIPTION
I changed the internal behavior of the "difference" function in **quriesObserver.ts** from **includes function** to using **has function** in sets

And this is faster when the arrays are longer. I included a link to the code sandbox below so you can see the specific performance differences.

## Codesandbox Link 
https://codesandbox.io/p/devbox/crazy-cherry-627tsr