### PR TITLE
docs: Document possible conflict between `PersistQueryClientProvider` and SSR streaming

### DIFF
--- a/docs/framework/react/guides/advanced-ssr.md
+++ b/docs/framework/react/guides/advanced-ssr.md
@@ -534,14 +534,14 @@ For more information, check out the [Next.js App with Prefetching Example](../ex
 
 ### Using the Persist Adapter with Streaming
 
-If you're using the persist adapter with the [Streaming with Server Components](#streaming-with-server-components) feature, you need to be careful not to save promises to storage. Since pending queries can be dehydrated and streamed to the client, you should configure the persister to only persist settled queries:
+If you're using the persist adapter with the [Streaming with Server Components](#streaming-with-server-components) feature, you need to be careful not to save promises to storage. Since pending queries can be dehydrated and streamed to the client, you should configure the persister to only persist successful queries:
 
 ```tsx
 <PersistQueryClientProvider
   client={queryClient}
   persistOptions={{
     persister,
-    // We don't want to save promises into the storage, so we only persist settled queries
+    // We don't want to save promises into the storage, so we only persist successful queries
     dehydrateOptions: { shouldDehydrateQuery: defaultShouldDehydrateQuery },
   }}
 >


### PR DESCRIPTION
## 🎯 Changes
Currently, using both `PersistQueryClientProvider` and query streaming in NextJS can cause exceptions during dehydration with the current example in the docs.

This PR documents the conflict and the prop you may use to solve it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance and configuration examples for using the Persist Adapter with Server Components and streaming, showing how to persist only settled queries to avoid serializing pending promises.
  * Guidance appears in two locations to improve discoverability (duplicate content).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->