### PR TITLE
docs: remove unnecessary trailing comma

### DIFF
--- a/docs/framework/react/reference/hydration.md
+++ b/docs/framework/react/reference/hydration.md
@@ -91,7 +91,7 @@ hydrate(queryClient, dehydratedState, options)
     - `mutations: MutationOptions` The default mutation options to use for the hydrated mutations.
     - `queries: QueryOptions` The default query options to use for the hydrated queries.
     - `deserializeData?: (data: any) => any` A function to transform (deserialize) data before it is put into the cache.
-  - `queryClient?: QueryClient`,
+  - `queryClient?: QueryClient`
     - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 ### Limitations
@@ -122,7 +122,7 @@ function App() {
   - Optional
   - `defaultOptions: QueryOptions`
     - The default query options to use for the hydrated queries.
-  - `queryClient?: QueryClient`,
+  - `queryClient?: QueryClient`
     - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 [//]: # 'HydrationBoundary'

--- a/docs/framework/react/reference/useIsFetching.md
+++ b/docs/framework/react/reference/useIsFetching.md
@@ -16,7 +16,7 @@ const isFetchingPosts = useIsFetching({ queryKey: ['posts'] })
 **Options**
 
 - `filters?: QueryFilters`: [Query Filters](../../guides/filters.md#query-filters)
-- `queryClient?: QueryClient`,
+- `queryClient?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 **Returns**

--- a/docs/framework/react/reference/useIsMutating.md
+++ b/docs/framework/react/reference/useIsMutating.md
@@ -16,7 +16,7 @@ const isMutatingPosts = useIsMutating({ mutationKey: ['posts'] })
 **Options**
 
 - `filters?: MutationFilters`: [Mutation Filters](../../guides/filters.md#mutation-filters)
-- `queryClient?: QueryClient`,
+- `queryClient?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 **Returns**

--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -103,7 +103,7 @@ mutate(variables, {
 
 **Parameter2 (QueryClient)**
 
-- `queryClient?: QueryClient`,
+- `queryClient?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 **Returns**

--- a/docs/framework/react/reference/useMutationState.md
+++ b/docs/framework/react/reference/useMutationState.md
@@ -72,7 +72,7 @@ const latest = data[data.length - 1]
   - `filters?: MutationFilters`: [Mutation Filters](../../guides/filters.md#mutation-filters)
   - `select?: (mutation: Mutation) => TResult`
     - Use this to transform the mutation state.
-- `queryClient?: QueryClient`,
+- `queryClient?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 **Returns**

--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -178,7 +178,7 @@ const {
 
 **Parameter2 (QueryClient)**
 
-- `queryClient?: QueryClient`,
+- `queryClient?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 **Returns**

--- a/docs/framework/react/reference/useQueryClient.md
+++ b/docs/framework/react/reference/useQueryClient.md
@@ -13,5 +13,5 @@ const queryClient = useQueryClient(queryClient?: QueryClient)
 
 **Options**
 
-- `queryClient?: QueryClient`,
+- `queryClient?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.


### PR DESCRIPTION
### Summary
This PR removes an unnecessary trailing comma

### Before
```ts
- `options: HydrateOptions`
  - Optional
  - `defaultOptions: QueryOptions`
    - The default query options to use for the hydrated queries.
  - `queryClient?: QueryClient`,
    - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
```

### After
```ts
- `state: DehydratedState`
  - The state to hydrate
- `options: HydrateOptions`
  - Optional
  - `defaultOptions: QueryOptions`
    - The default query options to use for the hydrated queries.
  - `queryClient?: QueryClient` // remove comma
    - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
```

### Why
- The trailing comma was a typo and inconsistent with other option notations.
- Aligns the style with the rest of the documentation.

### Applied Area
- `hydration.md`
- `useIsFetching.md`
- `useIsMutating.md`
- `useMutation.md`
- `useQuery.md`
- `useQueryClient.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Standardized formatting across React Query hydration and hooks references by removing trailing commas from the queryClient option.
  - Ensures consistent presentation in Options/Parameters sections for hydrate, HydrationBoundary, useIsFetching, useIsMutating, useMutation, useMutationState, useQuery, and useQueryClient.
  - Improves readability without altering examples, behavior, or APIs.
  - No functional or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->