### PR TITLE
chore(svelte-query/vite.config): enable coverage collection by default

### DIFF
--- a/packages/svelte-query/vite.config.ts
+++ b/packages/svelte-query/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     watch: false,
     environment: 'jsdom',
     setupFiles: ['./tests/test-setup.ts'],
-    coverage: { enabled: false, provider: 'istanbul', include: ['src/**/*'] },
+    coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
     typecheck: { enabled: true },
   },
 })


### PR DESCRIPTION
## 🎯 Changes

Re-enable coverage collection for `svelte-query`, which was disabled during the runes rewrite in #9694.

All other query packages (`react-query`, `solid-query`, `preact-query`, `vue-query`, `query-core`) have coverage enabled by default.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test coverage reporting configuration for development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->