### PR TITLE
ci: switch to `nxCloudId`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           main-branch-name: main
       - name: Run Checks
-        run: pnpm run test:pr --parallel=3
+        run: pnpm run test:pr
       - name: Verify Links
         run: pnpm run verify-links
       - name: Stop Nx Agents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Tools
         uses: tanstack/config/.github/setup@main
       - name: Run Tests
-        run: pnpm run test:ci --parallel=3
+        run: pnpm run test:ci
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,4 +1,4 @@
 distribute-on:
   small-changeset: 3 linux-medium-js
-  medium-changeset: 6 linux-medium-js
-  large-changeset: 10 linux-medium-js
+  medium-changeset: 4 linux-medium-js
+  large-changeset: 5 linux-medium-js

--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "main",
-  "nxCloudAccessToken": "ZDdkNDA4MGEtYjNmYi00MWI4LWE1N2QtYTdlNmYxMGJlZWM2fHJlYWQ=",
+  "nxCloudId": "6412c827e6da5d7b4a0b1fe3",
   "useInferencePlugins": false,
   "parallel": 5,
   "namedInputs": {


### PR DESCRIPTION
## 🎯 Changes

No longer need to use `nxCloudAccessToken` for read access.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI test execution by removing explicit parallelism in PR and release pipelines, aligning resource usage and stability.
  * Tuned automated change classification thresholds so medium and large releases are identified with smaller change counts, enabling more frequent versioning.
  * Updated build cloud configuration to the latest credential identifier for improved compatibility and security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->