### PR TITLE
(fix): commented out automatic search&replace in solid docs

### DIFF
--- a/docs/framework/solid/guides/queries.md
+++ b/docs/framework/solid/guides/queries.md
@@ -5,9 +5,9 @@ ref: docs/framework/react/guides/queries.md
 replace:
   {
     '@tanstack/react-query': '@tanstack/solid-query',
-    'useMutationState[(]': 'useMutationState(() => ',
-    'useMutation[(]': 'useMutation(() => ',
-    'useQuery[(]': 'useQuery(() => ',
-    'useQueries[(]': 'useQueries(() => ',
+    <!-- 'useMutationState[(]': 'useMutationState(() => ', -->
+    <!-- 'useMutation[(]': 'useMutation(() => ', -->
+    <!-- 'useQuery[(]': 'useQuery(() => ', -->
+    <!-- 'useQueries[(]': 'useQueries(() => ', -->
   }
 ---


### PR DESCRIPTION
React docs use object syntax inside useQuery({...}), useMutation({...}) and etc., but Solid requires a function returning an object: useQuery(() => ({ ... })). The current replace rule only prepends () => but does not wrap the object in parentheses, causing Solid examples to return undefined. This PR removes the useQuery, useMutation and etc replace rules.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

I didn’t run pnpm run test:pr because this PR does not modify any runtime or documentation build logic. Instead, it proposes a call for correction the Solid-specific documentation to fix a misunderstanding caused by the automatic React → Solid transformation. The current transformation produces invalid Solid examples, so this PR just comments out search&replace rule to call out about incorrect examples of code rather than providing a code fix that would require tests.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework integration guide by modifying hook mapping references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->