### PR TITLE
fix: improve type safety for structural sharing with selected data

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -525,7 +525,11 @@ export class QueryObserver<
         try {
           this.#selectFn = options.select
           data = options.select(data as any)
+
+          // Apply structural sharing on selected data
+          // Directly use replaceData which correctly applies structuralSharing
           data = replaceData(prevResult?.data, data, options)
+
           this.#selectResult = data
           this.#selectError = null
         } catch (selectError) {

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -260,11 +260,13 @@ export interface QueryOptions<
   /**
    * Set this to `false` to disable structural sharing between query results.
    * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
+   *
+   * When used with `select`, this function operates on the selected data type.
    * Defaults to `true`.
    */
   structuralSharing?:
     | boolean
-    | ((oldData: unknown | undefined, newData: unknown) => unknown)
+    | ((oldData: TData | undefined, newData: TData) => TData)
   _defaulted?: boolean
   /**
    * Additional payload to be stored on each query.


### PR DESCRIPTION
Currently, there is a TypeScript type error when using the structuralSharing and select options together in useQuery. This issue occurs because the structuralSharing function expects the original query function's return type (TQueryFnData), but at runtime, it actually receives the transformed data type (TData) returned by the select function.