### PR TITLE
refactor(query-core): improve replaceEqualDeep performance

### DIFF
--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -257,38 +257,39 @@ export function replaceEqualDeep(a: any, b: any): any {
   }
 
   const array = isPlainArray(a) && isPlainArray(b)
+  const object = !array && isPlainObject(a) && isPlainObject(b)
 
-  if (array || (isPlainObject(a) && isPlainObject(b))) {
-    const aItems = array ? a : Object.keys(a)
-    const aSize = aItems.length
-    const bItems = array ? b : Object.keys(b)
-    const bSize = bItems.length
-    const copy: any = array ? [] : {}
-    const aItemsSet = new Set(aItems)
+  if (!array && !object) return b
 
-    let equalItems = 0
+  const aItems = array ? a : Object.keys(a)
+  const aSize = aItems.length
+  const bItems = array ? b : Object.keys(b)
+  const bSize = bItems.length
+  const copy: any = array ? new Array(bSize) : {}
+  // const aItemsSet = new Set(aItems)
 
-    for (let i = 0; i < bSize; i++) {
-      const key = array ? i : bItems[i]
-      if (
-        ((!array && aItemsSet.has(key)) || array) &&
-        a[key] === undefined &&
-        b[key] === undefined
-      ) {
-        copy[key] = undefined
+  let equalItems = 0
+
+  for (let i = 0; i < bSize; i++) {
+    const key = array ? i : bItems[i]
+    const aItem = a[key]
+    if (
+      (array || a.hasOwnProperty(key)) &&
+      aItem === undefined &&
+      b[key] === undefined
+    ) {
+      copy[key] = undefined
+      equalItems++
+    } else {
+      const value = replaceEqualDeep(aItem, b[key])
+      copy[key] = value
+      if (value === aItem && aItem !== undefined) {
         equalItems++
-      } else {
-        copy[key] = replaceEqualDeep(a[key], b[key])
-        if (copy[key] === a[key] && a[key] !== undefined) {
-          equalItems++
-        }
       }
     }
-
-    return aSize === bSize && equalItems === aSize ? a : copy
   }
 
-  return b
+  return aSize === bSize && equalItems === aSize ? a : copy
 }
 
 /**


### PR DESCRIPTION
This PR replicates the changes that were done on `Tanstack/router` in https://github.com/TanStack/router/pull/5046.

TL;DR: Improve `replaceEqualDeep` performance by ~1.7x

How?
- pre-allocate new arrays w/ their eventual size (`new Array(bSize)`), to avoid the memory management that happens under the hood every time we add an item to it
- avoid re-reading the same value many times (`a[key]`) and instead store it as `const aItem`
- use `hasOwnProperty` instead of `includes` because in theory it's O(1) instead of O(n) (this is the one I'm the least sure of, it's hard to measure, but if it's not better, at least it's not worse)

Benchmark
```ts
describe("utils", () => {
  describe('replaceEqualDeep', () => {
    bench('old implementation', () => {
      replaceEqualDeepOld({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] })
      replaceEqualDeepOld({ a: 1, b: [2, 3] }, { a: 2, b: [2] })
    })

    bench('new implementation', () => {
      replaceEqualDeep({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] })
      replaceEqualDeep({ a: 1, b: [2, 3] }, { a: 2, b: [2] })
    })
  })
})
```

Results
```sh
 ✓  @tanstack/query-core  src/__tests__/utils.bench.ts > utils > replaceEqualDeep 1764ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · old implementation  1,443,693.60  0.0006  0.1350  0.0007  0.0007  0.0009  0.0010  0.0017  ±0.12%   721847
   · new implementation  2,549,117.84  0.0003  0.1561  0.0004  0.0004  0.0005  0.0005  0.0009  ±0.09%  1274559   fastest

 BENCH  Summary

   @tanstack/query-core  new implementation - src/__tests__/utils.bench.ts > utils > replaceEqualDeep
    1.77x faster than old implementation
```