### PR TITLE
chore(docs): update default staleTime explanation in documentation

### DIFF
--- a/docs/framework/react/guides/important-defaults.md
+++ b/docs/framework/react/guides/important-defaults.md
@@ -13,6 +13,8 @@ Out of the box, TanStack Query is configured with **aggressive but sane** defaul
   - set `staleTime` to e.g. `2 * 60 * 1000` to make sure data is read from the cache, without triggering any kinds of refetches, for 2 minutes, or until the Query is [invalidated manually](./query-invalidation.md).
   - set `staleTime` to `Infinity` to never trigger a refetch until the Query is [invalidated manually](./query-invalidation.md).
   - set `staleTime` to `'static'` to **never** trigger a refetch, even if the Query is [invalidated manually](./query-invalidation.md).
+ 
+- By default, `staleTime` is set to 0.
 
 - Stale queries are refetched automatically in the background when:
   - New instances of the query mount


### PR DESCRIPTION
## 🎯 Changes

Clarify the default value of staleTime in the documentation as `gcTime` default value is mentioned explicitly there.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React framework guide to clarify default behavior settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->