### PR TITLE
fix(query-core): focus check issue from retryer for refetchIntervallnBackground

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -390,7 +390,7 @@ export class Query<
   ): Promise<TData> {
     if (
       this.state.fetchStatus !== 'idle' &&
-      // If the promise in the retyer is already rejected, we have to definitely
+      // If the promise in the retryer is already rejected, we have to definitely
       // re-start the fetch; there is a chance that the query is still in a
       // pending state when that happens
       this.#retryer?.status() !== 'rejected'
@@ -541,6 +541,7 @@ export class Query<
       retryDelay: context.options.retryDelay,
       networkMode: context.options.networkMode,
       canRun: () => true,
+      refetchIntervalInBackground: this.options.refetchIntervalInBackground,
     })
 
     try {

--- a/packages/query-core/src/retryer.ts
+++ b/packages/query-core/src/retryer.ts
@@ -1,7 +1,7 @@
-import { focusManager } from './focusManager'
 import { onlineManager } from './onlineManager'
 import { pendingThenable } from './thenable'
 import { isServer, sleep } from './utils'
+import { focusManager } from './focusManager'
 import type { Thenable } from './thenable'
 import type { CancelOptions, DefaultError, NetworkMode } from './types'
 
@@ -18,6 +18,7 @@ interface RetryerConfig<TData = unknown, TError = DefaultError> {
   retryDelay?: RetryDelayValue<TError>
   networkMode: NetworkMode | undefined
   canRun: () => boolean
+  refetchIntervalInBackground?: boolean
 }
 
 export interface Retryer<TData = unknown> {
@@ -101,7 +102,7 @@ export function createRetryer<TData = unknown, TError = DefaultError>(
   }
 
   const canContinue = () =>
-    focusManager.isFocused() &&
+    (config.refetchIntervalInBackground === true || focusManager.isFocused()) &&
     (config.networkMode === 'always' || onlineManager.isOnline()) &&
     config.canRun()
 

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -275,6 +275,11 @@ export interface QueryOptions<
    * Maximum number of pages to store in the data of an infinite query.
    */
   maxPages?: number
+  /**
+   * If set to `true`, the query will continue to refetch while their tab/window is in the background.
+   * Defaults to `false`.
+   */
+  refetchIntervalInBackground?: boolean
 }
 
 export interface InitialPageParam<TPageParam = unknown> {


### PR DESCRIPTION
fixed #8353 

- Instead of removing focusManager.isFocused(), update retryer.ts to check (config.refetchIntervalInBackground === true || focusManager.isFocused())
- Passed the refetchIntervalInBackground option through query.ts.
- Added the refetchIntervalInBackground property to the QueryOptions interface in types.ts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Query option refetchIntervalInBackground (default: false) to allow scheduled refetches/retries to continue while the app/tab is in the background.

* **Tests**
  * Added tests verifying background refetch/retry behavior for enabled, disabled, and default cases to ensure pause/continue semantics based on focus and network state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->