### PR TITLE
test(query-core/queryClient): add test for 'getMutationDefaults' matching only relevant mutation defaults

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -2114,5 +2114,21 @@ describe('queryClient', () => {
         mutationOptions2,
       )
     })
+
+    test('should return only matching defaults when multiple mutation defaults are set', () => {
+      const key1 = queryKey()
+      const key2 = queryKey()
+      const mutationOptions1 = { retry: 1 }
+      const mutationOptions2 = { retry: 2 }
+      queryClient.setMutationDefaults(key1, mutationOptions1)
+      queryClient.setMutationDefaults(key2, mutationOptions2)
+
+      expect(queryClient.getMutationDefaults(key1)).toMatchObject(
+        mutationOptions1,
+      )
+      expect(queryClient.getMutationDefaults(key2)).toMatchObject(
+        mutationOptions2,
+      )
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add test to verify that `getMutationDefaults` returns only matching defaults when multiple mutation defaults are set with different keys
- Covers the `partialMatchKey` false branch in `getMutationDefaults` forEach loop

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify that mutation default options are correctly stored and retrieved independently for different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->