### PR TITLE
fix(query-codemods): fix duplicate 'a' typo in placeholder data error

### DIFF
--- a/packages/query-codemods/src/v5/keep-previous-data/utils/already-has-placeholder-data-property.cjs
+++ b/packages/query-codemods/src/v5/keep-previous-data/utils/already-has-placeholder-data-property.cjs
@@ -19,7 +19,7 @@ class AlreadyHasPlaceholderDataProperty extends Error {
     const start = location.start.line
     const end = location.end.line
 
-    return `The usage in file "${filePath}" at line ${start}:${end} already contains a a "placeholderData" property. Please migrate this usage manually.`
+    return `The usage in file "${filePath}" at line ${start}:${end} already contains a "placeholderData" property. Please migrate this usage manually.`
   }
 }
 


### PR DESCRIPTION
Fix duplicated article in placeholderData error message

## 🎯 Changes

Fixed a duplicated article ("a") typo in the error message in `already-has-placeholder-data-property.cjs`.

**Before:**
```
already contains a a "placeholderData" property.
```

**After:**
```
already contains a "placeholderData" property.
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
d "a" in the 


> Note: `pnpm run test:pr` fails due to a knip error about multiple versions of `vue-template-compiler` in the workspace, which appears unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a typo in an error message to improve clarity when validating placeholder data properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->