### PR TITLE
Fix unhandled promise rejections during de/rehydration of pending queries

### DIFF
--- a/.changeset/tall-banks-drop.md
+++ b/.changeset/tall-banks-drop.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-query': patch
+'@tanstack/query-core': patch
+---
+
+Avoid unhandled promise rejection errors during de/rehydration of pending queries.

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -1,4 +1,5 @@
 import { tryResolveSync } from './thenable'
+import { noop } from './utils'
 import type {
   DefaultError,
   MutationKey,
@@ -78,6 +79,26 @@ function dehydrateQuery(
   serializeData: TransformerFn,
   shouldRedactErrors: (error: unknown) => boolean,
 ): DehydratedQuery {
+  const promise = query.promise?.then(serializeData).catch((error) => {
+    if (!shouldRedactErrors(error)) {
+      // Reject original error if it should not be redacted
+      return Promise.reject(error)
+    }
+    // If not in production, log original error before rejecting redacted error
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(
+        `A query that was dehydrated as pending ended up rejecting. [${query.queryHash}]: ${error}; The error will be redacted in production builds`,
+      )
+    }
+    return Promise.reject(new Error('redacted'))
+  })
+
+  // Avoid unhandled promise rejections
+  // We need the promise we dehydrate to reject to get the correct result into
+  // the query cache, but we also want to avoid unhandled promise rejections
+  // in whatever environment the prefetches are happening in.
+  promise?.catch(noop)
+
   return {
     dehydratedAt: Date.now(),
     state: {
@@ -89,19 +110,7 @@ function dehydrateQuery(
     queryKey: query.queryKey,
     queryHash: query.queryHash,
     ...(query.state.status === 'pending' && {
-      promise: query.promise?.then(serializeData).catch((error) => {
-        if (!shouldRedactErrors(error)) {
-          // Reject original error if it should not be redacted
-          return Promise.reject(error)
-        }
-        // If not in production, log original error before rejecting redacted error
-        if (process.env.NODE_ENV !== 'production') {
-          console.error(
-            `A query that was dehydrated as pending ended up rejecting. [${query.queryHash}]: ${error}; The error will be redacted in production builds`,
-          )
-        }
-        return Promise.reject(new Error('redacted'))
-      }),
+      promise,
     }),
     ...(query.meta && { meta: query.meta }),
   }
@@ -259,10 +268,13 @@ export function hydrate(
         // which will re-use the passed `initialPromise`
         // Note that we need to call these even when data was synchronously
         // available, as we still need to set up the retryer
-        void query.fetch(undefined, {
-          // RSC transformed promises are not thenable
-          initialPromise: Promise.resolve(promise).then(deserializeData),
-        })
+        query
+          .fetch(undefined, {
+            // RSC transformed promises are not thenable
+            initialPromise: Promise.resolve(promise).then(deserializeData),
+          })
+          // Avoid unhandled promise rejections
+          .catch(noop)
       }
     },
   )

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -451,11 +451,6 @@ describe('React hydration', () => {
 
     const dehydratedState = dehydrate(prefetchQueryClient)
 
-    function ignore() {
-      // Ignore redacted unhandled rejection
-    }
-    process.addListener('unhandledRejection', ignore)
-
     // Mimic what React/our synchronous thenable does for already rejected promises
     // @ts-expect-error
     dehydratedState.queries[0].promise.status = 'failure'
@@ -484,7 +479,6 @@ describe('React hydration', () => {
     await vi.advanceTimersByTimeAsync(21)
     expect(rendered.getByText('new')).toBeInTheDocument()
 
-    process.removeListener('unhandledRejection', ignore)
     hydrateSpy.mockRestore()
     prefetchQueryClient.clear()
     clientQueryClient.clear()


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

This PR adds two `.catch(noop)` to handle previously unhandled promise rejection errors when dehydrating and hydrating promises, which happens when de/rehydrating pending queries.

The errors themselves are still propagated to the query client like before, this is just handling two extraneous promises we are not using the output of.

There are still other [active bugs](https://github.com/TanStack/query/issues/9642) stemming from how we use `query.fetch` to set up a retryer. I took a stab at adding a new `query.createRetryer` method and use that instead, but turns out this was a bigger refactor so I wanted to get this quick fix out quickly before revisiting that.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unhandled promise rejections during de/rehydration of pending queries, improving app stability and clearer error handling in development.

* **Tests**
  * Simplified hydration tests by removing temporary unhandled rejection listeners, reflecting the new safe handling behavior.

* **Chores**
  * Patch release updates to reflect stability improvements and ensure consistent behavior across related query packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->