### PR TITLE
test(svelte-query): add infinite query setQueryData test

### DIFF
--- a/packages/svelte-query/tests/createInfiniteQuery/ChangeClient.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/ChangeClient.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { QueryClient } from '@tanstack/query-core'
+  import { createInfiniteQuery } from '../../src/index.js'
+  import type { QueryObserverResult } from '@tanstack/query-core'
+  import type { Writable } from 'svelte/store'
+  import { sleep } from '@tanstack/query-test-utils'
+
+  export let states: Writable<Array<QueryObserverResult>>
+  export let queryClient: QueryClient
+
+  const queryKey = ['test']
+  
+  let firstPage = 0
+
+  const query = createInfiniteQuery(
+    {
+    queryKey: queryKey,
+    queryFn: ({ pageParam }) => sleep(10).then(() => pageParam),
+    getNextPageParam: (lastPage) => lastPage + 1,
+    initialPageParam: firstPage,
+    },
+    queryClient,
+  )
+
+  $: states.update((prev) => [...prev, $query])
+</script>
+
+<button
+on:click={() => {
+    queryClient.setQueryData(queryKey, {
+    pages: [7, 8],
+    pageParams: [7, 8],
+    })
+    firstPage = 7
+}}
+>
+setPages
+</button>
+
+<div>Data: {JSON.stringify($query.data)}</div>

--- a/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.test.ts
+++ b/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { render } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient } from '@tanstack/query-core'
+import { fireEvent, render } from '@testing-library/svelte'
 import { get, writable } from 'svelte/store'
 import BaseExample from './BaseExample.svelte'
 import SelectExample from './SelectExample.svelte'
+import ChangeClient from './ChangeClient.svelte'
 import type { Writable } from 'svelte/store'
-import type { QueryObserverResult } from '@tanstack/query-core'
+import type {  QueryObserverResult } from '@tanstack/query-core'
 
 describe('createInfiniteQuery', () => {
   beforeEach(() => {
@@ -15,7 +17,7 @@ describe('createInfiniteQuery', () => {
     vi.useRealTimers()
   })
 
-  test('Return the correct states for a successful query', async () => {
+ it('should return the correct states for a successful query', async () => {
     const statesStore: Writable<Array<QueryObserverResult>> = writable([])
 
     const rendered = render(BaseExample, {
@@ -104,7 +106,7 @@ describe('createInfiniteQuery', () => {
     })
   })
 
-  test('Select a part of the data', async () => {
+  it('should be able to select a part of the data', async () => {
     const statesStore: Writable<Array<QueryObserverResult>> = writable([])
 
     const rendered = render(SelectExample, {
@@ -127,5 +129,28 @@ describe('createInfiniteQuery', () => {
       data: { pages: ['count: 1'] },
       isSuccess: true,
     })
+  })
+
+it('should be able to set new pages with the query client', async () => {
+    const statesStore: Writable<Array<QueryObserverResult>> = writable([])
+    const queryClient = new QueryClient()
+
+    const rendered = render(ChangeClient, {
+      props: {
+        states: statesStore,
+        queryClient,
+      },
+    })
+
+    await vi.advanceTimersByTimeAsync(11)
+     expect(
+      rendered.getByText('Data: {"pages":[0],"pageParams":[0]}'),
+    ).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /setPages/i }))
+    await vi.advanceTimersByTimeAsync(11)
+    expect(
+      rendered.getByText('Data: {"pages":[7,8],"pageParams":[7,8]}'),
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Migrates equivalent test from react-query: https://github.com/TanStack/query/blob/571bc184fd0d2e5e450bdd6b5a40c84ddd5ad142/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx#L1171-L1226

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).