### PR TITLE
fix: update fetchNextPage condition in Example component

### DIFF
--- a/examples/react/load-more-infinite-scroll/src/pages/index.tsx
+++ b/examples/react/load-more-infinite-scroll/src/pages/index.tsx
@@ -50,10 +50,10 @@ function Example() {
   })
 
   React.useEffect(() => {
-    if (inView) {
+    if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage()
     }
-  }, [fetchNextPage, inView])
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   return (
     <div>


### PR DESCRIPTION
In the infinite scroll example, I added `hasNextPage && !isFetchingNextPage` guards to the `useEffect` that triggers `fetchNextPage`.
Without these guards, the effect may fire multiple times or after there are no more pages, causing unnecessary fetches.
This aligns the example with recommended usage from the docs of `useInfiniteQuery`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Infinite scroll now loads additional content only when a next page exists and no fetch is already in progress, preventing duplicate requests and erratic behavior near the viewport edge.

* **Performance**
  * Reduced unnecessary network calls during infinite scroll, improving responsiveness and bandwidth usage.
  * More predictable, smoother scrolling experience with fewer stalled or repeated loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->