### PR TITLE
docs: add missing eslint rules from left navigation

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1009,6 +1009,14 @@
         {
           "label": "Infinite Query Property Order",
           "to": "eslint/infinite-query-property-order"
+        },
+        {
+          "label": "No void Query Functions",
+          "to": "eslint/no-void-query-fn"
+        },
+        {
+          "label": "Mutation Property Order",
+          "to": "eslint/mutation-property-order"
         }
       ]
     },


### PR DESCRIPTION
## 🎯 Changes

Add missing ESLint rules to the left hand side navigation

<img width="536" height="370" alt="image" src="https://github.com/user-attachments/assets/654d6de3-51f2-4013-8f0d-7854b58af2d9" />

I noticed the new mutation rule didn't appear there, and when checking saw that a previously added rule was also missing from the list.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ESLint guidelines in the docs to include three new items, improving clarity on code standards. Additions include entries such as “No void Query Functions” and “Mutation Property Order.” This helps teams align on consistent linting expectations without altering existing rules or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->