### PR TITLE
docs(examples): update queryKey to be reactive in vue files

### DIFF
--- a/examples/vue/2.6-basic/src/Post.vue
+++ b/examples/vue/2.6-basic/src/Post.vue
@@ -20,7 +20,7 @@ export default defineComponent({
   emits: ['setPostId'],
   setup(props) {
     const { isPending, isError, isFetching, data, error } = useQuery({
-      queryKey: ['post', props.postId],
+      queryKey: ['post', () => props.postId],
       queryFn: () => fetcher(props.postId),
     })
 

--- a/examples/vue/2.7-basic/src/Post.vue
+++ b/examples/vue/2.7-basic/src/Post.vue
@@ -20,7 +20,7 @@ export default defineComponent({
   emits: ['setPostId'],
   setup(props) {
     const { isPending, isError, isFetching, data, error } = useQuery({
-      queryKey: ['post', props.postId],
+      queryKey: ['post', () => props.postId],
       queryFn: () => fetcher(props.postId),
     })
 

--- a/examples/vue/basic/src/Post.vue
+++ b/examples/vue/basic/src/Post.vue
@@ -20,7 +20,7 @@ export default defineComponent({
   emits: ['setPostId'],
   setup(props) {
     const { isPending, isError, isFetching, data, error } = useQuery({
-      queryKey: ['post', props.postId],
+      queryKey: ['post', () => props.postId],
       queryFn: () => fetcher(props.postId),
     })
 

--- a/examples/vue/dependent-queries/src/Post.vue
+++ b/examples/vue/dependent-queries/src/Post.vue
@@ -31,7 +31,7 @@ export default defineComponent({
       data: post,
       error,
     } = useQuery({
-      queryKey: ['post', props.postId],
+      queryKey: ['post', () => props.postId],
       queryFn: () => fetchPost(props.postId),
     })
 

--- a/examples/vue/persister/src/Post.vue
+++ b/examples/vue/persister/src/Post.vue
@@ -22,7 +22,7 @@ export default defineComponent({
   emits: ['setPostId'],
   setup(props) {
     const { isPending, isError, isFetching, data, error } = useQuery({
-      queryKey: ['post', props.postId] as const,
+      queryKey: ['post', () => props.postId] as const,
       queryFn: () => fetcher(props.postId),
       persister: experimental_createQueryPersister({
         storage: {


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

Change the value passed to `queryKey` in the vue examples to be reactive and trigger a refetch when the prop changes

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

Fixes #9782 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vue Query examples to demonstrate improved query key handling patterns for optimal caching behavior across Vue 2.6, 2.7, and 3.x applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->