### PR TITLE
Remove unnecessary data truthiness check in Suspense example

### DIFF
--- a/examples/react/suspense/src/components/Project.tsx
+++ b/examples/react/suspense/src/components/Project.tsx
@@ -22,13 +22,11 @@ export default function Project({
       <h1>
         {activeProject} {isFetching ? <Spinner /> : null}
       </h1>
-      {data ? (
-        <div>
-          <p>forks: {data.forks_count}</p>
-          <p>stars: {data.stargazers_count}</p>
-          <p>watchers: {data.watchers_count}</p>
-        </div>
-      ) : null}
+      <div>
+        <p>forks: {data.forks_count}</p>
+        <p>stars: {data.stargazers_count}</p>
+        <p>watchers: {data.watchers_count}</p>
+      </div>
       <br />
       <br />
     </div>


### PR DESCRIPTION
Isn't data guaranteed to be truth-y, as part of the larger principle of "Focus on the success case"?

We shouldn't need to check for it in the JSX. It's a bit misleading for those learning, too.

I'm assuming this is just a typo.

(Thanks to Jan Claasen for helping verify this issue.)