### PR TITLE
fix(core): make sure queries revert synchronously

### DIFF
--- a/packages/query-core/src/retryer.ts
+++ b/packages/query-core/src/retryer.ts
@@ -10,7 +10,7 @@ import type { CancelOptions, DefaultError, NetworkMode } from './types'
 interface RetryerConfig<TData = unknown, TError = DefaultError> {
   fn: () => TData | Promise<TData>
   initialPromise?: Promise<TData>
-  abort?: () => void
+  onCancel?: (error: TError) => void
   onFail?: (failureCount: number, error: TError) => void
   onPause?: () => void
   onContinue?: () => void
@@ -86,9 +86,10 @@ export function createRetryer<TData = unknown, TError = DefaultError>(
 
   const cancel = (cancelOptions?: CancelOptions): void => {
     if (!isResolved()) {
-      reject(new CancelledError(cancelOptions))
+      const error = new CancelledError(cancelOptions) as TError
+      reject(error)
 
-      config.abort?.()
+      config.onCancel?.(error)
     }
   }
   const cancelRetry = () => {


### PR DESCRIPTION
the switch from the callback approach to async/await with catch was necessary to be able to transform errors into revert-state data for imperative query calls; however, this was a change in behavior because catch in async/await doesn't happen immediately - it runs in the next microtask. That opened up an opportunity for a slight race condition if we re-start a fetch in-between. And who does that? Of course, React Strict Mode.

This PR moves the actual state reverting back to a callback (so it happens synchronously), while still keeping the try/catch refactoring merely to transform the promise and the usual error handling

fixes #9579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated cancellation behavior: cancellations now invoke an onCancel callback with error details; revert (when requested) happens during onCancel, and canceled fetches no longer auto-reapply revert in the error path. Existing data is retained when available; otherwise, the cancellation surfaces.
  - Renamed the configuration option from abort to onCancel for retry/cancellation handling (breaking change for integrators).
- Tests
  - Added coverage for unsubscribe/resubscribe during an in-flight fetch to validate the new cancellation semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->