### PR TITLE
WIP: infer errors from Throws returns

### DIFF
--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -12,9 +12,56 @@ import type {
   UseMutationOptions,
   UseMutationResult,
 } from './types'
-import type { DefaultError, QueryClient } from '@tanstack/query-core'
+import type {
+  DefaultError,
+  InferErrorFromFn,
+  MutationFunction,
+  QueryClient,
+  StripThrows,
+  ThrowsFnOptions,
+} from '@tanstack/query-core'
+
+type MutationFnData<TMutationFn extends (...args: Array<any>) => any> =
+  StripThrows<Awaited<ReturnType<TMutationFn>>>
+
+type MutationFnVariables<TMutationFn extends (...args: Array<any>) => any> =
+  Parameters<TMutationFn> extends [] ? void : Parameters<TMutationFn>[0]
 
 // HOOK
+
+export function useMutation<
+  TMutationFn extends MutationFunction<any, any>,
+  TOnMutateResult = unknown,
+>(
+  options: ThrowsFnOptions<
+    TMutationFn,
+    Omit<
+      UseMutationOptions<
+        MutationFnData<TMutationFn>,
+        InferErrorFromFn<TMutationFn>,
+        MutationFnVariables<TMutationFn>,
+        TOnMutateResult
+      >,
+      'mutationFn'
+    > & { mutationFn: TMutationFn }
+  >,
+  queryClient?: QueryClient,
+): UseMutationResult<
+  MutationFnData<TMutationFn>,
+  InferErrorFromFn<TMutationFn>,
+  MutationFnVariables<TMutationFn>,
+  TOnMutateResult
+>
+
+export function useMutation<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TOnMutateResult = unknown,
+>(
+  options: UseMutationOptions<TData, TError, TVariables, TOnMutateResult>,
+  queryClient?: QueryClient,
+): UseMutationResult<TData, TError, TVariables, TOnMutateResult>
 
 export function useMutation<
   TData = unknown,

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -3,9 +3,13 @@ import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
+  InferErrorFromFn,
   NoInfer,
   QueryClient,
+  QueryFunction,
   QueryKey,
+  StripThrows,
+  ThrowsFnOptions,
 } from '@tanstack/query-core'
 import type {
   DefinedUseQueryResult,
@@ -16,6 +20,54 @@ import type {
   DefinedInitialDataOptions,
   UndefinedInitialDataOptions,
 } from './queryOptions'
+
+export function useQuery<
+  TQueryKey extends QueryKey = QueryKey,
+  TQueryFn extends QueryFunction<any, TQueryKey> = QueryFunction<
+    any,
+    TQueryKey
+  >,
+  TQueryFnData = StripThrows<Awaited<ReturnType<TQueryFn>>>,
+  TData = TQueryFnData,
+>(
+  options: ThrowsFnOptions<
+    TQueryFn,
+    Omit<
+      DefinedInitialDataOptions<
+        TQueryFnData,
+        InferErrorFromFn<TQueryFn>,
+        TData,
+        TQueryKey
+      >,
+      'queryFn'
+    > & { queryFn: TQueryFn }
+  >,
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<NoInfer<TData>, InferErrorFromFn<TQueryFn>>
+
+export function useQuery<
+  TQueryKey extends QueryKey = QueryKey,
+  TQueryFn extends QueryFunction<any, TQueryKey> = QueryFunction<
+    any,
+    TQueryKey
+  >,
+  TQueryFnData = StripThrows<Awaited<ReturnType<TQueryFn>>>,
+  TData = TQueryFnData,
+>(
+  options: ThrowsFnOptions<
+    TQueryFn,
+    Omit<
+      UndefinedInitialDataOptions<
+        TQueryFnData,
+        InferErrorFromFn<TQueryFn>,
+        TData,
+        TQueryKey
+      >,
+      'queryFn'
+    > & { queryFn: TQueryFn }
+  >,
+  queryClient?: QueryClient,
+): UseQueryResult<NoInfer<TData>, InferErrorFromFn<TQueryFn>>
 
 export function useQuery<
   TQueryFnData = unknown,


### PR DESCRIPTION
## Summary
- infer hook error types from `Throws` return annotations when provided
- guard `any` and strip `Throws` to avoid pollution in data inference
- add type tests for auto inference and `Promise<any>` fallback

## Testing
- `pnpm --filter @tanstack/react-query test:types` (fails in `test:types:tscurrent` at `packages/react-query/src/__tests__/useQuery.test.tsx:2186`: NotifyOnChangeProps type mismatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced TypeScript error type inference in query and mutation operations for improved IDE autocomplete and compile-time type checking.
  * New type utilities for declaring and extracting error types from functions, enabling more precise error handling and type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->