### PR TITLE
docs(angular-query): fix error in code snippet

### DIFF
--- a/docs/framework/angular/guides/placeholder-query-data.md
+++ b/docs/framework/angular/guides/placeholder-query-data.md
@@ -45,7 +45,7 @@ export class BlogPostComponent {
     placeholderData: () => {
       // Use the smaller/preview version of the blogPost from the 'blogPosts'
       // query as the placeholder data for this blogPost query
-      return queryClient
+      return this.queryClient
         .getQueryData(['blogPosts'])
         ?.find((d) => d.id === this.postId())
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Angular guide example for placeholder data to properly reference the injected client, resolving a scoping issue and ensuring the snippet works as intended.
  * Clarified the steps for retrieving cached blog posts and selecting by post ID.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->