### PR TITLE
docs: fix type definition errors in useQuery options

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -91,7 +91,7 @@ const {
   - This function receives a `retryAttempt` integer and the actual Error and returns the delay to apply before the next attempt in milliseconds.
   - A function like `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)` applies exponential backoff.
   - A function like `attempt => attempt * 1000` applies linear backoff.
-- `staleTime: number | 'static' ((query: Query) => number | 'static')`
+- `staleTime: number | 'static' | ((query: Query) => number | 'static')`
   - Optional
   - Defaults to `0`
   - The time in milliseconds after which data is considered stale. This value only applies to the hook it is defined on.
@@ -154,12 +154,12 @@ const {
 - `initialDataUpdatedAt: number | (() => number | undefined)`
   - Optional
   - If set, this value will be used as the time (in milliseconds) of when the `initialData` itself was last updated.
-- `placeholderData: TData | (previousValue: TData | undefined; previousQuery: Query | undefined,) => TData`
+- `placeholderData: TData | (previousValue: TData | undefined, previousQuery: Query | undefined) => TData`
   - Optional
   - If set, this value will be used as the placeholder data for this particular query observer while the query is still in the `pending` state.
   - `placeholderData` is **not persisted** to the cache
   - If you provide a function for `placeholderData`, as a first argument you will receive previously watched query data if available, and the second argument will be the complete previousQuery instance.
-- `structuralSharing: boolean | (oldData: unknown | undefined, newData: unknown) => unknown)`
+- `structuralSharing: boolean | (oldData: unknown | undefined, newData: unknown) => unknown`
   - Optional
   - Defaults to `true`
   - If set to `false`, structural sharing between query results will be disabled.
@@ -178,7 +178,7 @@ const {
 
 **Parameter2 (QueryClient)**
 
-- `queryClient?: QueryClient`,
+- `queryClient?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 **Returns**


### PR DESCRIPTION
### Summary
This PR fixes several type definition issues in the `useQuery` documentation for better accuracy and consistency.

### Changes

1. **Fix union type error**
   - **Before**  
     ```ts
     - staleTime: number | 'static' ((query: Query) => number | 'static')
     ```
   - **After**  
     ```ts
     - staleTime: number | 'static' | ((query: Query) => number | 'static')
     ```
   - **Reason**: Added missing union separator `|` before the function type.

2. **Fix parameter separator error**
   - **Before**  
     ```ts
     - placeholderData: TData | (previousValue: TData | undefined; previousQuery: Query | undefined,) => TData
     ```
   - **After**  
     ```ts
     - placeholderData: TData | (previousValue: TData | undefined, previousQuery: Query | undefined) => TData
     ```
   - **Reason**: Corrected parameter separator (`;` → `,`) and removed redundant trailing comma in function parameters.

3. **Remove unnecessary parenthesis**
   - **Before**  
     ```ts
     - structuralSharing: boolean | (oldData: unknown | undefined, newData: unknown) => unknown)
     ```
   - **After**  
     ```ts
     - structuralSharing: boolean | (oldData: unknown | undefined, newData: unknown) => unknown
     ```
   - **Reason**: Removed extra closing parenthesis for correct syntax.

### Why
- Corrects syntax issues in type definitions.
- Ensures documentation matches actual `useQuery` implementation.
- Improves readability and avoids confusion for developers referencing the docs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated useQuery Options docs to clarify accepted types and signatures.
  - staleTime now documented to accept a function as well as a number or 'static'.
  - placeholderData signature corrected to a single function with clearly named parameters.
  - structuralSharing punctuation fixed to reflect the intended boolean or function type.
  - queryClient option formatting corrected by removing an extraneous comma.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->