### PR TITLE
docs: fix missing param in vue infinite queries sample

### DIFF
--- a/docs/framework/vue/guides/infinite-queries.md
+++ b/docs/framework/vue/guides/infinite-queries.md
@@ -10,7 +10,7 @@ ref: docs/framework/react/guides/infinite-queries.md
 <script setup>
 import { useInfiniteQuery } from '@tanstack/vue-query'
 
-const fetchProjects = async ({ pageParam = 0 }) => {
+const fetchProjects = async ({ pageParam }) => {
   const res = await fetch('/api/projects?cursor=' + pageParam)
   return res.json()
 }


### PR DESCRIPTION
Add required initialPageParam to useInfiniteQuery in Vue.js guide

## 🎯 Changes

Align React and Vue.js guides

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Vue infinite queries guide to show how to set an explicit initial page for pagination.
  * Clarified example usage for fetching subsequent pages and adjusted the example to rely on the documented initial page behavior so the starting page is explicit and consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->