### PR TITLE
docs(angular): fix TypeScript anchor link in mutation options

### DIFF
--- a/docs/framework/angular/guides/mutation-options.md
+++ b/docs/framework/angular/guides/mutation-options.md
@@ -5,7 +5,7 @@ title: Mutation Options
 
 One of the best ways to share mutation options between multiple places,
 is to use the `mutationOptions` helper. At runtime, this helper just returns whatever you pass into it,
-but it has a lot of advantages when using it [with TypeScript](../typescript#typing-query-options.md).
+but it has a lot of advantages when using it [with TypeScript](../typescript.md#typing-query-options).
 You can define all possible options for a mutation in one place,
 and you'll also get type inference and type safety for all of them.
 


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Fixes a broken link in the Angular Mutation Options guide.

The “with TypeScript” link was not reliably navigating to the “Typing Query Options” section. This updates it to an explicit file + anchor:
- from: ../typescript#typing-query-options
- to: ../typescript.md#typing-query-options

Docs-only change.(#typing-query-options.md), which prevents navigation.
Updated the link to use the correct anchor (#typing-query-options).
## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed documentation links in Angular guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->