### PR TITLE
fix: support refetchMode append in streamedQuery

### DIFF
--- a/packages/query-core/src/streamedQuery.ts
+++ b/packages/query-core/src/streamedQuery.ts
@@ -71,7 +71,10 @@ export function streamedQuery<
       })
     }
 
-    let result = initialValue
+    let result =
+    isRefetch && refetchMode === 'append'
+      ? (query.state.data as TData)
+      : initialValue
 
     const stream = await streamFn(context)
 


### PR DESCRIPTION
- Initialize result with existing query data when refetchMode is 'append'
- Fixes issue where refetch with append mode was discarding previous data

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data handling during refresh operations in append mode. Streamed queries now correctly preserve and extend existing data when performing refetches, ensuring proper data accumulation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->