### PR TITLE
Don't cancel fetchQuery when unmounting useQuery

### DIFF
--- a/.changeset/petite-towns-rule.md
+++ b/.changeset/petite-towns-rule.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+When running queryClient.fetchQuery, the query will no longer be cancelled if other observers are unsubscribed


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

This is an attempt to solve issue #9798.

It adds an query observer when running `fetchQuery`, to make sure the query is not cancelled if all other observers are unsubscribed.

**I am unfamiliar with this codebase, and at least one test is still failing. I am unsure if this is the right direction to fix the issue. If anyone wants to take over this PR, feel free to do so.**

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `fetchQuery` would cancel in-progress queries when other observers unsubscribed. Queries now continue to completion as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->