### PR TITLE
test(query-core/mutationObserver): add test for skipping 'notify' when 'setOptions' is called with same options

### DIFF
--- a/packages/query-core/src/__tests__/mutationObserver.test.tsx
+++ b/packages/query-core/src/__tests__/mutationObserver.test.tsx
@@ -476,4 +476,27 @@ describe('mutationObserver', () => {
       unsubscribe()
     })
   })
+
+  test('should not notify cache when setOptions is called with same options', () => {
+    const mutationObserver = new MutationObserver(queryClient, {
+      mutationFn: (text: string) => Promise.resolve(text),
+    })
+
+    const notifySpy = vi.spyOn(queryClient.getMutationCache(), 'notify')
+
+    const unsubscribe = mutationObserver.subscribe(() => undefined)
+
+    notifySpy.mockClear()
+
+    // Call setOptions with the same options
+    mutationObserver.setOptions({
+      mutationFn: mutationObserver.options.mutationFn,
+    })
+
+    expect(notifySpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'observerOptionsUpdated' }),
+    )
+
+    unsubscribe()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add test to verify that `MutationObserver.setOptions()` does not emit `observerOptionsUpdated` notification when called with unchanged options
- Covers the `shallowEqualObjects` check branch in `setOptions`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify that the mutation observer correctly handles unchanged options without triggering unnecessary notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->