### PR TITLE
refactor(angular-query): injectMutationState use signal sandwich pattern

### DIFF
--- a/.changeset/inject-is-mutating-readonly.md
+++ b/.changeset/inject-is-mutating-readonly.md
@@ -1,5 +1,0 @@
----
-'@tanstack/angular-query-experimental': patch
----
-
-Make `injectIsMutating` signal read-only to prevent external modifications to the internal state

--- a/.changeset/tidy-parents-send.md
+++ b/.changeset/tidy-parents-send.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-query-experimental': patch
+---
+
+Refactor `injectMutationState` to use signal sandwich pattern for improved consistency and maintainability


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed `injectMutationState` parameter from `injectMutationStateFn` to `mutationStateFn` for improved API consistency.
  * Refactored internal mutation state management with optimized signal handling patterns, streamlined subscription model, and enhanced state deduplication for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->