### PR TITLE
chore: add .cursor/rules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ stats-hydration.json
 stats.json
 stats.html
 .vscode/settings.json
+.cursor/rules
 
 *.log
 *.tsbuildinfo


### PR DESCRIPTION
To prevent this autogenerated file from being uploaded to remote, I add `.cursor/rules` to .gitignore

<img width="790" alt="image" src="https://github.com/user-attachments/assets/b4e3a335-74bf-43a9-9da3-d5d0688b79bb" />
