### PR TITLE
chore(angular-query): remove standalone component markers

### DIFF
--- a/docs/framework/angular/guides/mutations.md
+++ b/docs/framework/angular/guides/mutations.md
@@ -47,7 +47,6 @@ export class TodosComponent {
 
 ```angular-ts
 @Component({
-  standalone: true,
   selector: 'todo-item',
   imports: [ReactiveFormsModule],
   template: `

--- a/docs/framework/angular/guides/queries.md
+++ b/docs/framework/angular/guides/queries.md
@@ -37,7 +37,6 @@ result = injectQuery(() => ({ queryKey: ['todos'], queryFn: fetchTodoList }))
 ```angular-ts
 @Component({
   selector: 'todos',
-  standalone: true,
   template: `
     @if (todos.isPending()) {
       <span>Loading...</span>
@@ -70,7 +69,6 @@ If booleans aren't your thing, you can always use the `status` state as well:
 ```angular-ts
 @Component({
   selector: 'todos',
-  standalone: true,
   template: `
     @switch (todos.status()) {
       @case ('pending') {

--- a/docs/framework/angular/guides/query-cancellation.md
+++ b/docs/framework/angular/guides/query-cancellation.md
@@ -83,7 +83,6 @@ You might want to cancel a query manually. For example, if the request takes a l
 
 ```angular-ts
 @Component({
-  standalone: true,
   template: `<button (click)="onCancel()">Cancel</button>`,
 })
 export class TodosComponent {

--- a/docs/framework/angular/overview.md
+++ b/docs/framework/angular/overview.md
@@ -70,7 +70,6 @@ import { lastValueFrom } from 'rxjs'
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'simple-example',
-  standalone: true,
   template: `
     @if (query.isPending()) {
       Loading...

--- a/docs/framework/angular/quick-start.md
+++ b/docs/framework/angular/quick-start.md
@@ -55,7 +55,6 @@ import {
 } from '@tanstack/angular-query-experimental'
 
 @Component({
-  standalone: true,
   template: `
     <div>
       <button (click)="onAddTodo()">Add Todo</button>

--- a/examples/angular/auto-refetching/src/app/app.component.ts
+++ b/examples/angular/auto-refetching/src/app/app.component.ts
@@ -4,7 +4,6 @@ import { AutoRefetchingExampleComponent } from './components/auto-refetching.com
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-root',
-  standalone: true,
   template: `<auto-refetching-example />`,
   imports: [AutoRefetchingExampleComponent],
 })

--- a/examples/angular/basic-persister/src/app/components/post.component.ts
+++ b/examples/angular/basic-persister/src/app/components/post.component.ts
@@ -13,7 +13,6 @@ import { PostsService } from '../services/posts-service'
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'post',
-  standalone: true,
   templateUrl: './post.component.html',
 })
 export class PostComponent {

--- a/examples/angular/basic-persister/src/app/components/posts.component.ts
+++ b/examples/angular/basic-persister/src/app/components/posts.component.ts
@@ -12,7 +12,6 @@ import { PostsService } from '../services/posts-service'
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'posts',
-  standalone: true,
   templateUrl: './posts.component.html',
 })
 export class PostsComponent {

--- a/examples/angular/basic/src/app/components/post.component.ts
+++ b/examples/angular/basic/src/app/components/post.component.ts
@@ -12,7 +12,6 @@ import { PostsService } from '../services/posts-service'
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'post',
-  standalone: true,
   templateUrl: './post.component.html',
 })
 export class PostComponent {

--- a/examples/angular/optimistic-updates/src/app/app.component.ts
+++ b/examples/angular/optimistic-updates/src/app/app.component.ts
@@ -4,7 +4,6 @@ import { OptimisticUpdatesComponent } from './components/optimistic-updates.comp
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-root',
-  standalone: true,
   template: `<optimistic-updates />`,
   imports: [OptimisticUpdatesComponent],
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
@@ -145,7 +145,6 @@ describe('injectMutationState', () => {
             <span>{{ mutation.status }}</span>
           }
         `,
-        standalone: true,
       })
       class FakeComponent {
         name = input.required<string>()

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -306,7 +306,6 @@ describe('injectMutation', () => {
         <button (click)="mutate()"></button>
         <span>{{ mutation.data() }}</span>
       `,
-      standalone: true,
     })
     class FakeComponent {
       name = input.required<string>()
@@ -347,7 +346,6 @@ describe('injectMutation', () => {
         <button (click)="mutate()"></button>
         <span>{{ mutation.data() }}</span>
       `,
-      standalone: true,
     })
     class FakeComponent {
       name = input.required<string>()

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -514,7 +514,6 @@ describe('injectQuery', () => {
     @Component({
       selector: 'app-fake',
       template: `{{ query.data() }}`,
-      standalone: true,
     })
     class FakeComponent {
       name = input.required<string>()


### PR DESCRIPTION
Standalone components have been the default since Angular 19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Angular guides and quick start to remove standalone component usage in examples for consistency.
- Chores
  - Aligned Angular example apps to non-standalone components across auto-refetching, basic, basic-persister, and optimistic-updates samples.
- Tests
  - Updated test components to non-standalone configuration to match revised examples and docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->