### PR TITLE
test(query-core/mutations): fix typo - remove duplicate "should run" in mutation test name

### DIFF
--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -533,7 +533,7 @@ describe('mutations', () => {
     ])
   })
 
-  test('each scope should run should run in parallel, serial within scope', async () => {
+  test('each scope should run in parallel, serial within scope', async () => {
     const results: Array<string> = []
 
     executeMutation(


### PR DESCRIPTION
Fixed a typo in the test description by removing duplicate "should run" text.
