### PR TITLE
docs(query-core): fix duplicated word in thenable comment

### DIFF
--- a/packages/query-core/src/thenable.ts
+++ b/packages/query-core/src/thenable.ts
@@ -58,7 +58,7 @@ export function pendingThenable<T>(): PendingThenable<T> {
   function finalize(data: Fulfilled<T> | Rejected) {
     Object.assign(thenable, data)
 
-    // clear pending props props to avoid calling them twice
+    // clear pending props to avoid calling them twice
     delete (thenable as Partial<PendingThenable<T>>).resolve
     delete (thenable as Partial<PendingThenable<T>>).reject
   }


### PR DESCRIPTION
Remove the duplicated "props" in the `pendingThenable` finalize function comment.

## 🎯 Changes

### Summary                                                                               
                                                                                           
  - Fix a duplicated word typo in `packages/query-core/src/thenable.ts`                    
  - `"clear pending props props to avoid calling them twice"` → `"clear pending props to   
  avoid calling them twice"`                                                               

 ### Details

  The `finalize` function inside `pendingThenable()` had a minor comment typo where "props"
   was written twice.

  **Before:**
```
  // clear pending props props to avoid calling them twice
```
  **After:**
```
  // clear pending props to avoid calling them twice
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a minor typo in a comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->