### PR TITLE
docs: clarify that failureCount starts at 0 in retry callback

### DIFF
--- a/docs/framework/react/guides/query-retries.md
+++ b/docs/framework/react/guides/query-retries.md
@@ -10,7 +10,7 @@ You can configure retries both on a global level and an individual query level.
 - Setting `retry = false` will disable retries.
 - Setting `retry = 6` will retry failing requests 6 times before showing the final error thrown by the function.
 - Setting `retry = true` will infinitely retry failing requests.
-- Setting `retry = (failureCount, error) => ...` allows for custom logic based on why the request failed.
+- Setting `retry = (failureCount, error) => ...` allows for custom logic based on why the request failed. Note that `failureCount` starts at `0` for the first retry attempt.
 
 [//]: # 'Info'
 

--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -84,6 +84,7 @@ const {
   - If `false`, failed queries will not retry by default.
   - If `true`, failed queries will retry infinitely.
   - If set to a `number`, e.g. `3`, failed queries will retry until the failed query count meets that number.
+  - If set to a function, it will be called with `failureCount` (starting at `0` for the first retry) and `error` to determine if a retry should be attempted.
   - defaults to `3` on the client and `0` on the server
 - `retryOnMount: boolean`
   - If set to `false`, the query will not be retried on mount if it contains an error. Defaults to `true`.


### PR DESCRIPTION
## Summary

Added clarification that `failureCount` parameter in the retry callback function starts at `0` for the first retry attempt, not `1`.

## Changes

- `docs/framework/react/guides/query-retries.md`: Added note about `failureCount` starting at 0
- `docs/framework/react/reference/useQuery.md`: Added explanation for the function variant of `retry` option

This helps developers understand that on the first retry check, `failureCount` will be `0`, which can be surprising if not documented.

Fixes #10017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified retry functionality documentation to explain that the `failureCount` parameter starts at 0 for the first retry attempt and is provided to custom retry functions alongside the error for retry decision-making.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->