### PR TITLE
feat(devtools): add setting to hide disabled queries

### DIFF
--- a/packages/angular-query-experimental/src/providers.ts
+++ b/packages/angular-query-experimental/src/providers.ts
@@ -211,6 +211,10 @@ export interface DevtoolsOptions {
    * Use this so you can attach the devtool's styles to a specific element in the DOM.
    */
   shadowDOMTarget?: ShadowRoot
+  /**
+   * Set this to true to hide disabled queries from the devtools panel.
+   */
+  hideDisabled?: boolean
 
   /**
    * Whether the developer tools should load.

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -659,16 +659,27 @@ export const ContentView: Component<ContentViewProps> = (props) => {
 
   const queries = createMemo(
     on(
-      () => [queryCount(), props.localStore.filter, sort(), sortOrder()],
+      () => [
+        queryCount(),
+        props.localStore.filter,
+        sort(),
+        sortOrder(),
+        props.localStore.hideDisabled,
+      ],
       () => {
         const curr = query_cache().getAll()
 
-        const filtered = props.localStore.filter
+        let filtered = props.localStore.filter
           ? curr.filter(
               (item) =>
                 rankItem(item.queryHash, props.localStore.filter || '').passed,
             )
           : [...curr]
+
+        // Filter out disabled queries if hideDisabled is enabled
+        if (props.localStore.hideDisabled === 'true') {
+          filtered = filtered.filter((item) => !item.isDisabled())
+        }
 
         const sorted = sortFn()
           ? filtered.sort((a, b) => sortFn()!(a, b) * sortOrder())
@@ -1182,6 +1193,70 @@ export const ContentView: Component<ContentViewProps> = (props) => {
                         >
                           <span>System</span>
                           <Monitor />
+                        </DropdownMenu.Item>
+                      </DropdownMenu.SubContent>
+                    </DropdownMenu.Portal>
+                  </DropdownMenu.Sub>
+                  <DropdownMenu.Sub overlap gutter={8} shift={-4}>
+                    <DropdownMenu.SubTrigger
+                      class={cx(
+                        styles().settingsSubTrigger,
+                        'tsqd-settings-menu-sub-trigger',
+                        'tsqd-settings-menu-sub-trigger-disabled-queries',
+                      )}
+                    >
+                      <span>Disabled Queries</span>
+                      <ChevronDown />
+                    </DropdownMenu.SubTrigger>
+                    <DropdownMenu.Portal
+                      ref={(el) => setComputedVariables(el as HTMLDivElement)}
+                      mount={
+                        pip().pipWindow
+                          ? pip().pipWindow!.document.body
+                          : document.body
+                      }
+                    >
+                      <DropdownMenu.SubContent
+                        class={cx(
+                          styles().settingsMenu,
+                          'tsqd-settings-submenu',
+                        )}
+                      >
+                        <DropdownMenu.Item
+                          onSelect={() => {
+                            props.setLocalStore('hideDisabled', 'false')
+                          }}
+                          as="button"
+                          class={cx(
+                            styles().settingsSubButton,
+                            props.localStore.hideDisabled !== 'true' &&
+                              styles().themeSelectedButton,
+                            'tsqd-settings-menu-position-btn',
+                            'tsqd-settings-menu-position-btn-show',
+                          )}
+                        >
+                          <span>Show</span>
+                          <Show when={props.localStore.hideDisabled !== 'true'}>
+                            <CheckCircle />
+                          </Show>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item
+                          onSelect={() => {
+                            props.setLocalStore('hideDisabled', 'true')
+                          }}
+                          as="button"
+                          class={cx(
+                            styles().settingsSubButton,
+                            props.localStore.hideDisabled === 'true' &&
+                              styles().themeSelectedButton,
+                            'tsqd-settings-menu-position-btn',
+                            'tsqd-settings-menu-position-btn-hide',
+                          )}
+                        >
+                          <span>Hide</span>
+                          <Show when={props.localStore.hideDisabled === 'true'}>
+                            <CheckCircle />
+                          </Show>
                         </DropdownMenu.Item>
                       </DropdownMenu.SubContent>
                     </DropdownMenu.Portal>

--- a/packages/query-devtools/src/TanstackQueryDevtools.tsx
+++ b/packages/query-devtools/src/TanstackQueryDevtools.tsx
@@ -31,6 +31,7 @@ class TanstackQueryDevtools {
   #position: Signal<DevtoolsPosition | undefined>
   #initialIsOpen: Signal<boolean | undefined>
   #errorTypes: Signal<Array<DevtoolsErrorType> | undefined>
+  #hideDisabled: Signal<boolean | undefined>
   #Component: DevtoolsComponentType | undefined
   #dispose?: () => void
 
@@ -46,6 +47,7 @@ class TanstackQueryDevtools {
       errorTypes,
       styleNonce,
       shadowDOMTarget,
+      hideDisabled,
     } = config
     this.#client = createSignal(client)
     this.#queryFlavor = queryFlavor
@@ -57,6 +59,7 @@ class TanstackQueryDevtools {
     this.#position = createSignal(position)
     this.#initialIsOpen = createSignal(initialIsOpen)
     this.#errorTypes = createSignal(errorTypes)
+    this.#hideDisabled = createSignal(hideDisabled)
   }
 
   setButtonPosition(position: DevtoolsButtonPosition) {
@@ -88,6 +91,7 @@ class TanstackQueryDevtools {
       const [pos] = this.#position
       const [isOpen] = this.#initialIsOpen
       const [errors] = this.#errorTypes
+      const [hideDisabled] = this.#hideDisabled
       const [queryClient] = this.#client
       let Devtools: DevtoolsComponentType
 
@@ -120,6 +124,9 @@ class TanstackQueryDevtools {
             },
             get errorTypes() {
               return errors()
+            },
+            get hideDisabled() {
+              return hideDisabled()
             },
           }}
         />

--- a/packages/query-devtools/src/TanstackQueryDevtoolsPanel.tsx
+++ b/packages/query-devtools/src/TanstackQueryDevtoolsPanel.tsx
@@ -32,6 +32,7 @@ class TanstackQueryDevtoolsPanel {
   #position: Signal<DevtoolsPosition | undefined>
   #initialIsOpen: Signal<boolean | undefined>
   #errorTypes: Signal<Array<DevtoolsErrorType> | undefined>
+  #hideDisabled: Signal<boolean | undefined>
   #onClose: Signal<(() => unknown) | undefined>
   #Component: DevtoolsComponentType | undefined
   #dispose?: () => void
@@ -49,6 +50,7 @@ class TanstackQueryDevtoolsPanel {
       styleNonce,
       shadowDOMTarget,
       onClose,
+      hideDisabled,
     } = config
     this.#client = createSignal(client)
     this.#queryFlavor = queryFlavor
@@ -60,6 +62,7 @@ class TanstackQueryDevtoolsPanel {
     this.#position = createSignal(position)
     this.#initialIsOpen = createSignal(initialIsOpen)
     this.#errorTypes = createSignal(errorTypes)
+    this.#hideDisabled = createSignal(hideDisabled)
     this.#onClose = createSignal(onClose)
   }
 
@@ -96,6 +99,7 @@ class TanstackQueryDevtoolsPanel {
       const [pos] = this.#position
       const [isOpen] = this.#initialIsOpen
       const [errors] = this.#errorTypes
+      const [hideDisabled] = this.#hideDisabled
       const [queryClient] = this.#client
       const [onClose] = this.#onClose
       let Devtools: DevtoolsComponentType
@@ -129,6 +133,9 @@ class TanstackQueryDevtoolsPanel {
             },
             get errorTypes() {
               return errors()
+            },
+            get hideDisabled() {
+              return hideDisabled()
             },
             get onClose() {
               return onClose()

--- a/packages/query-devtools/src/contexts/QueryDevtoolsContext.ts
+++ b/packages/query-devtools/src/contexts/QueryDevtoolsContext.ts
@@ -29,6 +29,7 @@ export interface QueryDevtoolsProps {
   errorTypes?: Array<DevtoolsErrorType>
   shadowDOMTarget?: ShadowRoot
   onClose?: () => unknown
+  hideDisabled?: boolean
 }
 
 export const QueryDevtoolsContext = createContext<QueryDevtoolsProps>({

--- a/packages/react-query-devtools/src/ReactQueryDevtools.tsx
+++ b/packages/react-query-devtools/src/ReactQueryDevtools.tsx
@@ -42,6 +42,10 @@ export interface DevtoolsOptions {
    * Use this so you can attach the devtool's styles to specific element in the DOM.
    */
   shadowDOMTarget?: ShadowRoot
+  /**
+   * Set this to true to hide disabled queries from the devtools panel.
+   */
+  hideDisabled?: boolean
 }
 
 export function ReactQueryDevtools(
@@ -56,6 +60,7 @@ export function ReactQueryDevtools(
     errorTypes,
     styleNonce,
     shadowDOMTarget,
+    hideDisabled,
   } = props
   const [devtools] = React.useState(
     new TanstackQueryDevtools({
@@ -69,6 +74,7 @@ export function ReactQueryDevtools(
       errorTypes,
       styleNonce,
       shadowDOMTarget,
+      hideDisabled,
     }),
   )
 

--- a/packages/react-query-devtools/src/ReactQueryDevtoolsPanel.tsx
+++ b/packages/react-query-devtools/src/ReactQueryDevtoolsPanel.tsx
@@ -35,6 +35,10 @@ export interface DevtoolsPanelOptions {
    * Callback function that is called when the devtools panel is closed
    */
   onClose?: () => unknown
+  /**
+   * Set this to true to hide disabled queries from the devtools panel.
+   */
+  hideDisabled?: boolean
 }
 
 export function ReactQueryDevtoolsPanel(
@@ -42,7 +46,7 @@ export function ReactQueryDevtoolsPanel(
 ): React.ReactElement | null {
   const queryClient = useQueryClient(props.client)
   const ref = React.useRef<HTMLDivElement>(null)
-  const { errorTypes, styleNonce, shadowDOMTarget } = props
+  const { errorTypes, styleNonce, shadowDOMTarget, hideDisabled } = props
   const [devtools] = React.useState(
     new TanstackQueryDevtoolsPanel({
       client: queryClient,
@@ -56,6 +60,7 @@ export function ReactQueryDevtoolsPanel(
       styleNonce,
       shadowDOMTarget,
       onClose: props.onClose,
+      hideDisabled,
     }),
   )
 

--- a/packages/solid-query-devtools/src/devtools.tsx
+++ b/packages/solid-query-devtools/src/devtools.tsx
@@ -41,6 +41,10 @@ interface DevtoolsOptions {
    * Use this so you can attach the devtool's styles to specific element in the DOM.
    */
   shadowDOMTarget?: ShadowRoot
+  /**
+   * Set this to true to hide disabled queries from the devtools panel.
+   */
+  hideDisabled?: boolean
 }
 
 export default function SolidQueryDevtools(props: DevtoolsOptions) {
@@ -58,6 +62,7 @@ export default function SolidQueryDevtools(props: DevtoolsOptions) {
     errorTypes: props.errorTypes,
     styleNonce: props.styleNonce,
     shadowDOMTarget: props.shadowDOMTarget,
+    hideDisabled: props.hideDisabled,
   })
 
   createEffect(() => {

--- a/packages/svelte-query-devtools/src/Devtools.svelte
+++ b/packages/svelte-query-devtools/src/Devtools.svelte
@@ -17,6 +17,7 @@
   export let errorTypes: Array<DevtoolsErrorType> = []
   export let styleNonce: string | undefined = undefined
   export let shadowDOMTarget: ShadowRoot | undefined = undefined
+  export let hideDisabled: boolean = false
 
   let ref: HTMLDivElement
   let devtools: TanstackQueryDevtools | undefined
@@ -37,6 +38,7 @@
           errorTypes,
           styleNonce,
           shadowDOMTarget,
+          hideDisabled,
         })
 
         devtools.mount(ref)

--- a/packages/vue-query-devtools/src/devtools.vue
+++ b/packages/vue-query-devtools/src/devtools.vue
@@ -19,6 +19,7 @@ const devtools = new TanstackQueryDevtools({
   errorTypes: props.errorTypes,
   styleNonce: props.styleNonce,
   shadowDOMTarget: props.shadowDOMTarget,
+  hideDisabled: props.hideDisabled,
 })
 
 watchEffect(() => {

--- a/packages/vue-query-devtools/src/types.ts
+++ b/packages/vue-query-devtools/src/types.ts
@@ -38,4 +38,8 @@ export interface DevtoolsOptions {
    * Use this so you can attach the devtool's styles to specific element in the DOM.
    */
   shadowDOMTarget?: ShadowRoot
+  /**
+   * Set this to true to hide disabled queries from the devtools panel.
+   */
+  hideDisabled?: boolean
 }


### PR DESCRIPTION
This PR adds a new setting to the Query Devtools package that allows for filtering out disabled queries. 

<img width="594" height="464" alt="CleanShot 2025-07-25 at 17 06 47@2x" src="https://github.com/user-attachments/assets/ded5266e-f7b7-4c8a-bf14-5fc2233988d8" />
