### PR TITLE
perf(query-core): clear query's revertState once fetching ends successfully

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -604,6 +604,8 @@ export class Query<
             fetchMeta: action.meta ?? null,
           }
         case 'success':
+          // If fetching ends successfully, we don't need revertState as a fallback anymore.
+          this.#revertState = undefined
           return {
             ...state,
             data: action.data,


### PR DESCRIPTION
The `#revertState` attribute of the `Query` class is used as a fallback for fetching failure.
Clearing it once fetching ends successfully improve memory usage, particularly with queries returning large amount of data.

More context in this discussion: https://github.com/TanStack/query/discussions/9264

_NB: I didn't add unit tests for this modification. Indeed, as `#revertState` is a hash private attribute, I see no way to access it in unit tests to check if it is properly reset._