### PR TITLE
docs(react-query): undefined vs. null in query-functions.md

### DIFF
--- a/docs/framework/react/guides/query-functions.md
+++ b/docs/framework/react/guides/query-functions.md
@@ -5,6 +5,8 @@ title: Query Functions
 
 A query function can be literally any function that **returns a promise**. The promise that is returned should either **resolve the data** or **throw an error**.
 
+On success, the resolved value may be anything **except `undefined`**. Queries that resolve to `undefined` will be [treated as failed](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-react-query-4#undefined-is-an-illegal-cache-value-for-successful-queries). To store "nothing" as a successful result in the query cache, resolve `null` instead.
+
 All of the following are valid query function configurations:
 
 [//]: # 'Example'
@@ -22,6 +24,13 @@ useQuery({
 useQuery({
   queryKey: ['todos', todoId],
   queryFn: ({ queryKey }) => fetchTodoById(queryKey[1]),
+})
+useQuery({
+  queryKey: ['todos', todoId],
+  queryFn: async () => {
+    const allTodosById = await fetchAllTodosById()
+    return allTodosById[todoId] ?? null
+  },
 })
 ```
 

--- a/docs/framework/react/guides/query-functions.md
+++ b/docs/framework/react/guides/query-functions.md
@@ -25,13 +25,6 @@ useQuery({
   queryKey: ['todos', todoId],
   queryFn: ({ queryKey }) => fetchTodoById(queryKey[1]),
 })
-useQuery({
-  queryKey: ['todos', todoId],
-  queryFn: async () => {
-    const allTodosById = await fetchAllTodosById()
-    return allTodosById[todoId] ?? null
-  },
-})
 ```
 
 [//]: # 'Example'


### PR DESCRIPTION
## 🎯 Changes

The docs currently do not specify anything about `null` or `undefined` for `queryFn`s. I.e., whether each value is legal, what the semantics are etc. I found a few cases of people being confused about it, including [this discussion](https://github.com/TanStack/query/discussions/4964). That discussion mentioned a change in behaviour which is documented in [v3->v4 migration guide](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-react-query-4#undefined-is-an-illegal-cache-value-for-successful-queries), but I think this should be in the main docs as well.

## ✅ Checklist

- [ ] ~I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).~
  - I tried to run the docs locally but kept getting errors about `DATABASE_URL`. I've reviewed the rendered markdown from my changes though and it looks fine to me
- [ ] ~I have tested this code locally with `pnpm run test:pr`.~
  - N/A, no code changes

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance: query functions must not resolve to undefined (treated as a failed query); resolve null to represent “nothing” as a successful cached result.
  
<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->