### PR TITLE
docs(CONTRIBUTING): fix duplicate 'run' typo in changeset instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ You can use Gitpod (An Online open-source VS Code-like IDE that is free for Open
 
 ## Changesets
 
-This repo uses [Changesets](https://github.com/changesets/changesets) to automate releases. If your PR should release a new package version (patch, minor, or major), please run run `pnpm changeset` and commit the file. If needed, changeset descriptions can be more descriptive, and will be included in the changelog. If your PR affects docs, examples, styles, etc., you probably don't need to generate a changeset.
+This repo uses [Changesets](https://github.com/changesets/changesets) to automate releases. If your PR should release a new package version (patch, minor, or major), please run `pnpm changeset` and commit the file. If needed, changeset descriptions can be more descriptive, and will be included in the changelog. If your PR affects docs, examples, styles, etc., you probably don't need to generate a changeset.
 
 ## Pull requests
 


### PR DESCRIPTION
Fixed a duplicate "run" word in the Changesets section of CONTRIBUTING.md.

## 🎯 Changes

- Fix a duplicated word typo in CONTRIBUTING.md

**Before:**
```
please run run `pnpm changeset` and commit the file.
```

**After:**
```
please run `pnpm changeset` and commit the file.
```

This is a minor documentation typo fix that improves clarity for contributors.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to clarify changeset requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->