### PR TITLE
fix(examples): guard missing #app mount target in svelte simple example

### DIFF
--- a/examples/svelte/simple/src/main.ts
+++ b/examples/svelte/simple/src/main.ts
@@ -2,8 +2,9 @@ import { mount } from 'svelte'
 import './app.css'
 import App from './App.svelte'
 
-const app = mount(App, {
-  target: document.querySelector('#app')!,
-})
+const target = document.querySelector('#app')
+if (!target) throw new Error('Missing #app element')
+
+const app = mount(App, { target })
 
 export default app


### PR DESCRIPTION
### What
Adds a safety guard for the Svelte `simple` example mount target.

### Why
The example previously used a non-null assertion:

document.querySelector('#app')!

If the DOM element is missing or renamed, the example crashes at runtime. Since examples are frequently copied, adding a guard improves reliability and developer experience.

### Changes
- Adds runtime check for `#app` element
- Throws a clear error when the mount target is missing

### Scope
Example-only change. No package/runtime changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application initialization with explicit error handling to ensure the app properly detects and handles missing DOM elements during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->