### PR TITLE
docs: mention second parameter for `cancelQueries`

### DIFF
--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -409,6 +409,7 @@ await queryClient.cancelQueries({ queryKey: ['posts'], exact: true })
 **Options**
 
 - `filters?: QueryFilters`: [Query Filters](../../framework/react/guides/filters.md#query-filters)
+- `cancelOptions?: CancelOptions`: [Cancel Options](../../framework/react/guides/filters.md#query-filters)
 
 **Returns**
 


### PR DESCRIPTION
The API page for `cancelQueries` does not mention that it accepts second optional parameter of `CancelOptions` ([docs page](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientcancelqueries)), which is indicated by the TypeScript signature.