### PR TITLE
docs: fix missing comma in useMutation example to prevent syntax errors

### DIFF
--- a/docs/framework/react/typescript.md
+++ b/docs/framework/react/typescript.md
@@ -251,7 +251,7 @@ function groupMutationOptions() {
 
 useMutation({
   ...groupMutationOptions(),
-  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['groups'] })
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['groups'] }),
 })
 useIsMutating(groupMutationOptions())
 queryClient.isMutating(groupMutationOptions())

--- a/docs/framework/react/typescript.md
+++ b/docs/framework/react/typescript.md
@@ -250,7 +250,7 @@ function groupMutationOptions() {
 }
 
 useMutation({
-  ...groupMutationOptions()
+  ...groupMutationOptions(),
   onSuccess: () => queryClient.invalidateQueries({ queryKey: ['groups'] })
 })
 useIsMutating(groupMutationOptions())


### PR DESCRIPTION
### Summary

Fixed a missing comma in the useMutation example's options object:
```ts
useMutation({
  ...groupMutationOptions(),
  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['groups'] })
})
```
The comma after the spread operator was missing, which would cause a syntax error if users copy and paste the example.

### Changes

- Added the missing comma after the spread syntax to ensure valid JavaScript syntax.
- This prevents runtime or compilation errors for users following the example.
- Improves overall accuracy and reliability of the documentation.

This change maintains consistency with JavaScript object literal syntax rules and enhances developer experience by providing error-free examples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a React + TypeScript example in the docs so the mutation options snippet compiles and can be copy-pasted without edits. No behavior or API changes.
* **Style**
  * Minor formatting and punctuation improvement in the example for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->