### PR TITLE
docs: fill in Preact Installation doc instead of deriving from React

### DIFF
--- a/docs/framework/preact/installation.md
+++ b/docs/framework/preact/installation.md
@@ -1,6 +1,90 @@
 ---
 id: installation
 title: Installation
-ref: docs/framework/react/installation.md
-replace: { 'React': 'Preact', 'react-query': 'preact-query' }
 ---
+
+You can install Preact Query via [NPM](https://npmjs.com/),
+or a good ol' `<script>` via
+[ESM.sh](https://esm.sh/).
+
+### NPM
+
+```bash
+npm i @tanstack/preact-query
+```
+
+or
+
+```bash
+pnpm add @tanstack/preact-query
+```
+
+or
+
+```bash
+yarn add @tanstack/preact-query
+```
+
+or
+
+```bash
+bun add @tanstack/preact-query
+```
+
+Preact Query is compatible with Preact v10+.
+
+> Wanna give it a spin before you download? Try out the [simple](./examples/simple) or [basic](./examples/basic) examples!
+
+### CDN
+
+If you're not using a module bundler or package manager, you can also use this library via an ESM-compatible CDN such as [ESM.sh](https://esm.sh/). Simply add a `<script type="module">` tag to the bottom of your HTML file:
+
+```html
+<script type="module">
+  import { h, render } from 'https://esm.sh/preact@10.28.3'
+  import { QueryClient } from 'https://esm.sh/@tanstack/preact-query'
+</script>
+```
+
+> You can find instructions on how to use Preact without JSX [here](https://preactjs.com/guide/v10/no-build-workflows).
+
+### Requirements
+
+Preact Query is optimized for modern browsers. It is compatible with the following browsers config
+
+```
+Chrome >= 91
+Firefox >= 90
+Edge >= 91
+Safari >= 15
+iOS >= 15
+Opera >= 77
+```
+
+> Depending on your environment, you might need to add polyfills. If you want to support older browsers, you need to transpile the library from `node_modules` yourselves.
+
+### Recommendations
+
+It is recommended to also use our [ESLint Plugin Query](../../eslint/eslint-plugin-query.md) to help you catch bugs and inconsistencies while you code. You can install it via:
+
+```bash
+npm i -D @tanstack/eslint-plugin-query
+```
+
+or
+
+```bash
+pnpm add -D @tanstack/eslint-plugin-query
+```
+
+or
+
+```bash
+yarn add -D @tanstack/eslint-plugin-query
+```
+
+or
+
+```bash
+bun add -D @tanstack/eslint-plugin-query
+```


### PR DESCRIPTION
## 🎯 Changes

Docs, copied the "Installation" page from React & edited it w/ Preact info as just swapping "React" for "Preact" leads to some egregiously incorrect info:

> Preact Query is compatible with Preact v18+ and works with PreactDOM and Preact Native.

There is no Preact 18, no PreactDOM or Preact Native, for example.

Other pages will probably also need corrections but none stood out as much as this.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Preact installation documentation with comprehensive setup guidance
  * Added installation commands for npm, pnpm, yarn, and bun
  * Included CDN usage options and browser compatibility details
  * Added polyfills information and ESLint plugin recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->