### PR TITLE
fix(react-query): HydrationBoundary has strictly typed `state`

### DIFF
--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@tanstack/query-core'
 
 export interface HydrationBoundaryProps {
-  state: DehydratedState | null | undefined;
+  state: DehydratedState | null | undefined
   options?: OmitKeyof<HydrateOptions, 'defaultOptions'> & {
     defaultOptions?: OmitKeyof<
       Exclude<HydrateOptions['defaultOptions'], undefined>,


### PR DESCRIPTION
Only type definition changes, the `state` parameter is now required and must be `DehydratedState` (or nullish). Every case omitting this prop or passing a different shape is a bug now caught by `tsc`. Correct code has no action needed.

Closes #9323