### PR TITLE
fix(examples): guard missing filmId param in react star-wars example

### DIFF
--- a/examples/react/star-wars/src/Film.tsx
+++ b/examples/react/star-wars/src/Film.tsx
@@ -3,8 +3,11 @@ import { useQuery } from '@tanstack/react-query'
 import { getFilm, getCharacter } from './api'
 
 export default function Film() {
-  let params = useParams()
-  const filmId = params.filmId!
+  const { filmId } = useParams()
+
+  if (!filmId) {
+    return <p>Invalid film ID</p>
+  }
 
   const { data, status } = useQuery({
     queryKey: ['film', filmId],
@@ -21,7 +24,7 @@ export default function Film() {
       <p>{data.opening_crawl}</p>
       <br />
       <h4 className="text-2xl">Characters</h4>
-      {data.characters.map((character: any) => {
+      {data.characters.map((character: string) => {
         const characterUrlParts = character.split('/').filter(Boolean)
         const characterId = characterUrlParts[characterUrlParts.length - 1]
         return <Character characterId={characterId} key={characterId} />


### PR DESCRIPTION
### What
Adds a safety guard for a missing `filmId` route parameter in the React Star Wars example.

### Why
The example previously used a non-null assertion:

```ts
const filmId = params.filmId!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation and improved error handling for invalid film IDs in the Star Wars example.

* **Refactor**
  * Enhanced type safety and code structure in the example application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->