### PR TITLE
docs(solid): fix incorrect link to state managers guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -459,7 +459,7 @@
             },
             {
               "label": "Does this replace state managers?",
-              "to": "framework/angular/guides/does-this-replace-client-state"
+              "to": "framework/solid/guides/does-this-replace-client-state"
             }
           ]
         },


### PR DESCRIPTION
Fix broken navigation where clicking "Does this replace state managers?" in Solid docs incorrectly redirected to Angular guide instead of the proper Solid guide page.