### PR TITLE
typo react /vue in documentation

### DIFF
--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -8,7 +8,7 @@ title: QueryClient
 The `QueryClient` can be used to interact with a cache:
 
 ```tsx
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/vue-query'
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## 🎯 Changes
In the documentation for vue framework, the exemple in API Reference / QueryClient use import from '@tanstack/react-query' instead of '@tanstack/vuequery'

## ✅ Checklist

- X I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- X This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated QueryClient reference documentation examples with current library imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->