### PR TITLE
feat(react-query): add `suspense` option to UseQueryOptions with deprecation notice

### DIFF
--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -43,7 +43,15 @@ export interface UseQueryOptions<
     TData,
     TQueryFnData,
     TQueryKey
-  > {}
+  > {
+  /**
+   * If set to `true`, the query will suspend when `status === 'loading'`
+   * and throw errors when `status === 'error'`.
+   * Defaults to `false`.
+   * @deprecated This option will be removed in the next major version.
+   */
+  suspense?: boolean
+}
 
 export type UseSuspenseQueryOptions<
   TQueryFnData = unknown,


### PR DESCRIPTION
<img width="603" alt="image" src="https://github.com/user-attachments/assets/068b9c27-3264-4706-8992-fc148c1fd4fc" />

<img width="856" alt="image" src="https://github.com/user-attachments/assets/0b00ac4d-acd2-4cc0-b8e5-7fb4ee0bc966" />
