### PR TITLE
Add ability to pass mutation scope via mutate function

### DIFF
--- a/docs/framework/react/guides/mutations.md
+++ b/docs/framework/react/guides/mutations.md
@@ -404,6 +404,46 @@ const mutation = useMutation({
 ```
 
 [//]: # 'ExampleScopes'
+
+### Overriding Scope Per Mutation Call
+
+You can override the scope for individual mutation calls by passing a `scope` option to the `mutate` or `mutateAsync` function. This is useful when you want to dynamically control whether mutations run in parallel or serial:
+
+[//]: # 'ExampleScopeOverride'
+
+```tsx
+const mutation = useMutation({
+  mutationFn: addTodo,
+  scope: {
+    id: 'todo',
+  },
+})
+
+// This mutation will use the default 'todo' scope
+mutation.mutate(todo1)
+
+// This mutation will use a different scope and run in parallel
+mutation.mutate(todo2, {
+  scope: {
+    id: 'todo-urgent',
+  },
+})
+
+// Works the same with mutateAsync
+await mutation.mutateAsync(todo3, {
+  scope: {
+    id: 'todo-background',
+  },
+})
+```
+
+[//]: # 'ExampleScopeOverride'
+
+This allows you to have fine-grained control over mutation execution. For example, you could:
+- Run certain mutations in parallel while keeping others serial
+- Dynamically assign scopes based on user actions or data properties
+- Force multiple different mutations to run serially by giving them the same scope
+
 [//]: # 'Materials'
 
 ## Further reading

--- a/docs/framework/react/reference/useMutation.md
+++ b/docs/framework/react/reference/useMutation.md
@@ -109,7 +109,7 @@ mutate(variables, {
 
 **Returns**
 
-- `mutate: (variables: TVariables, { onSuccess, onSettled, onError }) => void`
+- `mutate: (variables: TVariables, { onSuccess, onSettled, onError, scope }) => void`
   - The mutation function you can call with variables to trigger the mutation and optionally hooks on additional callback options.
   - `variables: TVariables`
     - Optional
@@ -126,8 +126,12 @@ mutate(variables, {
     - Optional
     - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
     - Void function, the returned value will be ignored
+  - `scope: { id: string }`
+    - Optional
+    - Allows you to override the mutation scope for this specific mutation call
+    - See [Mutation Scopes](../guides/mutations.md#mutation-scopes) for more information
   - If you make multiple requests, `onSuccess` will fire only after the latest call you've made.
-- `mutateAsync: (variables: TVariables, { onSuccess, onSettled, onError }) => Promise<TData>`
+- `mutateAsync: (variables: TVariables, { onSuccess, onSettled, onError, scope }) => Promise<TData>`
   - Similar to `mutate` but returns a promise which can be awaited.
 - `status: MutationStatus`
   - Will be:

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1176,6 +1176,7 @@ export interface MutateOptions<
     onMutateResult: TOnMutateResult | undefined,
     context: MutationFunctionContext,
   ) => void
+  scope?: MutationScope
 }
 
 export type MutateFunction<


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-call scope override for mutations, letting individual mutation calls run in parallel or serial by scope.

* **Documentation**
  * Added guide and reference docs explaining per-call scope usage, examples, and behavior.

* **Tests**
  * Added tests covering scope overrides, default-scope behavior, forcing serial execution, and awaiting mutation results.

* **Bug Fixes / Reliability**
  * Improved mutation execution ordering and lifecycle handling when scopes are overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->