### PR TITLE
docs(vue): change query keys example to typescript

### DIFF
--- a/docs/framework/vue/guides/query-keys.md
+++ b/docs/framework/vue/guides/query-keys.md
@@ -7,7 +7,7 @@ ref: docs/framework/react/guides/query-keys.md
 [//]: # 'Example5'
 
 ```ts
-import type { Ref } from 'vue';
+import type { Ref } from 'vue'
 
 function useTodos(todoId: Ref<string>) {
   const queryKey = ['todos', todoId]


### PR DESCRIPTION
## 🎯 Changes

This example is written in Javascript, and the fact that `todoId` is a `Ref` is a bit hard to identify.

I propose to migrate this example to Typescript, with an import to Vue's Ref type and make the parameter to the example composable explicit.

There are more docs that could be improved this way, if it suits you I could also make the changes to these docs :)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Vue query keys guide to TypeScript examples.
  * Added Vue Ref type annotation and import for clearer examples.
  * Example function signature now accepts a Ref<string> and demonstrates using .value when accessing the ID.
  * Improved type-safety and clarity in the documentation samples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->