### PR TITLE
refactor(angular-query): move injectQueries to sub-path export

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,9 @@
   ],
   "ignoreWorkspaces": ["examples/**", "integrations/**"],
   "workspaces": {
+    "packages/angular-query-experimental": {
+      "entry": ["src/index.ts", "src/inject-queries-experimental/index.ts"]
+    },
     "packages/query-codemods": {
       "entry": ["src/v4/**/*.cjs", "src/v5/**/*.cjs"],
       "ignore": ["**/__testfixtures__/**"]

--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -55,6 +55,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
     },
+    "./inject-queries-experimental": {
+      "types": "./dist/inject-queries-experimental/index.d.ts",
+      "default": "./dist/inject-queries-experimental/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/packages/angular-query-experimental/src/index.ts
+++ b/packages/angular-query-experimental/src/index.ts
@@ -40,7 +40,6 @@ export type { InjectMutationStateOptions } from './inject-mutation-state'
 export { injectMutationState } from './inject-mutation-state'
 
 export type { QueriesOptions, QueriesResults } from './inject-queries'
-export { injectQueries } from './inject-queries'
 
 export type { InjectQueryOptions } from './inject-query'
 export { injectQuery } from './inject-query'

--- a/packages/angular-query-experimental/src/inject-queries-experimental/index.ts
+++ b/packages/angular-query-experimental/src/inject-queries-experimental/index.ts
@@ -1,0 +1,1 @@
+export * from '../inject-queries'

--- a/packages/angular-query-experimental/vite.config.ts
+++ b/packages/angular-query-experimental/vite.config.ts
@@ -111,7 +111,7 @@ export default mergeConfig(
   config,
   tanstackViteConfig({
     cjs: false,
-    entry: ['./src/index.ts'],
+    entry: ['./src/index.ts', './src/inject-queries-experimental/index.ts'],
     exclude: ['./src/__tests__'],
     srcDir: './src',
     tsconfigPath: './tsconfig.prod.json',


### PR DESCRIPTION
Move as of yet non-functional `injectQueries` to separate sub-path `experimental-inject-queries` to indicate its experimental status so it won't hold up releasing the other APIs as stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an experimental entry point to access the inject-queries API.

- Refactor
  - The main package no longer re-exports the inject-queries API; use the new experimental entry point.

- Chores
  - Build setup updated to produce outputs for the new experimental entry.
  - Workspace configuration updated to include the new experimental package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->