### PR TITLE
test(query-core/mutationObserver): add 'advanceTimersByTimeAsync' in all tests

### DIFF
--- a/packages/query-core/src/__tests__/mutationObserver.test.tsx
+++ b/packages/query-core/src/__tests__/mutationObserver.test.tsx
@@ -31,14 +31,13 @@ describe('mutationObserver', () => {
 
     unsubscribe1()
 
-    await vi.waitFor(() => {
-      // 1 call: loading
-      expect(subscription1Handler).toBeCalledTimes(1)
-      // 2 calls: loading, success
-      expect(subscription2Handler).toBeCalledTimes(2)
-    })
+    expect(subscription1Handler).toBeCalledTimes(1)
+    expect(subscription2Handler).toBeCalledTimes(1)
 
-    // Clean-up
+    await vi.advanceTimersByTimeAsync(20)
+    expect(subscription1Handler).toBeCalledTimes(1)
+    expect(subscription2Handler).toBeCalledTimes(2)
+
     unsubscribe2()
   })
 
@@ -53,15 +52,14 @@ describe('mutationObserver', () => {
     const unsubscribe = mutation.subscribe(subscriptionHandler)
 
     mutation.mutate('input')
-    await vi.waitFor(() =>
-      expect(queryClient.getMutationCache().findAll()).toHaveLength(1),
-    )
+
+    await vi.advanceTimersByTimeAsync(5)
+    expect(queryClient.getMutationCache().findAll()).toHaveLength(1)
 
     unsubscribe()
 
-    await vi.waitFor(() =>
-      expect(queryClient.getMutationCache().findAll()).toHaveLength(0),
-    )
+    await vi.advanceTimersByTimeAsync(10)
+    expect(queryClient.getMutationCache().findAll()).toHaveLength(0)
   })
 
   test('reset should remove observer to trigger GC', async () => {
@@ -75,15 +73,14 @@ describe('mutationObserver', () => {
     const unsubscribe = mutation.subscribe(subscriptionHandler)
 
     mutation.mutate('input')
-    await vi.waitFor(() =>
-      expect(queryClient.getMutationCache().findAll()).toHaveLength(1),
-    )
+
+    await vi.advanceTimersByTimeAsync(5)
+    expect(queryClient.getMutationCache().findAll()).toHaveLength(1)
 
     mutation.reset()
 
-    await vi.waitFor(() =>
-      expect(queryClient.getMutationCache().findAll()).toHaveLength(0),
-    )
+    await vi.advanceTimersByTimeAsync(10)
+    expect(queryClient.getMutationCache().findAll()).toHaveLength(0)
 
     unsubscribe()
   })
@@ -101,12 +98,11 @@ describe('mutationObserver', () => {
 
     mutation.mutate('input')
 
-    await vi.waitFor(() =>
-      expect(mutation.getCurrentResult()).toMatchObject({
-        status: 'success',
-        data: 'input',
-      }),
-    )
+    await vi.advanceTimersByTimeAsync(5)
+    expect(mutation.getCurrentResult()).toMatchObject({
+      status: 'success',
+      data: 'input',
+    })
 
     mutation.setOptions({
       mutationKey: [...key, '2'],
@@ -132,17 +128,16 @@ describe('mutationObserver', () => {
 
     mutationObserver.mutate('input')
 
-    await vi.waitFor(() =>
-      expect(
-        queryClient.getMutationCache().find({ mutationKey: [...key, '1'] }),
-      ).toMatchObject({
-        options: { mutationKey: [...key, '1'] },
-        state: {
-          status: 'success',
-          data: 'input',
-        },
-      }),
-    )
+    await vi.advanceTimersByTimeAsync(5)
+    expect(
+      queryClient.getMutationCache().find({ mutationKey: [...key, '1'] }),
+    ).toMatchObject({
+      options: { mutationKey: [...key, '1'] },
+      state: {
+        status: 'success',
+        data: 'input',
+      },
+    })
 
     mutationObserver.setOptions({
       mutationKey: [...key, '2'],
@@ -173,15 +168,14 @@ describe('mutationObserver', () => {
 
     mutationObserver.mutate('input')
 
-    await vi.waitFor(() =>
-      expect(queryClient.getMutationCache().find({})).toMatchObject({
-        options: { meta: { a: 1 } },
-        state: {
-          status: 'success',
-          data: 'input',
-        },
-      }),
-    )
+    await vi.advanceTimersByTimeAsync(5)
+    expect(queryClient.getMutationCache().find({})).toMatchObject({
+      options: { meta: { a: 1 } },
+      state: {
+        status: 'success',
+        data: 'input',
+      },
+    })
 
     mutationObserver.setOptions({
       meta: { a: 2 },
@@ -251,14 +245,14 @@ describe('mutationObserver', () => {
     const unsubscribe = mutationObserver.subscribe(subscriptionHandler)
 
     mutationObserver.mutate('input').catch(() => undefined)
-    await vi.waitFor(() =>
-      expect(queryClient.getMutationCache().find({})).toMatchObject({
-        options: { meta: { a: 1 } },
-        state: {
-          status: 'error',
-        },
-      }),
-    )
+
+    await vi.advanceTimersByTimeAsync(5)
+    expect(queryClient.getMutationCache().find({})).toMatchObject({
+      options: { meta: { a: 1 } },
+      state: {
+        status: 'error',
+      },
+    })
 
     mutationObserver.setOptions({
       meta: { a: 2 },


### PR DESCRIPTION
## before

<img width="976" alt="image" src="https://github.com/user-attachments/assets/229207fc-2fe9-484e-bb4d-10569b6adaf7" />

## after

<img width="979" alt="image" src="https://github.com/user-attachments/assets/d696ba62-a077-49f6-b366-9139033c9bf4" />
