### PR TITLE
Fix O(N) time & space in QueryCache search when queryKey is present 

### DIFF
--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { Query, QueryCache, QueryClient, QueryObserver } from '..'
+import { QueryCache, QueryClient, QueryObserver } from '..'
 
 describe('queryCache', () => {
   let queryClient: QueryClient

--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -348,25 +348,12 @@ describe('queryCache', () => {
       })
 
       expect(predicateCallCount).toBe(results.length)
-
-      const sortByHash = (a: Query | undefined, b: Query | undefined) => {
-        if (!a && !b) return 0
-        if (!a) return -1
-        if (!b) return 1
-        if (a.queryHash < b.queryHash) return -1
-        if (a.queryHash > b.queryHash) return 1
-        return 0
-      }
-      results.sort(sortByHash)
-
-      expect(results).toEqual(
-        [
-          exactMatchQuery,
-          primitiveSuffixQuery,
-          primitiveSuffixLength2Query,
-          matchingObjectSuffixQuery,
-        ].sort(sortByHash),
-      )
+      expect(results).toEqual([
+        exactMatchQuery,
+        primitiveSuffixQuery,
+        primitiveSuffixLength2Query,
+        matchingObjectSuffixQuery,
+      ])
     })
 
     test('should return all the queries when no filters are defined', async () => {

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -1,6 +1,5 @@
 import {
   ensureQueryFn,
-  hashKey,
   noop,
   replaceData,
   resolveEnabled,
@@ -21,7 +20,6 @@ import type {
   OmitKeyof,
   QueryFunctionContext,
   QueryKey,
-  QueryKeyHashFunction,
   QueryMeta,
   QueryOptions,
   QueryStatus,
@@ -156,40 +154,6 @@ export interface SetStateOptions {
   meta?: any
 }
 
-export class RefCountSet<T> {
-  #refcounts = new Map<T, number>();
-
-  [Symbol.iterator]() {
-    return this.#refcounts.keys()
-  }
-
-  get size() {
-    return this.#refcounts.size
-  }
-
-  add(value: T) {
-    const n = this.#refcounts.get(value) ?? 0
-    this.#refcounts.set(value, n + 1)
-  }
-
-  remove(value: T) {
-    let n = this.#refcounts.get(value)
-    if (n === undefined) {
-      return
-    }
-    n--
-    if (n === 0) {
-      this.#refcounts.delete(value)
-    } else {
-      this.#refcounts.set(value, n)
-    }
-  }
-}
-
-// Somewhere; I'm not sure what the appropriate place to store this is. Maybe part of QueryCache?
-// Making it global is easier in my example code.
-export const allQueryKeyHashFns = new RefCountSet<QueryKeyHashFunction<any>>()
-
 // CLASS
 
 export class Query<
@@ -238,16 +202,20 @@ export class Query<
   setOptions(
     options?: QueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   ): void {
-    const oldHashFn = this.options?.queryKeyHashFn
+    const oldOptions = (this.options as typeof this.options | undefined)
+      ? this.options
+      : undefined
+
     this.options = { ...this.#defaultOptions, ...options }
 
-    const newHashFn = this.options?.queryKeyHashFn
-    if (oldHashFn !== newHashFn) {
-      if (oldHashFn && oldHashFn !== hashKey) {
-        allQueryKeyHashFns.remove(oldHashFn)
-      }
-      if (newHashFn && newHashFn !== hashKey) {
-        allQueryKeyHashFns.add(newHashFn)
+    if (oldOptions) {
+      // Do not do this update when first created.
+      // The QueryCache manages admission / removal itself.
+      // We only need to keep it up-to-date here.
+      const prevHashFn = oldOptions.queryKeyHashFn
+      const newHashFn = this.options.queryKeyHashFn
+      if (prevHashFn !== newHashFn) {
+        this.#cache.onQueryKeyHashFunctionChanged(prevHashFn, newHashFn)
       }
     }
 

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -1,13 +1,14 @@
-import { hashQueryKeyByOptions, matchQuery } from './utils'
-import { Query } from './query'
+import { hashKey, hashQueryKeyByOptions, matchQuery } from './utils'
+import { Query, RefCountSet, allQueryKeyHashFns } from './query'
 import { notifyManager } from './notifyManager'
 import { Subscribable } from './subscribable'
-import type { QueryFilters } from './utils'
 import type { Action, QueryState } from './query'
+import type { QueryFilters } from './utils'
 import type {
   DefaultError,
   NotifyEvent,
   QueryKey,
+  QueryKeyHashFunction,
   QueryOptions,
   WithRequired,
 } from './types'
@@ -87,10 +88,218 @@ export interface QueryStore {
   values: () => IterableIterator<Query>
 }
 
+type Primitive = string | number | boolean | bigint | symbol | undefined | null
+function isPrimitive(value: unknown): value is Primitive {
+  if (value === undefined || value === null) {
+    return true
+  }
+  const t = typeof value
+  switch (t) {
+    case 'object':
+    case 'function':
+      return false
+    case 'string':
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+    case 'symbol':
+    case 'undefined':
+      return true
+    default:
+      t satisfies never
+      return false
+  }
+}
+
+type MapTrieNode<TValue> = {
+  key: Primitive
+  /**
+   * - Entries who's TKey path leads exactly to this node,
+   *   therefor their path is all primitives.
+   *   ourPath = [p1, p2, p3, ...pN]
+   *   theirPath = [p1, p2, p3, ...pN]
+   */
+  exact?: RefCountSet<TValue>
+  /**
+   * - Entries who's path after this point contains non-primitive keys.
+   *   Such entries cannot be looked up by value deeper in the trie.
+   *   Implies their TKey path != this node's keyPath.
+   *   ourPath = [p1, p2, p3, ...pN]
+   *   theirPath = [p1, p2, p3, ...pN, nonPrimitive, ...]
+   */
+  nonPrimitiveSuffix?: RefCountSet<TValue>
+  /** Child nodes storing entries who's TKey path is prefixed with this node's path. */
+  children?: Map<Primitive, MapTrieNode<TValue>>
+}
+
+/** Path length is always 1 greater than the key length, as it includes the root node. */
+function traverse<TValue>(
+  root: MapTrieNode<TValue>,
+  key: QueryKey,
+  // May create a child node if needed
+  lookup: (
+    parent: MapTrieNode<TValue>,
+    key: Primitive,
+  ) => MapTrieNode<TValue> | undefined,
+): Array<MapTrieNode<TValue>> {
+  const path: Array<MapTrieNode<TValue>> = [root]
+  let node: MapTrieNode<TValue> | undefined = root
+  for (let i = 0; i < key.length && node; i++) {
+    const keyPart = key[i]
+    if (isPrimitive(keyPart)) {
+      node = lookup(node, keyPart)
+    } else {
+      node = undefined
+    }
+    if (node) {
+      path.push(node)
+    }
+  }
+  return path
+}
+
+function gcPath(path: Array<MapTrieNode<any>>): void {
+  if (path.length === 0) {
+    return
+  }
+  for (let i = path.length - 1; i >= 0; i--) {
+    const node = path[i]
+    if (!node) {
+      throw new Error('Should never occur (bug in MapTrie)')
+    }
+
+    if (
+      node.exact?.size ||
+      node.nonPrimitiveSuffix?.size ||
+      node.children?.size
+    ) {
+      // Has data. Do not GC.
+      return
+    }
+
+    const parent = path[i - 1]
+    parent?.children?.delete(node.key)
+  }
+}
+
+class MapTrieSet<TKey extends QueryKey, TValue> {
+  #root: MapTrieNode<TValue> = {
+    key: undefined,
+  }
+
+  add(key: TKey, value: TValue): void {
+    const path = traverse(this.#root, key, (parent, keyPart) => {
+      parent.children ??= new Map()
+      let child = parent.children.get(keyPart)
+      if (!child) {
+        child = { key: keyPart }
+        parent.children.set(keyPart, child)
+      }
+      return child
+    })
+    const lastPathNode = path[path.length - 1]
+    if (!lastPathNode) {
+      throw new Error('Should never occur (bug in MapTrie)')
+    }
+
+    if (key.length === path.length - 1) {
+      lastPathNode.exact ??= new RefCountSet()
+      lastPathNode.exact.add(value)
+    } else {
+      lastPathNode.nonPrimitiveSuffix ??= new RefCountSet()
+      lastPathNode.nonPrimitiveSuffix.add(value)
+    }
+  }
+
+  remove(key: TKey, value: TValue): void {
+    const path = traverse(this.#root, key, (parent, keyPart) =>
+      parent.children?.get(keyPart),
+    )
+    const lastPathNode = path[path.length - 1]
+    if (!lastPathNode) {
+      throw new Error('Should never occur (bug in MapTrie)')
+    }
+    if (key.length === path.length - 1) {
+      lastPathNode.exact?.remove(value)
+      gcPath(path)
+    } else if (!isPrimitive(key[path.length - 1])) {
+      lastPathNode.nonPrimitiveSuffix?.remove(value)
+      gcPath(path)
+    }
+  }
+
+  /**
+   * Returns all values that match the given key:
+   * Either the value has the same key and is all primitives,
+   * Or the value's key is a suffix of the given key and contains a non-primitive key.
+   */
+  getByPrefix(key: TKey): Iterable<TValue> | undefined {
+    let miss = false
+    const path = traverse(this.#root, key, (parent, keyPart) => {
+      const child = parent.children?.get(keyPart)
+      if (!child) {
+        miss = true
+        return undefined
+      }
+      return child
+    })
+    // Failed to look up one of the primitive keys in the path.
+    // This means there's no match at all.
+    // Appears to be incorrectly reported by @typescript-eslint as always false :\
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (miss) {
+      return undefined
+    }
+
+    const lastNode = path[path.length - 1]
+    if (!lastNode) {
+      throw new Error('Should never occur (bug in MapTrie)')
+    }
+
+    // If the `key` is all primitives then we need to recurse to find all values
+    // that match the prefix, as these values will be stored deeper in the trie.
+    //
+    // If the `key` contains a non-primitive part after the returned path,
+    // then all possible values that have the suffix are stored in this node.
+    const isPrimitivePath = path.length - 1 === key.length
+    if (!isPrimitivePath) {
+      return lastNode.nonPrimitiveSuffix?.[Symbol.iterator]()
+    }
+
+    // See if we can avoid instantiating a generator
+    if (
+      !lastNode.children &&
+      (lastNode.exact || lastNode.nonPrimitiveSuffix) &&
+      !(lastNode.exact && lastNode.nonPrimitiveSuffix)
+    ) {
+      return lastNode.exact ?? lastNode.nonPrimitiveSuffix
+    }
+
+    return (function* depthFirstPrefixIterator() {
+      const queue = [lastNode]
+      while (queue.length > 0) {
+        const node = queue.pop()!
+        if (node.exact) {
+          yield* node.exact
+        }
+        if (node.nonPrimitiveSuffix) {
+          yield* node.nonPrimitiveSuffix
+        }
+        if (node.children) {
+          for (const child of node.children.values()) {
+            queue.push(child)
+          }
+        }
+      }
+    })()
+  }
+}
+
 // CLASS
 
 export class QueryCache extends Subscribable<QueryCacheListener> {
   #queries: QueryStore
+  #keyIndex = new MapTrieSet<QueryKey, Query>()
 
   constructor(public config: QueryCacheConfig = {}) {
     super()
@@ -133,6 +342,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
   add(query: Query<any, any, any, any>): void {
     if (!this.#queries.has(query.queryHash)) {
       this.#queries.set(query.queryHash, query)
+      this.#keyIndex.add(query.queryKey, query)
 
       this.notify({
         type: 'added',
@@ -149,6 +359,7 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
 
       if (queryInMap === query) {
         this.#queries.delete(query.queryHash)
+        this.#keyIndex.remove(query.queryKey, query)
       }
 
       this.notify({ type: 'removed', query })
@@ -184,17 +395,77 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     filters: WithRequired<QueryFilters, 'queryKey'>,
   ): Query<TQueryFnData, TError, TData> | undefined {
     const defaultedFilters = { exact: true, ...filters }
+    if (defaultedFilters.exact) {
+      return this.findExact(filters)
+    }
 
-    return this.getAll().find((query) =>
-      matchQuery(defaultedFilters, query),
-    ) as Query<TQueryFnData, TError, TData> | undefined
+    const candidates = this.#keyIndex.getByPrefix(filters.queryKey)
+    if (!candidates) {
+      return undefined
+    }
+
+    for (const query of candidates) {
+      if (matchQuery(defaultedFilters, query)) {
+        return query as unknown as
+          | Query<TQueryFnData, TError, TData>
+          | undefined
+      }
+    }
+
+    return undefined
   }
 
   findAll(filters: QueryFilters<any> = {}): Array<Query> {
+    if (filters.exact && filters.queryKey) {
+      const query = this.findExact(filters)
+      return query ? [query] : []
+    }
+
+    if (filters.queryKey) {
+      const withPrefix = this.#keyIndex.getByPrefix(filters.queryKey)
+      const candidates = withPrefix ? Array.from(withPrefix) : []
+      return candidates.filter((query) => matchQuery(filters, query))
+    }
+
     const queries = this.getAll()
     return Object.keys(filters).length > 0
       ? queries.filter((query) => matchQuery(filters, query))
       : queries
+  }
+
+  private findExact<
+    TQueryFnData = unknown,
+    TError = DefaultError,
+    TData = TQueryFnData,
+  >(
+    filters: QueryFilters<any>,
+  ): Query<TQueryFnData, TError, TData> | undefined {
+    const tryHashFn = (hashFn: QueryKeyHashFunction<any>) => {
+      try {
+        const query = this.get(hashFn(filters.queryKey))
+        if (query && matchQuery(filters, query)) {
+          // Confirmed the query actually uses the hash function we tried
+          // and matches the non-queryKey filters
+          return query
+        } else {
+          return undefined
+        }
+      } catch (error) {
+        return undefined
+      }
+    }
+
+    let query = tryHashFn(hashKey)
+    if (!query) {
+      for (const hashFn of allQueryKeyHashFns) {
+        query = tryHashFn(hashFn)
+        if (query) {
+          break
+        }
+      }
+    }
+
+    return query as unknown as Query<TQueryFnData, TError, TData> | undefined
   }
 
   notify(event: QueryCacheNotifyEvent): void {

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -434,10 +434,10 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
   ): Query<TQueryFnData, TError, TData> | undefined {
     const defaultedFilters = { exact: true, ...filters }
     if (defaultedFilters.exact) {
-      return this.findExact(filters)
+      return this.findExact(defaultedFilters)
     }
 
-    const candidates = this.#keyIndex.getByPrefix(filters.queryKey)
+    const candidates = this.#keyIndex.getByPrefix(defaultedFilters.queryKey)
     if (!candidates) {
       return undefined
     }

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -316,9 +316,8 @@ class MapTrieSet<TKey extends QueryKey, TValue> {
           yield* node.nonPrimitiveSuffix
         }
         if (node.children) {
-          for (const child of node.children.values()) {
-            queue.push(child)
-          }
+          const children = Array.from(node.children.values()).reverse()
+          children.forEach((child) => queue.push(child))
         }
       }
     })()


### PR DESCRIPTION
Fixes #9588 

- Accelerates QueryCache.find and QueryCache.findAll with `{ queryKey: [...], exact: true }` filters by trying to look up the query by hashing `filters.queryKey` with all known hash functions, improving time spent from O(queries) to O(hash functions) which is usually O(1).
- Accelerates QueryCache.find and QueryCache.findAll with `{ queryKey: [...] }` filters by indexing the queries by their queryKey in a `Map`-based prefix trie. Lookups in the trie have equivalent order and matching semantics as though the user's filters ran on `queryCache.getAll().filter(query => partialMatchKey(query.queryKey, filters.queryKey))` instead of on all queries. This improves time spent from O(queries) to O(filter.queryKey length + queriesInPrefix + logN(queriesInPrefix). The `logN(queriesInPrefix)` is spent sorting the queries to ensure they're visited by the user's filter in insertion order.
    - There's room for improvement here by eliminating sorting when the filter order is not observable by user code. For example, filters with no `predicate` function are likely safe to re-order arbitrarily as long as we return the results in the expected order; then if the filter returns 0 or 1 results sorting is skipped entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Re-exported Query at the package root.

- Bug Fixes
  - Query-key hashing changes are now tracked so the cache stays consistent after hash-function updates.

- Refactor
  - Internal indexing rewritten for faster, more accurate exact and prefix query lookups and improved scalability.

- Tests
  - Added tests covering prefix-based query filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->