### PR TITLE
docs(readme): fix broken Speakeasy image by replacing removed _build path with public asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ Still on **React Query v4**? No problem! Check out the v4 docs here: https://tan
 <a href="https://www.speakeasy.com/product/react-query?utm_source=tanstack&utm_campaign=tanstack">
   <picture>
     <source
-      srcset="https://tanstack.com/_build/assets/speakeasy-dark-BjP-Hd9M.svg"
+      srcset="https://tanstack.com/assets/speakeasy-dark-BjP-Hd9M.svg"
       media="(prefers-color-scheme: dark)"
     />
     <source
-      srcset="https://tanstack.com/_build/assets/speakeasy-light-UpY7QmwQ.svg"
+      srcset="https://tanstack.com/assets/speakeasy-light-UpY7QmwQ.svg"
       media="(prefers-color-scheme: light)"
     />
     <!-- fallback -->
     <img
-      src="https://tanstack.com/_build/assets/speakeasy-light-UpY7QmwQ.svg"
+      src="https://tanstack.com/assets/speakeasy-light-UpY7QmwQ.svg"
       alt="Speakeasy Logo"
     />
   </picture>


### PR DESCRIPTION
## Problem
The Speakeasy sponsor image in the README was previously using a `_build/assets/...` path.
This file seems to have been removed or moved, causing the image to break on GitHub.

While the path may have been valid before, `_build/` is generally reserved for internal static site builds (e.g. tanstack.com), and is not guaranteed to be stable or public.

## Solution
Replaced the `_build` path with a stable public URL under `https://tanstack.com/assets/`, which ensures consistent rendering on GitHub, npm, and other markdown consumers.

## Result
- Broken image is resolved
- The link is more stable and less dependent on internal site build structure