### PR TITLE
fix(vue-query): make vue-query client compatible with query-core

### DIFF
--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -32,8 +32,8 @@ function getAppMock(withUnmountHook = false): TestApp {
     unmount: vi.fn(),
     onUnmount: withUnmountHook
       ? vi.fn((u: UnmountCallback) => {
-        mock._unmount = u
-      })
+          mock._unmount = u
+        })
       : undefined,
     mixin: (m: ComponentOptions) => {
       mock._mixin = m

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -32,8 +32,8 @@ function getAppMock(withUnmountHook = false): TestApp {
     unmount: vi.fn(),
     onUnmount: withUnmountHook
       ? vi.fn((u: UnmountCallback) => {
-          mock._unmount = u
-        })
+        mock._unmount = u
+      })
       : undefined,
     mixin: (m: ComponentOptions) => {
       mock._mixin = m
@@ -269,11 +269,11 @@ describe('VueQueryPlugin', () => {
         ],
       })
 
-      expect(customClient.isRestoring.value).toBeTruthy()
+      expect(customClient.isRestoring?.value).toBeTruthy()
 
       await sleep(0)
 
-      expect(customClient.isRestoring.value).toBeFalsy()
+      expect(customClient.isRestoring?.value).toBeFalsy()
     })
 
     test('should delay useQuery subscription and not call fetcher if data is not stale', async () => {
@@ -311,14 +311,14 @@ describe('VueQueryPlugin', () => {
         customClient,
       )
 
-      expect(customClient.isRestoring.value).toBeTruthy()
+      expect(customClient.isRestoring?.value).toBeTruthy()
       expect(query.isFetching.value).toBeFalsy()
       expect(query.data.value).toStrictEqual(undefined)
       expect(fnSpy).toHaveBeenCalledTimes(0)
 
       await sleep(0)
 
-      expect(customClient.isRestoring.value).toBeFalsy()
+      expect(customClient.isRestoring?.value).toBeFalsy()
       expect(query.data.value).toStrictEqual({ foo: 'bar' })
       expect(fnSpy).toHaveBeenCalledTimes(0)
     })
@@ -373,7 +373,7 @@ describe('VueQueryPlugin', () => {
         customClient,
       )
 
-      expect(customClient.isRestoring.value).toBeTruthy()
+      expect(customClient.isRestoring?.value).toBeTruthy()
 
       expect(query.isFetching.value).toBeFalsy()
       expect(query.data.value).toStrictEqual(undefined)
@@ -384,7 +384,7 @@ describe('VueQueryPlugin', () => {
 
       await sleep(0)
 
-      expect(customClient.isRestoring.value).toBeFalsy()
+      expect(customClient.isRestoring?.value).toBeFalsy()
       expect(query.data.value).toStrictEqual({ foo1: 'bar1' })
       expect(queries.value[0].data).toStrictEqual({ foo2: 'bar2' })
       expect(fnSpy).toHaveBeenCalledTimes(0)

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -44,7 +44,7 @@ export class QueryClient extends QC {
     super(vueQueryConfig)
   }
 
-  isRestoring: Ref<boolean> = ref(false)
+  isRestoring?: Ref<boolean> = ref(false)
 
   isFetching(filters: MaybeRefDeep<QueryFilters> = {}): number {
     return super.isFetching(cloneDeepUnref(filters))

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -29,11 +29,11 @@ export type UseBaseQueryReturnType<
   TResult = QueryObserverResult<TData, TError>,
 > = {
   [K in keyof TResult]: K extends
-    | 'fetchNextPage'
-    | 'fetchPreviousPage'
-    | 'refetch'
-    ? TResult[K]
-    : Ref<Readonly<TResult>[K]>
+  | 'fetchNextPage'
+  | 'fetchPreviousPage'
+  | 'refetch'
+  ? TResult[K]
+  : Ref<Readonly<TResult>[K]>
 } & {
   suspense: () => Promise<TResult>
 }
@@ -93,7 +93,7 @@ export function useBaseQuery<
       TQueryKey
     > = client.defaultQueryOptions(clonedOptions)
 
-    defaulted._optimisticResults = client.isRestoring.value
+    defaulted._optimisticResults = client.isRestoring?.value
       ? 'isRestoring'
       : 'optimistic'
 
@@ -110,18 +110,20 @@ export function useBaseQuery<
     // noop
   }
 
-  watch(
-    client.isRestoring,
-    (isRestoring) => {
-      if (!isRestoring) {
-        unsubscribe()
-        unsubscribe = observer.subscribe((result) => {
-          updateState(state, result)
-        })
-      }
-    },
-    { immediate: true },
-  )
+  if (client.isRestoring) {
+    watch(
+      client.isRestoring,
+      (isRestoring) => {
+        if (!isRestoring) {
+          unsubscribe()
+          unsubscribe = observer.subscribe((result) => {
+            updateState(state, result)
+          })
+        }
+      },
+      { immediate: true },
+    )
+  }
 
   const updater = () => {
     observer.setOptions(defaultedOptions.value)

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -29,11 +29,11 @@ export type UseBaseQueryReturnType<
   TResult = QueryObserverResult<TData, TError>,
 > = {
   [K in keyof TResult]: K extends
-  | 'fetchNextPage'
-  | 'fetchPreviousPage'
-  | 'refetch'
-  ? TResult[K]
-  : Ref<Readonly<TResult>[K]>
+    | 'fetchNextPage'
+    | 'fetchPreviousPage'
+    | 'refetch'
+    ? TResult[K]
+    : Ref<Readonly<TResult>[K]>
 } & {
   suspense: () => Promise<TResult>
 }

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -44,69 +44,69 @@ type SkipTokenForUseQueries = symbol
 type GetUseQueryOptionsForUseQueries<T> =
   // Part 1: if UseQueryOptions are already being sent through, then just return T
   T extends UseQueryOptions
-    ? DeepUnwrapRef<T>
-    : // Part 2: responsible for applying explicit type parameter to function arguments, if object { queryFnData: TQueryFnData, error: TError, data: TData }
-      T extends {
-          queryFnData: infer TQueryFnData
-          error?: infer TError
-          data: infer TData
-        }
-      ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
-      : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-        ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
-        : T extends { data: infer TData; error?: infer TError }
-          ? UseQueryOptionsForUseQueries<unknown, TError, TData>
-          : // Part 3: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
-            T extends [infer TQueryFnData, infer TError, infer TData]
-            ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
-            : T extends [infer TQueryFnData, infer TError]
-              ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
-              : T extends [infer TQueryFnData]
-                ? UseQueryOptionsForUseQueries<TQueryFnData>
-                : // Part 4: responsible for inferring and enforcing type if no explicit parameter was provided
-                  T extends {
-                      queryFn?:
-                        | QueryFunction<infer TQueryFnData, infer TQueryKey>
-                        | SkipTokenForUseQueries
-                      select?: (data: any) => infer TData
-                      throwOnError?: ThrowOnError<any, infer TError, any, any>
-                    }
-                  ? UseQueryOptionsForUseQueries<
-                      TQueryFnData,
-                      unknown extends TError ? DefaultError : TError,
-                      unknown extends TData ? TQueryFnData : TData,
-                      TQueryKey
-                    >
-                  : T extends {
-                        queryFn?:
-                          | QueryFunction<infer TQueryFnData, infer TQueryKey>
-                          | SkipTokenForUseQueries
-                        throwOnError?: ThrowOnError<any, infer TError, any, any>
-                      }
-                    ? UseQueryOptionsForUseQueries<
-                        TQueryFnData,
-                        TError,
-                        TQueryFnData,
-                        TQueryKey
-                      >
-                    : // Fallback
-                      UseQueryOptionsForUseQueries
+  ? DeepUnwrapRef<T>
+  : // Part 2: responsible for applying explicit type parameter to function arguments, if object { queryFnData: TQueryFnData, error: TError, data: TData }
+  T extends {
+    queryFnData: infer TQueryFnData
+    error?: infer TError
+    data: infer TData
+  }
+  ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
+  : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
+  ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
+  : T extends { data: infer TData; error?: infer TError }
+  ? UseQueryOptionsForUseQueries<unknown, TError, TData>
+  : // Part 3: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
+  T extends [infer TQueryFnData, infer TError, infer TData]
+  ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
+  : T extends [infer TQueryFnData, infer TError]
+  ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
+  : T extends [infer TQueryFnData]
+  ? UseQueryOptionsForUseQueries<TQueryFnData>
+  : // Part 4: responsible for inferring and enforcing type if no explicit parameter was provided
+  T extends {
+    queryFn?:
+    | QueryFunction<infer TQueryFnData, infer TQueryKey>
+    | SkipTokenForUseQueries
+    select?: (data: any) => infer TData
+    throwOnError?: ThrowOnError<any, infer TError, any, any>
+  }
+  ? UseQueryOptionsForUseQueries<
+    TQueryFnData,
+    unknown extends TError ? DefaultError : TError,
+    unknown extends TData ? TQueryFnData : TData,
+    TQueryKey
+  >
+  : T extends {
+    queryFn?:
+    | QueryFunction<infer TQueryFnData, infer TQueryKey>
+    | SkipTokenForUseQueries
+    throwOnError?: ThrowOnError<any, infer TError, any, any>
+  }
+  ? UseQueryOptionsForUseQueries<
+    TQueryFnData,
+    TError,
+    TQueryFnData,
+    TQueryKey
+  >
+  : // Fallback
+  UseQueryOptionsForUseQueries
 
 // A defined initialData setting should return a DefinedQueryObserverResult rather than QueryObserverResult
 type GetDefinedOrUndefinedQueryResult<T, TData, TError = unknown> = T extends {
   initialData?: infer TInitialData
 }
   ? unknown extends TInitialData
-    ? QueryObserverResult<TData, TError>
-    : TInitialData extends TData
-      ? DefinedQueryObserverResult<TData, TError>
-      : TInitialData extends () => infer TInitialDataResult
-        ? unknown extends TInitialDataResult
-          ? QueryObserverResult<TData, TError>
-          : TInitialDataResult extends TData
-            ? DefinedQueryObserverResult<TData, TError>
-            : QueryObserverResult<TData, TError>
-        : QueryObserverResult<TData, TError>
+  ? QueryObserverResult<TData, TError>
+  : TInitialData extends TData
+  ? DefinedQueryObserverResult<TData, TError>
+  : TInitialData extends () => infer TInitialDataResult
+  ? unknown extends TInitialDataResult
+  ? QueryObserverResult<TData, TError>
+  : TInitialDataResult extends TData
+  ? DefinedQueryObserverResult<TData, TError>
+  : QueryObserverResult<TData, TError>
+  : QueryObserverResult<TData, TError>
   : QueryObserverResult<TData, TError>
 
 type GetUseQueryResult<T> =
@@ -118,51 +118,51 @@ type GetUseQueryResult<T> =
     any,
     any
   >
-    ? GetDefinedOrUndefinedQueryResult<
-        T,
-        undefined extends TData ? TQueryFnData : TData,
-        unknown extends TError ? DefaultError : TError
-      >
-    : // Part 2: responsible for mapping explicit type parameter to function result, if object
-      T extends { queryFnData: any; error?: infer TError; data: infer TData }
-      ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
-      : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-        ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
-        : T extends { data: infer TData; error?: infer TError }
-          ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
-          : // Part 3: responsible for mapping explicit type parameter to function result, if tuple
-            T extends [any, infer TError, infer TData]
-            ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
-            : T extends [infer TQueryFnData, infer TError]
-              ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
-              : T extends [infer TQueryFnData]
-                ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData>
-                : // Part 4: responsible for mapping inferred type to results, if no explicit parameter was provided
-                  T extends {
-                      queryFn?:
-                        | QueryFunction<infer TQueryFnData, any>
-                        | SkipTokenForUseQueries
-                      select?: (data: any) => infer TData
-                      throwOnError?: ThrowOnError<any, infer TError, any, any>
-                    }
-                  ? GetDefinedOrUndefinedQueryResult<
-                      T,
-                      unknown extends TData ? TQueryFnData : TData,
-                      unknown extends TError ? DefaultError : TError
-                    >
-                  : T extends {
-                        queryFn?:
-                          | QueryFunction<infer TQueryFnData, any>
-                          | SkipTokenForUseQueries
-                        throwOnError?: ThrowOnError<any, infer TError, any, any>
-                      }
-                    ? GetDefinedOrUndefinedQueryResult<
-                        T,
-                        TQueryFnData,
-                        unknown extends TError ? DefaultError : TError
-                      >
-                    : // Fallback
-                      QueryObserverResult
+  ? GetDefinedOrUndefinedQueryResult<
+    T,
+    undefined extends TData ? TQueryFnData : TData,
+    unknown extends TError ? DefaultError : TError
+  >
+  : // Part 2: responsible for mapping explicit type parameter to function result, if object
+  T extends { queryFnData: any; error?: infer TError; data: infer TData }
+  ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+  : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
+  ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
+  : T extends { data: infer TData; error?: infer TError }
+  ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+  : // Part 3: responsible for mapping explicit type parameter to function result, if tuple
+  T extends [any, infer TError, infer TData]
+  ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+  : T extends [infer TQueryFnData, infer TError]
+  ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
+  : T extends [infer TQueryFnData]
+  ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData>
+  : // Part 4: responsible for mapping inferred type to results, if no explicit parameter was provided
+  T extends {
+    queryFn?:
+    | QueryFunction<infer TQueryFnData, any>
+    | SkipTokenForUseQueries
+    select?: (data: any) => infer TData
+    throwOnError?: ThrowOnError<any, infer TError, any, any>
+  }
+  ? GetDefinedOrUndefinedQueryResult<
+    T,
+    unknown extends TData ? TQueryFnData : TData,
+    unknown extends TError ? DefaultError : TError
+  >
+  : T extends {
+    queryFn?:
+    | QueryFunction<infer TQueryFnData, any>
+    | SkipTokenForUseQueries
+    throwOnError?: ThrowOnError<any, infer TError, any, any>
+  }
+  ? GetDefinedOrUndefinedQueryResult<
+    T,
+    TQueryFnData,
+    unknown extends TError ? DefaultError : TError
+  >
+  : // Fallback
+  QueryObserverResult
 
 /**
  * UseQueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
@@ -174,37 +174,37 @@ export type UseQueriesOptions<
 > = TDepth['length'] extends MAXIMUM_DEPTH
   ? Array<UseQueryOptionsForUseQueries>
   : T extends []
-    ? []
-    : T extends [infer Head]
-      ? [...TResults, GetUseQueryOptionsForUseQueries<Head>]
-      : T extends [infer Head, ...infer Tails]
-        ? UseQueriesOptions<
-            [...Tails],
-            [...TResults, GetUseQueryOptionsForUseQueries<Head>],
-            [...TDepth, 1]
-          >
-        : ReadonlyArray<unknown> extends T
-          ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
-            // use this to infer the param types in the case of Array.map() argument
-            T extends Array<
-                UseQueryOptionsForUseQueries<
-                  infer TQueryFnData,
-                  infer TError,
-                  infer TData,
-                  infer TQueryKey
-                >
-              >
-            ? Array<
-                UseQueryOptionsForUseQueries<
-                  TQueryFnData,
-                  TError,
-                  TData,
-                  TQueryKey
-                >
-              >
-            : // Fallback
-              Array<UseQueryOptionsForUseQueries>
+  ? []
+  : T extends [infer Head]
+  ? [...TResults, GetUseQueryOptionsForUseQueries<Head>]
+  : T extends [infer Head, ...infer Tails]
+  ? UseQueriesOptions<
+    [...Tails],
+    [...TResults, GetUseQueryOptionsForUseQueries<Head>],
+    [...TDepth, 1]
+  >
+  : ReadonlyArray<unknown> extends T
+  ? T
+  : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+  // use this to infer the param types in the case of Array.map() argument
+  T extends Array<
+    UseQueryOptionsForUseQueries<
+      infer TQueryFnData,
+      infer TError,
+      infer TData,
+      infer TQueryKey
+    >
+  >
+  ? Array<
+    UseQueryOptionsForUseQueries<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryKey
+    >
+  >
+  : // Fallback
+  Array<UseQueryOptionsForUseQueries>
 
 /**
  * UseQueriesResults reducer recursively maps type param to results
@@ -216,16 +216,16 @@ export type UseQueriesResults<
 > = TDepth['length'] extends MAXIMUM_DEPTH
   ? Array<QueryObserverResult>
   : T extends []
-    ? []
-    : T extends [infer Head]
-      ? [...TResults, GetUseQueryResult<Head>]
-      : T extends [infer Head, ...infer Tails]
-        ? UseQueriesResults<
-            [...Tails],
-            [...TResults, GetUseQueryResult<Head>],
-            [...TDepth, 1]
-          >
-        : { [K in keyof T]: GetUseQueryResult<T[K]> }
+  ? []
+  : T extends [infer Head]
+  ? [...TResults, GetUseQueryResult<Head>]
+  : T extends [infer Head, ...infer Tails]
+  ? UseQueriesResults<
+    [...Tails],
+    [...TResults, GetUseQueryResult<Head>],
+    [...TDepth, 1]
+  >
+  : { [K in keyof T]: GetUseQueryResult<T[K]> }
 
 type UseQueriesOptionsArg<T extends Array<any>> = readonly [
   ...UseQueriesOptions<T>,
@@ -240,12 +240,12 @@ export function useQueries<
     ...options
   }: {
     queries:
-      | MaybeRefDeep<UseQueriesOptionsArg<T>>
-      | MaybeRefDeep<
-          readonly [
-            ...{ [K in keyof T]: GetUseQueryOptionsForUseQueries<T[K]> },
-          ]
-        >
+    | MaybeRefDeep<UseQueriesOptionsArg<T>>
+    | MaybeRefDeep<
+      readonly [
+        ...{ [K in keyof T]: GetUseQueryOptionsForUseQueries<T[K]> },
+      ]
+    >
     combine?: (result: UseQueriesResults<T>) => TCombinedResult
     shallow?: boolean
   },
@@ -274,7 +274,7 @@ export function useQueries<
       }
 
       const defaulted = client.defaultQueryOptions(clonedOptions)
-      defaulted._optimisticResults = client.isRestoring.value
+      defaulted._optimisticResults = client.isRestoring?.value
         ? 'isRestoring'
         : 'optimistic'
 
@@ -317,20 +317,22 @@ export function useQueries<
     // noop
   }
 
-  watch(
-    client.isRestoring,
-    (isRestoring) => {
-      if (!isRestoring) {
-        unsubscribe()
-        unsubscribe = observer.subscribe(() => {
-          state.value = getOptimisticResult()
-        })
+  if (client.isRestoring) {
+    watch(
+      client.isRestoring,
+      (isRestoring) => {
+        if (!isRestoring) {
+          unsubscribe()
+          unsubscribe = observer.subscribe(() => {
+            state.value = getOptimisticResult()
+          })
 
-        state.value = getOptimisticResult()
-      }
-    },
-    { immediate: true },
-  )
+          state.value = getOptimisticResult()
+        }
+      },
+      { immediate: true },
+    )
+  }
 
   watch(defaultedQueries, (queriesValue) => {
     observer.setQueries(

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -44,69 +44,69 @@ type SkipTokenForUseQueries = symbol
 type GetUseQueryOptionsForUseQueries<T> =
   // Part 1: if UseQueryOptions are already being sent through, then just return T
   T extends UseQueryOptions
-  ? DeepUnwrapRef<T>
-  : // Part 2: responsible for applying explicit type parameter to function arguments, if object { queryFnData: TQueryFnData, error: TError, data: TData }
-  T extends {
-    queryFnData: infer TQueryFnData
-    error?: infer TError
-    data: infer TData
-  }
-  ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
-  : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-  ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
-  : T extends { data: infer TData; error?: infer TError }
-  ? UseQueryOptionsForUseQueries<unknown, TError, TData>
-  : // Part 3: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
-  T extends [infer TQueryFnData, infer TError, infer TData]
-  ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
-  : T extends [infer TQueryFnData, infer TError]
-  ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
-  : T extends [infer TQueryFnData]
-  ? UseQueryOptionsForUseQueries<TQueryFnData>
-  : // Part 4: responsible for inferring and enforcing type if no explicit parameter was provided
-  T extends {
-    queryFn?:
-    | QueryFunction<infer TQueryFnData, infer TQueryKey>
-    | SkipTokenForUseQueries
-    select?: (data: any) => infer TData
-    throwOnError?: ThrowOnError<any, infer TError, any, any>
-  }
-  ? UseQueryOptionsForUseQueries<
-    TQueryFnData,
-    unknown extends TError ? DefaultError : TError,
-    unknown extends TData ? TQueryFnData : TData,
-    TQueryKey
-  >
-  : T extends {
-    queryFn?:
-    | QueryFunction<infer TQueryFnData, infer TQueryKey>
-    | SkipTokenForUseQueries
-    throwOnError?: ThrowOnError<any, infer TError, any, any>
-  }
-  ? UseQueryOptionsForUseQueries<
-    TQueryFnData,
-    TError,
-    TQueryFnData,
-    TQueryKey
-  >
-  : // Fallback
-  UseQueryOptionsForUseQueries
+    ? DeepUnwrapRef<T>
+    : // Part 2: responsible for applying explicit type parameter to function arguments, if object { queryFnData: TQueryFnData, error: TError, data: TData }
+      T extends {
+          queryFnData: infer TQueryFnData
+          error?: infer TError
+          data: infer TData
+        }
+      ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
+      : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
+        ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
+        : T extends { data: infer TData; error?: infer TError }
+          ? UseQueryOptionsForUseQueries<unknown, TError, TData>
+          : // Part 3: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
+            T extends [infer TQueryFnData, infer TError, infer TData]
+            ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData>
+            : T extends [infer TQueryFnData, infer TError]
+              ? UseQueryOptionsForUseQueries<TQueryFnData, TError>
+              : T extends [infer TQueryFnData]
+                ? UseQueryOptionsForUseQueries<TQueryFnData>
+                : // Part 4: responsible for inferring and enforcing type if no explicit parameter was provided
+                  T extends {
+                      queryFn?:
+                        | QueryFunction<infer TQueryFnData, infer TQueryKey>
+                        | SkipTokenForUseQueries
+                      select?: (data: any) => infer TData
+                      throwOnError?: ThrowOnError<any, infer TError, any, any>
+                    }
+                  ? UseQueryOptionsForUseQueries<
+                      TQueryFnData,
+                      unknown extends TError ? DefaultError : TError,
+                      unknown extends TData ? TQueryFnData : TData,
+                      TQueryKey
+                    >
+                  : T extends {
+                        queryFn?:
+                          | QueryFunction<infer TQueryFnData, infer TQueryKey>
+                          | SkipTokenForUseQueries
+                        throwOnError?: ThrowOnError<any, infer TError, any, any>
+                      }
+                    ? UseQueryOptionsForUseQueries<
+                        TQueryFnData,
+                        TError,
+                        TQueryFnData,
+                        TQueryKey
+                      >
+                    : // Fallback
+                      UseQueryOptionsForUseQueries
 
 // A defined initialData setting should return a DefinedQueryObserverResult rather than QueryObserverResult
 type GetDefinedOrUndefinedQueryResult<T, TData, TError = unknown> = T extends {
   initialData?: infer TInitialData
 }
   ? unknown extends TInitialData
-  ? QueryObserverResult<TData, TError>
-  : TInitialData extends TData
-  ? DefinedQueryObserverResult<TData, TError>
-  : TInitialData extends () => infer TInitialDataResult
-  ? unknown extends TInitialDataResult
-  ? QueryObserverResult<TData, TError>
-  : TInitialDataResult extends TData
-  ? DefinedQueryObserverResult<TData, TError>
-  : QueryObserverResult<TData, TError>
-  : QueryObserverResult<TData, TError>
+    ? QueryObserverResult<TData, TError>
+    : TInitialData extends TData
+      ? DefinedQueryObserverResult<TData, TError>
+      : TInitialData extends () => infer TInitialDataResult
+        ? unknown extends TInitialDataResult
+          ? QueryObserverResult<TData, TError>
+          : TInitialDataResult extends TData
+            ? DefinedQueryObserverResult<TData, TError>
+            : QueryObserverResult<TData, TError>
+        : QueryObserverResult<TData, TError>
   : QueryObserverResult<TData, TError>
 
 type GetUseQueryResult<T> =
@@ -118,51 +118,51 @@ type GetUseQueryResult<T> =
     any,
     any
   >
-  ? GetDefinedOrUndefinedQueryResult<
-    T,
-    undefined extends TData ? TQueryFnData : TData,
-    unknown extends TError ? DefaultError : TError
-  >
-  : // Part 2: responsible for mapping explicit type parameter to function result, if object
-  T extends { queryFnData: any; error?: infer TError; data: infer TData }
-  ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
-  : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-  ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
-  : T extends { data: infer TData; error?: infer TError }
-  ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
-  : // Part 3: responsible for mapping explicit type parameter to function result, if tuple
-  T extends [any, infer TError, infer TData]
-  ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
-  : T extends [infer TQueryFnData, infer TError]
-  ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
-  : T extends [infer TQueryFnData]
-  ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData>
-  : // Part 4: responsible for mapping inferred type to results, if no explicit parameter was provided
-  T extends {
-    queryFn?:
-    | QueryFunction<infer TQueryFnData, any>
-    | SkipTokenForUseQueries
-    select?: (data: any) => infer TData
-    throwOnError?: ThrowOnError<any, infer TError, any, any>
-  }
-  ? GetDefinedOrUndefinedQueryResult<
-    T,
-    unknown extends TData ? TQueryFnData : TData,
-    unknown extends TError ? DefaultError : TError
-  >
-  : T extends {
-    queryFn?:
-    | QueryFunction<infer TQueryFnData, any>
-    | SkipTokenForUseQueries
-    throwOnError?: ThrowOnError<any, infer TError, any, any>
-  }
-  ? GetDefinedOrUndefinedQueryResult<
-    T,
-    TQueryFnData,
-    unknown extends TError ? DefaultError : TError
-  >
-  : // Fallback
-  QueryObserverResult
+    ? GetDefinedOrUndefinedQueryResult<
+        T,
+        undefined extends TData ? TQueryFnData : TData,
+        unknown extends TError ? DefaultError : TError
+      >
+    : // Part 2: responsible for mapping explicit type parameter to function result, if object
+      T extends { queryFnData: any; error?: infer TError; data: infer TData }
+      ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+      : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
+        ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
+        : T extends { data: infer TData; error?: infer TError }
+          ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+          : // Part 3: responsible for mapping explicit type parameter to function result, if tuple
+            T extends [any, infer TError, infer TData]
+            ? GetDefinedOrUndefinedQueryResult<T, TData, TError>
+            : T extends [infer TQueryFnData, infer TError]
+              ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData, TError>
+              : T extends [infer TQueryFnData]
+                ? GetDefinedOrUndefinedQueryResult<T, TQueryFnData>
+                : // Part 4: responsible for mapping inferred type to results, if no explicit parameter was provided
+                  T extends {
+                      queryFn?:
+                        | QueryFunction<infer TQueryFnData, any>
+                        | SkipTokenForUseQueries
+                      select?: (data: any) => infer TData
+                      throwOnError?: ThrowOnError<any, infer TError, any, any>
+                    }
+                  ? GetDefinedOrUndefinedQueryResult<
+                      T,
+                      unknown extends TData ? TQueryFnData : TData,
+                      unknown extends TError ? DefaultError : TError
+                    >
+                  : T extends {
+                        queryFn?:
+                          | QueryFunction<infer TQueryFnData, any>
+                          | SkipTokenForUseQueries
+                        throwOnError?: ThrowOnError<any, infer TError, any, any>
+                      }
+                    ? GetDefinedOrUndefinedQueryResult<
+                        T,
+                        TQueryFnData,
+                        unknown extends TError ? DefaultError : TError
+                      >
+                    : // Fallback
+                      QueryObserverResult
 
 /**
  * UseQueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
@@ -174,37 +174,37 @@ export type UseQueriesOptions<
 > = TDepth['length'] extends MAXIMUM_DEPTH
   ? Array<UseQueryOptionsForUseQueries>
   : T extends []
-  ? []
-  : T extends [infer Head]
-  ? [...TResults, GetUseQueryOptionsForUseQueries<Head>]
-  : T extends [infer Head, ...infer Tails]
-  ? UseQueriesOptions<
-    [...Tails],
-    [...TResults, GetUseQueryOptionsForUseQueries<Head>],
-    [...TDepth, 1]
-  >
-  : ReadonlyArray<unknown> extends T
-  ? T
-  : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
-  // use this to infer the param types in the case of Array.map() argument
-  T extends Array<
-    UseQueryOptionsForUseQueries<
-      infer TQueryFnData,
-      infer TError,
-      infer TData,
-      infer TQueryKey
-    >
-  >
-  ? Array<
-    UseQueryOptionsForUseQueries<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryKey
-    >
-  >
-  : // Fallback
-  Array<UseQueryOptionsForUseQueries>
+    ? []
+    : T extends [infer Head]
+      ? [...TResults, GetUseQueryOptionsForUseQueries<Head>]
+      : T extends [infer Head, ...infer Tails]
+        ? UseQueriesOptions<
+            [...Tails],
+            [...TResults, GetUseQueryOptionsForUseQueries<Head>],
+            [...TDepth, 1]
+          >
+        : ReadonlyArray<unknown> extends T
+          ? T
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+            // use this to infer the param types in the case of Array.map() argument
+            T extends Array<
+                UseQueryOptionsForUseQueries<
+                  infer TQueryFnData,
+                  infer TError,
+                  infer TData,
+                  infer TQueryKey
+                >
+              >
+            ? Array<
+                UseQueryOptionsForUseQueries<
+                  TQueryFnData,
+                  TError,
+                  TData,
+                  TQueryKey
+                >
+              >
+            : // Fallback
+              Array<UseQueryOptionsForUseQueries>
 
 /**
  * UseQueriesResults reducer recursively maps type param to results
@@ -216,16 +216,16 @@ export type UseQueriesResults<
 > = TDepth['length'] extends MAXIMUM_DEPTH
   ? Array<QueryObserverResult>
   : T extends []
-  ? []
-  : T extends [infer Head]
-  ? [...TResults, GetUseQueryResult<Head>]
-  : T extends [infer Head, ...infer Tails]
-  ? UseQueriesResults<
-    [...Tails],
-    [...TResults, GetUseQueryResult<Head>],
-    [...TDepth, 1]
-  >
-  : { [K in keyof T]: GetUseQueryResult<T[K]> }
+    ? []
+    : T extends [infer Head]
+      ? [...TResults, GetUseQueryResult<Head>]
+      : T extends [infer Head, ...infer Tails]
+        ? UseQueriesResults<
+            [...Tails],
+            [...TResults, GetUseQueryResult<Head>],
+            [...TDepth, 1]
+          >
+        : { [K in keyof T]: GetUseQueryResult<T[K]> }
 
 type UseQueriesOptionsArg<T extends Array<any>> = readonly [
   ...UseQueriesOptions<T>,
@@ -240,12 +240,12 @@ export function useQueries<
     ...options
   }: {
     queries:
-    | MaybeRefDeep<UseQueriesOptionsArg<T>>
-    | MaybeRefDeep<
-      readonly [
-        ...{ [K in keyof T]: GetUseQueryOptionsForUseQueries<T[K]> },
-      ]
-    >
+      | MaybeRefDeep<UseQueriesOptionsArg<T>>
+      | MaybeRefDeep<
+          readonly [
+            ...{ [K in keyof T]: GetUseQueryOptionsForUseQueries<T[K]> },
+          ]
+        >
     combine?: (result: UseQueriesResults<T>) => TCombinedResult
     shallow?: boolean
   },

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -47,11 +47,15 @@ export const VueQueryPlugin = {
     }
 
     if (options.clientPersister) {
-      client.isRestoring.value = true
+      if (client.isRestoring) {
+        client.isRestoring.value = true
+      }
       const [unmount, promise] = options.clientPersister(client)
       persisterUnmount = unmount
       promise.then(() => {
-        client.isRestoring.value = false
+        if (client.isRestoring) {
+          client.isRestoring.value = false
+        }
         options.clientPersisterOnSuccess?.(client)
       })
     }


### PR DESCRIPTION
Make `vue-query` client compatible on type level with `query-core`.

Also adjusted code to conditionally access `isRestoring` flag.

> [!CAUTION]
> A note here is that while `compatible`, using `query-core` client would drop some `vue` specific optimizations.

closes: https://github.com/TanStack/query/issues/8937