### PR TITLE
chore: generateDocs.js, publish.js -> generateDocs.ts, publish.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "dev": "pnpm run watch",
     "prettier": "prettier --ignore-unknown '**/*'",
     "prettier:write": "pnpm run prettier --write",
-    "docs:generate": "node scripts/generateDocs.js",
-    "cipublish": "node scripts/publish.js",
+    "docs:generate": "node scripts/generateDocs.ts",
+    "cipublish": "node scripts/publish.ts",
     "verify-links": "node scripts/verify-links.ts"
   },
   "nx": {

--- a/scripts/generateDocs.ts
+++ b/scripts/generateDocs.ts
@@ -1,36 +1,39 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { generateReferenceDocs } from '@tanstack/config/typedoc'
+import fg from 'fast-glob'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
-/** @type {import('@tanstack/config/typedoc').Package[]} */
-const packages = [
-  {
-    name: 'angular-query-experimental',
-    entryPoints: [
-      resolve(__dirname, '../packages/angular-query-experimental/src/index.ts'),
-    ],
-    tsconfig: resolve(
-      __dirname,
-      '../packages/angular-query-experimental/tsconfig.json',
-    ),
-    outputDir: resolve(__dirname, '../docs/framework/angular/reference'),
-    exclude: ['./packages/query-core/**/*'],
-  },
-  {
-    name: 'svelte-query',
-    entryPoints: [resolve(__dirname, '../packages/svelte-query/src/index.ts')],
-    tsconfig: resolve(__dirname, '../packages/svelte-query/tsconfig.json'),
-    outputDir: resolve(__dirname, '../docs/framework/svelte/reference'),
-    exclude: ['./packages/query-core/**/*'],
-  },
-]
-
-await generateReferenceDocs({ packages })
-
-import fg from 'fast-glob'
-import { readFileSync, writeFileSync } from 'node:fs'
+await generateReferenceDocs({
+  packages: [
+    {
+      name: 'angular-query-experimental',
+      entryPoints: [
+        resolve(
+          __dirname,
+          '../packages/angular-query-experimental/src/index.ts',
+        ),
+      ],
+      tsconfig: resolve(
+        __dirname,
+        '../packages/angular-query-experimental/tsconfig.json',
+      ),
+      outputDir: resolve(__dirname, '../docs/framework/angular/reference'),
+      exclude: ['./packages/query-core/**/*'],
+    },
+    {
+      name: 'svelte-query',
+      entryPoints: [
+        resolve(__dirname, '../packages/svelte-query/src/index.ts'),
+      ],
+      tsconfig: resolve(__dirname, '../packages/svelte-query/tsconfig.json'),
+      outputDir: resolve(__dirname, '../docs/framework/svelte/reference'),
+      exclude: ['./packages/query-core/**/*'],
+    },
+  ],
+})
 
 // Define the pattern to match all generated markdown files
 const markdownFilesPattern = 'docs/framework/{angular,svelte}/reference/**/*.md'

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { publish } from '@tanstack/config/publish'


### PR DESCRIPTION
We are now on Node v24, so we can use TypeScript natively.

- generateDocs.js -> generateDocs.ts
- publish.js -> publish.ts