### PR TITLE
test: rename dependant queries to dependent queries

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -365,10 +365,10 @@ describe('injectQuery', () => {
     expect(query.status()).toBe('success')
   })
 
-  test('should properly execute dependant queries', async () => {
+  test('should properly execute dependent queries', async () => {
     const query1 = TestBed.runInInjectionContext(() => {
       return injectQuery(() => ({
-        queryKey: ['dependant1'],
+        queryKey: ['dependent1'],
         queryFn: () => sleep(10).then(() => 'Some data'),
       }))
     })
@@ -380,7 +380,7 @@ describe('injectQuery', () => {
     const query2 = TestBed.runInInjectionContext(() => {
       return injectQuery(
         computed(() => ({
-          queryKey: ['dependant2'],
+          queryKey: ['dependent2'],
           queryFn: dependentQueryFn,
           enabled: !!query1.data(),
         })),
@@ -402,7 +402,7 @@ describe('injectQuery', () => {
     expect(query2.status()).toStrictEqual('success')
     expect(dependentQueryFn).toHaveBeenCalledTimes(1)
     expect(dependentQueryFn).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ['dependant2'] }),
+      expect.objectContaining({ queryKey: ['dependent2'] }),
     )
   })
 

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -246,9 +246,9 @@ describe('useQuery', () => {
     })
   })
 
-  test('should properly execute dependant queries', async () => {
+  test('should properly execute dependent queries', async () => {
     const { data } = useQuery({
-      queryKey: ['dependant1'],
+      queryKey: ['dependent1'],
       queryFn: () => sleep(0).then(() => 'Some data'),
     })
 
@@ -259,7 +259,7 @@ describe('useQuery', () => {
       .mockImplementation(() => sleep(10).then(() => 'Some data'))
     const { fetchStatus, status } = useQuery(
       reactive({
-        queryKey: ['dependant2'],
+        queryKey: ['dependent2'],
         queryFn: dependentQueryFn,
         enabled,
       }),
@@ -280,7 +280,7 @@ describe('useQuery', () => {
     expect(status.value).toStrictEqual('success')
     expect(dependentQueryFn).toHaveBeenCalledTimes(1)
     expect(dependentQueryFn).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ['dependant2'] }),
+      expect.objectContaining({ queryKey: ['dependent2'] }),
     )
   })
 


### PR DESCRIPTION
## 🎯 Changes
<!-- What changes are made in this PR? Describe the change and its motivation. -->
This updates two test cases to use the more common spelling “dependent” instead of “dependant”:
- Angular experimental `injectQuery` tests
- Vue `useQuery` tests

No runtime behavior changes—test-only rename + matching `queryKey` strings for consistency.

## ✅ Checklist
- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact
- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected naming consistency across test suites to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->