### PR TITLE
fix(solid-query): strip promise field in hydratableObserverResult to …

### DIFF
--- a/.changeset/curly-places-train.md
+++ b/.changeset/curly-places-train.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+fix(solid-query): prevent SSR stream hang caused by unstripped promise field

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -76,9 +76,10 @@ const hydratableObserverResult = <
   if (!isServer) return result
   const obj: any = {
     ...unwrap(result),
-    // During SSR, functions cannot be serialized, so we need to remove them
-    // This is safe because we will add these functions back when the query is hydrated
+    // During SSR, non-serializable values (functions, promises) must be removed.                   
+    // This is safe because they will be reconstructed when the query is hydrated.
     refetch: undefined,
+    promise: undefined,
   }
 
   // If the query is an infinite query, we need to remove additional properties


### PR DESCRIPTION
## 🎯 Changes
`hydratableObserverResult()` strips `refetch`, `fetchNextPage`, and `fetchPreviousPage` during SSR, but doesn't strip the `promise` field from `QueryObserverResult`.

The `promise` field (from `QueryObserver.getOptimisticResult()`) is a controlled Promise that may never resolve — for example when `enabled: false`. When included in the value returned from `createResource`'s fetcher, Solid's SSR serialization waits for it indefinitely, causing the streaming response to never close (browser tab spinner spins forever).

**Fix:** Add `promise: undefined` alongside the existing `refetch: undefined`.

**Reproduction**

1. Create a Solid component that uses `useQuery` with `enabled: false`:                             
                                                                                                      
```tsx                                                                                              
import { useQuery } from '@tanstack/solid-query'                                                    

const App = () => {
  const query = useQuery(() => ({
    queryKey: ['test'],
    queryFn: () => Promise.resolve('hello'),
    enabled: false,
  }))
  return <div>{query.status}</div>
}
```

2. Render with Solid's streaming SSR (renderToStream)
3. The SSR response stream never closes, `document.readyState` stays 'loading' and the browser tab
spinner spins forever

Any query that doesn't immediately fetch is affected, not just enabled: false. This includes queries where the server sets `enabled: !isServer` as a global default.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing
      guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a
      [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
