### PR TITLE
ci: update changesets auto-merge logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,27 +34,24 @@ jobs:
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents
-      - name: Version Packages
-        run: pnpm run changeset:version
+      - name: Run Changesets (version or publish)
+        id: changesets
+        uses: changesets/action@v1.5.3
+        with:
+          version: pnpm run changeset:version
+          publish: pnpm run changeset:publish
+          commit: 'ci: Version Packages'
+          title: 'ci: Version Packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Commit version files
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git config --global user.name 'Tanner Linsley'
-            git config --global user.email 'tannerlinsley@users.noreply.github.com'
-            git add -A
-            git commit -m "ci: Version Packages"
-            git push
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish Packages
-        run: |
-          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-          pnpm run changeset:publish
-        env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Auto-merge Changesets PR
+        if: steps.changesets.outputs.hasChangesets
+        run: gh pr --repo "$REPO" merge --auto --squash "$PR_NUM"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.changesets.outputs.pullRequestNumber }}
+          REPO: ${{ github.repository }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.6.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Auto-merge Changesets PR
         if: steps.changesets.outputs.hasChangesets
-        run: gh pr --repo "$REPO" merge --auto --squash "$PR_NUM"
+        run: gh pr --repo "$REPO" merge --squash "$PR_NUM"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.changesets.outputs.pullRequestNumber }}

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -7,7 +7,7 @@ export {
   dehydrate,
   hydrate,
 } from './hydration'
-export { InfiniteQueryObserver } from './infiniteQueryObserver'
+export { InfiniteQueryObserver, doesNotExist } from './infiniteQueryObserver'
 export { MutationCache } from './mutationCache'
 export type { MutationCacheNotifyEvent } from './mutationCache'
 export { MutationObserver } from './mutationObserver'

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -7,7 +7,7 @@ export {
   dehydrate,
   hydrate,
 } from './hydration'
-export { InfiniteQueryObserver, doesNotExist } from './infiniteQueryObserver'
+export { InfiniteQueryObserver } from './infiniteQueryObserver'
 export { MutationCache } from './mutationCache'
 export type { MutationCacheNotifyEvent } from './mutationCache'
 export { MutationObserver } from './mutationObserver'


### PR DESCRIPTION
## 🎯 Changes

Switches to the official `changesets/action`, but uses `gh pr merge` to auto-merge its release PR.

Solution taken from https://github.com/changesets/action/issues/310#issuecomment-2770423999

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched release pipeline to a PR-driven Changesets workflow for versioning and publishing.
  * Enabled automatic merge of generated version bump PRs when changes are detected.
  * Consolidated separate versioning and publishing steps into a single automated flow.
  * Updated release automation to support token-based publishing.
  * Adjusted coverage upload to work seamlessly with the new PR-based process.
  * Removed manual commit/push steps from the release process to streamline automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->