### PR TITLE
fix(query-core): prevent state override when observer remount occurs …

### DIFF
--- a/packages/query-core/src/retryer.ts
+++ b/packages/query-core/src/retryer.ts
@@ -58,10 +58,12 @@ export function canFetch(networkMode: NetworkMode | undefined): boolean {
 export class CancelledError extends Error {
   revert?: boolean
   silent?: boolean
+  isObserverRemoval?: boolean
   constructor(options?: CancelOptions) {
     super('CancelledError')
     this.revert = options?.revert
     this.silent = options?.silent
+    this.isObserverRemoval = options?.isObserverRemoval
   }
 }
 

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1329,6 +1329,7 @@ export interface DefaultOptions<TError = DefaultError> {
 export interface CancelOptions {
   revert?: boolean
   silent?: boolean
+  isObserverRemoval?: boolean
 }
 
 export interface SetDataOptions {


### PR DESCRIPTION
fixes: #9579 
comment: [#9579 (comment)](https://github.com/TanStack/query/issues/9579#issuecomment-3203591586)

## Description

This PR fixes an issue where `isLoading` incorrectly becomes `false` during an active fetch when using React StrictMode with signal destructuring in the queryFn.

## Problem

This issue does not appear to be solely related to `StrictMode`, but rather occurs when using `signal` within the `queryFn` under `StrictMode`.
In fact, if you remove the `signal` from the provided code as shown below,
```tsx
queryFn: () => {
  return new Promise((resolve) => {
    setTimeout(
      () => {
        const now = Date.now();
        console.log(`fetchCompleted index=${index}, time=${now}`);
        resolve(`request ${index}, time=${now}`);
      },
      4000,
      // { signal }
    );
  });
},
```
`isLoading` will correctly become `true`.
The problem arises because when the `signal` option is present and the fetch starts, destructuring the signal sets `abortSignalConsumed = true` https://github.com/TanStack/query/blob/7c464e3ded7c4764170839b4aa7f763c7d0aa647/packages/query-core/src/query.ts#L428. Due to `StrictMode`, during cleanup the following condition is met inside `removeObserver`
```ts
if (this.#abortSignalConsumed) {
  this.#retryer.cancel({ revert: true });
}
```
https://github.com/TanStack/query/blob/7c464e3ded7c4764170839b4aa7f763c7d0aa647/packages/query-core/src/query.ts#L351-L352
This triggers an asynchronous execution of `this.#retryer.cancel({ revert: true })`.
As a result, the sequence becomes: immediate re-mount → new observer added → second fetch begins → meanwhile, the asynchronous `catch` logic from the first fetch executes, which then hits the following branch
```ts
else if (error.revert) {
  this.setState({
    ...this.#revertState,
    fetchStatus: 'idle' as const,
  })
}
```
https://github.com/TanStack/query/blob/7c464e3ded7c4764170839b4aa7f763c7d0aa647/packages/query-core/src/query.ts#L555-L567
This causes the state to be overwritten with the initial values, leading to the observed issue.
The reason it did not occur in the previous version is that `onError` existed and handled the case, but now the logic is fully asynchronous and falls into `catch`, which results in the problem you are seeing.

## Solution

The fix adds a check to prevent state reversion when
1. The cancellation was triggered by observer removal (`isObserverRemoval` flag)
2. New observers have already been added (`this.observers.length > 0`)

This pattern is typical of React StrictMode's cleanup simulation where components are immediately remounted.

## Changes

- Added `isObserverRemoval` flag to `CancelOptions` and `CancelledError`
- Modified `removeObserver` to pass this flag when cancelling with revert
- Updated the catch block in `fetch` method to check for this condition before reverting state
- Added test case to verify the fix

## Testing

- [x] All existing tests pass
- [x] Added new test: `should not override fetching state when revert happens after new observer subscribes`
- [x] Manually tested with the reproduction case in StrictMode