### PR TITLE
Make hydrationQueue a derived value

### DIFF
--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -56,6 +56,10 @@ export const HydrationBoundary = ({
         }
 
         const queryCache = client.getQueryCache()
+        // State is supplied from the outside and we might as well fail
+        // gracefully if it has the wrong shape, so while we type `queries`
+        // as required, we still provide a fallback.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         const queries = (state as DehydratedState).queries || []
 
         const newQueries: DehydratedState['queries'] = []


### PR DESCRIPTION
After the fixes in:

https://github.com/TanStack/query/pull/9157
https://github.com/TanStack/query/pull/9188

I noticed a version of this bug was still happening: https://github.com/TanStack/query/issues/8677

@TkDodo Pointed out a potential solution, which is to move `hydrationQueue` from being a state, to being a derived value instead.

I think this makes a lot of sense. It should always be safe to recalculate this and there should be no situation where the component rerenders without the effect running where we want to preserve the values.

Tests are passing without changes.