### PR TITLE
fix(query-core): do not fetch if queryFn is skipToken

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -969,6 +969,17 @@ describe('queryClient', () => {
       await vi.advanceTimersByTimeAsync(15)
       expect(queryCache.find({ queryKey: key })).not.toBeDefined()
     })
+
+    test('should not call fetch if queryFn is skipToken', async () => {
+      const key = queryKey()
+
+      const fetchQuery = vi.spyOn(queryClient, 'fetchQuery');
+      await queryClient.prefetchQuery({
+        queryKey: key,
+        queryFn: skipToken,
+      })
+      expect(fetchQuery).not.toBeCalled()
+    })
   })
 
   describe('removeQueries', () => {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -377,6 +377,7 @@ export class QueryClient {
   >(
     options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   ): Promise<void> {
+    if (options.queryFn === skipToken) return Promise.resolve()
     return this.fetchQuery(options).then(noop).catch(noop)
   }
 


### PR DESCRIPTION
sometimes I want to call prefetch with a condition:

Repro:
```tsx
usePrefetchQuery({
  queryKey: ['todo', id],
  queryFn: id ? () => getTodo({ id }) : skipToken,
});
```

but there will be an error:
```
Attempted to invoke queryFn when set to skipToken. This is likely a configuration error. Query hash: '["todo",null]'
```