### PR TITLE
feat(vue-query): support useQuery options getter

### DIFF
--- a/.changeset/dark-birds-turn.md
+++ b/.changeset/dark-birds-turn.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query': minor
+---
+
+feat(vue-query): support useQuery options getter

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -44,6 +44,24 @@ describe('useQuery', () => {
     )
   })
 
+  test('should work with options getter', async () => {
+    const query = useQuery(() => ({
+      queryKey: ['key01'],
+      queryFn: () => sleep(0).then(() => 'result01'),
+    }))
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'result01' },
+      isPending: { value: false },
+      isFetching: { value: false },
+      isFetched: { value: true },
+      isSuccess: { value: true },
+    })
+  })
+
   test('should return pending status initially', () => {
     const query = useQuery({
       queryKey: ['key1'],

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -82,7 +82,11 @@ export function useBaseQuery<
   const client = queryClient || useQueryClient()
 
   const defaultedOptions = computed(() => {
-    const clonedOptions = cloneDeepUnref(options as any)
+    let resolvedOptions = options
+    if (typeof resolvedOptions === 'function') {
+      resolvedOptions = resolvedOptions()
+    }
+    const clonedOptions = cloneDeepUnref(resolvedOptions as any)
 
     if (typeof clonedOptions.enabled === 'function') {
       clonedOptions.enabled = clonedOptions.enabled()

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -114,12 +114,8 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UseQueryOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryFnData,
-    TQueryKey
+  options: MaybeRefOrGetter<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
   >,
   queryClient?: QueryClient,
 ): UseQueryReturnType<TData, TError>
@@ -130,12 +126,8 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UseQueryOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryFnData,
-    TQueryKey
+  options: MaybeRefOrGetter<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
   >,
   queryClient?: QueryClient,
 ):


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Fixes: https://github.com/TanStack/query/issues/9789

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * useQuery now supports an options getter function, enabling dynamic option resolution. Options can be passed as a static object or as a reactive getter that returns the configuration, providing greater flexibility for reactive updates and computed query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->