### PR TITLE
docs: clarify and complete example for overriding callbacks in mutate()

### DIFF
--- a/docs/framework/react/guides/mutations.md
+++ b/docs/framework/react/guides/mutations.md
@@ -182,4 +182,27 @@ useMutation({
 
 [//]: # 'Example5'
 
-You might find that you want to **trigger additional callbacks** beyond the ones defined on `useMutation` when calling `mutate`. This can be used to trigger component-specific side effects. To do that, you can provide any of the same callback options to the `
+You might find that you want to **trigger additional callbacks** beyond the ones defined on `useMutation` when calling `mutate`. This can be used to trigger component-specific side effects. To do that, you can provide any of the same callback options (eg. `onSuccess`, `onError`, or `onSettled`) to the `mutate` function as its second argument. These will override or supplement the default callbacks defined in the hook, providing more you with more component-level control.
+
+[//]: # 'Example6'
+
+```tsx
+const mutation = useMutation({
+  mutationFn: createUser,
+  onSuccess: () => {
+    console.log('Default success handler');
+  },
+});
+
+mutation.mutate(newUserData, {
+  onSuccess: (data) => {
+    console.log('This runs only for this specific mutation call:', data);
+  },
+  onError: (error) => {
+    console.error('This error handler is specific to this call:', error);
+  },
+});
+```
+
+[//]: # 'Example6'
+


### PR DESCRIPTION
This PR improves the documentation by completing the explanation of how to provide per-call callbacks to the mutate function. It includes a code example that shows how to override default mutation callbacks for component-specific behavior.