### PR TITLE
feat(vue-query): allow options getters in additional composables

### DIFF
--- a/.changeset/curvy-webs-create.md
+++ b/.changeset/curvy-webs-create.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query': minor
+---
+
+feat(vue-query): allow options getters in additional composables

--- a/packages/vue-query/src/__mocks__/useBaseQuery.ts
+++ b/packages/vue-query/src/__mocks__/useBaseQuery.ts
@@ -1,9 +1,9 @@
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 
-const { useBaseQuery: originImpl, unrefQueryArgs: originalParse } =
-  (await vi.importActual('../useBaseQuery')) as any
+const { useBaseQuery: originImpl } = (await vi.importActual(
+  '../useBaseQuery',
+)) as any
 
 export const useBaseQuery: Mock<(...args: Array<any>) => any> =
   vi.fn(originImpl)
-export const unrefQueryArgs = originalParse

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
@@ -5,7 +5,7 @@ import { infiniteQueryOptions } from '../infiniteQueryOptions'
 
 vi.mock('../useQueryClient')
 
-describe('useQuery', () => {
+describe('useInfiniteQuery', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -82,6 +82,39 @@ describe('useMutation', () => {
     })
   })
 
+  test('should work with options getter and be reactive', async () => {
+    const result = 'Mock data'
+    const keyRef = ref('key01')
+    const fnMock = vi.fn((params: string) => sleep(10).then(() => params))
+    const mutation = useMutation(() => ({
+      mutationKey: [keyRef.value],
+      mutationFn: fnMock,
+    }))
+
+    mutation.mutate(result)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fnMock).toHaveBeenCalledTimes(1)
+    expect(fnMock).toHaveBeenNthCalledWith(
+      1,
+      result,
+      expect.objectContaining({ mutationKey: ['key01'] }),
+    )
+
+    keyRef.value = 'key02'
+    await vi.advanceTimersByTimeAsync(0)
+    mutation.mutate(result)
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fnMock).toHaveBeenCalledTimes(2)
+    expect(fnMock).toHaveBeenNthCalledWith(
+      2,
+      result,
+      expect.objectContaining({ mutationKey: ['key02'] }),
+    )
+  })
+
   test('should update reactive options', async () => {
     const queryClient = useQueryClient()
     const mutationCache = queryClient.getMutationCache()

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -255,7 +255,7 @@ describe('useQueries', () => {
   })
 
   test('should be `enabled` to accept getter function', async () => {
-    const fetchFn = vi.fn()
+    const fetchFn = vi.fn(() => 'foo')
     const checked = ref(false)
 
     useQueries({
@@ -278,7 +278,7 @@ describe('useQueries', () => {
   })
 
   test('should allow getters for query keys', async () => {
-    const fetchFn = vi.fn()
+    const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
     const key2 = ref('key2')
 
@@ -307,7 +307,7 @@ describe('useQueries', () => {
   })
 
   test('should allow arbitrarily nested getters for query keys', async () => {
-    const fetchFn = vi.fn()
+    const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
     const key2 = ref('key2')
     const key3 = ref('key3')
@@ -327,6 +327,69 @@ describe('useQueries', () => {
               foo: {
                 bar: {
                   baz: () => key5.value,
+                },
+              },
+            }),
+          ],
+          queryFn: fetchFn,
+        },
+      ],
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    key1.value = 'key1-updated'
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+
+    key2.value = 'key2-updated'
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+
+    key3.value = 'key3-updated'
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchFn).toHaveBeenCalledTimes(4)
+
+    key4.value = 'key4-updated'
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchFn).toHaveBeenCalledTimes(5)
+
+    key5.value = 'key5-updated'
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchFn).toHaveBeenCalledTimes(6)
+  })
+
+  test('should work with options getter and be reactive', async () => {
+    const fetchFn = vi.fn(() => 'foo')
+    const key1 = ref('key1')
+    const key2 = ref('key2')
+    const key3 = ref('key3')
+    const key4 = ref('key4')
+    const key5 = ref('key5')
+
+    useQueries({
+      queries: () => [
+        {
+          queryKey: [
+            'key',
+            key1,
+            key2.value,
+            { key: key3.value },
+            [{ foo: { bar: key4.value } }],
+            () => ({
+              foo: {
+                bar: {
+                  baz: key5.value,
                 },
               },
             }),

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -62,6 +62,39 @@ describe('useQuery', () => {
     })
   })
 
+  test('should work with options getter and be reactive', async () => {
+    const keyRef = ref('key011')
+    const resultRef = ref('result02')
+    const query = useQuery(() => ({
+      queryKey: [keyRef.value],
+      queryFn: () => sleep(0).then(() => resultRef.value),
+    }))
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'result02' },
+      isPending: { value: false },
+      isFetching: { value: false },
+      isFetched: { value: true },
+      isSuccess: { value: true },
+    })
+
+    resultRef.value = 'result021'
+    keyRef.value = 'key012'
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'result021' },
+      isPending: { value: false },
+      isFetching: { value: false },
+      isFetched: { value: true },
+      isSuccess: { value: true },
+    })
+  })
+
   test('should return pending status initially', () => {
     const query = useQuery({
       queryKey: ['key1'],
@@ -274,7 +307,7 @@ describe('useQuery', () => {
   })
 
   test('should use the current value for the queryKey when refetch is called', async () => {
-    const fetchFn = vi.fn()
+    const fetchFn = vi.fn(() => 'foo')
     const keyRef = ref('key11')
     const query = useQuery({
       queryKey: ['key10', keyRef],
@@ -302,7 +335,7 @@ describe('useQuery', () => {
   })
 
   test('should be `enabled` to accept getter function', async () => {
-    const fetchFn = vi.fn()
+    const fetchFn = vi.fn(() => 'foo')
     const checked = ref(false)
 
     useQuery({
@@ -321,7 +354,7 @@ describe('useQuery', () => {
   })
 
   test('should allow getters for query keys', async () => {
-    const fetchFn = vi.fn()
+    const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
     const key2 = ref('key2')
 
@@ -346,7 +379,7 @@ describe('useQuery', () => {
   })
 
   test('should allow arbitrarily nested getters for query keys', async () => {
-    const fetchFn = vi.fn()
+    const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
     const key2 = ref('key2')
     const key3 = ref('key3')

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -240,6 +240,7 @@ export function useQueries<
     ...options
   }: ShallowOption & {
     queries:
+      | (() => MaybeRefDeep<UseQueriesOptionsArg<T>>)
       | MaybeRefDeep<UseQueriesOptionsArg<T>>
       | MaybeRefDeep<
           readonly [
@@ -261,8 +262,12 @@ export function useQueries<
   const client = queryClient || useQueryClient()
 
   const defaultedQueries = computed(() => {
+    const resolvedQueries =
+      typeof queries === 'function'
+        ? (queries as () => MaybeRefDeep<UseQueriesOptionsArg<T>>)()
+        : queries
     // Only unref the top level array.
-    const queriesRaw = unref(queries) as ReadonlyArray<any>
+    const queriesRaw = unref(resolvedQueries) as ReadonlyArray<any>
 
     // Unref the rest for each element in the top level array.
     return queriesRaw.map((queryOptions) => {


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Options getters now supported in composables: `useIsFetching`, `useMutation`, `useMutationState`, and `useQueries` can accept functions that dynamically return options or filters, enabling more reactive and flexible configuration patterns.

* **Tests**
  * Added comprehensive test coverage verifying reactive behavior of options getters across affected composables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->