### PR TITLE
Allow including devtools panel in production builds

### DIFF
--- a/packages/react-query-devtools/src/index.ts
+++ b/packages/react-query-devtools/src/index.ts
@@ -10,11 +10,6 @@ export const ReactQueryDevtools: (typeof Devtools)['ReactQueryDevtools'] =
       }
     : Devtools.ReactQueryDevtools
 
-export const ReactQueryDevtoolsPanel: (typeof DevtoolsPanel)['ReactQueryDevtoolsPanel'] =
-  process.env.NODE_ENV !== 'development'
-    ? function () {
-        return null
-      }
-    : DevtoolsPanel.ReactQueryDevtoolsPanel
+export const ReactQueryDevtoolsPanel: (typeof DevtoolsPanel)['ReactQueryDevtoolsPanel'] = DevtoolsPanel.ReactQueryDevtoolsPanel
 
 export type DevtoolsPanelOptions = DevtoolsPanel.DevtoolsPanelOptions

--- a/packages/solid-query-devtools/src/index.tsx
+++ b/packages/solid-query-devtools/src/index.tsx
@@ -9,10 +9,6 @@ export const SolidQueryDevtools: typeof SolidQueryDevtoolsComp = isDev
       return null
     }
 
-export const SolidQueryDevtoolsPanel: typeof SolidQueryDevtoolsCompPanel = isDev
-  ? clientOnly(() => import('./devtoolsPanel'))
-  : function () {
-      return null
-    }
+export const SolidQueryDevtoolsPanel: typeof SolidQueryDevtoolsCompPanel = clientOnly(() => import('./devtoolsPanel'))
 
 export type { DevtoolsPanelOptions } from './devtoolsPanel'


### PR DESCRIPTION
This PR removes the `isDev` condition from the `ReactQueryDevtoolsPanel` components.

It does not remove the same condition from `ReactQueryDevtools`.

I think it should be possible for developers to opt-in if they want these devtools panels in production.

This one might need some discussion about whether we would want to remove these checks from `ReactQueryDevtoolsPanel` too. The checks are nice to protect developers from accidentally bundling devtools in production but if that is desired there is currently no way for the developer to override it.