### PR TITLE
refactor(query-core): add "Set" instead of "includes"

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -261,13 +261,14 @@ export function replaceEqualDeep(a: any, b: any): any {
     const bItems = array ? b : Object.keys(b)
     const bSize = bItems.length
     const copy: any = array ? [] : {}
+    const aItemsSet = new Set(aItems)
 
     let equalItems = 0
 
     for (let i = 0; i < bSize; i++) {
       const key = array ? i : bItems[i]
       if (
-        ((!array && aItems.includes(key)) || array) &&
+        ((!array && aItemsSet.has(key)) || array) &&
         a[key] === undefined &&
         b[key] === undefined
       ) {


### PR DESCRIPTION
The function "include" has O(n) complexity. I changed "include" to "has" in Set. So, it would be faster than original function 