### PR TITLE
fix(publish): resolve `cipublish` error on v4 branch

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -371,7 +371,10 @@ async function run() {
   changedPackages.forEach((pkg) => {
     const packageDir = path.join(rootDir, 'packages', pkg.packageDir)
 
-    const cmd = `cd ${packageDir} && pnpm publish --tag ${npmTag} --access=public --no-git-checks`
+    const cmd = `cd ${packageDir} && pnpm publish ${
+      // check v4, v5, v6, v7..., and if it's false, then it's a tag for npm (ex. latest, beta, alpha, rc)
+      /^v\d+$/.test(npmTag) ? `` : `--tag ${npmTag}`
+    } --access=public --no-git-checks`
     console.info(`  Publishing ${pkg.name}@${version} to npm...`)
     execSync(cmd, {
       stdio: [process.stdin, process.stdout, process.stderr],

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -372,7 +372,7 @@ async function run() {
     const packageDir = path.join(rootDir, 'packages', pkg.packageDir)
 
     const cmd = `cd ${packageDir} && pnpm publish --tag ${
-      // check v4, v5, v6, v7..., and if it's false, then it's a tag for npm (ex. latest, beta, alpha, rc)
+      // check npmTag is v{number}..., and if it's true, query-v{number}
       /^v\d+$/.test(npmTag) ? `query-${npmTag}` : npmTag
     } --access=public --no-git-checks`
     console.info(`  Publishing ${pkg.name}@${version} to npm...`)

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -371,9 +371,9 @@ async function run() {
   changedPackages.forEach((pkg) => {
     const packageDir = path.join(rootDir, 'packages', pkg.packageDir)
 
-    const cmd = `cd ${packageDir} && pnpm publish ${
+    const cmd = `cd ${packageDir} && pnpm publish --tag ${
       // check v4, v5, v6, v7..., and if it's false, then it's a tag for npm (ex. latest, beta, alpha, rc)
-      /^v\d+$/.test(npmTag) ? `` : `--tag ${npmTag}`
+      /^v\d+$/.test(npmTag) ? `query-${npmTag}` : npmTag
     } --access=public --no-git-checks`
     console.info(`  Publishing ${pkg.name}@${version} to npm...`)
     execSync(cmd, {


### PR DESCRIPTION
We can check [failed workflow](https://github.com/TanStack/query/actions/runs/15253548826/job/42895742832)

#### Below is the error message

```
Publishing all packages to npm with tag "v4"
  Publishing @tanstack/query-core@4.39.0 to npm...
  npm error Tag name must not be a valid SemVer range: v4
  npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-05-26T12_12_25_592Z-debug-0.log
  Error: Command failed: cd /home/runner/work/query/query/packages/query-core && pnpm publish --tag v4 --access=public --no-git-checks
```


## Fix publish failure when tag is set to v{number}

While publishing from the `v4` branch of TanStack Query, we encountered an issue caused by the [`tag option`](https://pnpm.io/cli/publish#--tag-tag). The current npm publish logic treats v4 as a valid [SemVer range](https://semver.org/), which triggers an error:

#### Below is the publish function node/22.12.0/lib/node_modules/npm/lib/commands

![image](https://github.com/user-attachments/assets/9ab894f7-3bba-4e6d-834d-5bda8ee94458)

I’ve tested this behavior locally with --dry-run, and the issue no longer occurs after rewriting --tag to query-v4 only for the v4 branch, not for main, beta, alpha, or rc.


## AS-IS(Not work)
v4 is valid range of semver so It can't be npm tag name
```shell
pnpm publish --tag v4 // invalid tag name
```

## To-BE(Work)
query-v4 is invalid range of semver, so it can be npm tag name
```shell
pnpm publish --tag query-v4 // valid tag name
```