### PR TITLE
feat(query-core): pass mutation meta as optional second argument to mutationFn

### DIFF
--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -48,10 +48,11 @@ mutate(variables, {
 
 **Parameter1 (Options)**
 
-- `mutationFn: (variables: TVariables) => Promise<TData>`
+- `mutationFn: (variables: TVariables, meta?: MutationMeta) => Promise<TData>`
   - **Required, but only if no default mutation function has been defined**
   - A function that performs an asynchronous task and returns a promise.
   - `variables` is an object that `mutate` will pass to your `mutationFn`
+  - `meta` is the optional `meta` parameter which is also passed to `useMutation`
 - `gcTime: number | Infinity`
   - The time in milliseconds that unused/inactive cache data remains in memory. When a mutation's cache becomes unused or inactive, that cache data will be garbage collected after this duration. When different cache times are specified, the longest one will be used.
   - If set to `Infinity`, will disable garbage collection

--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -51,7 +51,7 @@ describe('mutations', () => {
     )
 
     expect(fn).toHaveBeenCalledTimes(1)
-    expect(fn).toHaveBeenCalledWith('vars')
+    expect(fn).toHaveBeenCalledWith('vars', undefined)
   })
 
   test('mutation should set correct success states', async () => {
@@ -421,6 +421,21 @@ describe('mutations', () => {
     await vi.waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
 
     expect(onSuccess).toHaveBeenCalledWith(2)
+  })
+
+  test('mutationFn should have access to mutation meta', async () => {
+    const mutation = new MutationObserver(queryClient, {
+      mutationFn: (_: void, meta) => {
+        return Promise.resolve(meta?.test)
+      },
+      meta: {
+        test: 'update',
+      },
+    })
+
+    await mutation.mutate()
+
+    expect(mutation.getCurrentResult().data).toEqual('update')
   })
 
   describe('scoped mutations', () => {

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -171,7 +171,7 @@ export class Mutation<
         if (!this.options.mutationFn) {
           return Promise.reject(new Error('No mutationFn found'))
         }
-        return this.options.mutationFn(variables)
+        return this.options.mutationFn(variables, this.options.meta)
       },
       onFail: (failureCount, error) => {
         this.#dispatch({ type: 'failed', failureCount, error })

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1089,6 +1089,7 @@ export type MutationMeta = Register extends {
 
 export type MutationFunction<TData = unknown, TVariables = unknown> = (
   variables: TVariables,
+  meta?: MutationMeta
 ) => Promise<TData>
 
 export interface MutationOptions<


### PR DESCRIPTION
Related discussion [here](https://github.com/TanStack/query/discussions/8543). Below is copied from there:

I wanted to take a moment and make a case for making `meta` accessible in `mutationFn`!

In my mind, the `meta` field is a very convenient way to ensure access to shared context needed for all queries and/or mutations in an app. For example, in our web app, we have an API client which is instantiated once on load and then made accessible anywhere in the app through React Context. This is pretty convenient, but this API client is needed for _every_ query or mutation we ever make that hits our API (which is 99% of them). So it is actually still pretty _inconvenient_ that any time we ever want to use `useQuery` or `useMutation`, we also need to call `useApiClient` (our custom hook) to pass the API client into the query/mutation function.

When I read the docs for the `meta` option, and how we can globally override the type, I thought it seemed like the perfect way to implement a lightweight wrapper around `useQuery` and `useMutation` to always make the API client accessible in query/mutation functions by default. For example:

```tsx
export function useApiQuery<
  TQueryFnData = unknown,
  TError = DefaultError,
  TData = TQueryFnData,
  TQueryKey extends QueryKey = QueryKey,
>(
  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
  queryClient?: QueryClient,
) {
  const apiClient = useApiClient();

  return useQuery<TQueryFnData, TError, TData, TQueryKey>(
    {
      ...options,
      meta: {
        ...options.meta,
        apiClient,
      },
    },
    queryClient,
  );
}
```

Now instead of doing this _every_ time we need to execute an API query:
```tsx
const apiClient = useApiClient();

const { data } = useQuery({
  queryKey: ['someKey'],
  queryFn: () => getSomeData(apiClient),
});
```

We can simply do this:
```tsx
const { data } = useApiQuery({
  queryKey: ['someKey'],
  queryFn: ({ meta }) => getSomeData(meta!.apiClient),
});
```

Ideally, we wouldn't have to assert that `meta` is defined either, but the benefit here outweighs that easily. We have hundreds, and will eventually have thousands, of these API queries in our app. So having this available in the `queryFn` saves writing a remarkable amount of boilerplate.

Much to my dismay, as I was implementing this, I realized that we do not get similar access to `meta` within the `mutationFn` used by `useMutation`. So we need to keep using the old pattern.

I wonder then if it would be reasonable to add `meta` or a similar context containing `meta` as a second argument to `mutationFn`. For us, it would be incredibly useful. I know that an authenticated API client accessible through context is a very common pattern in React apps, so I imagine this would be useful to others as well.

Let me know what you think!