### PR TITLE
docs: fix mutation status type

### DIFF
--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -128,7 +128,7 @@ mutate(variables, {
   - If you make multiple requests, `onSuccess` will fire only after the latest call you've made.
 - `mutateAsync: (variables: TVariables, { onSuccess, onSettled, onError }) => Promise<TData>`
   - Similar to `mutate` but returns a promise which can be awaited.
-- `status: string`
+- `status: MutationStatus`
   - Will be:
     - `idle` initial status prior to the mutation function executing.
     - `pending` if the mutation is currently executing.


### PR DESCRIPTION
### Summary
This PR fixes the `status` type in mutation documentation

### Changes
**Update type definition**
   - Before: `status: string`
   - After:  `status: MutationStatus`
   - Reason: Reflects actual internal implementation and improves type accuracy.

```ts
// packages/query-core/src/mutation.ts
export interface MutationState<
  TData = unknown,
  TError = DefaultError,
  TVariables = unknown,
  TContext = unknown,
> {
  context: TContext | undefined
  data: TData | undefined
  error: TError | null
  failureCount: number
  failureReason: TError | null
  isPaused: boolean
  status: MutationStatus // use MutationStatus type
  variables: TVariables | undefined
  submittedAt: number
}
```

### Why
- Ensures documentation consistency with internal implementation.
- Improves type accuracy for better DX (developer experience).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated useMutation docs: status is now a typed state with four values — idle, pending, success, error.
  - Added derived booleans: isIdle, isPending, isSuccess, isError (based on status).
  - Confirmed mutateAsync behavior remains unchanged.
  - Improved guidance for interpreting mutation state and handling UI states accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->