### PR TITLE
refactor: simplify `setQueryData` by using `ensure` directly instead of `get` then `ensure`

### DIFF
--- a/packages/query-broadcast-client-experimental/src/index.ts
+++ b/packages/query-broadcast-client-experimental/src/index.ts
@@ -78,7 +78,7 @@ export function broadcastQueryClient({
           return
         }
 
-        queryCache.build(
+        queryCache.ensure(
           queryClient,
           {
             queryKey,
@@ -95,7 +95,7 @@ export function broadcastQueryClient({
           query.setState(state)
           return
         }
-        queryCache.build(
+        queryCache.ensure(
           queryClient,
           {
             queryKey,

--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -261,7 +261,7 @@ describe('mutations', () => {
 
     const mutation = queryClient
       .getMutationCache()
-      .build<string, unknown, string, string>(
+      .create<string, unknown, string, string>(
         queryClient,
         {
           mutationKey: key,
@@ -329,7 +329,7 @@ describe('mutations', () => {
   test('addObserver should not add an existing observer', () => {
     const mutationCache = queryClient.getMutationCache()
     const observer = new MutationObserver(queryClient, {})
-    const currentMutation = mutationCache.build(queryClient, {})
+    const currentMutation = mutationCache.create(queryClient, {})
 
     const fn = vi.fn()
 

--- a/packages/query-core/src/__tests__/utils.ts
+++ b/packages/query-core/src/__tests__/utils.ts
@@ -17,7 +17,7 @@ export function executeMutation<TVariables>(
 ) {
   return queryClient
     .getMutationCache()
-    .build(queryClient, options)
+    .create(queryClient, options)
     .execute(variables)
 }
 

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -184,7 +184,7 @@ export function hydrate(
   const queries = (dehydratedState as DehydratedState).queries || []
 
   mutations.forEach(({ state, ...mutationOptions }) => {
-    mutationCache.build(
+    mutationCache.create(
       client,
       {
         ...client.getDefaultOptions().hydrate?.mutations,
@@ -227,7 +227,7 @@ export function hydrate(
         }
       } else {
         // Restore query
-        query = queryCache.build(
+        query = queryCache.ensure(
           client,
           {
             ...client.getDefaultOptions().hydrate?.queries,

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -97,7 +97,7 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
    * Creates a new mutation instance and adds it to the cache.
    * Unlike QueryCache.ensure(), this always creates a new mutation since
    * each mutation execution should be unique.
-   * 
+   *
    * @param client - The QueryClient instance
    * @param options - Mutation options
    * @param state - Optional initial state for the new mutation

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -93,7 +93,17 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
     this.#mutationId = 0
   }
 
-  build<TData, TError, TVariables, TContext>(
+  /**
+   * Creates a new mutation instance and adds it to the cache.
+   * Unlike QueryCache.ensure(), this always creates a new mutation since
+   * each mutation execution should be unique.
+   * 
+   * @param client - The QueryClient instance
+   * @param options - Mutation options
+   * @param state - Optional initial state for the new mutation
+   * @returns A new Mutation instance
+   */
+  create<TData, TError, TVariables, TContext>(
     client: QueryClient,
     options: MutationOptions<TData, TError, TVariables, TContext>,
     state?: MutationState<TData, TError, TVariables, TContext>,

--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -118,7 +118,7 @@ export class MutationObserver<
 
     this.#currentMutation = this.#client
       .getMutationCache()
-      .build(this.#client, this.options)
+      .create(this.#client, this.options)
 
     this.#currentMutation.addObserver(this)
 

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -100,7 +100,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
   /**
    * Ensures a query exists in the cache, creating it if it doesn't exist.
    * This is the primary method for ensuring a query exists in the cache.
-   * 
+   *
    * @param client - The QueryClient instance
    * @param options - Query options including the queryKey
    * @param state - Optional initial state for newly created queries
@@ -174,7 +174,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
 
   /**
    * Retrieves an existing query from the cache by its hash.
-   * 
+   *
    * @param queryHash - The hash string identifying the query
    * @returns The existing Query instance, or undefined if not found
    */

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -97,7 +97,16 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     this.#queries = new Map<string, Query>()
   }
 
-  build<
+  /**
+   * Ensures a query exists in the cache, creating it if it doesn't exist.
+   * This is the primary method for ensuring a query exists in the cache.
+   * 
+   * @param client - The QueryClient instance
+   * @param options - Query options including the queryKey
+   * @param state - Optional initial state for newly created queries
+   * @returns Always returns a Query instance (creates one if needed)
+   */
+  ensure<
     TQueryFnData = unknown,
     TError = DefaultError,
     TData = TQueryFnData,
@@ -163,6 +172,12 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     })
   }
 
+  /**
+   * Retrieves an existing query from the cache by its hash.
+   * 
+   * @param queryHash - The hash string identifying the query
+   * @returns The existing Query instance, or undefined if not found
+   */
   get<
     TQueryFnData = unknown,
     TError = DefaultError,

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -147,7 +147,7 @@ export class QueryClient {
     options: EnsureQueryDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   ): Promise<TData> {
     const defaultedOptions = this.defaultQueryOptions(options)
-    const query = this.#queryCache.build(this, defaultedOptions)
+    const query = this.#queryCache.ensure(this, defaultedOptions)
     const cachedData = query.state.data
 
     if (cachedData === undefined) {
@@ -205,7 +205,7 @@ export class QueryClient {
     }
 
     return this.#queryCache
-      .build(this, defaultedOptions)
+      .ensure(this, defaultedOptions)
       .setData(data, { ...options, manual: true })
   }
 
@@ -361,7 +361,7 @@ export class QueryClient {
       defaultedOptions.retry = false
     }
 
-    const query = this.#queryCache.build(this, defaultedOptions)
+    const query = this.#queryCache.ensure(this, defaultedOptions)
 
     return query.isStaleByTime(
       resolveStaleTime(defaultedOptions.staleTime, query),

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -194,19 +194,18 @@ export class QueryClient {
       QueryKey
     >({ queryKey })
 
-    const query = this.#queryCache.get<TInferredQueryFnData>(
-      defaultedOptions.queryHash,
+    const query = this.#queryCache.ensure<TInferredQueryFnData>(
+      this,
+      defaultedOptions,
     )
-    const prevData = query?.state.data
+    const prevData = query.state.data
     const data = functionalUpdate(updater, prevData)
 
     if (data === undefined) {
       return undefined
     }
 
-    return this.#queryCache
-      .ensure(this, defaultedOptions)
-      .setData(data, { ...options, manual: true })
+    return query.setData(data, { ...options, manual: true })
   }
 
   setQueriesData<

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -232,7 +232,7 @@ export class QueryObserver<
       TQueryKey
     >,
   ): QueryObserverResult<TData, TError> {
-    const query = this.#client.getQueryCache().build(this.#client, options)
+    const query = this.#client.getQueryCache().ensure(this.#client, options)
 
     const result = this.createResult(query, options)
 
@@ -306,7 +306,7 @@ export class QueryObserver<
 
     const query = this.#client
       .getQueryCache()
-      .build(this.#client, defaultedOptions)
+      .ensure(this.#client, defaultedOptions)
 
     return query.fetch().then(() => this.createResult(query, defaultedOptions))
   }
@@ -691,7 +691,7 @@ export class QueryObserver<
   }
 
   #updateQuery(): void {
-    const query = this.#client.getQueryCache().build(this.#client, this.options)
+    const query = this.#client.getQueryCache().ensure(this.#client, this.options)
 
     if (query === this.#currentQuery) {
       return

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -691,7 +691,9 @@ export class QueryObserver<
   }
 
   #updateQuery(): void {
-    const query = this.#client.getQueryCache().ensure(this.#client, this.options)
+    const query = this.#client
+      .getQueryCache()
+      .ensure(this.#client, this.options)
 
     if (query === this.#currentQuery) {
       return

--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -18,7 +18,7 @@ describe('persistQueryClientSubscribe', () => {
       dehydrateOptions: { shouldDehydrateMutation: () => true },
     })
 
-    queryClient.getMutationCache().build(queryClient, {
+    queryClient.getMutationCache().create(queryClient, {
       mutationFn: (text: string) => Promise.resolve(text),
     })
 


### PR DESCRIPTION
This commit builds on the changes from #9216.

Refactored the `setQueryData` method in `QueryClient` to simplify its logic and improve readability.

The previous implementation of `setQueryData` was redundant:

1. It first called `this.#queryCache.get()` to retrieve an existing query.
2. Then, it called `this.#queryCache.ensure()` which internally also performs a "get or create" operation.

This meant the query was potentially being retrieved or checked for existence twice. The `ensure()` method already handles the logic of getting an existing query or creating a new one if it doesn't exist.

The `setQueryData` method has been updated to:

1. Directly call `this.#queryCache.ensure()` to get or create the query.
2. Use the returned query instance to access `state.data` for the `functionalUpdate`.
3. Call `setData()` on the same query instance.

**Before:**

```typescript
    const query = this.#queryCache.get<TInferredQueryFnData>(
      defaultedOptions.queryHash,
    )
    const prevData = query?.state.data
    const data = functionalUpdate(updater, prevData)

    if (data === undefined) {
      return undefined
    }

    return this.#queryCache
      .ensure(this, defaultedOptions)
      .setData(data, { ...options, manual: true })
```

**After:**

```typescript
    const query = this.#queryCache.ensure<TInferredQueryFnData>(
      this,
      defaultedOptions,
    )
    const prevData = query.state.data
    const data = functionalUpdate(updater, prevData)

    if (data === undefined) {
      return undefined
    }

    return query.setData(data, { ...options, manual: true })
```