### PR TITLE
fix(query-core): we don't want errors that get reverted internally to throw on imperative methods

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -495,7 +495,10 @@ export class Query<
       this.#dispatch({ type: 'fetch', meta: context.fetchOptions?.meta })
     }
 
-    const onError = (error: TError | { silent?: boolean }) => {
+    const onError = (
+      error: TError | { silent?: boolean },
+    ): TData | undefined => {
+      let result: TData | undefined
       // Optimistically update state if needed
       if (!(isCancelledError(error) && error.silent)) {
         this.#dispatch({
@@ -515,10 +518,14 @@ export class Query<
           error as any,
           this as Query<any, any, any, any>,
         )
+      } else if (error.revert) {
+        // ensure error gets transformed to TData if possible after revert
+        result = this.state.data
       }
 
       // Schedule query gc after fetching
       this.scheduleGc()
+      return result
     }
 
     // Try to fetch the data


### PR DESCRIPTION
to achieve that, we let the retryer's `onError` "transform" the result back to potentially TData, and if so, we'll resolve the promise to that instead; that means calls to `fetchQuery` will be "successful" when a cancellation happens in the meantime, but they will then resolve to the reverted data; also, if the initial fetch is cancelled, we would still throw, as there is no data to revert to.