### PR TITLE
feat(query-core, react-query): add types, deprecate `isLoading` in favor of `isPending` in mutation observer results

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -669,6 +669,9 @@ export interface MutationObserverBaseResult<
 > extends MutationState<TData, TError, TVariables, TContext> {
   isError: boolean
   isIdle: boolean
+  /**
+   * @deprecated This property will be removed in the next major version. Use `isPending` instead.
+   */
   isLoading: boolean
   isPending: boolean
   isSuccess: boolean
@@ -686,7 +689,11 @@ export interface MutationObserverIdleResult<
   error: null
   isError: false
   isIdle: true
+  /**
+   * @deprecated This property will be removed in the next major version. Use `isPending` instead.
+   */
   isLoading: false
+  isPending: false
   isSuccess: false
   status: 'idle'
 }
@@ -701,7 +708,11 @@ export interface MutationObserverLoadingResult<
   error: null
   isError: false
   isIdle: false
+  /**
+   * @deprecated This property will be removed in the next major version. Use `isPending` instead.
+   */
   isLoading: true
+  isPending: true
   isSuccess: false
   status: 'loading'
 }
@@ -716,7 +727,11 @@ export interface MutationObserverErrorResult<
   error: TError
   isError: true
   isIdle: false
+  /**
+   * @deprecated This property will be removed in the next major version. Use `isPending` instead.
+   */
   isLoading: false
+  isPending: false
   isSuccess: false
   status: 'error'
 }
@@ -731,7 +746,11 @@ export interface MutationObserverSuccessResult<
   error: null
   isError: false
   isIdle: false
+  /**
+   * @deprecated This property will be removed in the next major version. Use `isPending` instead.
+   */
   isLoading: false
+  isPending: false
   isSuccess: true
   status: 'success'
 }

--- a/packages/react-query/src/__tests__/queryOptions.types.test.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.types.test.tsx
@@ -1,16 +1,17 @@
 import { expectTypeOf } from 'expect-type'
 import {
+  type DefinedUseQueryResult,
   QueryCache,
   type UseQueryResult,
+  type UseSuspenseQueryResult,
+  queryOptions,
   useQueries,
   useQuery,
   useQueryClient,
-} from '@tanstack/react-query'
-import { queryOptions } from '..'
-import { useSuspenseQueries, useSuspenseQuery } from '..'
-import { type UseSuspenseQueryResult } from '../useSuspenseQuery'
+  useSuspenseQueries,
+  useSuspenseQuery,
+} from '..'
 import { doNotExecute } from './utils'
-import type { DefinedUseQueryResult } from '@tanstack/react-query'
 
 const queryKey = ['key'] as const
 const queryFn = () => Promise.resolve({ field: 'success' })

--- a/packages/react-query/src/__tests__/useSuspenseQueries.types.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.types.test.tsx
@@ -1,8 +1,10 @@
 import { expectTypeOf } from 'expect-type'
-import { queryOptions } from '..'
-import { useSuspenseQueries } from '..'
+import {
+  type UseSuspenseQueryResult,
+  queryOptions,
+  useSuspenseQueries,
+} from '..'
 import { doNotExecute } from './utils'
-import type { UseSuspenseQueryResult } from '../useSuspenseQuery'
 
 export const queryKey = ['key'] as const
 const sleep = (ms: number) =>

--- a/packages/react-query/src/__tests__/useSuspenseQuery.types.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQuery.types.test.tsx
@@ -1,9 +1,5 @@
 import { expectTypeOf } from 'expect-type'
-import {
-  type UseSuspenseQueryResult,
-  useSuspenseQuery,
-} from '../useSuspenseQuery'
-import { queryOptions } from '..'
+import { type UseSuspenseQueryResult, queryOptions, useSuspenseQuery } from '..'
 import { doNotExecute } from './utils'
 
 const queryKey = ['key'] as const

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -13,6 +13,15 @@ export type { QueriesResults, QueriesOptions } from './useQueries'
 export { useQuery } from './useQuery'
 export { useSuspenseQuery } from './useSuspenseQuery'
 export { useSuspenseQueries } from './useSuspenseQueries'
+export type {
+  SuspenseQueriesResults,
+  SuspenseQueriesOptions,
+} from './useSuspenseQueries'
+export { queryOptions } from './queryOptions'
+export type {
+  DefinedInitialDataOptions,
+  UndefinedInitialDataOptions,
+} from './queryOptions'
 export {
   defaultContext,
   QueryClientProvider,
@@ -31,4 +40,3 @@ export { useIsMutating } from './useIsMutating'
 export { useMutation } from './useMutation'
 export { useInfiniteQuery } from './useInfiniteQuery'
 export { useIsRestoring, IsRestoringProvider } from './isRestoring'
-export { queryOptions } from './queryOptions'

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -22,7 +22,7 @@ type ProhibitedQueryOptionsKeyInV5 = keyof Pick<
   'useErrorBoundary' | 'suspense' | 'getNextPageParam' | 'getPreviousPageParam'
 >
 
-type UndefinedInitialDataOptions<
+export type UndefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
@@ -34,7 +34,7 @@ type UndefinedInitialDataOptions<
     | NonUndefinedGuard<TQueryFnData>
 }
 
-type DefinedInitialDataOptions<
+export type DefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -3,11 +3,13 @@
 import type * as React from 'react'
 import type {
   DefinedQueryObserverResult,
+  DistributiveOmit,
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
   MutateFunction,
   MutationObserverOptions,
   MutationObserverResult,
+  OmitKeyof,
   QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
@@ -43,6 +45,25 @@ export interface UseQueryOptions<
     TQueryKey
   > {}
 
+export type UseSuspenseQueryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = OmitKeyof<
+  UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  | 'enabled'
+  | 'useErrorBoundary'
+  | 'suspense'
+  | 'placeholderData'
+  | 'networkMode'
+  | 'onSuccess'
+  | 'onError'
+  | 'onSettled'
+  | 'getPreviousPageParam'
+  | 'getNextPageParam'
+>
+
 export interface UseInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
@@ -67,6 +88,14 @@ export type UseQueryResult<
   TData = unknown,
   TError = unknown,
 > = UseBaseQueryResult<TData, TError>
+
+export type UseSuspenseQueryResult<
+  TData = unknown,
+  TError = unknown,
+> = DistributiveOmit<
+  DefinedQueryObserverResult<TData, TError>,
+  'isPlaceholderData'
+>
 
 export type DefinedUseBaseQueryResult<
   TData = unknown,

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -136,7 +136,6 @@ export function useQuery<
     'queryKey' | 'queryFn'
   >,
 ): UseQueryResult<TData, TError>
-/** @deprecated */
 export function useQuery<
   TQueryFnData,
   TError,

--- a/packages/react-query/src/useSuspenseQueries.ts
+++ b/packages/react-query/src/useSuspenseQueries.ts
@@ -1,10 +1,10 @@
 import { useQueries } from './useQueries'
-import type { UseQueryOptions } from './types'
-import type { NetworkMode, QueryFunction } from '@tanstack/query-core'
 import type {
+  UseQueryOptions,
   UseSuspenseQueryOptions,
   UseSuspenseQueryResult,
-} from './useSuspenseQuery'
+} from './types'
+import type { NetworkMode, QueryFunction } from '@tanstack/query-core'
 
 // Avoid TS depth-limit error in case of large array literal
 type MAXIMUM_DEPTH = 20

--- a/packages/react-query/src/useSuspenseQuery.ts
+++ b/packages/react-query/src/useSuspenseQuery.ts
@@ -1,39 +1,7 @@
 import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type {
-  DefinedQueryObserverResult,
-  DistributiveOmit,
-  OmitKeyof,
-  QueryKey,
-} from '@tanstack/query-core'
-import type { UseQueryOptions } from './types'
-
-export type UseSuspenseQueryResult<
-  TData = unknown,
-  TError = unknown,
-> = DistributiveOmit<
-  DefinedQueryObserverResult<TData, TError>,
-  'isPlaceholderData'
->
-
-export type UseSuspenseQueryOptions<
-  TQueryFnData = unknown,
-  TError = unknown,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = OmitKeyof<
-  UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  | 'enabled'
-  | 'useErrorBoundary'
-  | 'suspense'
-  | 'placeholderData'
-  | 'networkMode'
-  | 'onSuccess'
-  | 'onError'
-  | 'onSettled'
-  | 'getPreviousPageParam'
-  | 'getNextPageParam'
->
+import type { QueryKey } from '@tanstack/query-core'
+import type { UseSuspenseQueryOptions, UseSuspenseQueryResult } from './types'
 
 export function useSuspenseQuery<
   TQueryFnData = unknown,
@@ -49,6 +17,9 @@ export function useSuspenseQuery<
       suspense: true,
       placeholderData: undefined,
       networkMode: 'always',
+      onSuccess: undefined,
+      onError: undefined,
+      onSettled: undefined,
     },
     QueryObserver,
   ) as UseSuspenseQueryResult<TData, TError>


### PR DESCRIPTION
This pull request introduces several changes to improve type definitions, deprecate legacy properties, and reorganize imports across the `query-core` and `react-query` packages. The most notable updates include the addition of new type definitions for suspense queries, deprecation of the `isLoading` property in favor of `isPending`, and the centralization of type definitions to reduce duplication.

### Deprecation and Property Updates:
* Marked the `isLoading` property as deprecated in multiple `MutationObserver` result interfaces (`MutationObserverBaseResult`, `MutationObserverIdleResult`, `MutationObserverLoadingResult`, `MutationObserverErrorResult`, `MutationObserverSuccessResult`) and added the `isPending` property as its replacement. (`[[1]](diffhunk://#diff-988cd43951b30185641ccb757eefd39c6e67027d7ccab1f445117b4c0401dc8bR672-R674)`, `[[2]](diffhunk://#diff-988cd43951b30185641ccb757eefd39c6e67027d7ccab1f445117b4c0401dc8bR692-R696)`, `[[3]](diffhunk://#diff-988cd43951b30185641ccb757eefd39c6e67027d7ccab1f445117b4c0401dc8bR711-R715)`, `[[4]](diffhunk://#diff-988cd43951b30185641ccb757eefd39c6e67027d7ccab1f445117b4c0401dc8bR730-R734)`, `[[5]](diffhunk://#diff-988cd43951b30185641ccb757eefd39c6e67027d7ccab1f445117b4c0401dc8bR749-R753)`)

### Type Definition Enhancements:
* Introduced `UseSuspenseQueryOptions` and `UseSuspenseQueryResult` types in `react-query` to support suspense queries and moved their definitions to `packages/react-query/src/types.ts` for better organization. (`[[1]](diffhunk://#diff-ac3343c834b1a6ecb51aa339ab1cf591e1f595d9edfed5ee0d0bc85fd172e66fR48-R66)`, `[[2]](diffhunk://#diff-ac3343c834b1a6ecb51aa339ab1cf591e1f595d9edfed5ee0d0bc85fd172e66fR92-R99)`)
* Exported new types such as `SuspenseQueriesResults`, `SuspenseQueriesOptions`, `DefinedInitialDataOptions`, and `UndefinedInitialDataOptions` from `packages/react-query/src/index.ts` for broader accessibility. (`[[1]](diffhunk://#diff-9b31e5c002b04b3eec4908fa8c713d3915cb2ffcf43145f01c9f122246eebe86R16-R24)`, `[[2]](diffhunk://#diff-9b31e5c002b04b3eec4908fa8c713d3915cb2ffcf43145f01c9f122246eebe86L34)`)

### Code Simplification and Consolidation:
* Removed redundant type definitions and imports from `useSuspenseQuery.ts`, consolidating them into `types.ts` to reduce duplication and improve maintainability. (`[[1]](diffhunk://#diff-4e4ea16608f7d425268364d616efdfa42fb68f618ab6ddc649d414f8e8764c5cL3-R4)`, `[[2]](diffhunk://#diff-4e4ea16608f7d425268364d616efdfa42fb68f618ab6ddc649d414f8e8764c5cR20-R22)`)
* Reorganized imports in test files (`queryOptions.types.test.tsx`, `useSuspenseQueries.types.test.tsx`, `useSuspenseQuery.types.test.tsx`) to align with the new centralized type definitions. (`[[1]](diffhunk://#diff-917f744ad3743ab8bac082cd8c618434b16db096a117b82f9871f8ed08f88689R3-L13)`, `[[2]](diffhunk://#diff-f9563f22f7ffa75dc73929f2dc6e42501cbd39effe124645b0b220fba6ee6ce6L2-L5)`, `[[3]](diffhunk://#diff-d88e5088c9c051e63a1517fb7b80d86470f511f21888464195f48884a353d58eL2-R2)`)

### Miscellaneous:
* Updated `queryOptions.ts` to export `DefinedInitialDataOptions` and `UndefinedInitialDataOptions` types, making them available for external use. (`[[1]](diffhunk://#diff-b078edfbebf4ff2913af7088150bab53c78e24d4af82e38f7327ca5493c2b64cL25-R25)`, `[[2]](diffhunk://#diff-b078edfbebf4ff2913af7088150bab53c78e24d4af82e38f7327ca5493c2b64cL37-R37)`)