### PR TITLE
test(svelte-query/useMutationState): add test for 'select' option in 'useMutationState'

### DIFF
--- a/packages/svelte-query/tests/useMutationState/SelectExample.svelte
+++ b/packages/svelte-query/tests/useMutationState/SelectExample.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { QueryClient } from '@tanstack/query-core'
+  import {
+    createMutation,
+    setQueryClientContext,
+    useMutationState,
+  } from '../../src/index.js'
+  import type {
+    Accessor,
+    CreateMutationOptions,
+    MutationStateOptions,
+  } from '../../src/index.js'
+
+  let {
+    mutationOpts,
+    mutationStateOpts,
+  }: {
+    mutationOpts: Accessor<CreateMutationOptions>
+    mutationStateOpts: MutationStateOptions<any>
+  } = $props()
+
+  const queryClient = new QueryClient()
+  setQueryClientContext(queryClient)
+
+  const mutation = createMutation(mutationOpts)
+
+  const variables = useMutationState(mutationStateOpts)
+</script>
+
+<button onclick={() => mutation.mutate()}>mutate</button>
+
+<div>
+  Variables: {JSON.stringify(variables)}
+</div>

--- a/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
+++ b/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
 import { sleep } from '@tanstack/query-test-utils'
 import BaseExample from './BaseExample.svelte'
+import SelectExample from './SelectExample.svelte'
+import type { Mutation } from '@tanstack/query-core'
 
 describe('useMutationState', () => {
   beforeEach(() => {
@@ -77,6 +79,32 @@ describe('useMutationState', () => {
     await vi.advanceTimersByTimeAsync(21)
     expect(errorMutationFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('Data: ["error"]')).toBeInTheDocument()
+  })
+
+  test('should return selected value when using select option', async () => {
+    const mutationKey = ['select']
+
+    const rendered = render(SelectExample, {
+      props: {
+        mutationOpts: () => ({
+          mutationKey,
+          mutationFn: () => sleep(10).then(() => 'data'),
+        }),
+        mutationStateOpts: {
+          filters: { mutationKey },
+          select: (mutation: Mutation) => mutation.state.status,
+        },
+      },
+    })
+
+    expect(rendered.getByText('Variables: []')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('Variables: ["pending"]')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('Variables: ["success"]')).toBeInTheDocument()
   })
 
   test('Can select specific mutation using mutation key', async () => {


### PR DESCRIPTION
## 🎯 Changes

Add a test for the `select` option in `useMutationState`, covering the truthy branch of the `options.select` ternary (`options.select ? options.select(mutation) : mutation.state`).

Existing tests only called `useMutationState` without `select`, leaving the `options.select(mutation)` path uncovered.

The new test verifies that `select: (mutation) => mutation.state.status` correctly extracts mutation status values (`"pending"` → `"success"`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for mutation state selection functionality, validating state transitions through mutation lifecycle stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->