### PR TITLE
fix(svelte-query): suppress false positive unused import warnings

### DIFF
--- a/packages/svelte-query/vite.config.ts
+++ b/packages/svelte-query/vite.config.ts
@@ -17,6 +17,21 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      onwarn(warning, warn) {
+        // Suppress false positive "unused import" warnings from @tanstack/query-core
+        // These imports (notifyManager, replaceEqualDeep) are actually used in the code
+        if (
+          warning.code === 'UNUSED_EXTERNAL_IMPORT' &&
+          warning.message?.includes('@tanstack/query-core')
+        ) {
+          return
+        }
+        warn(warning)
+      },
+    },
+  },
   test: {
     name: packageJson.name,
     dir: './tests',


### PR DESCRIPTION
Fixes #9740

Added rollup onwarn handler to suppress UNUSED_EXTERNAL_IMPORT warnings for @tanstack/query-core imports. These warnings are false positives as the imports (notifyManager, replaceEqualDeep) are actually used in the compiled code but Rollup's tree-shaking analysis fails to detect this in Svelte 5's runes context ($effect, $state, $derived).

The warning appeared during SvelteKit project builds mentioning:
- notifyManager (used in createMutation.svelte.ts)
- replaceEqualDeep (used in useMutationState.svelte.ts)

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build process to suppress known false-positive warnings while continuing to report other warnings normally.
  * Build output is now cleaner and easier to review without changing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->