### PR TITLE
fix: support async Svelte

### DIFF
--- a/.changeset/thin-bugs-change.md
+++ b/.changeset/thin-bugs-change.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/svelte-query': patch
+---
+
+fix: support async Svelte

--- a/packages/svelte-query/src/createBaseQuery.svelte.ts
+++ b/packages/svelte-query/src/createBaseQuery.svelte.ts
@@ -1,3 +1,4 @@
+import { onDestroy } from 'svelte'
 import { useIsRestoring } from './useIsRestoring.js'
 import { useQueryClient } from './useQueryClient.js'
 import { createRawRef } from './containers.svelte.js'
@@ -8,7 +9,6 @@ import type {
   CreateBaseQueryOptions,
   CreateBaseQueryResult,
 } from './types.js'
-import { onDestroy } from 'svelte'
 
 /**
  * Base implementation for `createQuery` and `createInfiniteQuery`

--- a/packages/svelte-query/src/createBaseQuery.svelte.ts
+++ b/packages/svelte-query/src/createBaseQuery.svelte.ts
@@ -93,9 +93,13 @@ export function createBaseQuery<
     },
   )
   // ...and finally also cleanup via onDestroy because that one runs on the server whereas $effect.pre does not.
-  onDestroy(() => {
-    unsubscribe()
-  })
+  // (in a try-catch because it theoretically can be called in a non-component context - that should not happen
+  // but it would be a breaking change technically to error out here. SSR-safe because this wouldn't be called during SSR if it was not in a component)
+  try {
+    onDestroy(() => {
+      unsubscribe()
+    })
+  } catch (e) {}
 
   watchChanges(
     () => resolvedOptions,


### PR DESCRIPTION
## 🎯 Changes

Svelte 5 now supports async await in components. One behavior there is that when a component is created as part of a boundary that has pending async work, its `$effect`s will not run until that async work is done.

The way the code is written right now means you can end up in an infinite pending state: If you do `await someQuery.promise`, the `$effect` for the subscription will never run, and therefore the `await` will never resolve. This PR fixes it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable support for async Svelte so queries behave correctly in modern Svelte environments.
  * Improved query lifecycle and subscription handling to ensure consistent result updates and proper cleanup across server and client lifecycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->