### PR TITLE
refactor(angular-query): restructure package type declaration location

### DIFF
--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -27,7 +27,7 @@
     "tanstack"
   ],
   "scripts": {
-    "clean": "premove ./build ./dist ./coverage ./dist-ts",
+    "clean": "premove ./dist ./coverage ./dist-ts",
     "compile": "tsc --build",
     "test:eslint": "eslint ./src",
     "test:types": "npm-run-all --serial test:types:*",
@@ -59,9 +59,9 @@
   },
   "sideEffects": false,
   "files": [
-    "dist",
-    "src",
-    "!src/__tests__"
+    "**/*.d.ts",
+    "**/*.mjs",
+    "**/*.mjs.map"
   ],
   "dependencies": {
     "@tanstack/query-core": "workspace:*",
@@ -82,5 +82,9 @@
   "peerDependencies": {
     "@angular/common": ">=16.0.0",
     "@angular/core": ">=16.0.0"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "linkDirectory": false
   }
 }

--- a/packages/angular-query-experimental/scripts/prepack.js
+++ b/packages/angular-query-experimental/scripts/prepack.js
@@ -1,1 +1,106 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Prepack script that prepares the package for publishing by:
+ * 1. Creating a modified package.json without dev dependencies, publishConfig and build scripts
+ * 2. Updating file paths to remove 'dist/' prefixes (since files will be at root in published package)
+ * 3. Writing this modified package.json to the `dist` directory
+ * 4. Copying additional files like README.md to the dist directory
+ *
+ * Type declarations need to be in the package root or corresponding sub-path to support
+ * sub-path exports in applications still using `moduleResolution: node`.
+ */
+
 console.log('Running prepack script')
+
+/**
+ * Files to copy to the dist directory
+ * @type {string[]}
+ */
+const FILES_TO_COPY = ['README.md']
+
+/**
+ * Fields to remove from the package.json copy
+ * @type {string[]}
+ */
+const FIELDS_TO_REMOVE = [
+  'devDependencies',
+  'files',
+  'publishConfig',
+  'scripts',
+]
+
+/**
+ * Replaces 'dist/' or './dist/' prefix from a file path with './'
+ * Only matches at the start of the path to avoid false matches
+ * @param {string} filePath - The file path to process
+ * @returns {string} The path without dist prefix
+ */
+function replaceDist(filePath) {
+  // Only match dist/ at the beginning of the path, followed by a filename
+  // This prevents matching strings like "distributed/file.js" or "some/dist/path"
+  return filePath.replace(/^(?:\.\/)?dist\/(?=.+)/, './')
+}
+
+/**
+ * Recursively processes package.json `exports` to remove dist prefixes
+ * @param {Record<string, any>} exports - The exports object to process
+ * @returns {Record<string, any>} The processed exports object
+ */
+function processExports(exports) {
+  return Object.fromEntries(
+    Object.entries(exports).map(([key, value]) => [
+      key,
+      typeof value === 'string'
+        ? replaceDist(value)
+        : typeof value === 'object' && value !== null
+          ? processExports(value)
+          : value,
+    ]),
+  )
+}
+
+console.log('Copying modified package.json')
+
+/** @type {Record<string, any>} */
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+
+const modifiedPackageJson = { ...packageJson }
+
+if (modifiedPackageJson.types) {
+  modifiedPackageJson.types = replaceDist(modifiedPackageJson.types)
+}
+
+if (modifiedPackageJson.module) {
+  modifiedPackageJson.module = replaceDist(modifiedPackageJson.module)
+}
+
+if (modifiedPackageJson.exports) {
+  modifiedPackageJson.exports = processExports(modifiedPackageJson.exports)
+}
+
+for (const field of FIELDS_TO_REMOVE) {
+  delete modifiedPackageJson[field]
+}
+
+if (!fs.existsSync('dist')) {
+  fs.mkdirSync('dist', { recursive: true })
+}
+
+fs.writeFileSync(
+  path.join('dist', 'package.json'),
+  JSON.stringify(modifiedPackageJson, null, 2),
+)
+
+console.log('Copying other files')
+for (const file of FILES_TO_COPY) {
+  if (fs.existsSync(file)) {
+    fs.copyFileSync(file, path.join('dist', file))
+    console.log(`${file}`)
+  } else {
+    console.log(`${file} not found, skipping`)
+  }
+}
+
+console.log('prepack complete')

--- a/packages/angular-query-experimental/tsconfig.json
+++ b/packages/angular-query-experimental/tsconfig.json
@@ -7,6 +7,6 @@
     "useDefineForClassFields": false,
     "target": "ES2022"
   },
-  "include": ["src", "*.config.js", "*.config.ts", "package.json"],
+  "include": ["src", "scripts", "*.config.js", "*.config.ts", "package.json"],
   "references": [{ "path": "../query-core" }, { "path": "../query-devtools" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2307,6 +2307,7 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(less@4.3.0)(lightningcss@1.29.2)(sass@1.88.0)(terser@5.39.1)(tsx@4.20.1)(yaml@2.8.0))
+    publishDirectory: dist
 
   packages/angular-query-persist-client:
     dependencies:


### PR DESCRIPTION
To support future sub-path exports in apps using `moduleResolution: node` type declarations need to be located in the same path as the corresponding implementation .mjs file