### PR TITLE
fix(query-core): set options before checking experimental_prefetchInR…

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -82,14 +82,15 @@ export class QueryObserver<
     this.#client = client
     this.#selectError = null
     this.#currentThenable = pendingThenable()
+
+    this.bindMethods()
+    this.setOptions(options)
+    
     if (!this.options.experimental_prefetchInRender) {
       this.#currentThenable.reject(
         new Error('experimental_prefetchInRender feature flag is not enabled'),
       )
     }
-
-    this.bindMethods()
-    this.setOptions(options)
   }
 
   protected bindMethods(): void {

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -85,7 +85,7 @@ export class QueryObserver<
 
     this.bindMethods()
     this.setOptions(options)
-    
+
     if (!this.options.experimental_prefetchInRender) {
       this.#currentThenable.reject(
         new Error('experimental_prefetchInRender feature flag is not enabled'),


### PR DESCRIPTION
In this PR

- https://github.com/TanStack/router/pull/3893

I'm facing the error, in the /e2e/solid-start/basic-solid-query project in the Posts and Users pages:

`Cannot read properties of undefined (reading 'experimental_prefetchInRender')`

I believe it's because it's checking the property on the options object before setting the options object on the next line.

This swaps that around