### PR TITLE
test(query-core/mutationCache): add test for 'remove' splicing target mutation from scope with multiple mutations

### DIFF
--- a/packages/query-core/src/__tests__/mutationCache.test.tsx
+++ b/packages/query-core/src/__tests__/mutationCache.test.tsx
@@ -445,4 +445,27 @@ describe('mutationCache', () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('remove', () => {
+    test('should remove only the target mutation from scope when multiple scoped mutations exist', () => {
+      const testCache = new MutationCache()
+      const testClient = new QueryClient({ mutationCache: testCache })
+
+      const mutation1 = testCache.build(testClient, {
+        scope: { id: 'scope1' },
+        mutationFn: () => Promise.resolve('data1'),
+      })
+      const mutation2 = testCache.build(testClient, {
+        scope: { id: 'scope1' },
+        mutationFn: () => Promise.resolve('data2'),
+      })
+
+      expect(testCache.getAll()).toHaveLength(2)
+
+      testCache.remove(mutation1)
+
+      expect(testCache.getAll()).toHaveLength(1)
+      expect(testCache.getAll()).toEqual([mutation2])
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `remove` correctly splices only the target mutation from the scope's internal array when multiple scoped mutations exist.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for mutation removal behavior to ensure targeted removal works correctly when multiple mutations coexist within the same scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->