### PR TITLE
refactor(angular-query): make injectIsMutating signal read-only

### DIFF
--- a/.changeset/inject-is-mutating-readonly.md
+++ b/.changeset/inject-is-mutating-readonly.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-query-experimental': patch
+---
+
+Make `injectIsMutating` signal read-only to prevent external modifications to the internal state

--- a/packages/angular-query-experimental/src/inject-is-mutating.ts
+++ b/packages/angular-query-experimental/src/inject-is-mutating.ts
@@ -25,7 +25,7 @@ export interface InjectIsMutatingOptions {
  * Can be used for app-wide loading indicators
  * @param filters - The filters to apply to the query.
  * @param options - Additional configuration
- * @returns signal with number of fetching mutations.
+ * @returns A read-only signal with the number of fetching mutations.
  */
 export function injectIsMutating(
   filters?: MutationFilters,
@@ -60,5 +60,5 @@ export function injectIsMutating(
 
   destroyRef.onDestroy(unsubscribe)
 
-  return result
+  return result.asReadonly()
 }

--- a/packages/angular-query-experimental/tsconfig.json
+++ b/packages/angular-query-experimental/tsconfig.json
@@ -7,6 +7,13 @@
     "useDefineForClassFields": false,
     "target": "ES2022"
   },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictStandalone": true,
+    "strictTemplates": true
+  },
   "include": ["src", "scripts", "test-setup.ts", "*.config.*", "package.json"],
   "references": [{ "path": "../query-core" }, { "path": "../query-devtools" }]
 }


### PR DESCRIPTION
## 🎯 Changes

The signal returned by injectIsMutating should be read-only as it is not supposed to be changed outside the library.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The mutating signal used for mutation tracking is now exposed as read-only to prevent external modification.

* **Chores**
  * Angular compiler strictness settings were tightened to improve type safety and template checks.

* **Documentation**
  * Added a changeset entry recording a patch release and the read-only signal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->