### PR TITLE
fix(core): never revert to undefined data

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -996,7 +996,7 @@ describe('queryClient', () => {
       const key1 = queryKey()
       queryClient.setQueryData(key1, 'data')
 
-      void queryClient.fetchQuery({
+      const pending = queryClient.fetchQuery({
         queryKey: key1,
         queryFn: () => sleep(1000).then(() => 'data2'),
       })
@@ -1004,6 +1004,9 @@ describe('queryClient', () => {
       await vi.advanceTimersByTimeAsync(10)
 
       await queryClient.cancelQueries()
+
+      // with previous data present, imperative fetch should resolve to that data after cancel
+      await expect(pending).resolves.toBe('data')
 
       const state1 = queryClient.getQueryState(key1)
       expect(state1).toMatchObject({

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
+  CancelledError,
   MutationObserver,
   QueryClient,
   QueryObserver,
@@ -1059,6 +1060,24 @@ describe('queryClient', () => {
       expect(state1).toMatchObject({
         status: 'error',
       })
+    })
+
+    test('should throw CancelledError when initial fetch is cancelled', async () => {
+      const key = queryKey()
+
+      const promise = queryClient.fetchQuery({
+        queryKey: key,
+        queryFn: async () => {
+          await sleep(50)
+          return 25
+        },
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      await queryClient.cancelQueries({ queryKey: key })
+
+      await expect(promise).rejects.toBeInstanceOf(CancelledError)
     })
   })
 

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -559,10 +559,11 @@ export class Query<
           })
           // transform error into reverted state data
           // if the initial fetch was cancelled, we have no data, so we have
-          // to get into error state with the CancelledError
-          if (this.state.data !== undefined) {
-            return this.state.data
+          // to get reject with a CancelledError
+          if (this.state.data === undefined) {
+            throw error
           }
+          return this.state.data
         }
       }
       this.#dispatch({

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -558,7 +558,11 @@ export class Query<
             fetchStatus: 'idle' as const,
           })
           // transform error into reverted state data
-          return this.state.data!
+          // if the initial fetch was cancelled, we have no data, so we have
+          // to get into error state with the CancelledError
+          if (this.state.data !== undefined) {
+            return this.state.data
+          }
         }
       }
       this.#dispatch({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public CancelledError to surface cancellation outcomes.

- **Bug Fixes**
  - Cancelling an initial in-flight fetch now raises CancelledError instead of resolving with missing/undefined data; previous data is preserved when available.

- **Tests**
  - Refactored and added tests to validate cancellation behavior, error propagation, and post-cancellation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->