### PR TITLE
fix: useSusupenseQuery documantation enabled options remove

### DIFF
--- a/docs/framework/react/reference/useSuspenseQuery.md
+++ b/docs/framework/react/reference/useSuspenseQuery.md
@@ -12,7 +12,6 @@ const result = useSuspenseQuery(options)
 The same as for [useQuery](../useQuery.md), except for:
 
 - `throwOnError`
-- `enabled`
 - `placeholderData`
 
 **Returns**


### PR DESCRIPTION
## 🎯 Changes
Non-functional enabled option removed from useSuspenseQuery documantation. co-authered by @yakupozbaydar

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).
