### PR TITLE
fix(core): do not reject promise right away - only when `promise` gets used

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -267,9 +267,12 @@ export class QueryObserver<
       get: (target, key) => {
         this.trackProp(key as keyof QueryObserverResult)
         onPropTracked?.(key as keyof QueryObserverResult)
-        if (key === 'promise' && !this.options.experimental_prefetchInRender) {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          ;(this.#currentThenable as PendingThenable<TData>).reject?.(
+        if (
+          key === 'promise' &&
+          !this.options.experimental_prefetchInRender &&
+          this.#currentThenable.status === 'pending'
+        ) {
+          this.#currentThenable.reject(
             new Error(
               'experimental_prefetchInRender feature flag is not enabled',
             ),


### PR DESCRIPTION
fixes #8209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Prevented premature errors when the experimental prefetch-in-render flag is disabled; errors now occur only if a query’s promise is explicitly accessed.

- Refactor
  - Switched from eager to lazy error handling to avoid initialization failures and preserve normal behavior unless the promise is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->