### PR TITLE
test(react-query/HydrationBoundary): add tests for 'enabled: false' and 'staleTime: Infinity'

### DIFF
--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -502,8 +502,9 @@ describe('React hydration', () => {
       </QueryClientProvider>,
     )
 
-    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('["stringCached"]')).toBeInTheDocument()
 
+    await vi.advanceTimersByTimeAsync(11)
     expect(queryFn).toHaveBeenCalledTimes(0)
     expect(rendered.getByText('["stringCached"]')).toBeInTheDocument()
 
@@ -531,8 +532,9 @@ describe('React hydration', () => {
       </QueryClientProvider>,
     )
 
-    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('["stringCached"]')).toBeInTheDocument()
 
+    await vi.advanceTimersByTimeAsync(11)
     expect(queryFn).toHaveBeenCalledTimes(0)
     expect(rendered.getByText('["stringCached"]')).toBeInTheDocument()
 


### PR DESCRIPTION
## 🎯 Changes

Add test cases for `HydrationBoundary` to verify that queries with `enabled: false` or `staleTime: Infinity` do not trigger unnecessary refetches during hydration.

### Tests Added
- `should not refetch when query has enabled set to false`
- `should not refetch when query has staleTime set to Infinity`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added two tests verifying hydration does not trigger refetches for queries that are disabled or have infinite stale time; confirms cached pre-hydrated data is shown and the query function is not invoked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->