### PR TITLE
refactor(query-core): extract context creation to functions and move type assertions

### DIFF
--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -54,22 +54,24 @@ export function infiniteQueryBehavior<TQueryFnData, TError, TData, TPageParam>(
             return Promise.resolve(data)
           }
 
-          const queryFnContext: OmitKeyof<
-            QueryFunctionContext<QueryKey, unknown>,
-            'signal'
-          > = {
-            client: context.client,
-            queryKey: context.queryKey,
-            pageParam: param,
-            direction: previous ? 'backward' : 'forward',
-            meta: context.options.meta,
+          const createQueryFnContext = () => {
+            const queryFnContext: OmitKeyof<
+              QueryFunctionContext<QueryKey, unknown>,
+              'signal'
+            > = {
+              client: context.client,
+              queryKey: context.queryKey,
+              pageParam: param,
+              direction: previous ? 'backward' : 'forward',
+              meta: context.options.meta,
+            }
+            addSignalProperty(queryFnContext)
+            return queryFnContext as QueryFunctionContext<QueryKey, unknown>
           }
 
-          addSignalProperty(queryFnContext)
+          const queryFnContext = createQueryFnContext()
 
-          const page = await queryFn(
-            queryFnContext as QueryFunctionContext<QueryKey, unknown>,
-          )
+          const page = await queryFn(queryFnContext)
 
           const { maxPages } = context.options
           const addTo = previous ? addToStart : addToEnd

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -17,7 +17,6 @@ import type {
   FetchStatus,
   InitialDataFunction,
   OmitKeyof,
-  QueryFunction,
   QueryFunctionContext,
   QueryKey,
   QueryMeta,
@@ -411,48 +410,59 @@ export class Query<
       const queryFn = ensureQueryFn(this.options, fetchOptions)
 
       // Create query function context
-      const queryFnContext: OmitKeyof<
-        QueryFunctionContext<TQueryKey>,
-        'signal'
-      > = {
-        client: this.#client,
-        queryKey: this.queryKey,
-        meta: this.meta,
+      const createQueryFnContext = (): QueryFunctionContext<TQueryKey> => {
+        const queryFnContext: OmitKeyof<
+          QueryFunctionContext<TQueryKey>,
+          'signal'
+        > = {
+          client: this.#client,
+          queryKey: this.queryKey,
+          meta: this.meta,
+        }
+        addSignalProperty(queryFnContext)
+        return queryFnContext as QueryFunctionContext<TQueryKey>
       }
 
-      addSignalProperty(queryFnContext)
+      const queryFnContext = createQueryFnContext()
 
       this.#abortSignalConsumed = false
       if (this.options.persister) {
         return this.options.persister(
-          queryFn as QueryFunction<any>,
-          queryFnContext as QueryFunctionContext<TQueryKey>,
+          queryFn,
+          queryFnContext,
           this as unknown as Query,
         )
       }
 
-      return queryFn(queryFnContext as QueryFunctionContext<TQueryKey>)
+      return queryFn(queryFnContext)
     }
 
     // Trigger behavior hook
-    const context: OmitKeyof<
-      FetchContext<TQueryFnData, TError, TData, TQueryKey>,
-      'signal'
-    > = {
-      fetchOptions,
-      options: this.options,
-      queryKey: this.queryKey,
-      client: this.#client,
-      state: this.state,
-      fetchFn,
+    const createFetchContext = (): FetchContext<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryKey
+    > => {
+      const context: OmitKeyof<
+        FetchContext<TQueryFnData, TError, TData, TQueryKey>,
+        'signal'
+      > = {
+        fetchOptions,
+        options: this.options,
+        queryKey: this.queryKey,
+        client: this.#client,
+        state: this.state,
+        fetchFn,
+      }
+
+      addSignalProperty(context)
+      return context as FetchContext<TQueryFnData, TError, TData, TQueryKey>
     }
 
-    addSignalProperty(context)
+    const context = createFetchContext()
 
-    this.options.behavior?.onFetch(
-      context as FetchContext<TQueryFnData, TError, TData, TQueryKey>,
-      this as unknown as Query,
-    )
+    this.options.behavior?.onFetch(context, this as unknown as Query)
 
     // Store state in case the current fetch needs to be reverted
     this.#revertState = this.state


### PR DESCRIPTION
This refactor extracts the creation of the query function context and fetch context into dedicated helper functions (e.g., `createQueryFnContext`), improving code readability. This change:

- Moves type assertions and type handling higher up, reducing inline type noise and making type boundaries clearer.
- Replaces ad-hoc object construction with a function that does one thing (build query contexts).

No functional behavior is changed; this is a structural and type-safety improvement.