### PR TITLE
fix(solid-query): export `queryOptions` without type errors

### DIFF
--- a/packages/solid-query/src/queryOptions.ts
+++ b/packages/solid-query/src/queryOptions.ts
@@ -41,7 +41,7 @@ export function queryOptions<
 ): ReturnType<
   UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
 > & {
-  queryKey: DataTag<TQueryKey, TQueryFnData>
+  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 
 export function queryOptions<
@@ -61,7 +61,7 @@ export function queryOptions<
 ): ReturnType<
   DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
 > & {
-  queryKey: DataTag<TQueryKey, TQueryFnData>
+  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 
 export function queryOptions(options: unknown) {


### PR DESCRIPTION
fixes #8833 