### PR TITLE
docs(focusManager): fix duplicate 'event' typo in test comment

### DIFF
--- a/packages/query-core/src/__tests__/focusManager.test.tsx
+++ b/packages/query-core/src/__tests__/focusManager.test.tsx
@@ -98,7 +98,7 @@ describe('focusManager', () => {
 
     unsubscribe()
 
-    // Should unsubscribe our event event
+    // Should unsubscribe our event listener once
     expect(unsubscribeSpy).toHaveBeenCalledTimes(1)
 
     handlerSpy.mockRestore()


### PR DESCRIPTION
Remove the duplicated "event" in the test comment of focusManager.test.tsx.

## 🎯 Changes

Fixed a duplicated word typo in the test comment of focusManager.test.tsx.

The test comment had a repeated word "event event" which has been corrected to "event listener once" for better clarity and accuracy.

**Before:**
```
// Should unsubscribe our event event
```

**After:**
```
// Should unsubscribe our event listener once
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified test comment for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->