### PR TITLE
test(react-query/ssr): add 'useIsFetching' test for SSR

### DIFF
--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -7,6 +7,7 @@ import {
   QueryClient,
   QueryClientProvider,
   useInfiniteQuery,
+  useIsFetching,
   useQuery,
 } from '..'
 import { setIsServer } from './utils'
@@ -170,6 +171,37 @@ describe('Server Side Rendering', () => {
 
     expect(markup).toContain('page 1')
     expect(queryFn).toHaveBeenCalledTimes(1)
+
+    queryCache.clear()
+  })
+
+  it('useIsFetching should return 0 after prefetch completes', async () => {
+    const key = queryKey()
+    const queryFn = () => sleep(10).then(() => 'data')
+
+    function Page() {
+      const { data } = useQuery({ queryKey: key, queryFn })
+      const isFetching = useIsFetching()
+
+      return (
+        <div>
+          <div>{data}</div>
+          <div>{`isFetching: ${isFetching}`}</div>
+        </div>
+      )
+    }
+
+    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    await vi.advanceTimersByTimeAsync(10)
+
+    const markup = renderToString(
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>,
+    )
+
+    expect(markup).toContain('data')
+    expect(markup).toContain('isFetching: 0')
 
     queryCache.clear()
   })


### PR DESCRIPTION
## 🎯 Changes

Add `useIsFetching` test for SSR in `ssr.test.tsx`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `useIsFetching` hook is now exported from the public API and available for use.

* **Tests**
  * Added server-side rendering test coverage for `useIsFetching` to validate fetching state behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->