### PR TITLE
feat(query-core): add context to mutationfn

### DIFF
--- a/docs/framework/angular/guides/mutations.md
+++ b/docs/framework/angular/guides/mutations.md
@@ -90,20 +90,20 @@ export class TodosComponent {
 ```ts
 mutation = injectMutation(() => ({
   mutationFn: addTodo,
-  onMutate: (variables) => {
+  onMutate: (variables, context) => {
     // A mutation is about to happen!
 
-    // Optionally return a context containing data to use when for example rolling back
+    // Optionally return a scope containing data to use when for example rolling back
     return { id: 1 }
   },
-  onError: (error, variables, context) => {
+  onError: (error, variables, scope) => {
     // An error happened!
-    console.log(`rolling back optimistic update with id ${context.id}`)
+    console.log(`rolling back optimistic update with id ${scope.id}`)
   },
-  onSuccess: (data, variables, context) => {
+  onSuccess: (data, variables, scope) => {
     // Boom baby!
   },
-  onSettled: (data, error, variables, context) => {
+  onSettled: (data, error, variables, scope) => {
     // Error or success... doesn't matter!
   },
 }))
@@ -130,25 +130,25 @@ mutation = injectMutation(() => ({
 ```ts
 mutation = injectMutation(() => ({
   mutationFn: addTodo,
-  onSuccess: (data, variables, context) => {
+  onSuccess: (data, variables, scope) => {
     // I will fire first
   },
-  onError: (error, variables, context) => {
+  onError: (error, variables, scope) => {
     // I will fire first
   },
-  onSettled: (data, error, variables, context) => {
+  onSettled: (data, error, variables, scope) => {
     // I will fire first
   },
 }))
 
 mutation.mutate(todo, {
-  onSuccess: (data, variables, context) => {
+  onSuccess: (data, variables, scope) => {
     // I will fire second!
   },
-  onError: (error, variables, context) => {
+  onError: (error, variables, scope) => {
     // I will fire second!
   },
-  onSettled: (data, error, variables, context) => {
+  onSettled: (data, error, variables, scope) => {
     // I will fire second!
   },
 })
@@ -161,7 +161,7 @@ mutation.mutate(todo, {
 export class Example {
   mutation = injectMutation(() => ({
     mutationFn: addTodo,
-    onSuccess: (data, variables, context) => {
+    onSuccess: (data, variables, scope) => {
       // Will be called 3 times
     },
   }))
@@ -169,7 +169,7 @@ export class Example {
   doMutations() {
     ;['Todo 1', 'Todo 2', 'Todo 3'].forEach((todo) => {
       this.mutation.mutate(todo, {
-        onSuccess: (data, variables, context) => {
+        onSuccess: (data, variables, scope) => {
           // Will execute only once, for the last mutation (Todo 3),
           // regardless which mutation resolves first
         },
@@ -214,31 +214,29 @@ const queryClient = new QueryClient()
 // Define the "addTodo" mutation
 queryClient.setMutationDefaults(['addTodo'], {
   mutationFn: addTodo,
-  onMutate: async (variables) => {
+  onMutate: async (variables, context) => {
     // Cancel current queries for the todos list
-    await queryClient.cancelQueries({ queryKey: ['todos'] })
+    await context.client.cancelQueries({ queryKey: ['todos'] })
 
     // Create optimistic todo
     const optimisticTodo = { id: uuid(), title: variables.title }
 
     // Add optimistic todo to todos list
-    queryClient.setQueryData(['todos'], (old) => [...old, optimisticTodo])
+    context.client.setQueryData(['todos'], (old) => [...old, optimisticTodo])
 
-    // Return context with the optimistic todo
-    return { optimisticTodo }
+    // Return scope with the optimistic todo
+    return { optimisticTodo, client: context.client }
   },
-  onSuccess: (result, variables, context) => {
+  onSuccess: (result, variables, scope) => {
     // Replace optimistic todo in the todos list with the result
-    queryClient.setQueryData(['todos'], (old) =>
-      old.map((todo) =>
-        todo.id === context.optimisticTodo.id ? result : todo,
-      ),
+    scope.client.setQueryData(['todos'], (old) =>
+      old.map((todo) => (todo.id === scope.optimisticTodo.id ? result : todo)),
     )
   },
-  onError: (error, variables, context) => {
+  onError: (error, variables, scope) => {
     // Remove optimistic todo from the todos list
-    queryClient.setQueryData(['todos'], (old) =>
-      old.filter((todo) => todo.id !== context.optimisticTodo.id),
+    scope.client.setQueryData(['todos'], (old) =>
+      old.filter((todo) => todo.id !== scope.optimisticTodo.id),
     )
   },
   retry: 3,

--- a/docs/framework/angular/guides/optimistic-updates.md
+++ b/docs/framework/angular/guides/optimistic-updates.md
@@ -87,28 +87,28 @@ queryClient = inject(QueryClient)
 updateTodo = injectMutation(() => ({
   mutationFn: updateTodo,
   // When mutate is called:
-  onMutate: async (newTodo) => {
+  onMutate: async (newTodo, context) => {
     // Cancel any outgoing refetches
     // (so they don't overwrite our optimistic update)
-    await this.queryClient.cancelQueries({ queryKey: ['todos'] })
+    await context.client.cancelQueries({ queryKey: ['todos'] })
 
     // Snapshot the previous value
-    const previousTodos = client.getQueryData(['todos'])
+    const previousTodos = context.client.getQueryData(['todos'])
 
     // Optimistically update to the new value
-    this.queryClient.setQueryData(['todos'], (old) => [...old, newTodo])
+    context.client.setQueryData(['todos'], (old) => [...old, newTodo])
 
-    // Return a context object with the snapshotted value
-    return { previousTodos }
+    // Return a scope object with the snapshotted value
+    return { previousTodos, client: context.client }
   },
   // If the mutation fails,
-  // use the context returned from onMutate to roll back
-  onError: (err, newTodo, context) => {
-    client.setQueryData(['todos'], context.previousTodos)
+  // use the scope returned from onMutate to roll back
+  onError: (err, newTodo, scope) => {
+    scope.client.setQueryData(['todos'], scope.previousTodos)
   },
   // Always refetch after error or success:
-  onSettled: () => {
-    this.queryClient.invalidateQueries({ queryKey: ['todos'] })
+  onSettled: (data, error, variables, scope) => {
+    scope.client.invalidateQueries({ queryKey: ['todos'] })
   },
 }))
 ```
@@ -122,30 +122,27 @@ queryClient = inject(QueryClient)
 updateTodo = injectMutation(() => ({
   mutationFn: updateTodo,
   // When mutate is called:
-  onMutate: async (newTodo) => {
+  onMutate: async (newTodo, context) => {
     // Cancel any outgoing refetches
     // (so they don't overwrite our optimistic update)
-    await this.queryClient.cancelQueries({ queryKey: ['todos', newTodo.id] })
+    await context.client.cancelQueries({ queryKey: ['todos', newTodo.id] })
 
     // Snapshot the previous value
-    const previousTodo = this.queryClient.getQueryData(['todos', newTodo.id])
+    const previousTodo = context.client.getQueryData(['todos', newTodo.id])
 
     // Optimistically update to the new value
-    this.queryClient.setQueryData(['todos', newTodo.id], newTodo)
+    context.client.setQueryData(['todos', newTodo.id], newTodo)
 
-    // Return a context with the previous and new todo
-    return { previousTodo, newTodo }
+    // Return a scope with the previous and new todo
+    return { previousTodo, newTodo, client: context.client }
   },
-  // If the mutation fails, use the context we returned above
-  onError: (err, newTodo, context) => {
-    this.queryClient.setQueryData(
-      ['todos', context.newTodo.id],
-      context.previousTodo,
-    )
+  // If the mutation fails, use the scope we returned above
+  onError: (err, newTodo, scope) => {
+    scope.client.setQueryData(['todos', scope.newTodo.id], scope.previousTodo)
   },
   // Always refetch after error or success:
-  onSettled: (newTodo) => {
-    this.queryClient.invalidateQueries({ queryKey: ['todos', newTodo.id] })
+  onSettled: (newTodo, error, variables, scope) => {
+    scope.client.invalidateQueries({ queryKey: ['todos', newTodo.id] })
   },
 }))
 ```
@@ -157,7 +154,7 @@ updateTodo = injectMutation(() => ({
 injectMutation({
   mutationFn: updateTodo,
   // ...
-  onSettled: (newTodo, error, variables, context) => {
+  onSettled: (newTodo, error, variables, scope) => {
     if (error) {
       // do something
     }

--- a/docs/framework/angular/reference/functions/injectmutation.md
+++ b/docs/framework/angular/reference/functions/injectmutation.md
@@ -6,10 +6,10 @@ title: injectMutation
 # Function: injectMutation()
 
 ```ts
-function injectMutation<TData, TError, TVariables, TContext>(
+function injectMutation<TData, TError, TVariables, TScope>(
   injectMutationFn,
   options?,
-): CreateMutationResult<TData, TError, TVariables, TContext>
+): CreateMutationResult<TData, TError, TVariables, TScope>
 ```
 
 Injects a mutation: an imperative function that can be invoked which typically performs server side effects.
@@ -24,13 +24,13 @@ Unlike queries, mutations are not run automatically.
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Parameters
 
 ### injectMutationFn
 
-() => [`CreateMutationOptions`](../../interfaces/createmutationoptions.md)\<`TData`, `TError`, `TVariables`, `TContext`\>
+() => [`CreateMutationOptions`](../../interfaces/createmutationoptions.md)\<`TData`, `TError`, `TVariables`, `TScope`\>
 
 A function that returns mutation options.
 
@@ -42,7 +42,7 @@ Additional configuration
 
 ## Returns
 
-[`CreateMutationResult`](../../type-aliases/createmutationresult.md)\<`TData`, `TError`, `TVariables`, `TContext`\>
+[`CreateMutationResult`](../../type-aliases/createmutationresult.md)\<`TData`, `TError`, `TVariables`, `TScope`\>
 
 The mutation.
 

--- a/docs/framework/angular/reference/functions/mutationoptions.md
+++ b/docs/framework/angular/reference/functions/mutationoptions.md
@@ -6,9 +6,9 @@ title: mutationOptions
 # Function: mutationOptions()
 
 ```ts
-function mutationOptions<TData, TError, TVariables, TContext>(
+function mutationOptions<TData, TError, TVariables, TScope>(
   options,
-): CreateMutationOptions<TData, TError, TVariables, TContext>
+): CreateMutationOptions<TData, TError, TVariables, TScope>
 ```
 
 Allows to share and re-use mutation options in a type-safe way.
@@ -46,19 +46,19 @@ mutation.mutate({ title: 'New Title' })
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Parameters
 
 ### options
 
-`MutationObserverOptions`\<`TData`, `TError`, `TVariables`, `TContext`\>
+`MutationObserverOptions`\<`TData`, `TError`, `TVariables`, `TScope`\>
 
 The mutation options.
 
 ## Returns
 
-[`CreateMutationOptions`](../../interfaces/createmutationoptions.md)\<`TData`, `TError`, `TVariables`, `TContext`\>
+[`CreateMutationOptions`](../../interfaces/createmutationoptions.md)\<`TData`, `TError`, `TVariables`, `TScope`\>
 
 Mutation options.
 

--- a/docs/framework/angular/reference/interfaces/basemutationnarrowing.md
+++ b/docs/framework/angular/reference/interfaces/basemutationnarrowing.md
@@ -3,7 +3,7 @@ id: BaseMutationNarrowing
 title: BaseMutationNarrowing
 ---
 
-# Interface: BaseMutationNarrowing\<TData, TError, TVariables, TContext\>
+# Interface: BaseMutationNarrowing\<TData, TError, TVariables, TScope\>
 
 ## Type Parameters
 
@@ -13,7 +13,7 @@ title: BaseMutationNarrowing
 
 • **TVariables** = `unknown`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Properties
 
@@ -25,17 +25,12 @@ isError: SignalFunction<
     TData,
     TError,
     TVariables,
-    TContext,
+    TScope,
     Override<
-      MutationObserverErrorResult<TData, TError, TVariables, TContext>,
-      { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+      MutationObserverErrorResult<TData, TError, TVariables, TScope>,
+      { mutate: CreateMutateFunction<TData, TError, TVariables, TScope> }
     > & {
-      mutateAsync: CreateMutateAsyncFunction<
-        TData,
-        TError,
-        TVariables,
-        TContext
-      >
+      mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
     }
   >
 >
@@ -55,17 +50,12 @@ isIdle: SignalFunction<
     TData,
     TError,
     TVariables,
-    TContext,
+    TScope,
     Override<
-      MutationObserverIdleResult<TData, TError, TVariables, TContext>,
-      { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+      MutationObserverIdleResult<TData, TError, TVariables, TScope>,
+      { mutate: CreateMutateFunction<TData, TError, TVariables, TScope> }
     > & {
-      mutateAsync: CreateMutateAsyncFunction<
-        TData,
-        TError,
-        TVariables,
-        TContext
-      >
+      mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
     }
   >
 >
@@ -85,17 +75,12 @@ isPending: SignalFunction<
     TData,
     TError,
     TVariables,
-    TContext,
+    TScope,
     Override<
-      MutationObserverLoadingResult<TData, TError, TVariables, TContext>,
-      { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+      MutationObserverLoadingResult<TData, TError, TVariables, TScope>,
+      { mutate: CreateMutateFunction<TData, TError, TVariables, TScope> }
     > & {
-      mutateAsync: CreateMutateAsyncFunction<
-        TData,
-        TError,
-        TVariables,
-        TContext
-      >
+      mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
     }
   >
 >
@@ -115,17 +100,12 @@ isSuccess: SignalFunction<
     TData,
     TError,
     TVariables,
-    TContext,
+    TScope,
     Override<
-      MutationObserverSuccessResult<TData, TError, TVariables, TContext>,
-      { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+      MutationObserverSuccessResult<TData, TError, TVariables, TScope>,
+      { mutate: CreateMutateFunction<TData, TError, TVariables, TScope> }
     > & {
-      mutateAsync: CreateMutateAsyncFunction<
-        TData,
-        TError,
-        TVariables,
-        TContext
-      >
+      mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
     }
   >
 >

--- a/docs/framework/angular/reference/interfaces/createmutationoptions.md
+++ b/docs/framework/angular/reference/interfaces/createmutationoptions.md
@@ -3,11 +3,11 @@ id: CreateMutationOptions
 title: CreateMutationOptions
 ---
 
-# Interface: CreateMutationOptions\<TData, TError, TVariables, TContext\>
+# Interface: CreateMutationOptions\<TData, TError, TVariables, TScope\>
 
 ## Extends
 
-- `OmitKeyof`\<`MutationObserverOptions`\<`TData`, `TError`, `TVariables`, `TContext`\>, `"_defaulted"`\>
+- `OmitKeyof`\<`MutationObserverOptions`\<`TData`, `TError`, `TVariables`, `TScope`\>, `"_defaulted"`\>
 
 ## Type Parameters
 
@@ -17,4 +17,4 @@ title: CreateMutationOptions
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`

--- a/docs/framework/angular/reference/type-aliases/createbasemutationresult.md
+++ b/docs/framework/angular/reference/type-aliases/createbasemutationresult.md
@@ -3,13 +3,13 @@ id: CreateBaseMutationResult
 title: CreateBaseMutationResult
 ---
 
-# Type Alias: CreateBaseMutationResult\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateBaseMutationResult\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateBaseMutationResult<TData, TError, TVariables, TContext> = Override<
-  MutationObserverResult<TData, TError, TVariables, TContext>,
+type CreateBaseMutationResult<TData, TError, TVariables, TScope> = Override<
+  MutationObserverResult<TData, TError, TVariables, TScope>,
   {
-    mutate: CreateMutateFunction<TData, TError, TVariables, TContext>
+    mutate: CreateMutateFunction<TData, TError, TVariables, TScope>
   }
 > &
   object
@@ -20,7 +20,7 @@ type CreateBaseMutationResult<TData, TError, TVariables, TContext> = Override<
 ### mutateAsync
 
 ```ts
-mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
+mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
 ```
 
 ## Type Parameters
@@ -31,7 +31,7 @@ mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
 
 • **TVariables** = `unknown`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Defined in
 

--- a/docs/framework/angular/reference/type-aliases/createmutateasyncfunction.md
+++ b/docs/framework/angular/reference/type-aliases/createmutateasyncfunction.md
@@ -3,11 +3,11 @@ id: CreateMutateAsyncFunction
 title: CreateMutateAsyncFunction
 ---
 
-# Type Alias: CreateMutateAsyncFunction\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateMutateAsyncFunction\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateMutateAsyncFunction<TData, TError, TVariables, TContext> =
-  MutateFunction<TData, TError, TVariables, TContext>
+type CreateMutateAsyncFunction<TData, TError, TVariables, TScope> =
+  MutateFunction<TData, TError, TVariables, TScope>
 ```
 
 ## Type Parameters
@@ -18,7 +18,7 @@ type CreateMutateAsyncFunction<TData, TError, TVariables, TContext> =
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Defined in
 

--- a/docs/framework/angular/reference/type-aliases/createmutatefunction.md
+++ b/docs/framework/angular/reference/type-aliases/createmutatefunction.md
@@ -3,12 +3,10 @@ id: CreateMutateFunction
 title: CreateMutateFunction
 ---
 
-# Type Alias: CreateMutateFunction()\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateMutateFunction()\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateMutateFunction<TData, TError, TVariables, TContext> = (
-  ...args
-) => void
+type CreateMutateFunction<TData, TError, TVariables, TScope> = (...args) => void
 ```
 
 ## Type Parameters
@@ -19,13 +17,13 @@ type CreateMutateFunction<TData, TError, TVariables, TContext> = (
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Parameters
 
 ### args
 
-...`Parameters`\<`MutateFunction`\<`TData`, `TError`, `TVariables`, `TContext`\>\>
+...`Parameters`\<`MutateFunction`\<`TData`, `TError`, `TVariables`, `TScope`\>\>
 
 ## Returns
 

--- a/docs/framework/angular/reference/type-aliases/createmutationresult.md
+++ b/docs/framework/angular/reference/type-aliases/createmutationresult.md
@@ -3,11 +3,11 @@ id: CreateMutationResult
 title: CreateMutationResult
 ---
 
-# Type Alias: CreateMutationResult\<TData, TError, TVariables, TContext, TState\>
+# Type Alias: CreateMutationResult\<TData, TError, TVariables, TScope, TState\>
 
 ```ts
-type CreateMutationResult<TData, TError, TVariables, TContext, TState> =
-  BaseMutationNarrowing<TData, TError, TVariables, TContext> &
+type CreateMutationResult<TData, TError, TVariables, TScope, TState> =
+  BaseMutationNarrowing<TData, TError, TVariables, TScope> &
     MapToSignals<OmitKeyof<TState, keyof BaseMutationNarrowing, 'safely'>>
 ```
 
@@ -19,9 +19,9 @@ type CreateMutationResult<TData, TError, TVariables, TContext, TState> =
 
 • **TVariables** = `unknown`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
-• **TState** = `CreateStatusBasedMutationResult`\<[`CreateBaseMutationResult`](../createbasemutationresult.md)\[`"status"`\], `TData`, `TError`, `TVariables`, `TContext`\>
+• **TState** = `CreateStatusBasedMutationResult`\<[`CreateBaseMutationResult`](../createbasemutationresult.md)\[`"status"`\], `TData`, `TError`, `TVariables`, `TScope`\>
 
 ## Defined in
 

--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -48,10 +48,11 @@ mutate(variables, {
 
 **Parameter1 (Options)**
 
-- `mutationFn: (variables: TVariables) => Promise<TData>`
+- `mutationFn: (variables: TVariables, context: MutationFunctionContext) => Promise<TData>`
   - **Required, but only if no default mutation function has been defined**
   - A function that performs an asynchronous task and returns a promise.
   - `variables` is an object that `mutate` will pass to your `mutationFn`
+  - `context` is an object that `mutate` will pass to your `mutationFn`. Contains reference to `QueryClient`, `mutationKey` and optional `meta` object.
 - `gcTime: number | Infinity`
   - The time in milliseconds that unused/inactive cache data remains in memory. When a mutation's cache becomes unused or inactive, that cache data will be garbage collected after this duration. When different cache times are specified, the longest one will be used.
   - If set to `Infinity`, will disable garbage collection
@@ -63,20 +64,20 @@ mutate(variables, {
   - Optional
   - defaults to `'online'`
   - see [Network Mode](../../guides/network-mode.md) for more information.
-- `onMutate: (variables: TVariables) => Promise<TContext | void> | TContext | void`
+- `onMutate: (variables: TVariables) => Promise<TScope | void> | TScope | void`
   - Optional
   - This function will fire before the mutation function is fired and is passed the same variables the mutation function would receive
   - Useful to perform optimistic updates to a resource in hopes that the mutation succeeds
   - The value returned from this function will be passed to both the `onError` and `onSettled` functions in the event of a mutation failure and can be useful for rolling back optimistic updates.
-- `onSuccess: (data: TData, variables: TVariables, context: TContext) => Promise<unknown> | unknown`
+- `onSuccess: (data: TData, variables: TVariables, scope: TScope) => Promise<unknown> | unknown`
   - Optional
   - This function will fire when the mutation is successful and will be passed the mutation's result.
   - If a promise is returned, it will be awaited and resolved before proceeding
-- `onError: (err: TError, variables: TVariables, context?: TContext) => Promise<unknown> | unknown`
+- `onError: (err: TError, variables: TVariables, scope?: TScope) => Promise<unknown> | unknown`
   - Optional
   - This function will fire if the mutation encounters an error and will be passed the error.
   - If a promise is returned, it will be awaited and resolved before proceeding
-- `onSettled: (data: TData, error: TError, variables: TVariables, context?: TContext) => Promise<unknown> | unknown`
+- `onSettled: (data: TData, error: TError, variables: TVariables, scope?: TScope) => Promise<unknown> | unknown`
   - Optional
   - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
   - If a promise is returned, it will be awaited and resolved before proceeding
@@ -113,15 +114,15 @@ mutate(variables, {
   - `variables: TVariables`
     - Optional
     - The variables object to pass to the `mutationFn`.
-  - `onSuccess: (data: TData, variables: TVariables, context: TContext) => void`
+  - `onSuccess: (data: TData, variables: TVariables, scope: TScope) => void`
     - Optional
     - This function will fire when the mutation is successful and will be passed the mutation's result.
     - Void function, the returned value will be ignored
-  - `onError: (err: TError, variables: TVariables, context: TContext | undefined) => void`
+  - `onError: (err: TError, variables: TVariables, scope: TScope | undefined) => void`
     - Optional
     - This function will fire if the mutation encounters an error and will be passed the error.
     - Void function, the returned value will be ignored
-  - `onSettled: (data: TData | undefined, error: TError | null, variables: TVariables, context: TContext | undefined) => void`
+  - `onSettled: (data: TData | undefined, error: TError | null, variables: TVariables, scope: TScope | undefined) => void`
     - Optional
     - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
     - Void function, the returned value will be ignored

--- a/docs/framework/svelte/reference/functions/createmutation.md
+++ b/docs/framework/svelte/reference/functions/createmutation.md
@@ -6,10 +6,10 @@ title: createMutation
 # Function: createMutation()
 
 ```ts
-function createMutation<TData, TError, TVariables, TContext>(
+function createMutation<TData, TError, TVariables, TScope>(
   options,
   queryClient?,
-): CreateMutationResult<TData, TError, TVariables, TContext>
+): CreateMutationResult<TData, TError, TVariables, TScope>
 ```
 
 ## Type Parameters
@@ -20,13 +20,13 @@ function createMutation<TData, TError, TVariables, TContext>(
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Parameters
 
 ### options
 
-[`StoreOrVal`](../../type-aliases/storeorval.md)\<[`CreateMutationOptions`](../../type-aliases/createmutationoptions.md)\<`TData`, `TError`, `TVariables`, `TContext`\>\>
+[`StoreOrVal`](../../type-aliases/storeorval.md)\<[`CreateMutationOptions`](../../type-aliases/createmutationoptions.md)\<`TData`, `TError`, `TVariables`, `TScope`\>\>
 
 ### queryClient?
 
@@ -34,7 +34,7 @@ function createMutation<TData, TError, TVariables, TContext>(
 
 ## Returns
 
-[`CreateMutationResult`](../../type-aliases/createmutationresult.md)\<`TData`, `TError`, `TVariables`, `TContext`\>
+[`CreateMutationResult`](../../type-aliases/createmutationresult.md)\<`TData`, `TError`, `TVariables`, `TScope`\>
 
 ## Defined in
 

--- a/docs/framework/svelte/reference/type-aliases/createbasemutationresult.md
+++ b/docs/framework/svelte/reference/type-aliases/createbasemutationresult.md
@@ -3,13 +3,13 @@ id: CreateBaseMutationResult
 title: CreateBaseMutationResult
 ---
 
-# Type Alias: CreateBaseMutationResult\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateBaseMutationResult\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateBaseMutationResult<TData, TError, TVariables, TContext> = Override<
-  MutationObserverResult<TData, TError, TVariables, TContext>,
+type CreateBaseMutationResult<TData, TError, TVariables, TScope> = Override<
+  MutationObserverResult<TData, TError, TVariables, TScope>,
   {
-    mutate: CreateMutateFunction<TData, TError, TVariables, TContext>
+    mutate: CreateMutateFunction<TData, TError, TVariables, TScope>
   }
 > &
   object
@@ -20,7 +20,7 @@ type CreateBaseMutationResult<TData, TError, TVariables, TContext> = Override<
 ### mutateAsync
 
 ```ts
-mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
+mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
 ```
 
 ## Type Parameters
@@ -31,7 +31,7 @@ mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
 
 • **TVariables** = `unknown`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Defined in
 

--- a/docs/framework/svelte/reference/type-aliases/createmutateasyncfunction.md
+++ b/docs/framework/svelte/reference/type-aliases/createmutateasyncfunction.md
@@ -3,11 +3,11 @@ id: CreateMutateAsyncFunction
 title: CreateMutateAsyncFunction
 ---
 
-# Type Alias: CreateMutateAsyncFunction\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateMutateAsyncFunction\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateMutateAsyncFunction<TData, TError, TVariables, TContext> =
-  MutateFunction<TData, TError, TVariables, TContext>
+type CreateMutateAsyncFunction<TData, TError, TVariables, TScope> =
+  MutateFunction<TData, TError, TVariables, TScope>
 ```
 
 ## Type Parameters
@@ -18,7 +18,7 @@ type CreateMutateAsyncFunction<TData, TError, TVariables, TContext> =
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Defined in
 

--- a/docs/framework/svelte/reference/type-aliases/createmutatefunction.md
+++ b/docs/framework/svelte/reference/type-aliases/createmutatefunction.md
@@ -3,12 +3,10 @@ id: CreateMutateFunction
 title: CreateMutateFunction
 ---
 
-# Type Alias: CreateMutateFunction()\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateMutateFunction()\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateMutateFunction<TData, TError, TVariables, TContext> = (
-  ...args
-) => void
+type CreateMutateFunction<TData, TError, TVariables, TScope> = (...args) => void
 ```
 
 ## Type Parameters
@@ -19,13 +17,13 @@ type CreateMutateFunction<TData, TError, TVariables, TContext> = (
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Parameters
 
 ### args
 
-...`Parameters`\<`MutateFunction`\<`TData`, `TError`, `TVariables`, `TContext`\>\>
+...`Parameters`\<`MutateFunction`\<`TData`, `TError`, `TVariables`, `TScope`\>\>
 
 ## Returns
 

--- a/docs/framework/svelte/reference/type-aliases/createmutationoptions.md
+++ b/docs/framework/svelte/reference/type-aliases/createmutationoptions.md
@@ -3,11 +3,11 @@ id: CreateMutationOptions
 title: CreateMutationOptions
 ---
 
-# Type Alias: CreateMutationOptions\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateMutationOptions\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateMutationOptions<TData, TError, TVariables, TContext> = OmitKeyof<
-  MutationObserverOptions<TData, TError, TVariables, TContext>,
+type CreateMutationOptions<TData, TError, TVariables, TScope> = OmitKeyof<
+  MutationObserverOptions<TData, TError, TVariables, TScope>,
   '_defaulted'
 >
 ```
@@ -22,7 +22,7 @@ Options for createMutation
 
 • **TVariables** = `void`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Defined in
 

--- a/docs/framework/svelte/reference/type-aliases/createmutationresult.md
+++ b/docs/framework/svelte/reference/type-aliases/createmutationresult.md
@@ -3,11 +3,11 @@ id: CreateMutationResult
 title: CreateMutationResult
 ---
 
-# Type Alias: CreateMutationResult\<TData, TError, TVariables, TContext\>
+# Type Alias: CreateMutationResult\<TData, TError, TVariables, TScope\>
 
 ```ts
-type CreateMutationResult<TData, TError, TVariables, TContext> = Readable<
-  CreateBaseMutationResult<TData, TError, TVariables, TContext>
+type CreateMutationResult<TData, TError, TVariables, TScope> = Readable<
+  CreateBaseMutationResult<TData, TError, TVariables, TScope>
 >
 ```
 
@@ -21,7 +21,7 @@ Result from createMutation
 
 • **TVariables** = `unknown`
 
-• **TContext** = `unknown`
+• **TScope** = `unknown`
 
 ## Defined in
 

--- a/docs/reference/MutationCache.md
+++ b/docs/reference/MutationCache.md
@@ -28,15 +28,15 @@ Its available methods are:
 
 **Options**
 
-- `onError?: (error: unknown, variables: unknown, context: unknown, mutation: Mutation) => Promise<unknown> | unknown`
+- `onError?: (error: unknown, variables: unknown, scope: unknown, mutation: Mutation) => Promise<unknown> | unknown`
   - Optional
   - This function will be called if some mutation encounters an error.
   - If you return a Promise from it, it will be awaited
-- `onSuccess?: (data: unknown, variables: unknown, context: unknown, mutation: Mutation) => Promise<unknown> | unknown`
+- `onSuccess?: (data: unknown, variables: unknown, scope: unknown, mutation: Mutation) => Promise<unknown> | unknown`
   - Optional
   - This function will be called if some mutation is successful.
   - If you return a Promise from it, it will be awaited
-- `onSettled?: (data: unknown | undefined, error: unknown | null, variables: unknown, context: unknown, mutation: Mutation) => Promise<unknown> | unknown`
+- `onSettled?: (data: unknown | undefined, error: unknown | null, variables: unknown, scope: unknown, mutation: Mutation) => Promise<unknown> | unknown`
   - Optional
   - This function will be called if some mutation is settled (either successful or errored).
   - If you return a Promise from it, it will be awaited
@@ -50,7 +50,7 @@ Its available methods are:
 The `onError`, `onSuccess`, `onSettled` and `onMutate` callbacks on the MutationCache can be used to handle these events on a global level. They are different to `defaultOptions` provided to the QueryClient because:
 
 - `defaultOptions` can be overridden by each Mutation - the global callbacks will **always** be called.
-- `onMutate` does not allow returning a context value.
+- `onMutate` does not allow returning a scope value.
 
 ## `mutationCache.getAll`
 

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -46,16 +46,16 @@ export function injectMutation<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
   injectMutationFn: () => CreateMutationOptions<
     TData,
     TError,
     TVariables,
-    TContext
+    TScope
   >,
   options?: InjectMutationOptions,
-): CreateMutationResult<TData, TError, TVariables, TContext> {
+): CreateMutationResult<TData, TError, TVariables, TScope> {
   !options?.injector && assertInInjectionContext(injectMutation)
   const injector = options?.injector ?? inject(Injector)
   const destroyRef = injector.get(DestroyRef)
@@ -70,7 +70,7 @@ export function injectMutation<
   const optionsSignal = computed(injectMutationFn)
 
   const observerSignal = (() => {
-    let instance: MutationObserver<TData, TError, TVariables, TContext> | null =
+    let instance: MutationObserver<TData, TError, TVariables, TScope> | null =
       null
 
     return computed(() => {
@@ -79,7 +79,7 @@ export function injectMutation<
   })()
 
   const mutateFnSignal = computed<
-    CreateMutateFunction<TData, TError, TVariables, TContext>
+    CreateMutateFunction<TData, TError, TVariables, TScope>
   >(() => {
     const observer = observerSignal()
     return (variables, mutateOptions) => {
@@ -102,7 +102,7 @@ export function injectMutation<
     TData,
     TError,
     TVariables,
-    TContext
+    TScope
   > | null>(null)
 
   effect(
@@ -167,6 +167,6 @@ export function injectMutation<
     TData,
     TError,
     TVariables,
-    TContext
+    TScope
   >
 }

--- a/packages/angular-query-experimental/src/mutation-options.ts
+++ b/packages/angular-query-experimental/src/mutation-options.ts
@@ -35,30 +35,27 @@ export function mutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
   options: WithRequired<
-    CreateMutationOptions<TData, TError, TVariables, TContext>,
+    CreateMutationOptions<TData, TError, TVariables, TScope>,
     'mutationKey'
   >,
 ): WithRequired<
-  CreateMutationOptions<TData, TError, TVariables, TContext>,
+  CreateMutationOptions<TData, TError, TVariables, TScope>,
   'mutationKey'
 >
 export function mutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
   options: Omit<
-    CreateMutationOptions<TData, TError, TVariables, TContext>,
+    CreateMutationOptions<TData, TError, TVariables, TScope>,
     'mutationKey'
   >,
-): Omit<
-  CreateMutationOptions<TData, TError, TVariables, TContext>,
-  'mutationKey'
->
+): Omit<CreateMutationOptions<TData, TError, TVariables, TScope>, 'mutationKey'>
 
 /**
  * Allows to share and re-use mutation options in a type-safe way.
@@ -94,9 +91,9 @@ export function mutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
-  options: CreateMutationOptions<TData, TError, TVariables, TContext>,
-): CreateMutationOptions<TData, TError, TVariables, TContext> {
+  options: CreateMutationOptions<TData, TError, TVariables, TScope>,
+): CreateMutationOptions<TData, TError, TVariables, TScope> {
   return options
 }

--- a/packages/angular-query-experimental/src/types.ts
+++ b/packages/angular-query-experimental/src/types.ts
@@ -163,9 +163,9 @@ export interface CreateMutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > extends OmitKeyof<
-    MutationObserverOptions<TData, TError, TVariables, TContext>,
+    MutationObserverOptions<TData, TError, TVariables, TScope>,
     '_defaulted'
   > {}
 
@@ -176,9 +176,9 @@ export type CreateMutateFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > = (
-  ...args: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
+  ...args: Parameters<MutateFunction<TData, TError, TVariables, TScope>>
 ) => void
 
 /**
@@ -188,8 +188,8 @@ export type CreateMutateAsyncFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> = MutateFunction<TData, TError, TVariables, TContext>
+  TScope = unknown,
+> = MutateFunction<TData, TError, TVariables, TScope>
 
 /**
  * @public
@@ -198,12 +198,12 @@ export type CreateBaseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
 > = Override<
-  MutationObserverResult<TData, TError, TVariables, TContext>,
-  { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+  MutationObserverResult<TData, TError, TVariables, TScope>,
+  { mutate: CreateMutateFunction<TData, TError, TVariables, TScope> }
 > & {
-  mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
+  mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
 }
 
 /**
@@ -214,9 +214,9 @@ type CreateStatusBasedMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
 > = Extract<
-  CreateBaseMutationResult<TData, TError, TVariables, TContext>,
+  CreateBaseMutationResult<TData, TError, TVariables, TScope>,
   { status: TStatus }
 >
 
@@ -229,74 +229,68 @@ export interface BaseMutationNarrowing<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
 > {
   isSuccess: SignalFunction<
     (
-      this: CreateMutationResult<TData, TError, TVariables, TContext>,
+      this: CreateMutationResult<TData, TError, TVariables, TScope>,
     ) => this is CreateMutationResult<
       TData,
       TError,
       TVariables,
-      TContext,
+      TScope,
       CreateStatusBasedMutationResult<
         'success',
         TData,
         TError,
         TVariables,
-        TContext
+        TScope
       >
     >
   >
   isError: SignalFunction<
     (
-      this: CreateMutationResult<TData, TError, TVariables, TContext>,
+      this: CreateMutationResult<TData, TError, TVariables, TScope>,
     ) => this is CreateMutationResult<
       TData,
       TError,
       TVariables,
-      TContext,
+      TScope,
       CreateStatusBasedMutationResult<
         'error',
         TData,
         TError,
         TVariables,
-        TContext
+        TScope
       >
     >
   >
   isPending: SignalFunction<
     (
-      this: CreateMutationResult<TData, TError, TVariables, TContext>,
+      this: CreateMutationResult<TData, TError, TVariables, TScope>,
     ) => this is CreateMutationResult<
       TData,
       TError,
       TVariables,
-      TContext,
+      TScope,
       CreateStatusBasedMutationResult<
         'pending',
         TData,
         TError,
         TVariables,
-        TContext
+        TScope
       >
     >
   >
   isIdle: SignalFunction<
     (
-      this: CreateMutationResult<TData, TError, TVariables, TContext>,
+      this: CreateMutationResult<TData, TError, TVariables, TScope>,
     ) => this is CreateMutationResult<
       TData,
       TError,
       TVariables,
-      TContext,
-      CreateStatusBasedMutationResult<
-        'idle',
-        TData,
-        TError,
-        TVariables,
-        TContext
-      >
+      TScope,
+      CreateStatusBasedMutationResult<'idle', TData, TError, TVariables, TScope>
     >
   >
 }
@@ -308,13 +302,13 @@ export type CreateMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
   TState = CreateStatusBasedMutationResult<
     CreateBaseMutationResult['status'],
     TData,
     TError,
     TVariables,
-    TContext
+    TScope
   >,
-> = BaseMutationNarrowing<TData, TError, TVariables, TContext> &
+> = BaseMutationNarrowing<TData, TError, TVariables, TScope> &
   MapToSignals<OmitKeyof<TState, keyof BaseMutationNarrowing, 'safely'>>

--- a/packages/eslint-plugin-query/src/__tests__/mutation-property-order.rule.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/mutation-property-order.rule.test.ts
@@ -143,9 +143,9 @@ function getCode({ mutationFunction: mutationFunction, properties }: TestCase) {
       case 'onMutate':
         return 'onMutate: (data) => {\n return { foo: data }\n}'
       case 'onError':
-        return 'onError: (error, variables, context) => {\n  console.log("error:", error, "context:", context)\n}'
+        return 'onError: (error, variables, scope) => {\n  console.log("error:", error, "scope:", scope)\n}'
       case 'onSettled':
-        return 'onSettled: (data, error, variables, context) => {\n  console.log("settled", context)\n}'
+        return 'onSettled: (data, error, variables, scope) => {\n  console.log("settled", scope)\n}'
     }
   }
   return `
@@ -202,11 +202,11 @@ const regressionTestCases = {
         onMutate: (data) => {
           return { foo: data }
         },
-        onError: (error, variables, context) => {
-          console.log(error, context)
+        onError: (error, variables, scope) => {
+          console.log(error, scope)
         },
-        onSettled: (data, error, variables, context) => {
-          console.log('settled', context)
+        onSettled: (data, error, variables, scope) => {
+          console.log('settled', scope)
         },
       })
       `,

--- a/packages/query-core/src/__tests__/mutationCache.test.tsx
+++ b/packages/query-core/src/__tests__/mutationCache.test.tsx
@@ -27,7 +27,7 @@ describe('mutationCache', () => {
           mutationKey: key,
           mutationFn: () =>
             sleep(10).then(() => Promise.reject(new Error('error'))),
-          onMutate: () => 'context',
+          onMutate: () => 'scope',
         },
         'vars',
       ).catch(() => undefined)
@@ -39,7 +39,7 @@ describe('mutationCache', () => {
       expect(onError).toHaveBeenCalledWith(
         new Error('error'),
         'vars',
-        'context',
+        'scope',
         mutation,
       )
       expect(onSuccess).not.toHaveBeenCalled()
@@ -48,7 +48,7 @@ describe('mutationCache', () => {
         undefined,
         new Error('error'),
         'vars',
-        'context',
+        'scope',
         mutation,
       )
     })
@@ -109,7 +109,7 @@ describe('mutationCache', () => {
         {
           mutationKey: key,
           mutationFn: () => sleep(10).then(() => ({ data: 5 })),
-          onMutate: () => 'context',
+          onMutate: () => 'scope',
         },
         'vars',
       )
@@ -121,7 +121,7 @@ describe('mutationCache', () => {
       expect(onSuccess).toHaveBeenCalledWith(
         { data: 5 },
         'vars',
-        'context',
+        'scope',
         mutation,
       )
       expect(onError).not.toHaveBeenCalled()
@@ -130,7 +130,7 @@ describe('mutationCache', () => {
         { data: 5 },
         null,
         'vars',
-        'context',
+        'scope',
         mutation,
       )
     })
@@ -187,7 +187,7 @@ describe('mutationCache', () => {
         {
           mutationKey: key,
           mutationFn: () => sleep(10).then(() => ({ data: 5 })),
-          onMutate: () => 'context',
+          onMutate: () => 'scope',
         },
         'vars',
       )

--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -632,7 +632,7 @@ describe('mutations', () => {
           mutationFn: () => Promise.resolve('success'),
           onMutate: () => {
             results.push('onMutate-sync')
-            return { backup: 'data' } // onMutate can return context
+            return { backup: 'data' } // onMutate can return scope
           },
           onSuccess: () => {
             results.push('onSuccess-implicit-void')
@@ -760,8 +760,8 @@ describe('mutations', () => {
             results.push('sync-onError')
             return Promise.resolve('error-return-ignored')
           },
-          onSettled: (_data, _error, _variables, context) => {
-            results.push(`settled-context-${context?.rollback}`)
+          onSettled: (_data, _error, _variables, scope) => {
+            results.push(`settled-scope-${scope?.rollback}`)
             return Promise.all([
               Promise.resolve('cleanup-1'),
               Promise.resolve('cleanup-2'),
@@ -781,7 +781,7 @@ describe('mutations', () => {
       expect(results).toEqual([
         'sync-onMutate',
         'async-onSuccess',
-        'settled-context-data',
+        'settled-scope-data',
       ])
     })
 
@@ -812,8 +812,8 @@ describe('mutations', () => {
               sleep(20).then(() => results.push('error-cleanup-2')),
             ])
           },
-          onSettled: (_data, _error, _variables, context) => {
-            results.push(`settled-error-${context?.backup}`)
+          onSettled: (_data, _error, _variables, scope) => {
+            results.push(`settled-error-${scope?.backup}`)
             return Promise.allSettled([
               Promise.resolve('settled-cleanup'),
               Promise.reject('settled-error'),

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -423,6 +423,7 @@ describe('core/utils', () => {
       const filters = { mutationKey: ['key1'] }
       const queryClient = new QueryClient()
       const mutation = new Mutation({
+        client: queryClient,
         mutationId: 1,
         mutationCache: queryClient.getMutationCache(),
         options: {},

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -14,13 +14,13 @@ interface MutationCacheConfig {
   onError?: (
     error: DefaultError,
     variables: unknown,
-    context: unknown,
+    scope: unknown,
     mutation: Mutation<unknown, unknown, unknown>,
   ) => Promise<unknown> | unknown
   onSuccess?: (
     data: unknown,
     variables: unknown,
-    context: unknown,
+    scope: unknown,
     mutation: Mutation<unknown, unknown, unknown>,
   ) => Promise<unknown> | unknown
   onMutate?: (
@@ -31,7 +31,7 @@ interface MutationCacheConfig {
     data: unknown | undefined,
     error: DefaultError | null,
     variables: unknown,
-    context: unknown,
+    scope: unknown,
     mutation: Mutation<unknown, unknown, unknown>,
   ) => Promise<unknown> | unknown
 }
@@ -93,12 +93,13 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
     this.#mutationId = 0
   }
 
-  build<TData, TError, TVariables, TContext>(
+  build<TData, TError, TVariables, TScope>(
     client: QueryClient,
-    options: MutationOptions<TData, TError, TVariables, TContext>,
-    state?: MutationState<TData, TError, TVariables, TContext>,
-  ): Mutation<TData, TError, TVariables, TContext> {
+    options: MutationOptions<TData, TError, TVariables, TScope>,
+    state?: MutationState<TData, TError, TVariables, TScope>,
+  ): Mutation<TData, TError, TVariables, TScope> {
     const mutation = new Mutation({
+      client,
       mutationCache: this,
       mutationId: ++this.#mutationId,
       options: client.defaultMutationOptions(options),
@@ -195,15 +196,15 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
     TData = unknown,
     TError = DefaultError,
     TVariables = any,
-    TContext = unknown,
+    TScope = unknown,
   >(
     filters: MutationFilters,
-  ): Mutation<TData, TError, TVariables, TContext> | undefined {
+  ): Mutation<TData, TError, TVariables, TScope> | undefined {
     const defaultedFilters = { exact: true, ...filters }
 
     return this.getAll().find((mutation) =>
       matchMutation(defaultedFilters, mutation),
-    ) as Mutation<TData, TError, TVariables, TContext> | undefined
+    ) as Mutation<TData, TError, TVariables, TScope> | undefined
   }
 
   findAll(filters: MutationFilters = {}): Array<Mutation> {

--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -13,8 +13,8 @@ import type { Action, Mutation } from './mutation'
 
 // TYPES
 
-type MutationObserverListener<TData, TError, TVariables, TContext> = (
-  result: MutationObserverResult<TData, TError, TVariables, TContext>,
+type MutationObserverListener<TData, TError, TVariables, TScope> = (
+  result: MutationObserverResult<TData, TError, TVariables, TScope>,
 ) => void
 
 // CLASS
@@ -23,21 +23,21 @@ export class MutationObserver<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > extends Subscribable<
-  MutationObserverListener<TData, TError, TVariables, TContext>
+  MutationObserverListener<TData, TError, TVariables, TScope>
 > {
-  options!: MutationObserverOptions<TData, TError, TVariables, TContext>
+  options!: MutationObserverOptions<TData, TError, TVariables, TScope>
 
   #client: QueryClient
-  #currentResult: MutationObserverResult<TData, TError, TVariables, TContext> =
+  #currentResult: MutationObserverResult<TData, TError, TVariables, TScope> =
     undefined!
-  #currentMutation?: Mutation<TData, TError, TVariables, TContext>
-  #mutateOptions?: MutateOptions<TData, TError, TVariables, TContext>
+  #currentMutation?: Mutation<TData, TError, TVariables, TScope>
+  #mutateOptions?: MutateOptions<TData, TError, TVariables, TScope>
 
   constructor(
     client: QueryClient,
-    options: MutationObserverOptions<TData, TError, TVariables, TContext>,
+    options: MutationObserverOptions<TData, TError, TVariables, TScope>,
   ) {
     super()
 
@@ -53,10 +53,10 @@ export class MutationObserver<
   }
 
   setOptions(
-    options: MutationObserverOptions<TData, TError, TVariables, TContext>,
+    options: MutationObserverOptions<TData, TError, TVariables, TScope>,
   ) {
     const prevOptions = this.options as
-      | MutationObserverOptions<TData, TError, TVariables, TContext>
+      | MutationObserverOptions<TData, TError, TVariables, TScope>
       | undefined
     this.options = this.#client.defaultMutationOptions(options)
     if (!shallowEqualObjects(this.options, prevOptions)) {
@@ -84,7 +84,7 @@ export class MutationObserver<
     }
   }
 
-  onMutationUpdate(action: Action<TData, TError, TVariables, TContext>): void {
+  onMutationUpdate(action: Action<TData, TError, TVariables, TScope>): void {
     this.#updateResult()
 
     this.#notify(action)
@@ -94,7 +94,7 @@ export class MutationObserver<
     TData,
     TError,
     TVariables,
-    TContext
+    TScope
   > {
     return this.#currentResult
   }
@@ -110,7 +110,7 @@ export class MutationObserver<
 
   mutate(
     variables: TVariables,
-    options?: MutateOptions<TData, TError, TVariables, TContext>,
+    options?: MutateOptions<TData, TError, TVariables, TScope>,
   ): Promise<TData> {
     this.#mutateOptions = options
 
@@ -128,7 +128,7 @@ export class MutationObserver<
   #updateResult(): void {
     const state =
       this.#currentMutation?.state ??
-      getDefaultState<TData, TError, TVariables, TContext>()
+      getDefaultState<TData, TError, TVariables, TScope>()
 
     this.#currentResult = {
       ...state,
@@ -138,10 +138,10 @@ export class MutationObserver<
       isIdle: state.status === 'idle',
       mutate: this.mutate,
       reset: this.reset,
-    } as MutationObserverResult<TData, TError, TVariables, TContext>
+    } as MutationObserverResult<TData, TError, TVariables, TScope>
   }
 
-  #notify(action?: Action<TData, TError, TVariables, TContext>): void {
+  #notify(action?: Action<TData, TError, TVariables, TScope>): void {
     notifyManager.batch(() => {
       // First trigger the mutate callbacks
       if (this.#mutateOptions && this.hasListeners()) {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -512,11 +512,11 @@ export class QueryClient {
     TData = unknown,
     TError = DefaultError,
     TVariables = void,
-    TContext = unknown,
+    TScope = unknown,
   >(
     mutationKey: MutationKey,
     options: OmitKeyof<
-      MutationObserverOptions<TData, TError, TVariables, TContext>,
+      MutationObserverOptions<TData, TError, TVariables, TScope>,
       'mutationKey'
     >,
   ): void {

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1091,36 +1091,44 @@ export type MutationMeta = Register extends {
     : Record<string, unknown>
   : Record<string, unknown>
 
+export type MutationFunctionContext = {
+  client: QueryClient
+  meta: MutationMeta | undefined
+  mutationKey?: MutationKey
+}
+
 export type MutationFunction<TData = unknown, TVariables = unknown> = (
   variables: TVariables,
+  context: MutationFunctionContext,
 ) => Promise<TData>
 
 export interface MutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > {
   mutationFn?: MutationFunction<TData, TVariables>
   mutationKey?: MutationKey
   onMutate?: (
     variables: TVariables,
-  ) => Promise<TContext | undefined> | TContext | undefined
+    context: MutationFunctionContext,
+  ) => Promise<TScope | undefined> | TScope | undefined
   onSuccess?: (
     data: TData,
     variables: TVariables,
-    context: TContext,
+    scope: TScope,
   ) => Promise<unknown> | unknown
   onError?: (
     error: TError,
     variables: TVariables,
-    context: TContext | undefined,
+    scope: TScope | undefined,
   ) => Promise<unknown> | unknown
   onSettled?: (
     data: TData | undefined,
     error: TError | null,
     variables: TVariables,
-    context: TContext | undefined,
+    scope: TScope | undefined,
   ) => Promise<unknown> | unknown
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
@@ -1135,8 +1143,8 @@ export interface MutationObserverOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> extends MutationOptions<TData, TError, TVariables, TContext> {
+  TScope = unknown,
+> extends MutationOptions<TData, TError, TVariables, TScope> {
   throwOnError?: boolean | ((error: TError) => boolean)
 }
 
@@ -1144,19 +1152,19 @@ export interface MutateOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > {
-  onSuccess?: (data: TData, variables: TVariables, context: TContext) => void
+  onSuccess?: (data: TData, variables: TVariables, scope: TScope) => void
   onError?: (
     error: TError,
     variables: TVariables,
-    context: TContext | undefined,
+    scope: TScope | undefined,
   ) => void
   onSettled?: (
     data: TData | undefined,
     error: TError | null,
     variables: TVariables,
-    context: TContext | undefined,
+    scope: TScope | undefined,
   ) => void
 }
 
@@ -1164,18 +1172,18 @@ export type MutateFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > = (
   variables: TVariables,
-  options?: MutateOptions<TData, TError, TVariables, TContext>,
+  options?: MutateOptions<TData, TError, TVariables, TScope>,
 ) => Promise<TData>
 
 export interface MutationObserverBaseResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> extends MutationState<TData, TError, TVariables, TContext> {
+  TScope = unknown,
+> extends MutationState<TData, TError, TVariables, TScope> {
   /**
    * The last successfully resolved data for the mutation.
    */
@@ -1228,7 +1236,7 @@ export interface MutationObserverBaseResult<
    * - If you make multiple requests, `onSuccess` will fire only after the latest call you've made.
    * - All the callback functions (`onSuccess`, `onError`, `onSettled`) are void functions, and the returned value will be ignored.
    */
-  mutate: MutateFunction<TData, TError, TVariables, TContext>
+  mutate: MutateFunction<TData, TError, TVariables, TScope>
   /**
    * A function to clean the mutation internal state (i.e., it resets the mutation to its initial state).
    */
@@ -1239,8 +1247,8 @@ export interface MutationObserverIdleResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> extends MutationObserverBaseResult<TData, TError, TVariables, TContext> {
+  TScope = unknown,
+> extends MutationObserverBaseResult<TData, TError, TVariables, TScope> {
   data: undefined
   variables: undefined
   error: null
@@ -1255,8 +1263,8 @@ export interface MutationObserverLoadingResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> extends MutationObserverBaseResult<TData, TError, TVariables, TContext> {
+  TScope = unknown,
+> extends MutationObserverBaseResult<TData, TError, TVariables, TScope> {
   data: undefined
   variables: TVariables
   error: null
@@ -1271,8 +1279,8 @@ export interface MutationObserverErrorResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> extends MutationObserverBaseResult<TData, TError, TVariables, TContext> {
+  TScope = unknown,
+> extends MutationObserverBaseResult<TData, TError, TVariables, TScope> {
   data: undefined
   error: TError
   variables: TVariables
@@ -1287,8 +1295,8 @@ export interface MutationObserverSuccessResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> extends MutationObserverBaseResult<TData, TError, TVariables, TContext> {
+  TScope = unknown,
+> extends MutationObserverBaseResult<TData, TError, TVariables, TScope> {
   data: TData
   error: null
   variables: TVariables
@@ -1303,12 +1311,12 @@ export type MutationObserverResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > =
-  | MutationObserverIdleResult<TData, TError, TVariables, TContext>
-  | MutationObserverLoadingResult<TData, TError, TVariables, TContext>
-  | MutationObserverErrorResult<TData, TError, TVariables, TContext>
-  | MutationObserverSuccessResult<TData, TError, TVariables, TContext>
+  | MutationObserverIdleResult<TData, TError, TVariables, TScope>
+  | MutationObserverLoadingResult<TData, TError, TVariables, TScope>
+  | MutationObserverErrorResult<TData, TError, TVariables, TScope>
+  | MutationObserverSuccessResult<TData, TError, TVariables, TScope>
 
 export interface QueryClientConfig {
   queryCache?: QueryCache

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -46,7 +46,7 @@ export interface MutationFilters<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
 > {
   /**
    * Match mutation key exactly
@@ -55,9 +55,7 @@ export interface MutationFilters<
   /**
    * Include mutations matching this predicate function
    */
-  predicate?: (
-    mutation: Mutation<TData, TError, TVariables, TContext>,
-  ) => boolean
+  predicate?: (mutation: Mutation<TData, TError, TVariables, TScope>) => boolean
   /**
    * Include mutations matching this mutation key
    */

--- a/packages/react-query/src/__tests__/mutationOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/mutationOptions.test-d.tsx
@@ -54,15 +54,15 @@ describe('mutationOptions', () => {
     })
   })
 
-  it('should infer context type correctly', () => {
+  it('should infer scope type correctly', () => {
     mutationOptions<number, DefaultError, void, { name: string }>({
       mutationFn: () => Promise.resolve(5),
       mutationKey: ['key'],
       onMutate: () => {
-        return { name: 'context' }
+        return { name: 'scope' }
       },
-      onSuccess: (_data, _variables, context) => {
-        expectTypeOf(context).toEqualTypeOf<{ name: string }>()
+      onSuccess: (_data, _variables, scope) => {
+        expectTypeOf(scope).toEqualTypeOf<{ name: string }>()
       },
     })
   })

--- a/packages/react-query/src/mutationOptions.ts
+++ b/packages/react-query/src/mutationOptions.ts
@@ -5,34 +5,34 @@ export function mutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
   options: WithRequired<
-    UseMutationOptions<TData, TError, TVariables, TContext>,
+    UseMutationOptions<TData, TError, TVariables, TScope>,
     'mutationKey'
   >,
 ): WithRequired<
-  UseMutationOptions<TData, TError, TVariables, TContext>,
+  UseMutationOptions<TData, TError, TVariables, TScope>,
   'mutationKey'
 >
 export function mutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
   options: Omit<
-    UseMutationOptions<TData, TError, TVariables, TContext>,
+    UseMutationOptions<TData, TError, TVariables, TScope>,
     'mutationKey'
   >,
-): Omit<UseMutationOptions<TData, TError, TVariables, TContext>, 'mutationKey'>
+): Omit<UseMutationOptions<TData, TError, TVariables, TScope>, 'mutationKey'>
 export function mutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
-  options: UseMutationOptions<TData, TError, TVariables, TContext>,
-): UseMutationOptions<TData, TError, TVariables, TContext> {
+  options: UseMutationOptions<TData, TError, TVariables, TScope>,
+): UseMutationOptions<TData, TError, TVariables, TScope> {
   return options
 }

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -193,9 +193,9 @@ export interface UseMutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > extends OmitKeyof<
-    MutationObserverOptions<TData, TError, TVariables, TContext>,
+    MutationObserverOptions<TData, TError, TVariables, TScope>,
     '_defaulted'
   > {}
 
@@ -203,31 +203,31 @@ export type UseMutateFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > = (
-  ...args: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
+  ...args: Parameters<MutateFunction<TData, TError, TVariables, TScope>>
 ) => void
 
 export type UseMutateAsyncFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> = MutateFunction<TData, TError, TVariables, TContext>
+  TScope = unknown,
+> = MutateFunction<TData, TError, TVariables, TScope>
 
 export type UseBaseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
 > = Override<
-  MutationObserverResult<TData, TError, TVariables, TContext>,
-  { mutate: UseMutateFunction<TData, TError, TVariables, TContext> }
-> & { mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TContext> }
+  MutationObserverResult<TData, TError, TVariables, TScope>,
+  { mutate: UseMutateFunction<TData, TError, TVariables, TScope> }
+> & { mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TScope> }
 
 export type UseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
-> = UseBaseMutationResult<TData, TError, TVariables, TContext>
+  TScope = unknown,
+> = UseBaseMutationResult<TData, TError, TVariables, TScope>

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -20,19 +20,16 @@ export function useMutation<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
-  options: UseMutationOptions<TData, TError, TVariables, TContext>,
+  options: UseMutationOptions<TData, TError, TVariables, TScope>,
   queryClient?: QueryClient,
-): UseMutationResult<TData, TError, TVariables, TContext> {
+): UseMutationResult<TData, TError, TVariables, TScope> {
   const client = useQueryClient(queryClient)
 
   const [observer] = React.useState(
     () =>
-      new MutationObserver<TData, TError, TVariables, TContext>(
-        client,
-        options,
-      ),
+      new MutationObserver<TData, TError, TVariables, TScope>(client, options),
   )
 
   React.useEffect(() => {
@@ -50,7 +47,7 @@ export function useMutation<
   )
 
   const mutate = React.useCallback<
-    UseMutateFunction<TData, TError, TVariables, TContext>
+    UseMutateFunction<TData, TError, TVariables, TScope>
   >(
     (variables, mutateOptions) => {
       observer.mutate(variables, mutateOptions).catch(noop)

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -144,9 +144,9 @@ export interface SolidMutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > extends OmitKeyof<
-    MutationObserverOptions<TData, TError, TVariables, TContext>,
+    MutationObserverOptions<TData, TError, TVariables, TScope>,
     '_defaulted'
   > {}
 
@@ -154,40 +154,40 @@ export type UseMutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> = Accessor<SolidMutationOptions<TData, TError, TVariables, TContext>>
+  TScope = unknown,
+> = Accessor<SolidMutationOptions<TData, TError, TVariables, TScope>>
 
 export type UseMutateFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > = (
-  ...args: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
+  ...args: Parameters<MutateFunction<TData, TError, TVariables, TScope>>
 ) => void
 
 export type UseMutateAsyncFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> = MutateFunction<TData, TError, TVariables, TContext>
+  TScope = unknown,
+> = MutateFunction<TData, TError, TVariables, TScope>
 
 export type UseBaseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
 > = Override<
-  MutationObserverResult<TData, TError, TVariables, TContext>,
-  { mutate: UseMutateFunction<TData, TError, TVariables, TContext> }
+  MutationObserverResult<TData, TError, TVariables, TScope>,
+  { mutate: UseMutateFunction<TData, TError, TVariables, TScope> }
 > & {
-  mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TContext>
+  mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TScope>
 }
 
 export type UseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
-> = UseBaseMutationResult<TData, TError, TVariables, TContext>
+  TScope = unknown,
+> = UseBaseMutationResult<TData, TError, TVariables, TScope>

--- a/packages/solid-query/src/useMutation.ts
+++ b/packages/solid-query/src/useMutation.ts
@@ -16,19 +16,19 @@ export function useMutation<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
-  options: UseMutationOptions<TData, TError, TVariables, TContext>,
+  options: UseMutationOptions<TData, TError, TVariables, TScope>,
   queryClient?: Accessor<QueryClient>,
-): UseMutationResult<TData, TError, TVariables, TContext> {
+): UseMutationResult<TData, TError, TVariables, TScope> {
   const client = createMemo(() => useQueryClient(queryClient?.()))
 
-  const observer = new MutationObserver<TData, TError, TVariables, TContext>(
+  const observer = new MutationObserver<TData, TError, TVariables, TScope>(
     client(),
     options(),
   )
 
-  const mutate: UseMutateFunction<TData, TError, TVariables, TContext> = (
+  const mutate: UseMutateFunction<TData, TError, TVariables, TScope> = (
     variables,
     mutateOptions,
   ) => {
@@ -36,7 +36,7 @@ export function useMutation<
   }
 
   const [state, setState] = createStore<
-    UseMutationResult<TData, TError, TVariables, TContext>
+    UseMutationResult<TData, TError, TVariables, TScope>
   >({
     ...observer.getCurrentResult(),
     mutate,

--- a/packages/svelte-query/src/createMutation.ts
+++ b/packages/svelte-query/src/createMutation.ts
@@ -14,22 +14,20 @@ export function createMutation<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
-  options: StoreOrVal<
-    CreateMutationOptions<TData, TError, TVariables, TContext>
-  >,
+  options: StoreOrVal<CreateMutationOptions<TData, TError, TVariables, TScope>>,
   queryClient?: QueryClient,
-): CreateMutationResult<TData, TError, TVariables, TContext> {
+): CreateMutationResult<TData, TError, TVariables, TScope> {
   const client = useQueryClient(queryClient)
 
   const optionsStore = isSvelteStore(options) ? options : readable(options)
 
-  const observer = new MutationObserver<TData, TError, TVariables, TContext>(
+  const observer = new MutationObserver<TData, TError, TVariables, TScope>(
     client,
     get(optionsStore),
   )
-  let mutate: CreateMutateFunction<TData, TError, TVariables, TContext>
+  let mutate: CreateMutateFunction<TData, TError, TVariables, TScope>
 
   optionsStore.subscribe(($options) => {
     mutate = (variables, mutateOptions) => {

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -87,9 +87,9 @@ export type CreateMutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > = OmitKeyof<
-  MutationObserverOptions<TData, TError, TVariables, TContext>,
+  MutationObserverOptions<TData, TError, TVariables, TScope>,
   '_defaulted'
 >
 
@@ -97,28 +97,28 @@ export type CreateMutateFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > = (
-  ...args: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
+  ...args: Parameters<MutateFunction<TData, TError, TVariables, TScope>>
 ) => void
 
 export type CreateMutateAsyncFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> = MutateFunction<TData, TError, TVariables, TContext>
+  TScope = unknown,
+> = MutateFunction<TData, TError, TVariables, TScope>
 
 export type CreateBaseMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
+  TScope = unknown,
 > = Override<
-  MutationObserverResult<TData, TError, TVariables, TContext>,
-  { mutate: CreateMutateFunction<TData, TError, TVariables, TContext> }
+  MutationObserverResult<TData, TError, TVariables, TScope>,
+  { mutate: CreateMutateFunction<TData, TError, TVariables, TScope> }
 > & {
-  mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TContext>
+  mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TScope>
 }
 
 /** Result from createMutation */
@@ -126,8 +126,8 @@ export type CreateMutationResult<
   TData = unknown,
   TError = DefaultError,
   TVariables = unknown,
-  TContext = unknown,
-> = Readable<CreateBaseMutationResult<TData, TError, TVariables, TContext>>
+  TScope = unknown,
+> = Readable<CreateBaseMutationResult<TData, TError, TVariables, TScope>>
 
 /** Options for useMutationState */
 export type MutationStateOptions<TResult = MutationState> = {

--- a/packages/vue-query/src/mutationCache.ts
+++ b/packages/vue-query/src/mutationCache.ts
@@ -12,10 +12,10 @@ export class MutationCache extends MC {
     TData = unknown,
     TError = DefaultError,
     TVariables = any,
-    TContext = unknown,
+    TScope = unknown,
   >(
     filters: MaybeRefDeep<MutationFilters>,
-  ): Mutation<TData, TError, TVariables, TContext> | undefined {
+  ): Mutation<TData, TError, TVariables, TScope> | undefined {
     return super.find(cloneDeepUnref(filters))
   }
 

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -456,11 +456,11 @@ export class QueryClient extends QC {
     TData = unknown,
     TError = DefaultError,
     TVariables = void,
-    TContext = unknown,
+    TScope = unknown,
   >(
     mutationKey: MaybeRefDeep<MutationKey>,
     options: MaybeRefDeep<
-      MutationObserverOptions<TData, TError, TVariables, TContext>
+      MutationObserverOptions<TData, TError, TVariables, TScope>
     >,
   ): void {
     super.setMutationDefaults(

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -24,53 +24,53 @@ import type {
 import type { MaybeRefDeep, ShallowOption } from './types'
 import type { QueryClient } from './queryClient'
 
-type MutationResult<TData, TError, TVariables, TContext> = DistributiveOmit<
-  MutationObserverResult<TData, TError, TVariables, TContext>,
+type MutationResult<TData, TError, TVariables, TScope> = DistributiveOmit<
+  MutationObserverResult<TData, TError, TVariables, TScope>,
   'mutate' | 'reset'
 >
 
-type UseMutationOptionsBase<TData, TError, TVariables, TContext> =
-  MutationObserverOptions<TData, TError, TVariables, TContext> & ShallowOption
+type UseMutationOptionsBase<TData, TError, TVariables, TScope> =
+  MutationObserverOptions<TData, TError, TVariables, TScope> & ShallowOption
 
 export type UseMutationOptions<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
-> = MaybeRefDeep<UseMutationOptionsBase<TData, TError, TVariables, TContext>>
+  TScope = unknown,
+> = MaybeRefDeep<UseMutationOptionsBase<TData, TError, TVariables, TScope>>
 
 type MutateSyncFunction<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 > = (
-  ...options: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
+  ...options: Parameters<MutateFunction<TData, TError, TVariables, TScope>>
 ) => void
 
 export type UseMutationReturnType<
   TData,
   TError,
   TVariables,
-  TContext,
-  TResult = MutationResult<TData, TError, TVariables, TContext>,
+  TScope,
+  TResult = MutationResult<TData, TError, TVariables, TScope>,
 > = ToRefs<Readonly<TResult>> & {
-  mutate: MutateSyncFunction<TData, TError, TVariables, TContext>
-  mutateAsync: MutateFunction<TData, TError, TVariables, TContext>
-  reset: MutationObserverResult<TData, TError, TVariables, TContext>['reset']
+  mutate: MutateSyncFunction<TData, TError, TVariables, TScope>
+  mutateAsync: MutateFunction<TData, TError, TVariables, TScope>
+  reset: MutationObserverResult<TData, TError, TVariables, TScope>['reset']
 }
 
 export function useMutation<
   TData = unknown,
   TError = DefaultError,
   TVariables = void,
-  TContext = unknown,
+  TScope = unknown,
 >(
   mutationOptions: MaybeRefDeep<
-    UseMutationOptionsBase<TData, TError, TVariables, TContext>
+    UseMutationOptionsBase<TData, TError, TVariables, TScope>
   >,
   queryClient?: QueryClient,
-): UseMutationReturnType<TData, TError, TVariables, TContext> {
+): UseMutationReturnType<TData, TError, TVariables, TScope> {
   if (process.env.NODE_ENV === 'development') {
     if (!getCurrentScope()) {
       console.warn(
@@ -94,7 +94,7 @@ export function useMutation<
 
   const mutate = (
     variables: TVariables,
-    mutateOptions?: MutateOptions<TData, TError, TVariables, TContext>,
+    mutateOptions?: MutateOptions<TData, TError, TVariables, TScope>,
   ) => {
     observer.mutate(variables, mutateOptions).catch(() => {
       // This is intentional
@@ -114,7 +114,7 @@ export function useMutation<
     : readonly(state)
 
   const resultRefs = toRefs(readonlyState) as ToRefs<
-    Readonly<MutationResult<TData, TError, TVariables, TContext>>
+    Readonly<MutationResult<TData, TError, TVariables, TScope>>
   >
 
   watch(


### PR DESCRIPTION
### Description

Kicking off where #9193 left off, i've added the same code modifications to add context to mutationFn, in addition i've changed type references & documentation references to the word `context` in reference to callbacks such as `onError | onSuccess | onSettled` to the word `scope` to avoid confusion – `TContext` also becomes `TScope`.

I've not changed the implementation of `MutationObserverResult` from `context` to `scope` because this would be a breaking change to the APIs available as far as I can tell – maybe this should be a follow up for v6 to create alignment across the codebase?

Finally, I was wondering if we should be passing the context to the aforementioned callbacks but then we do have the `scope` ability to for instance, you could pass the client along as seen in the changed examples...

Let me know if i've missed anything or misunderstood some of the agreements in the other PR.

### Related Issues

* closes #9193