### PR TITLE
test(query-core/queryObserver): add test for 'getOptimisticResult' updating 'currentResult' with changed data

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1510,6 +1510,32 @@ describe('queryObserver', () => {
     expect(result.isEnabled).toBe(true)
   })
 
+  test('should update currentResult when getOptimisticResult is called with changed data', () => {
+    const key = queryKey()
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => 'data',
+    })
+
+    const defaultedOptions = queryClient.defaultQueryOptions({
+      queryKey: key,
+      queryFn: () => 'data',
+    })
+
+    // First render: no data yet
+    const initialResult = observer.getOptimisticResult(defaultedOptions)
+    expect(initialResult.data).toBeUndefined()
+
+    // Another component sets data (e.g., dependent query resolved)
+    queryClient.setQueryData(key, 'updated')
+
+    // Re-render: getOptimisticResult should pick up the new data and update currentResult
+    const updatedResult = observer.getOptimisticResult(defaultedOptions)
+    expect(updatedResult.data).toBe('updated')
+    expect(observer.getCurrentResult().data).toBe('updated')
+  })
+
   describe('StrictMode behavior', () => {
     it('should deduplicate calls to queryFn', async () => {
       const key = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `getOptimisticResult` updates `currentResult` when the query data has changed between renders (e.g., via `setQueryData`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).