### PR TITLE
Updates examples for invalidation from mutations

### DIFF
--- a/docs/framework/react/guides/invalidations-from-mutations.md
+++ b/docs/framework/react/guides/invalidations-from-mutations.md
@@ -27,9 +27,15 @@ const queryClient = useQueryClient()
 // When this mutation succeeds, invalidate any queries with the `todos` or `reminders` query key
 const mutation = useMutation({
   mutationFn: addTodo,
-  onSuccess: () => {
-    queryClient.invalidateQueries({ queryKey: ['todos'] })
-    queryClient.invalidateQueries({ queryKey: ['reminders'] })
+  onSuccess: async () => {
+    // If you're invalidating a single query
+    await queryClient.invalidateQueries({ queryKey: ['todos'] })
+
+    // If you're invalidating multiple queries
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['todos'] }),
+      queryClient.invalidateQueries({ queryKey: ['reminders'] })
+    ])
   },
 })
 ```


### PR DESCRIPTION
If my memory serves me right, returning a Promise makes sure the data is updated before the mutation is entirely complete (i.e., `isPending` is true until onSuccess is fulfilled)

This updates the code examples to reflect that. Please correct me if I'm mistaken.