### PR TITLE
Update bundlephobia link to TanStack React Query

### DIFF
--- a/docs/framework/react/comparison.md
+++ b/docs/framework/react/comparison.md
@@ -79,8 +79,8 @@ Feature/Capability Key:
 
 > **<sup>8</sup> React Router cache persistence** - React Router does not cache data beyond the currently matched routes. If a route is left, its data is lost.
 
-[bpl-react-query]: https://bundlephobia.com/result?p=react-query
-[bp-react-query]: https://badgen.net/bundlephobia/minzip/react-query?label=💾
+[bpl-react-query]: https://bundlephobia.com/result?p=@tanstack/react-query
+[bp-react-query]: https://badgen.net/bundlephobia/minzip/@tanstack/react-query?label=💾
 [gh-react-query]: https://github.com/tannerlinsley/react-query
 [stars-react-query]: https://img.shields.io/github/stars/tannerlinsley/react-query?label=%F0%9F%8C%9F
 [swr]: https://github.com/vercel/swr


### PR DESCRIPTION
The bundlephobia links were pointing to the old react-query package (v3) instead of the current @tanstack/react-query package.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external links for React Query references to point to TanStack React Query.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->