### PR TITLE
fix(angular-query): fix package publishing

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -22,6 +22,9 @@
     "packages/vue-query": {
       "ignore": ["**/__mocks__/**"],
       "ignoreDependencies": ["vue2", "vue2.7"]
+    },
+    "packages/angular-query-experimental": {
+      "ignore": ["scripts/prepack.js"]
     }
   }
 }

--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -43,8 +43,8 @@
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "pnpm pack && publint ./dist/*.tgz --strict && attw ./dist/*.tgz; premove ./dist/*.tgz",
-    "build": "vite build && pnpm run prepack",
-    "prepack": "node ./scripts/prepack.js"
+    "build": "vite build && pnpm run prepare-package",
+    "prepare-package": "node ./scripts/prepare-package.js"
   },
   "type": "module",
   "types": "dist/index.d.ts",
@@ -60,7 +60,8 @@
   "sideEffects": false,
   "files": [
     "**/*.d.ts",
-    "**/*.mjs.*"
+    "**/*.mjs",
+    "**/*.mjs.map"
   ],
   "dependencies": {
     "@tanstack/query-core": "workspace:*",
@@ -84,6 +85,15 @@
   },
   "publishConfig": {
     "directory": "dist",
-    "linkDirectory": false
+    "linkDirectory": false,
+    "types": "index.d.ts",
+    "module": "index.mjs",
+    "exports": {
+      ".": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "./package.json": "./package.json"
+    }
   }
 }

--- a/packages/angular-query-experimental/scripts/prepack.js
+++ b/packages/angular-query-experimental/scripts/prepack.js
@@ -1,6 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+// Currently unused as life-cycle scripts do not run on CI
+
 console.log('Running prepack script')
 
 /**

--- a/packages/angular-query-experimental/scripts/prepare-package.js
+++ b/packages/angular-query-experimental/scripts/prepare-package.js
@@ -1,0 +1,26 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+console.log('Running prepare package script')
+
+/**
+ * Files to link from the dist directory
+ * @type {string[]}
+ */
+const FILES_TO_LINK = ['README.md', 'package.json']
+
+if (!fs.existsSync('dist')) {
+  fs.mkdirSync('dist', { recursive: true })
+}
+
+console.log('Linking files')
+for (const fileName of FILES_TO_LINK) {
+  if (fs.existsSync(fileName)) {
+    fs.linkSync(fileName, path.join('dist', fileName))
+    console.log(`${fileName}`)
+  } else {
+    console.log(`${fileName} not found, skipping`)
+  }
+}
+
+console.log('prepare package complete')


### PR DESCRIPTION
As the publish script removes package scripts we currently cannot rely on a prepack lifecycle script. Use file links instead to be able to publish from the dist sub directory.