### PR TITLE
fix: Add useSuspenseQuery replacement rule for Solid docs

### DIFF
--- a/docs/framework/solid/guides/request-waterfalls.md
+++ b/docs/framework/solid/guides/request-waterfalls.md
@@ -11,5 +11,7 @@ replace:
     'useQuery[(]': 'useQuery(() => ',
     'useQueries[(]': 'useQueries(() => ',
     'useInfiniteQuery[(]': 'useInfiniteQuery(() => ',
+    'useSuspenseQuery': 'useQuery',
+    'useSuspenseQueries': 'useQueries',
   }
 ---


### PR DESCRIPTION
## Description

Fixes #9654

Solid Query documentation incorrectly shows `useSuspenseQuery` which doesn't exist in Solid Query. This PR adds replacement rules to convert `useSuspenseQuery` to `useQuery` and `useSuspenseQueries` to `useQueries`.

## Changes Made

- Added `'useSuspenseQuery': 'useQuery'` to replacement rules
- Added `'useSuspenseQueries': 'useQueries'` to replacement rules
- File: `docs/framework/solid/guides/request-waterfalls.md`

## Problem

The Solid Query documentation shows examples using `useSuspenseQuery` and `useSuspenseQueries` which are React-specific hooks. These hooks don't exist in Solid Query. When users try to use these examples in their Solid code, they encounter errors.

## Solution

The documentation uses an automatic replacement system to convert React code examples to Solid. By adding these two replacement rules, the documentation will now correctly show `useQuery` and `useQueries` instead of the non-existent `useSuspenseQuery` hooks.

## Testing

This is a documentation-only change. The replacement rules will ensure that future documentation builds will show the correct Solid Query API calls.

## Screenshots

N/A - Documentation change only

## Related Issues

Closes #9654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation covering additional hook alias mappings for suspense-related queries, expanding framework guides with more comprehensive reference material for available query hook options and their cross-framework equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->