### PR TITLE
chore(angular-query): remove jsdoc eslint rules

### DIFF
--- a/packages/angular-query-experimental/eslint.config.js
+++ b/packages/angular-query-experimental/eslint.config.js
@@ -1,20 +1,10 @@
 // @ts-check
 
-import pluginJsdoc from 'eslint-plugin-jsdoc'
 import vitest from '@vitest/eslint-plugin'
 import rootConfig from './root.eslint.config.js'
 
 export default [
   ...rootConfig,
-  pluginJsdoc.configs['flat/recommended-typescript'],
-  {
-    rules: {
-      'jsdoc/require-hyphen-before-param-description': 1,
-      'jsdoc/sort-tags': 1,
-      'jsdoc/require-throws': 1,
-      'jsdoc/check-tag-names': ['warn'],
-    },
-  },
   {
     plugins: { vitest },
     rules: {
@@ -29,7 +19,6 @@ export default [
     rules: {
       '@typescript-eslint/no-unnecessary-condition': 'off',
       '@typescript-eslint/require-await': 'off',
-      'jsdoc/require-returns': 'off',
     },
   },
 ]

--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -95,7 +95,6 @@
     "@angular/platform-browser": "^20.0.0",
     "@tanstack/query-test-utils": "workspace:*",
     "@testing-library/angular": "^18.0.0",
-    "eslint-plugin-jsdoc": "^50.5.0",
     "npm-run-all2": "^5.0.0",
     "rxjs": "^7.8.2",
     "vite-plugin-dts": "4.2.3",

--- a/packages/angular-query-experimental/src/__tests__/test-utils.ts
+++ b/packages/angular-query-experimental/src/__tests__/test-utils.ts
@@ -4,8 +4,6 @@ import { expect } from 'vitest'
 import type { InputSignal, Signal } from '@angular/core'
 import type { ComponentFixture } from '@angular/core/testing'
 
-/* eslint jsdoc/require-jsdoc: 0, jsdoc/require-param: 0 */
-
 // Evaluate all signals on an object and return the result
 function evaluateSignals<T extends Record<string, any>>(
   obj: T,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2251,9 +2251,6 @@ importers:
       '@testing-library/angular':
         specifier: ^18.0.0
         version: 18.0.0(b638270d50b9f611fb362719c9f1adf5)
-      eslint-plugin-jsdoc:
-        specifier: ^50.5.0
-        version: 50.5.0(eslint@9.36.0(jiti@2.5.1))
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2


### PR DESCRIPTION
## 🎯 Changes

Only the Angular adapter has these rules and it's distracting

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed JSDoc-related ESLint configuration and development dependencies from the Angular Query experimental package build toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->