### PR TITLE
Mention query keys needs to be serializable using `JSON.stringify`

### DIFF
--- a/docs/framework/react/guides/query-keys.md
+++ b/docs/framework/react/guides/query-keys.md
@@ -3,7 +3,7 @@ id: query-keys
 title: Query Keys
 ---
 
-At its core, TanStack Query manages query caching for you based on query keys. Query keys have to be an Array at the top level, and can be as simple as an Array with a single string, or as complex as an array of many strings and nested objects. As long as the query key is serializable, and **unique to the query's data**, you can use it!
+At its core, TanStack Query manages query caching for you based on query keys. Query keys have to be an Array at the top level, and can be as simple as an Array with a single string, or as complex as an array of many strings and nested objects. As long as the query key is serializable using `JSON.stringify`, and **unique to the query's data**, you can use it!
 
 ## Simple Query Keys
 


### PR DESCRIPTION
This was not clear to me and so maybe a useful addition to the docs.