### PR TITLE
fix(query-core): handle combine throwing in QueriesObserver notify

### DIFF
--- a/.changeset/brave-tigers-wave.md
+++ b/.changeset/brave-tigers-wave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+fix: handle combine throwing in QueriesObserver notify

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -630,4 +630,43 @@ describe('queriesObserver', () => {
       { status: 'success', data: 3 },
     ])
   })
+
+  test('should still notify listeners when combine throws after query reset', async () => {
+    const key1 = queryKey()
+    const queryFn1 = vi.fn().mockReturnValue({ name: 'test' })
+
+    const combine = vi.fn(
+      (results: Array<QueryObserverResult>) => {
+        // This simulates a combine function that assumes data is always defined
+        // (like useSuspenseQueries types suggest)
+        return results.map((r) => (r.data as { name: string }).name)
+      },
+    )
+
+    const observer = new QueriesObserver<Array<string>>(
+      queryClient,
+      [{ queryKey: key1, queryFn: queryFn1 }],
+      { combine },
+    )
+
+    const results: Array<Array<QueryObserverResult>> = []
+    const unsubscribe = observer.subscribe((result) => {
+      results.push(result)
+    })
+
+    // Wait for queries to resolve
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Reset the query - this transitions it to pending state
+    // which should cause combine to throw since data is undefined
+    queryClient.resetQueries({ queryKey: key1 })
+
+    // The listener should still have been notified despite combine throwing
+    const lastResult = results[results.length - 1]
+    expect(lastResult).toBeDefined()
+    expect(lastResult![0]!.status).toBe('pending')
+    expect(lastResult![0]!.data).toBeUndefined()
+
+    unsubscribe()
+  })
 })


### PR DESCRIPTION
Fixes #10129

When `useSuspenseQueries` is used with `combine`, the types narrow `data` to always be defined. But if a query transitions back to pending/error state (e.g. via `queryClient.resetQueries()`), the `combine` function gets called with results where `data` is `undefined`, causing a runtime TypeError.

This happens because `QueriesObserver.#notify()` calls `combine` as an optimization check — to see if the combined result changed before notifying listeners. The listeners themselves receive raw results (not the combined one), so the combine call is purely for deduplication.

The fix wraps the combine call in a try/catch. If combine throws, we treat it as a change and notify listeners anyway. This lets the framework-level code (React Suspense / Error Boundary) handle the state transition properly.

Added a test that reproduces the exact scenario: subscribe to a `QueriesObserver` with a combine function that accesses `data` properties, let queries resolve, then call `resetQueries` — previously this would throw, now it correctly notifies listeners with the pending result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Observers now reliably notify listeners even when a data-combining step throws during result evaluation.

* **Tests**
  * Added test validating notification behavior when queries are reset and combined-data assumptions fail.

* **Chores**
  * Added a changeset documenting the fix and bumping the patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->