### PR TITLE
fix(solid-query): prevent suspense trigger with pre-cached data

### DIFF
--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -260,7 +260,8 @@ export function useBaseQuery<
           setStateWithReconciliation(observerResult)
           return reject(observerResult.error)
         }
-        if (!observerResult.isLoading) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- data can be undefined at runtime despite type inference
+        if (!observerResult.isLoading || observerResult.data !== undefined) {
           resolver = null
           return resolve(
             hydratableObserverResult(obs.getCurrentQuery(), observerResult),
@@ -376,9 +377,16 @@ export function useBaseQuery<
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
       if (prop === 'data') {
-        if (state.data !== undefined) {
-          return queryResource.latest?.data
+        const stateData = state.data
+
+        if (!observerResult.isFetching && stateData !== undefined) {
+          return stateData
         }
+
+        if (!observerResult.isFetching && observerResult.data !== undefined) {
+          return observerResult.data
+        }
+
         return queryResource()?.data
       }
       return Reflect.get(target, prop)


### PR DESCRIPTION
When using `refetchOnMount: false` with pre-cached data, the first `setQueryData` call would incorrectly trigger a Suspense fallback. This happened because the Proxy handler was calling `queryResource()` even when cached data was available.

This fix ensures that:
1. The resource resolves immediately when data is already available, regardless of the `isLoading` state
2. The Proxy handler returns cached data directly when `isFetching` is false and data exists, avoiding unnecessary resource access

Closes #9883

## 🎯 Changes

useBaseQuery.ts (line 263): Added || observerResult.data !== undefined condition to resolve the resource immediately when cached data exists, even if isLoading is true

useBaseQuery.ts (line 378-390): Modified the Proxy handler to check isFetching state before accessing queryResource(). When isFetching is false and data exists in either state or observerResult, return it directly without triggering Suspense

suspense.test.tsx: Added test case to verify that Suspense is never triggered when using refetchOnMount: false with pre-cached data, including initial render and subsequent setQueryData calls


## result 

https://github.com/user-attachments/assets/2518236a-1b99-406f-9a52-e7dce58894f2


## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Suspense mode handling to better manage pre-cached query data, preventing unnecessary suspension during data mutations.
  * Enhanced data retrieval logic to prioritize available cached data and optimize loading state detection.

* **Tests**
  * Added comprehensive test coverage for Suspense mode behavior with pre-cached data and disabled refetch on mount.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->