### PR TITLE
feat(query-core): add structuralSharing option to useQueries

### DIFF
--- a/.changeset/silver-coins-mix.md
+++ b/.changeset/silver-coins-mix.md
@@ -2,6 +2,7 @@
 '@tanstack/angular-query-experimental': minor
 '@tanstack/svelte-query': minor
 '@tanstack/react-query': minor
+'@tanstack/preact-query': minor
 '@tanstack/solid-query': minor
 '@tanstack/query-core': minor
 '@tanstack/vue-query': minor

--- a/.changeset/silver-coins-mix.md
+++ b/.changeset/silver-coins-mix.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/angular-query-experimental': minor
+'@tanstack/svelte-query': minor
+'@tanstack/react-query': minor
+'@tanstack/solid-query': minor
+'@tanstack/query-core': minor
+'@tanstack/vue-query': minor
+---
+
+feat(query-core): Allow disabling structuralSharing for useQueries.

--- a/docs/framework/react/reference/useQueries.md
+++ b/docs/framework/react/reference/useQueries.md
@@ -27,7 +27,8 @@ The `useQueries` hook accepts an options object with a **queries** key whose val
 - `structuralSharing?: boolean | ((oldData: unknown | undefined, newData: unknown) => unknown)`
   - Optional
   - Defaults to `true`.
-  - If set to false, structural sharing between query results will be disabled.
+  - Only applies when `combine` is provided.
+  - If set to `false`, structural sharing between query results will be disabled.
   - If set to a function, the old and new data values will be passed through this function, which should combine them into resolved data for the query. This way, you can retain references from the old data to improve performance even when that data contains non-serializable values.
 
 > Having the same query key more than once in the array of query objects may cause some data to be shared between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired structure.

--- a/docs/framework/react/reference/useQueries.md
+++ b/docs/framework/react/reference/useQueries.md
@@ -24,6 +24,9 @@ The `useQueries` hook accepts an options object with a **queries** key whose val
   - Use this to provide a custom QueryClient. Otherwise, the one from the nearest context will be used.
 - `combine?: (result: UseQueriesResults) => TCombinedResult`
   - Use this to combine the results of the queries into a single value.
+- `structuralSharing?: boolean`
+  - Set this to `false` to disable structural sharing between query results when `combine` is provided.
+  - Defaults to `true`.
 
 > Having the same query key more than once in the array of query objects may cause some data to be shared between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired structure.
 
@@ -37,7 +40,7 @@ The `useQueries` hook returns an array with all the query results. The order ret
 
 ## Combine
 
-If you want to combine `data` (or other Query information) from the results into a single value, you can use the `combine` option. The result will be structurally shared to be as referentially stable as possible.
+If you want to combine `data` (or other Query information) from the results into a single value, you can use the `combine` option. The result will be structurally shared to be as referentially stable as possible. If you want to disable structural sharing for the combined result, you can set the `structuralSharing` option to `false`.
 
 ```tsx
 const ids = [1, 2, 3]

--- a/docs/framework/react/reference/useQueries.md
+++ b/docs/framework/react/reference/useQueries.md
@@ -24,9 +24,11 @@ The `useQueries` hook accepts an options object with a **queries** key whose val
   - Use this to provide a custom QueryClient. Otherwise, the one from the nearest context will be used.
 - `combine?: (result: UseQueriesResults) => TCombinedResult`
   - Use this to combine the results of the queries into a single value.
-- `structuralSharing?: boolean`
-  - Set this to `false` to disable structural sharing between query results when `combine` is provided.
+- `structuralSharing?: boolean | ((oldData: unknown | undefined, newData: unknown) => unknown)`
+  - Optional
   - Defaults to `true`.
+  - If set to false, structural sharing between query results will be disabled.
+  - If set to a function, the old and new data values will be passed through this function, which should combine them into resolved data for the query. This way, you can retain references from the old data to improve performance even when that data contains non-serializable values.
 
 > Having the same query key more than once in the array of query objects may cause some data to be shared between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired structure.
 
@@ -40,7 +42,7 @@ The `useQueries` hook returns an array with all the query results. The order ret
 
 ## Combine
 
-If you want to combine `data` (or other Query information) from the results into a single value, you can use the `combine` option. The result will be structurally shared to be as referentially stable as possible. If you want to disable structural sharing for the combined result, you can set the `structuralSharing` option to `false`.
+If you want to combine `data` (or other Query information) from the results into a single value, you can use the `combine` option. The result will be structurally shared to be as referentially stable as possible. If you want to disable structural sharing for the combined result, you can set the `structuralSharing` option to `false`, or provide a custom function to implement your own structural sharing logic.
 
 ```tsx
 const ids = [1, 2, 3]

--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -213,10 +213,13 @@ export interface InjectQueriesOptions<
   combine?: (result: QueriesResults<T>) => TCombinedResult
   /**
    * Set this to `false` to disable structural sharing between query results.
+   * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
    * Only applies when `combine` is provided.
    * Defaults to `true`.
    */
-  structuralSharing?: boolean
+  structuralSharing?:
+    | boolean
+    | ((oldData: unknown | undefined, newData: unknown) => unknown)
 }
 
 /**

--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -279,9 +279,7 @@ export function injectQueries<
     const optimisticResultSignal = computed(() =>
       observerSignal().getOptimisticResult(
         defaultedQueries(),
-        (optionsSignal() as QueriesObserverOptions<TCombinedResult>).combine,
-        (optionsSignal() as QueriesObserverOptions<TCombinedResult>)
-          .structuralSharing,
+        optionsSignal() as QueriesObserverOptions<TCombinedResult>,
       ),
     )
 

--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -211,6 +211,12 @@ export interface InjectQueriesOptions<
         ...{ [K in keyof T]: GetCreateQueryOptionsForCreateQueries<T[K]> },
       ]
   combine?: (result: QueriesResults<T>) => TCombinedResult
+  /**
+   * Set this to `false` to disable structural sharing between query results.
+   * Only applies when `combine` is provided.
+   * Defaults to `true`.
+   */
+  structuralSharing?: boolean
 }
 
 /**
@@ -271,6 +277,8 @@ export function injectQueries<
       observerSignal().getOptimisticResult(
         defaultedQueries(),
         (optionsSignal() as QueriesObserverOptions<TCombinedResult>).combine,
+        (optionsSignal() as QueriesObserverOptions<TCombinedResult>)
+          .structuralSharing,
       ),
     )
 

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -271,8 +271,7 @@ export function useQueries<
   const [optimisticResult, getCombinedResult, trackResult] =
     observer.getOptimisticResult(
       defaultedQueries,
-      (options as QueriesObserverOptions<TCombinedResult>).combine,
-      options.structuralSharing,
+      options as QueriesObserverOptions<TCombinedResult>,
     )
 
   const shouldSubscribe = !isRestoring && options.subscribed !== false

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -218,10 +218,13 @@ export function useQueries<
     combine?: (result: QueriesResults<T>) => TCombinedResult
     /**
      * Set this to `false` to disable structural sharing between query results.
+     * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
      * Only applies when `combine` is provided.
      * Defaults to `true`.
      */
-    structuralSharing?: boolean
+    structuralSharing?:
+      | boolean
+      | ((oldData: unknown | undefined, newData: unknown) => unknown)
     subscribed?: boolean
   },
   queryClient?: QueryClient,

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -216,6 +216,12 @@ export function useQueries<
       | readonly [...QueriesOptions<T>]
       | readonly [...{ [K in keyof T]: GetUseQueryOptionsForUseQueries<T[K]> }]
     combine?: (result: QueriesResults<T>) => TCombinedResult
+    /**
+     * Set this to `false` to disable structural sharing between query results.
+     * Only applies when `combine` is provided.
+     * Defaults to `true`.
+     */
+    structuralSharing?: boolean
     subscribed?: boolean
   },
   queryClient?: QueryClient,
@@ -263,6 +269,7 @@ export function useQueries<
     observer.getOptimisticResult(
       defaultedQueries,
       (options as QueriesObserverOptions<TCombinedResult>).combine,
+      options.structuralSharing,
     )
 
   const shouldSubscribe = !isRestoring && options.subscribed !== false

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -466,10 +466,9 @@ describe('queriesObserver', () => {
       { queryKey: key1, queryFn: queryFn1 },
       { queryKey: key2, queryFn: queryFn2 },
     ]
-    const [newRaw, getNewCombined] = observer.getOptimisticResult(
-      newQueries,
-      { combine },
-    )
+    const [newRaw, getNewCombined] = observer.getOptimisticResult(newQueries, {
+      combine,
+    })
     const newCombined = getNewCombined(newRaw)
 
     expect(newCombined.count).toBe(2)
@@ -586,10 +585,9 @@ describe('queriesObserver', () => {
     expect(initialCombined.count).toBe(2)
 
     const newQueries = [{ queryKey: key1, queryFn: queryFn1 }]
-    const [newRaw, getNewCombined] = observer.getOptimisticResult(
-      newQueries,
-      { combine },
-    )
+    const [newRaw, getNewCombined] = observer.getOptimisticResult(newQueries, {
+      combine,
+    })
     const newCombined = getNewCombined(newRaw)
 
     expect(newCombined.count).toBe(1)
@@ -654,15 +652,13 @@ describe('queriesObserver', () => {
       { combine: combine1 },
     )
 
-    const [raw1, getCombined1] = observer.getOptimisticResult(
-      queries,
-      { combine: combine1 },
-    )
+    const [raw1, getCombined1] = observer.getOptimisticResult(queries, {
+      combine: combine1,
+    })
     const combined1 = getCombined1(raw1)
-    const [raw2, getCombined2] = observer.getOptimisticResult(
-      queries,
-      { combine: combine2 },
-    )
+    const [raw2, getCombined2] = observer.getOptimisticResult(queries, {
+      combine: combine2,
+    })
     const combined2 = getCombined2(raw2)
 
     expect(combined1.total).toBe(2)
@@ -913,16 +909,14 @@ describe('queriesObserver', () => {
       { combine },
     )
 
-    const [raw1, getCombined1] = observer.getOptimisticResult(
-      queries,
-      { combine },
-    )
+    const [raw1, getCombined1] = observer.getOptimisticResult(queries, {
+      combine,
+    })
     const combined1 = getCombined1(raw1)
 
-    const [raw2, getCombined2] = observer.getOptimisticResult(
-      queries,
-      { combine },
-    )
+    const [raw2, getCombined2] = observer.getOptimisticResult(queries, {
+      combine,
+    })
     const combined2 = getCombined2(raw2)
 
     // Same combine, same queries → cached result returned
@@ -948,16 +942,14 @@ describe('queriesObserver', () => {
         combine,
       })
 
-      const [raw1, getCombined1] = observer.getOptimisticResult(
-        queries,
-        { combine },
-      )
+      const [raw1, getCombined1] = observer.getOptimisticResult(queries, {
+        combine,
+      })
       getCombined1(raw1)
 
-      const [raw2, getCombined2] = observer.getOptimisticResult(
-        queries,
-        { combine },
-      )
+      const [raw2, getCombined2] = observer.getOptimisticResult(queries, {
+        combine,
+      })
       getCombined2(raw2)
 
       expect(combine).toHaveBeenCalledTimes(1)

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -343,6 +343,7 @@ describe('queriesObserver', () => {
           { queryKey: key1, queryFn: queryFn1 },
         ],
         undefined,
+        undefined,
       )[0],
     )
 
@@ -457,6 +458,7 @@ describe('queriesObserver', () => {
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
       combine,
+      undefined,
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -469,6 +471,7 @@ describe('queriesObserver', () => {
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       newQueries,
       combine,
+      undefined,
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -580,6 +583,7 @@ describe('queriesObserver', () => {
         { queryKey: key2, queryFn: queryFn2 },
       ],
       combine,
+      undefined,
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -589,6 +593,7 @@ describe('queriesObserver', () => {
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       newQueries,
       combine,
+      undefined,
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -616,6 +621,7 @@ describe('queriesObserver', () => {
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
       combine,
+      undefined,
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -624,6 +630,7 @@ describe('queriesObserver', () => {
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       [{ queryKey: key2, queryFn: queryFn2 }],
       combine,
+      undefined,
     )
     const newCombined = getNewCombined(newRaw)
 

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -343,7 +343,6 @@ describe('queriesObserver', () => {
           { queryKey: key1, queryFn: queryFn1 },
         ],
         undefined,
-        undefined,
       )[0],
     )
 
@@ -457,8 +456,7 @@ describe('queriesObserver', () => {
 
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine,
-      undefined,
+      { combine },
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -470,8 +468,7 @@ describe('queriesObserver', () => {
     ]
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       newQueries,
-      combine,
-      undefined,
+      { combine },
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -498,8 +495,7 @@ describe('queriesObserver', () => {
 
     const [rawResult, getCombinedResult] = observer.getOptimisticResult(
       [query],
-      combine,
-      undefined,
+      { combine },
     )
     expect(getCombinedResult(rawResult)).toEqual(['data'])
     expect(combine).toHaveBeenCalledTimes(1)
@@ -532,8 +528,7 @@ describe('queriesObserver', () => {
 
     const [rawResult, getCombinedResult] = observer.getOptimisticResult(
       [query],
-      combine,
-      undefined,
+      { combine },
     )
     expect(getCombinedResult(rawResult)).toEqual(['data'])
     expect(combine).toHaveBeenCalledTimes(1)
@@ -584,8 +579,7 @@ describe('queriesObserver', () => {
         { queryKey: key1, queryFn: queryFn1 },
         { queryKey: key2, queryFn: queryFn2 },
       ],
-      combine,
-      undefined,
+      { combine },
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -594,8 +588,7 @@ describe('queriesObserver', () => {
     const newQueries = [{ queryKey: key1, queryFn: queryFn1 }]
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       newQueries,
-      combine,
-      undefined,
+      { combine },
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -622,8 +615,7 @@ describe('queriesObserver', () => {
 
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine,
-      undefined,
+      { combine },
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -631,8 +623,7 @@ describe('queriesObserver', () => {
 
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       [{ queryKey: key2, queryFn: queryFn2 }],
-      combine,
-      undefined,
+      { combine },
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -665,14 +656,12 @@ describe('queriesObserver', () => {
 
     const [raw1, getCombined1] = observer.getOptimisticResult(
       queries,
-      combine1,
-      undefined,
+      { combine: combine1 },
     )
     const combined1 = getCombined1(raw1)
     const [raw2, getCombined2] = observer.getOptimisticResult(
       queries,
-      combine2,
-      undefined,
+      { combine: combine2 },
     )
     const combined2 = getCombined2(raw2)
 
@@ -701,8 +690,7 @@ describe('queriesObserver', () => {
 
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine,
-      false,
+      { combine, structuralSharing: false },
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -714,8 +702,7 @@ describe('queriesObserver', () => {
 
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine2,
-      false,
+      { combine: combine2, structuralSharing: false },
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -745,8 +732,7 @@ describe('queriesObserver', () => {
 
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine,
-      true,
+      { combine, structuralSharing: true },
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -758,8 +744,7 @@ describe('queriesObserver', () => {
 
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine2,
-      true,
+      { combine: combine2, structuralSharing: true },
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -798,8 +783,7 @@ describe('queriesObserver', () => {
 
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine,
-      customStructuralSharing,
+      { combine, structuralSharing: customStructuralSharing },
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -836,8 +820,7 @@ describe('queriesObserver', () => {
 
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine,
-      customStructuralSharing,
+      { combine, structuralSharing: customStructuralSharing },
     )
     const initialCombined = getInitialCombined(initialRaw)
 
@@ -849,8 +832,7 @@ describe('queriesObserver', () => {
         { queryKey: key1, queryFn: queryFn1 },
         { queryKey: secondKey, queryFn: () => 2 },
       ],
-      combine,
-      customStructuralSharing,
+      { combine, structuralSharing: customStructuralSharing },
     )
     const newCombined = getNewCombined(newRaw)
 
@@ -884,8 +866,7 @@ describe('queriesObserver', () => {
 
     const [, getCombined] = observer.getOptimisticResult(
       [{ queryKey: key, queryFn }],
-      combine,
-      undefined,
+      { combine },
     )
     const combined = getCombined()
 
@@ -904,7 +885,6 @@ describe('queriesObserver', () => {
 
     const [, , trackResult] = observer.getOptimisticResult(
       [{ queryKey: key, queryFn, notifyOnChangeProps: ['data'] }],
-      undefined,
       undefined,
     )
 
@@ -935,15 +915,13 @@ describe('queriesObserver', () => {
 
     const [raw1, getCombined1] = observer.getOptimisticResult(
       queries,
-      combine,
-      undefined,
+      { combine },
     )
     const combined1 = getCombined1(raw1)
 
     const [raw2, getCombined2] = observer.getOptimisticResult(
       queries,
-      combine,
-      undefined,
+      { combine },
     )
     const combined2 = getCombined2(raw2)
 
@@ -972,15 +950,13 @@ describe('queriesObserver', () => {
 
       const [raw1, getCombined1] = observer.getOptimisticResult(
         queries,
-        combine,
-        undefined,
+        { combine },
       )
       getCombined1(raw1)
 
       const [raw2, getCombined2] = observer.getOptimisticResult(
         queries,
-        combine,
-        undefined,
+        { combine },
       )
       getCombined2(raw2)
 
@@ -1006,7 +982,6 @@ describe('queriesObserver', () => {
         { queryKey: key1, queryFn: queryFn1 },
         { queryKey: key2, queryFn: queryFn2 },
       ],
-      undefined,
       undefined,
     )
 
@@ -1113,8 +1088,7 @@ describe('queriesObserver', () => {
 
     const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine,
-      customStructuralSharing,
+      { combine, structuralSharing: customStructuralSharing },
     )
     const initialCombined = getInitialCombined(initialRaw)
     const initialArrayRef = initialCombined.existingArray
@@ -1128,8 +1102,7 @@ describe('queriesObserver', () => {
 
     const [newRaw, getNewCombined] = observer.getOptimisticResult(
       [{ queryKey: key1, queryFn: queryFn1 }],
-      combine2,
-      customStructuralSharing,
+      { combine: combine2, structuralSharing: customStructuralSharing },
     )
     const newCombined = getNewCombined(newRaw)
 

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -499,6 +499,7 @@ describe('queriesObserver', () => {
     const [rawResult, getCombinedResult] = observer.getOptimisticResult(
       [query],
       combine,
+      undefined,
     )
     expect(getCombinedResult(rawResult)).toEqual(['data'])
     expect(combine).toHaveBeenCalledTimes(1)
@@ -532,6 +533,7 @@ describe('queriesObserver', () => {
     const [rawResult, getCombinedResult] = observer.getOptimisticResult(
       [query],
       combine,
+      undefined,
     )
     expect(getCombinedResult(rawResult)).toEqual(['data'])
     expect(combine).toHaveBeenCalledTimes(1)
@@ -661,14 +663,209 @@ describe('queriesObserver', () => {
       { combine: combine1 },
     )
 
-    const [raw1, getCombined1] = observer.getOptimisticResult(queries, combine1)
+    const [raw1, getCombined1] = observer.getOptimisticResult(
+      queries,
+      combine1,
+      undefined,
+    )
     const combined1 = getCombined1(raw1)
-
-    const [raw2, getCombined2] = observer.getOptimisticResult(queries, combine2)
+    const [raw2, getCombined2] = observer.getOptimisticResult(
+      queries,
+      combine2,
+      undefined,
+    )
     const combined2 = getCombined2(raw2)
 
     expect(combined1.total).toBe(2)
     expect(combined2.total).toBe(8)
+  })
+
+  it('should not use structural sharing when structuralSharing is false', () => {
+    const key1 = queryKey()
+    const queryFn1 = vi.fn().mockReturnValue(1)
+
+    queryClient.setQueryData(key1, 'cached-1')
+
+    // Create a combine function that returns a new object with a nested array
+    const nestedArray = ['a', 'b', 'c']
+    const combine = vi.fn((_results: Array<QueryObserverResult>) => ({
+      nested: nestedArray,
+    }))
+
+    const observer = new QueriesObserver<{
+      nested: Array<string>
+    }>(queryClient, [{ queryKey: key1, queryFn: queryFn1 }], {
+      combine,
+      structuralSharing: false,
+    })
+
+    const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine,
+      false,
+    )
+    const initialCombined = getInitialCombined(initialRaw)
+
+    // Create a new combine function reference to trigger re-combine
+    // but with the same nested array content
+    const combine2 = vi.fn((_results: Array<QueryObserverResult>) => ({
+      nested: ['a', 'b', 'c'], // Same content, different reference
+    }))
+
+    const [newRaw, getNewCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine2,
+      false,
+    )
+    const newCombined = getNewCombined(newRaw)
+
+    // With structuralSharing: false, even though the nested array has the same content,
+    // the reference should NOT be preserved (no replaceEqualDeep optimization)
+    expect(newCombined.nested).toEqual(initialCombined.nested)
+    expect(newCombined.nested).not.toBe(initialCombined.nested)
+  })
+
+  it('should use structural sharing when structuralSharing is true', () => {
+    const key1 = queryKey()
+    const queryFn1 = vi.fn().mockReturnValue(1)
+
+    queryClient.setQueryData(key1, 'cached-1')
+
+    // Create a combine function that returns a new object with a nested array
+    const combine = vi.fn((_results: Array<QueryObserverResult>) => ({
+      nested: ['a', 'b', 'c'],
+    }))
+
+    const observer = new QueriesObserver<{
+      nested: Array<string>
+    }>(queryClient, [{ queryKey: key1, queryFn: queryFn1 }], {
+      combine,
+      structuralSharing: true,
+    })
+
+    const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine,
+      true,
+    )
+    const initialCombined = getInitialCombined(initialRaw)
+
+    // Create a new combine function reference to trigger re-combine
+    // but with the same nested array content
+    const combine2 = vi.fn((_results: Array<QueryObserverResult>) => ({
+      nested: ['a', 'b', 'c'], // Same content, different reference
+    }))
+
+    const [newRaw, getNewCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine2,
+      true,
+    )
+    const newCombined = getNewCombined(newRaw)
+
+    // With structuralSharing: true, replaceEqualDeep should preserve the reference
+    // since the nested array has the same content
+    expect(newCombined.nested).toEqual(initialCombined.nested)
+    expect(newCombined.nested).toBe(initialCombined.nested)
+  })
+
+  it('should use custom structuralSharing function when provided', () => {
+    const combine = vi.fn((results: Array<QueryObserverResult>) => ({
+      count: results.length,
+      data: results.map((r) => r.data),
+    }))
+
+    const customStructuralSharing = vi.fn(
+      (_oldData: unknown, newData: unknown) => {
+        // Custom logic: always return the new data but with a marker
+        return { ...(newData as object), customShared: true }
+      },
+    )
+
+    const key1 = queryKey()
+    const queryFn1 = vi.fn().mockReturnValue(1)
+
+    queryClient.setQueryData(key1, 'cached-1')
+
+    const observer = new QueriesObserver<{
+      count: number
+      data: Array<unknown>
+      customShared?: boolean
+    }>(queryClient, [{ queryKey: key1, queryFn: queryFn1 }], {
+      combine,
+      structuralSharing: customStructuralSharing,
+    })
+
+    const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine,
+      customStructuralSharing,
+    )
+    const initialCombined = getInitialCombined(initialRaw)
+
+    expect(initialCombined.count).toBe(1)
+    expect(initialCombined.customShared).toBe(true)
+    expect(customStructuralSharing).toHaveBeenCalledTimes(1)
+  })
+
+  it('should pass old and new data to custom structuralSharing function', () => {
+    const combine = vi.fn((results: Array<QueryObserverResult>) => ({
+      count: results.length,
+      data: results.map((r) => r.data),
+    }))
+
+    const customStructuralSharing = vi.fn(
+      (_oldData: unknown, newData: unknown) => {
+        // Return new data with reference to old data for testing
+        return newData
+      },
+    )
+
+    const key1 = queryKey()
+    const queryFn1 = vi.fn().mockReturnValue(1)
+
+    queryClient.setQueryData(key1, 'cached-1')
+
+    const observer = new QueriesObserver<{
+      count: number
+      data: Array<unknown>
+    }>(queryClient, [{ queryKey: key1, queryFn: queryFn1 }], {
+      combine,
+      structuralSharing: customStructuralSharing,
+    })
+
+    const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine,
+      customStructuralSharing,
+    )
+    const initialCombined = getInitialCombined(initialRaw)
+
+    expect(initialCombined.count).toBe(1)
+
+    const secondKey = queryKey()
+    const [newRaw, getNewCombined] = observer.getOptimisticResult(
+      [
+        { queryKey: key1, queryFn: queryFn1 },
+        { queryKey: secondKey, queryFn: () => 2 },
+      ],
+      combine,
+      customStructuralSharing,
+    )
+    const newCombined = getNewCombined(newRaw)
+
+    expect(newCombined.count).toBe(2)
+    expect(customStructuralSharing).toHaveBeenCalledTimes(2)
+    expect(customStructuralSharing).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      expect.objectContaining({ count: 1 }),
+    )
+    expect(customStructuralSharing).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ count: 1 }),
+      expect.objectContaining({ count: 2 }),
+    )
   })
 
   it('should use fallback result when combineResult is called without raw argument', () => {
@@ -688,6 +885,7 @@ describe('queriesObserver', () => {
     const [, getCombined] = observer.getOptimisticResult(
       [{ queryKey: key, queryFn }],
       combine,
+      undefined,
     )
     const combined = getCombined()
 
@@ -706,6 +904,7 @@ describe('queriesObserver', () => {
 
     const [, , trackResult] = observer.getOptimisticResult(
       [{ queryKey: key, queryFn, notifyOnChangeProps: ['data'] }],
+      undefined,
       undefined,
     )
 
@@ -734,10 +933,18 @@ describe('queriesObserver', () => {
       { combine },
     )
 
-    const [raw1, getCombined1] = observer.getOptimisticResult(queries, combine)
+    const [raw1, getCombined1] = observer.getOptimisticResult(
+      queries,
+      combine,
+      undefined,
+    )
     const combined1 = getCombined1(raw1)
 
-    const [raw2, getCombined2] = observer.getOptimisticResult(queries, combine)
+    const [raw2, getCombined2] = observer.getOptimisticResult(
+      queries,
+      combine,
+      undefined,
+    )
     const combined2 = getCombined2(raw2)
 
     // Same combine, same queries → cached result returned
@@ -766,12 +973,14 @@ describe('queriesObserver', () => {
       const [raw1, getCombined1] = observer.getOptimisticResult(
         queries,
         combine,
+        undefined,
       )
       getCombined1(raw1)
 
       const [raw2, getCombined2] = observer.getOptimisticResult(
         queries,
         combine,
+        undefined,
       )
       getCombined2(raw2)
 
@@ -797,6 +1006,7 @@ describe('queriesObserver', () => {
         { queryKey: key1, queryFn: queryFn1 },
         { queryKey: key2, queryFn: queryFn2 },
       ],
+      undefined,
       undefined,
     )
 
@@ -857,5 +1067,73 @@ describe('queriesObserver', () => {
       { status: 'success', data: 2 },
       { status: 'success', data: 3 },
     ])
+  })
+
+  it('should retain references with custom structuralSharing function', () => {
+    // This test verifies that a custom structuralSharing function can retain references
+    const existingArray = [1, 2, 3]
+
+    const combine = vi.fn((results: Array<QueryObserverResult>) => ({
+      count: results.length,
+      data: results.map((r) => r.data),
+      existingArray,
+    }))
+
+    const customStructuralSharing = vi.fn(
+      (oldData: unknown, newData: unknown) => {
+        const oldTyped = oldData as
+          | { existingArray?: Array<number> }
+          | undefined
+        const newTyped = newData as { existingArray: Array<number> }
+        // Retain the existingArray reference from old data if it deeply equals
+        if (
+          oldTyped?.existingArray &&
+          JSON.stringify(oldTyped.existingArray) ===
+            JSON.stringify(newTyped.existingArray)
+        ) {
+          return { ...newTyped, existingArray: oldTyped.existingArray }
+        }
+        return newTyped
+      },
+    )
+
+    const key1 = queryKey()
+    const queryFn1 = vi.fn().mockReturnValue(1)
+
+    queryClient.setQueryData(key1, 'cached-1')
+
+    const observer = new QueriesObserver<{
+      count: number
+      data: Array<unknown>
+      existingArray: Array<number>
+    }>(queryClient, [{ queryKey: key1, queryFn: queryFn1 }], {
+      combine,
+      structuralSharing: customStructuralSharing,
+    })
+
+    const [initialRaw, getInitialCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine,
+      customStructuralSharing,
+    )
+    const initialCombined = getInitialCombined(initialRaw)
+    const initialArrayRef = initialCombined.existingArray
+
+    // Trigger a re-combine by changing the combine function reference
+    const combine2 = vi.fn((results: Array<QueryObserverResult>) => ({
+      count: results.length,
+      data: results.map((r) => r.data),
+      existingArray, // Same array content
+    }))
+
+    const [newRaw, getNewCombined] = observer.getOptimisticResult(
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      combine2,
+      customStructuralSharing,
+    )
+    const newCombined = getNewCombined(newRaw)
+
+    // The existingArray reference should be retained from the old data
+    expect(newCombined.existingArray).toBe(initialArrayRef)
   })
 })

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -32,10 +32,13 @@ export interface QueriesObserverOptions<
   combine?: CombineFn<TCombinedResult>
   /**
    * Set this to `false` to disable structural sharing between query results.
+   * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
    * Only applies when `combine` is provided.
    * Defaults to `true`.
    */
-  structuralSharing?: boolean
+  structuralSharing?:
+    | boolean
+    | ((oldData: unknown | undefined, newData: unknown) => unknown)
 }
 
 export class QueriesObserver<
@@ -178,7 +181,10 @@ export class QueriesObserver<
   getOptimisticResult(
     queries: Array<QueryObserverOptions>,
     combine: CombineFn<TCombinedResult> | undefined,
-    structuralSharing: boolean | undefined,
+    structuralSharing:
+      | boolean
+      | ((oldData: unknown | undefined, newData: unknown) => unknown)
+      | undefined,
   ): [
     rawResult: Array<QueryObserverResult>,
     combineResult: (r?: Array<QueryObserverResult>) => TCombinedResult,
@@ -233,7 +239,10 @@ export class QueriesObserver<
   #combineResult(
     input: Array<QueryObserverResult>,
     combine: CombineFn<TCombinedResult> | undefined,
-    structuralSharing: boolean | undefined = true,
+    structuralSharing:
+      | boolean
+      | ((oldData: unknown | undefined, newData: unknown) => unknown)
+      | undefined = true,
     queryHashes?: Array<string>,
   ): TCombinedResult {
     if (combine) {
@@ -258,9 +267,17 @@ export class QueriesObserver<
 
         const combined = combine(input)
 
-        this.#combinedResult = structuralSharing
-          ? replaceEqualDeep(this.#combinedResult, combined)
-          : combined
+        if (typeof structuralSharing === 'function') {
+          this.#combinedResult = structuralSharing(
+            this.#combinedResult,
+            combined,
+          ) as TCombinedResult
+        } else {
+          this.#combinedResult =
+            structuralSharing !== false
+              ? replaceEqualDeep(this.#combinedResult, combined)
+              : combined
+        }
       }
 
       return this.#combinedResult

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -30,6 +30,12 @@ export interface QueriesObserverOptions<
   TCombinedResult = Array<QueryObserverResult>,
 > {
   combine?: CombineFn<TCombinedResult>
+  /**
+   * Set this to `false` to disable structural sharing between query results.
+   * Only applies when `combine` is provided.
+   * Defaults to `true`.
+   */
+  structuralSharing?: boolean
 }
 
 export class QueriesObserver<
@@ -172,6 +178,7 @@ export class QueriesObserver<
   getOptimisticResult(
     queries: Array<QueryObserverOptions>,
     combine: CombineFn<TCombinedResult> | undefined,
+    structuralSharing: boolean | undefined,
   ): [
     rawResult: Array<QueryObserverResult>,
     combineResult: (r?: Array<QueryObserverResult>) => TCombinedResult,
@@ -188,7 +195,12 @@ export class QueriesObserver<
     return [
       result,
       (r?: Array<QueryObserverResult>) => {
-        return this.#combineResult(r ?? result, combine, queryHashes)
+        return this.#combineResult(
+          r ?? result,
+          combine,
+          structuralSharing,
+          queryHashes,
+        )
       },
       () => {
         return this.#trackResult(result, matches)
@@ -221,6 +233,7 @@ export class QueriesObserver<
   #combineResult(
     input: Array<QueryObserverResult>,
     combine: CombineFn<TCombinedResult> | undefined,
+    structuralSharing: boolean | undefined = true,
     queryHashes?: Array<string>,
   ): TCombinedResult {
     if (combine) {
@@ -242,10 +255,12 @@ export class QueriesObserver<
         if (queryHashes !== undefined) {
           this.#lastQueryHashes = queryHashes
         }
-        this.#combinedResult = replaceEqualDeep(
-          this.#combinedResult,
-          combine(input),
-        )
+
+        const combined = combine(input)
+
+        this.#combinedResult = structuralSharing
+          ? replaceEqualDeep(this.#combinedResult, combined)
+          : combined
       }
 
       return this.#combinedResult
@@ -316,6 +331,7 @@ export class QueriesObserver<
         : this.#combineResult(
             this.#trackResult(this.#result, this.#observerMatches),
             this.#options?.combine,
+            this.#options?.structuralSharing,
           )
 
       if (shouldSkipCombine || previousResult !== newResult) {

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -180,11 +180,7 @@ export class QueriesObserver<
 
   getOptimisticResult(
     queries: Array<QueryObserverOptions>,
-    combine: CombineFn<TCombinedResult> | undefined,
-    structuralSharing:
-      | boolean
-      | ((oldData: unknown | undefined, newData: unknown) => unknown)
-      | undefined,
+    options?: QueriesObserverOptions<TCombinedResult>,
   ): [
     rawResult: Array<QueryObserverResult>,
     combineResult: (r?: Array<QueryObserverResult>) => TCombinedResult,
@@ -201,12 +197,7 @@ export class QueriesObserver<
     return [
       result,
       (r?: Array<QueryObserverResult>) => {
-        return this.#combineResult(
-          r ?? result,
-          combine,
-          structuralSharing,
-          queryHashes,
-        )
+        return this.#combineResult(r ?? result, options, queryHashes)
       },
       () => {
         return this.#trackResult(result, matches)
@@ -238,13 +229,11 @@ export class QueriesObserver<
 
   #combineResult(
     input: Array<QueryObserverResult>,
-    combine: CombineFn<TCombinedResult> | undefined,
-    structuralSharing:
-      | boolean
-      | ((oldData: unknown | undefined, newData: unknown) => unknown)
-      | undefined = true,
+    options?: QueriesObserverOptions<TCombinedResult>,
     queryHashes?: Array<string>,
   ): TCombinedResult {
+    const combine = options?.combine
+    const structuralSharing = options?.structuralSharing ?? true
     if (combine) {
       const lastHashes = this.#lastQueryHashes
       const queryHashesChanged =
@@ -338,13 +327,10 @@ export class QueriesObserver<
     if (this.hasListeners()) {
       const shouldSkipCombine = this.#shouldSkipCombine()
       const previousResult = this.#combinedResult
+      const newTracked = this.#trackResult(this.#result, this.#observerMatches)
       const newResult = shouldSkipCombine
         ? previousResult
-        : this.#combineResult(
-            this.#trackResult(this.#result, this.#observerMatches),
-            this.#options?.combine,
-            this.#options?.structuralSharing,
-          )
+        : this.#combineResult(newTracked, this.#options)
 
       if (shouldSkipCombine || previousResult !== newResult) {
         notifyManager.batch(() => {

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -1,7 +1,7 @@
 import { notifyManager } from './notifyManager'
 import { QueryObserver } from './queryObserver'
 import { Subscribable } from './subscribable'
-import { replaceEqualDeep, shallowEqualObjects } from './utils'
+import { replaceData, shallowEqualObjects } from './utils'
 import type {
   DefaultedQueryObserverOptions,
   QueryObserverOptions,
@@ -265,19 +265,14 @@ export class QueriesObserver<
           this.#lastQueryHashes = queryHashes
         }
 
-        const combined = combine(input)
-
-        if (typeof structuralSharing === 'function') {
-          this.#combinedResult = structuralSharing(
-            this.#combinedResult,
-            combined,
-          ) as TCombinedResult
-        } else {
-          this.#combinedResult =
-            structuralSharing !== false
-              ? replaceEqualDeep(this.#combinedResult, combined)
-              : combined
-        }
+        this.#combinedResult = replaceData(
+          this.#combinedResult,
+          combine(input),
+          {
+            structuralSharing,
+            queryHash: queryHashes,
+          },
+        )
       }
 
       return this.#combinedResult

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -401,7 +401,10 @@ export function sleep(timeout: number): Promise<void> {
 
 export function replaceData<
   TData,
-  TOptions extends QueryOptions<any, any, any, any>,
+  TOptions extends {
+    structuralSharing?: boolean | ((prev: unknown, data: unknown) => unknown)
+    queryHash?: string | Array<string>
+  },
 >(prevData: TData | undefined, data: TData, options: TOptions): TData {
   if (typeof options.structuralSharing === 'function') {
     return options.structuralSharing(prevData, data) as TData
@@ -410,8 +413,14 @@ export function replaceData<
       try {
         return replaceEqualDeep(prevData, data)
       } catch (error) {
+        let hashInfo = ''
+        if (Array.isArray(options.queryHash)) {
+          hashInfo = `queryHashes: [${options.queryHash.join(', ')}]`
+        } else if (options.queryHash) {
+          hashInfo = `queryHash: ${options.queryHash}`
+        }
         console.error(
-          `Structural sharing requires data to be JSON serializable. To fix this, turn off structuralSharing or return JSON-serializable data from your queryFn. [${options.queryHash}]: ${error}`,
+          `Structural sharing requires data to be JSON serializable. To fix this, turn off structuralSharing or return JSON-serializable data from your queryFn. [${hashInfo}]: ${error}`,
         )
 
         // Prevent the replaceEqualDeep from being called again down below.

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -274,8 +274,7 @@ export function useQueries<
   const [optimisticResult, getCombinedResult, trackResult] =
     observer.getOptimisticResult(
       defaultedQueries,
-      (options as QueriesObserverOptions<TCombinedResult>).combine,
-      options.structuralSharing,
+      options as QueriesObserverOptions<TCombinedResult>,
     )
 
   const shouldSubscribe = !isRestoring && subscribed

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -218,10 +218,13 @@ export function useQueries<
     combine?: (result: QueriesResults<T>) => TCombinedResult
     /**
      * Set this to `false` to disable structural sharing between query results.
+     * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
      * Only applies when `combine` is provided.
      * Defaults to `true`.
      */
-    structuralSharing?: boolean
+    structuralSharing?:
+      | boolean
+      | ((oldData: unknown | undefined, newData: unknown) => unknown)
     subscribed?: boolean
   },
   queryClient?: QueryClient,

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -216,6 +216,12 @@ export function useQueries<
       | readonly [...QueriesOptions<T>]
       | readonly [...{ [K in keyof T]: GetUseQueryOptionsForUseQueries<T[K]> }]
     combine?: (result: QueriesResults<T>) => TCombinedResult
+    /**
+     * Set this to `false` to disable structural sharing between query results.
+     * Only applies when `combine` is provided.
+     * Defaults to `true`.
+     */
+    structuralSharing?: boolean
     subscribed?: boolean
   },
   queryClient?: QueryClient,
@@ -266,6 +272,7 @@ export function useQueries<
     observer.getOptimisticResult(
       defaultedQueries,
       (options as QueriesObserverOptions<TCombinedResult>).combine,
+      options.structuralSharing,
     )
 
   const shouldSubscribe = !isRestoring && subscribed

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -195,10 +195,13 @@ export function useQueries<
     combine?: (result: QueriesResults<T>) => TCombinedResult
     /**
      * Set this to `false` to disable structural sharing between query results.
+     * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
      * Only applies when `combine` is provided.
      * Defaults to `true`.
      */
-    structuralSharing?: boolean
+    structuralSharing?:
+      | boolean
+      | ((oldData: unknown | undefined, newData: unknown) => unknown)
   }>,
   queryClient?: Accessor<QueryClient>,
 ): TCombinedResult {

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -193,6 +193,12 @@ export function useQueries<
       | readonly [...QueriesOptions<T>]
       | readonly [...{ [K in keyof T]: GetOptions<T[K]> }]
     combine?: (result: QueriesResults<T>) => TCombinedResult
+    /**
+     * Set this to `false` to disable structural sharing between query results.
+     * Only applies when `combine` is provided.
+     * Defaults to `true`.
+     */
+    structuralSharing?: boolean
   }>,
   queryClient?: Accessor<QueryClient>,
 ): TCombinedResult {
@@ -219,6 +225,7 @@ export function useQueries<
     queriesOptions().combine
       ? ({
           combine: queriesOptions().combine,
+          structuralSharing: queriesOptions().structuralSharing,
         } as QueriesObserverOptions<TCombinedResult>)
       : undefined,
   )
@@ -227,6 +234,8 @@ export function useQueries<
     observer.getOptimisticResult(
       defaultedQueries(),
       (queriesOptions() as QueriesObserverOptions<TCombinedResult>).combine,
+      (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
+        .structuralSharing,
     )[1](),
   )
 
@@ -239,6 +248,8 @@ export function useQueries<
             defaultedQueries(),
             (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
               .combine,
+            (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
+              .structuralSharing,
           )[1](),
         ),
     ),
@@ -304,22 +315,14 @@ export function useQueries<
   onMount(() => {
     observer.setQueries(
       defaultedQueries(),
-      queriesOptions().combine
-        ? ({
-            combine: queriesOptions().combine,
-          } as QueriesObserverOptions<TCombinedResult>)
-        : undefined,
+      queriesOptions() as QueriesObserverOptions<TCombinedResult>,
     )
   })
 
   createComputed(() => {
     observer.setQueries(
       defaultedQueries(),
-      queriesOptions().combine
-        ? ({
-            combine: queriesOptions().combine,
-          } as QueriesObserverOptions<TCombinedResult>)
-        : undefined,
+      queriesOptions() as QueriesObserverOptions<TCombinedResult>,
     )
   })
 

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -236,9 +236,7 @@ export function useQueries<
   const [state, setState] = createStore<TCombinedResult>(
     observer.getOptimisticResult(
       defaultedQueries(),
-      (queriesOptions() as QueriesObserverOptions<TCombinedResult>).combine,
-      (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
-        .structuralSharing,
+      queriesOptions() as QueriesObserverOptions<TCombinedResult>,
     )[1](),
   )
 
@@ -249,10 +247,7 @@ export function useQueries<
         setState(
           observer.getOptimisticResult(
             defaultedQueries(),
-            (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
-              .combine,
-            (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
-              .structuralSharing,
+            queriesOptions() as QueriesObserverOptions<TCombinedResult>,
           )[1](),
         ),
     ),

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -199,10 +199,13 @@ export function createQueries<
     combine?: (result: QueriesResults<T>) => TCombinedResult
     /**
      * Set this to `false` to disable structural sharing between query results.
+     * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
      * Only applies when `combine` is provided.
      * Defaults to `true`.
      */
-    structuralSharing?: boolean
+    structuralSharing?:
+      | boolean
+      | ((oldData: unknown | undefined, newData: unknown) => unknown)
   }>,
   queryClient?: Accessor<QueryClient>,
 ): TCombinedResult {

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -197,13 +197,20 @@ export function createQueries<
           ...{ [K in keyof T]: GetCreateQueryOptionsForCreateQueries<T[K]> },
         ]
     combine?: (result: QueriesResults<T>) => TCombinedResult
+    /**
+     * Set this to `false` to disable structural sharing between query results.
+     * Only applies when `combine` is provided.
+     * Defaults to `true`.
+     */
+    structuralSharing?: boolean
   }>,
   queryClient?: Accessor<QueryClient>,
 ): TCombinedResult {
   const client = $derived(useQueryClient(queryClient?.()))
   const isRestoring = useIsRestoring()
 
-  const { queries, combine } = $derived.by(createQueriesOptions)
+  const { queries, ...derivedCreateQueriesOptions } =
+    $derived.by(createQueriesOptions)
   const resolvedQueryOptions = $derived(
     queries.map((opts) => {
       const resolvedOptions = client.defaultQueryOptions(opts)
@@ -220,14 +227,15 @@ export function createQueries<
     new QueriesObserver<TCombinedResult>(
       client,
       resolvedQueryOptions,
-      combine as QueriesObserverOptions<TCombinedResult>,
+      derivedCreateQueriesOptions as QueriesObserverOptions<TCombinedResult>,
     ),
   )
 
   function createResult() {
     const [_, getCombinedResult, trackResult] = observer.getOptimisticResult(
       resolvedQueryOptions,
-      combine as QueriesObserverOptions<TCombinedResult>['combine'],
+      derivedCreateQueriesOptions.combine as QueriesObserverOptions<TCombinedResult>['combine'],
+      derivedCreateQueriesOptions.structuralSharing,
     )
     return getCombinedResult(trackResult())
   }
@@ -244,9 +252,10 @@ export function createQueries<
   })
 
   $effect.pre(() => {
-    observer.setQueries(resolvedQueryOptions, {
-      combine,
-    } as QueriesObserverOptions<TCombinedResult>)
+    observer.setQueries(
+      resolvedQueryOptions,
+      derivedCreateQueriesOptions as QueriesObserverOptions<TCombinedResult>,
+    )
     update(createResult())
   })
 

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -237,8 +237,7 @@ export function createQueries<
   function createResult() {
     const [_, getCombinedResult, trackResult] = observer.getOptimisticResult(
       resolvedQueryOptions,
-      derivedCreateQueriesOptions.combine as QueriesObserverOptions<TCombinedResult>['combine'],
-      derivedCreateQueriesOptions.structuralSharing,
+      derivedCreateQueriesOptions as QueriesObserverOptions<TCombinedResult>,
     )
     return getCombinedResult(trackResult())
   }

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -248,6 +248,12 @@ export function useQueries<
           ]
         >
     combine?: (result: UseQueriesResults<T>) => TCombinedResult
+    /**
+     * Set this to `false` to disable structural sharing between query results.
+     * Only applies when `combine` is provided.
+     * Defaults to `true`.
+     */
+    structuralSharing?: boolean
   },
   queryClient?: QueryClient,
 ): Readonly<Ref<TCombinedResult>> {
@@ -296,6 +302,7 @@ export function useQueries<
     const [results, getCombinedResult] = observer.getOptimisticResult(
       defaultedQueries.value,
       (options as QueriesObserverOptions<TCombinedResult>).combine,
+      options.structuralSharing,
     )
 
     return getCombinedResult(
@@ -306,6 +313,7 @@ export function useQueries<
             const [{ [index]: query }] = observer.getOptimisticResult(
               defaultedQueries.value,
               (options as QueriesObserverOptions<TCombinedResult>).combine,
+              options.structuralSharing,
             )
 
             return query!.refetch(...args)

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -250,10 +250,13 @@ export function useQueries<
     combine?: (result: UseQueriesResults<T>) => TCombinedResult
     /**
      * Set this to `false` to disable structural sharing between query results.
+     * Set this to a function which accepts the old and new data and returns resolved data of the same type to implement custom structural sharing logic.
      * Only applies when `combine` is provided.
      * Defaults to `true`.
      */
-    structuralSharing?: boolean
+    structuralSharing?:
+      | boolean
+      | ((oldData: unknown | undefined, newData: unknown) => unknown)
   },
   queryClient?: QueryClient,
 ): Readonly<Ref<TCombinedResult>> {

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -304,8 +304,7 @@ export function useQueries<
   const getOptimisticResult = () => {
     const [results, getCombinedResult] = observer.getOptimisticResult(
       defaultedQueries.value,
-      (options as QueriesObserverOptions<TCombinedResult>).combine,
-      options.structuralSharing,
+      options as QueriesObserverOptions<TCombinedResult>,
     )
 
     return getCombinedResult(
@@ -315,8 +314,7 @@ export function useQueries<
           refetch: async (...args: Array<any>) => {
             const [{ [index]: query }] = observer.getOptimisticResult(
               defaultedQueries.value,
-              (options as QueriesObserverOptions<TCombinedResult>).combine,
-              options.structuralSharing,
+              options as QueriesObserverOptions<TCombinedResult>,
             )
 
             return query!.refetch(...args)


### PR DESCRIPTION
## 🎯 Changes

Add a `structuralSharing` option to useQueries/createQueries/injectQueries that allows disabling structural sharing for the combined result. When set to `false`, the combined result will not use `replaceEqualDeep` for referential stability. Defaults to `true`.

Full disclosure: Docs were generated by Claude, all other implementation was done without AI.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional structuralSharing option to useQueries across React, Vue, Svelte, Solid, Preact, and Angular — allows disabling or customizing structural sharing for combined query results (defaults to true).
  * Enabled structuralSharing support in core query logic to honor the new option.

* **Documentation**
  * Updated useQueries reference to document structuralSharing and its effect on combined results.

* **Chores**
  * Bumped minor versions for multiple query packages and added a changeset entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->