### PR TITLE
refactor(react-query): replace magic number with named constant in suspense timers

### DIFF
--- a/packages/react-query/src/suspense.ts
+++ b/packages/react-query/src/suspense.ts
@@ -24,9 +24,10 @@ export const ensureSuspenseTimers = (
   if (defaultedOptions.suspense) {
     // Handle staleTime to ensure minimum 1000ms in Suspense mode
     // This prevents unnecessary refetching when components remount after suspending
+    const MIN_SUSPENSE_TIME_MS = 1000
 
     const clamp = (value: number | 'static' | undefined) =>
-      value === 'static' ? value : Math.max(value ?? 1000, 1000)
+      value === 'static' ? value : Math.max(value ?? MIN_SUSPENSE_TIME_MS, MIN_SUSPENSE_TIME_MS)
 
     const originalStaleTime = defaultedOptions.staleTime
     defaultedOptions.staleTime =
@@ -35,7 +36,7 @@ export const ensureSuspenseTimers = (
         : clamp(originalStaleTime)
 
     if (typeof defaultedOptions.gcTime === 'number') {
-      defaultedOptions.gcTime = Math.max(defaultedOptions.gcTime, 1000)
+      defaultedOptions.gcTime = Math.max(defaultedOptions.gcTime, MIN_SUSPENSE_TIME_MS)
     }
   }
 }


### PR DESCRIPTION
## Summary

  - Replace hardcoded 1000ms values with `MIN_SUSPENSE_TIME_MS` constant in suspense timer logic
  - Improves code readability and maintainability by eliminating magic numbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardizes minimum Suspense timing to 1s, providing more predictable loading fallback behavior.
  * Aligns cache cleanup minimums in Suspense mode for consistent timing across queries.
  * No changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->