### PR TITLE
refactor(react-query): change the order of const variables

### DIFF
--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -49,9 +49,9 @@ export function useBaseQuery<
     }
   }
 
-  const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
   const errorResetBoundary = useQueryErrorResetBoundary()
+  const client = useQueryClient(queryClient)
   const defaultedOptions = client.defaultQueryOptions(options)
 
   ;(client.getDefaultOptions().queries as any)?._experimental_beforeQuery?.(


### PR DESCRIPTION
I changed the order of some const variables. This is more readable because those two sentences

```
const client = useQueryClient(queryClient)
const defaultedOptions = client.defaultQueryOptions(options)
```

are one set 