### PR TITLE
fix(query-core, react-query): infinite re-renders in useQueries

### DIFF
--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -118,21 +118,22 @@ export class QueriesObserver<
         observer.getCurrentResult(),
       )
 
+      const hasLengthChange = prevObservers.length !== newObservers.length
       const hasIndexChange = newObservers.some(
         (observer, index) => observer !== prevObservers[index],
       )
+      const hasStructuralChange = hasLengthChange || hasIndexChange
 
-      const hasResultChange =
-        prevObservers.length === newObservers.length && !hasIndexChange
-          ? newResult.some((result, index) => {
-              const prev = this.#result[index]
-              return !prev || !shallowEqualObjects(result, prev)
-            })
-          : true
+      const hasResultChange = hasStructuralChange
+        ? true
+        : newResult.some((result, index) => {
+            const prev = this.#result[index]
+            return !prev || !shallowEqualObjects(result, prev)
+          })
 
-      if (!hasIndexChange && !hasResultChange) return
+      if (!hasStructuralChange && !hasResultChange) return
 
-      if (hasIndexChange) {
+      if (hasStructuralChange) {
         this.#observers = newObservers
       }
 
@@ -140,7 +141,7 @@ export class QueriesObserver<
 
       if (!this.hasListeners()) return
 
-      if (hasIndexChange) {
+      if (hasStructuralChange) {
         difference(prevObservers, newObservers).forEach((observer) => {
           observer.destroy()
         })

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -1742,7 +1742,6 @@ describe('useQueries', () => {
     expect(spy).toHaveBeenCalledTimes(3)
   })
 
-  // Regression test for issue #9638
   it('should not cause infinite re-renders when removing last query', async () => {
     let renderCount = 0
 
@@ -1767,7 +1766,6 @@ describe('useQueries', () => {
           <div data-testid="query-count">queries: {result.length}</div>
           <button
             onClick={() => {
-              // This should NOT cause infinite re-renders (removing last query)
               setQueries([{
                 queryKey: ['query1'],
                 queryFn: () => 'data1',
@@ -1778,7 +1776,6 @@ describe('useQueries', () => {
           </button>
           <button
             onClick={() => {
-              // This should work fine (removing first query)
               setQueries([{
                 queryKey: ['query2'],
                 queryFn: () => 'data2',
@@ -1794,28 +1791,19 @@ describe('useQueries', () => {
     const rendered = renderWithClient(queryClient, <Page />)
     
     await vi.advanceTimersByTimeAsync(0)
-
-    // Reset render count after initial render
     renderCount = 0
 
-    // Remove last query - this was causing infinite re-renders
     fireEvent.click(rendered.getByRole('button', { name: /remove last/i }))
-
     await vi.advanceTimersByTimeAsync(100)
 
-    // Should have a reasonable number of renders (not infinite)
     expect(renderCount).toBeLessThan(10)
     expect(rendered.getByTestId('query-count').textContent).toBe('queries: 1')
 
-    // Reset render count
     renderCount = 0
 
-    // Remove first query - this should also work fine
     fireEvent.click(rendered.getByRole('button', { name: /remove first/i }))
-
     await vi.advanceTimersByTimeAsync(100)
 
-    // Should have a reasonable number of renders
     expect(renderCount).toBeLessThan(10)
     expect(rendered.getByTestId('query-count').textContent).toBe('queries: 1')
   })

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -1766,20 +1766,24 @@ describe('useQueries', () => {
           <div data-testid="query-count">queries: {result.length}</div>
           <button
             onClick={() => {
-              setQueries([{
-                queryKey: ['query1'],
-                queryFn: () => 'data1',
-              }])
+              setQueries([
+                {
+                  queryKey: ['query1'],
+                  queryFn: () => 'data1',
+                },
+              ])
             }}
           >
             remove last
           </button>
           <button
             onClick={() => {
-              setQueries([{
-                queryKey: ['query2'],
-                queryFn: () => 'data2',
-              }])
+              setQueries([
+                {
+                  queryKey: ['query2'],
+                  queryFn: () => 'data2',
+                },
+              ])
             }}
           >
             remove first
@@ -1789,7 +1793,7 @@ describe('useQueries', () => {
     }
 
     const rendered = renderWithClient(queryClient, <Page />)
-    
+
     await vi.advanceTimersByTimeAsync(0)
     renderCount = 0
 


### PR DESCRIPTION
Fixes #9638

  `useQueries` was causing infinite re-renders when dynamically removing the **last query** from the queries array. This issue was introduced in v5.85.9 after PR #9592.

 ### Problem
  The `queriesObserver.ts` change detection logic had a flaw when handling array length changes:
  - When removing the last query: `hasIndexChange = false` but `hasResultChange = true`
  - This bypassed the early return condition, leading to infinite update cycles
  

 ### Solution

Improved the change detection logic in `queriesObserver.ts` and added test in `useQueries.test.tsx`

```ts
// AS-IS
const hasIndexChange = newObservers.some(
  (observer, index) => observer !== prevObservers[index],
)

const hasResultChange =
  prevObservers.length === newObservers.length && !hasIndexChange
    ? newResult.some((result, index) => {
        const prev = this.#result[index]
        return !prev || !shallowEqualObjects(result, prev)
      })
    : true  // Issue: array length changes always return true

if (!hasIndexChange && !hasResultChange) return  // Missing condition!
```

```ts
// TO-BE
const hasLengthChange = prevObservers.length !== newObservers.length
const hasIndexChange = newObservers.some(
  (observer, index) => observer !== prevObservers[index],
)
const hasStructuralChange = hasLengthChange || hasIndexChange

// Only check result changes when there’s no structural change
const hasResultChange = hasStructuralChange
  ? true
  : newResult.some((result, index) => {
      const prev = this.#result[index]
      return !prev || !shallowEqualObjects(result, prev)
    })

if (!hasStructuralChange && !hasResultChange) return
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents infinite re-renders when removing the last query in useQueries.
  * Improves stability when adding, removing, or reordering queries, ensuring results update correctly and only when needed.
  * Ensures new queries are properly subscribed and removed ones are cleaned up to avoid stale updates.

* **Tests**
  * Added coverage to verify no re-render loops when removing the last or first query and that the query count updates as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->