### PR TITLE
docs(angular): fix QueryClient field in paginated guide

### DIFF
--- a/docs/framework/angular/guides/paginated-queries.md
+++ b/docs/framework/angular/guides/paginated-queries.md
@@ -70,7 +70,7 @@ const result = injectQuery(() => ({
 })
 export class PaginationExampleComponent {
   page = signal(0)
-  queryClient = inject(QueryClient)
+  #queryClient = inject(QueryClient)
 
   query = injectQuery(() => ({
     queryKey: ['projects', this.page()],


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
this.#queryClient... (with #), which in TS/JS means a private class field. The declaration queryClient = inject(QueryClient) creates a public field named queryClient, so this.#queryClient would be undefined and the snippet breaks.

So I changed the declaration to match what the code is actually calling:

• from: queryClient = inject(QueryClient)
• to: #queryClient = inject(QueryClient)

## ✅ Checklist

- [] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in the paginated queries guide to follow best practices for property visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->