### PR TITLE
fix(query-core): add reject callback to .then() in tryResolveSync

### DIFF
--- a/packages/query-core/src/thenable.ts
+++ b/packages/query-core/src/thenable.ts
@@ -98,7 +98,7 @@ export function tryResolveSync(promise: Promise<unknown> | Thenable<unknown>) {
     .then((result) => {
       data = result
       return result
-    })
+    }, noop)
     // .catch can be unavailable on certain kinds of thenable's
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     ?.catch(noop)


### PR DESCRIPTION
fixes https://github.com/TanStack/query/issues/9232

I encountered an error when using React Query prefetching in a Next.js app with the App Router.
The [official example](https://tanstack.com/query/latest/docs/framework/react/examples/nextjs-app-prefetching) works with Next.js 15, but running the same example on Next.js 14 causes an error if the prefetched query fails before hydration.

In Next.js 14, if a prefetched query fails quickly and `HydrationBoundary` tries to hydrate that query, the following error occurs:

> reject is not a function
<img width="568" alt="d8cf6a2e-5ca6-4ad5-957e-212a1c9718d3" src="https://github.com/user-attachments/assets/2f4ca21d-bf92-4c7f-b4cb-3bf64bf2725f" />

Here’s a CodeSandbox that reproduces the issue:
https://codesandbox.io/p/devbox/gifted-framework-fycm7x?workspaceId=ws_JRuwL4n9AbbzLmYKLLAozM

The error seems to originate from [this line](https://github.com/facebook/react/blob/c0464aedb16b1c970d717651bba8d1c66c578729/packages/react-server/src/ReactFlightReplyServer.js#L162) in React:

```ts
Chunk.prototype.then = function <T>(
  this: SomeChunk<T>,
  resolve: (value: T) => mixed,
  reject: (reason: mixed) => mixed,
) {

    // ... omit

    default:
      // 👇 reject is not a function!
      reject(chunk.reason);
      break;
```

This code assumes the `reject` callback is always defined. However, `tryResolveSync` currently does not pass the `reject` argument to `.then()`.

This issue does not occur in Next.js 15, which uses a different implementation.
It seems that [this code in React](https://github.com/facebook/react/blob/c0464aedb16b1c970d717651bba8d1c66c578729/packages/react-client/src/ReactFlightClient.js#L285-L289) is what Next.js 15 uses instead:

```ts
    default:
      if (reject) {
        reject(chunk.reason);
      }
      break;
```

Although `.catch()` is also present in `tryResolveSync`, it’s not sufficient for environments that rely on the second argument to `.then()` for error handling (like the one shown above).

This PR adds an explicit `reject` callback to the `.then()` call in `tryResolveSync` to ensure compatibility with those use cases and prevent runtime errors in apps using Next.js 14.

