### PR TITLE
fix(query-persist-client-core): allow restoring null values

### DIFF
--- a/.changeset/tender-cameras-brush.md
+++ b/.changeset/tender-cameras-brush.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-persist-client-core': patch
+---
+
+allow restoring null values

--- a/packages/query-persist-client-core/src/createPersister.ts
+++ b/packages/query-persist-client-core/src/createPersister.ts
@@ -221,7 +221,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
         },
       )
 
-      if (restoredData != null) {
+      if (restoredData !== undefined) {
         return Promise.resolve(restoredData as T)
       }
     }


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
experimental persister now allows to restore `null` values

Fixes: https://github.com/TanStack/query/issues/9658

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restores persisted data correctly when the value is null, preventing unnecessary refetches.
  - Improves consistency of persistence behavior across sessions with no changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->