### PR TITLE
docs(solid-query/quick-start): remove incomplete Available Functions section and fix outdated 'create' references

### DIFF
--- a/docs/framework/solid/quick-start.md
+++ b/docs/framework/solid/quick-start.md
@@ -49,25 +49,11 @@ function App() {
 }
 ```
 
-## Available Functions
-
-Solid Query offers useful primitives and functions that will make managing server state in SolidJS apps easier.
-
-- `useQuery`
-- `useQueries`
-- `useInfiniteQuery`
-- `useMutation`
-- `useIsFetching`
-- `useIsMutating`
-- `useQueryClient`
-- `QueryClient`
-- `QueryClientProvider`
-
 ## Important Differences between Solid Query & React Query
 
 Solid Query offers an API similar to React Query, but there are some key differences to be mindful of.
 
-- Arguments to `solid-query` primitives (like `useQuery`, `useMutation`, `useIsFetching`) listed above are functions, so that they can be tracked in a reactive scope.
+- Arguments to `solid-query` primitives (like `useQuery`, `useMutation`, `useIsFetching`) are functions, so that they can be tracked in a reactive scope.
 
 ```tsx
 // ❌ react version


### PR DESCRIPTION
## 🎯 Changes

### Remove incomplete Available Functions section

The Available Functions list was incomplete (missing `queryOptions`, `infiniteQueryOptions`, `mutationOptions`, `useMutationState`, `useIsRestoring`, etc.) and would continue to fall out of sync. Since the reference docs already cover each function in detail, this section is unnecessary.

### Fix outdated references

- `createMutation` → `useMutation` in primitives description
- Remove `(createX)` reference in destructuring note
- Remove `listed above` that referenced the removed section

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Available Functions" list from the docs.
  * Updated guidance on which query and mutation primitives are tracked in reactive scopes, now referencing the mutation hook.
  * Clarified and reformatted the note that Solid Query primitives do not support destructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->