### PR TITLE
fix(eslint-plugin-query): add ESLint v10 to peerDependencies

### DIFF
--- a/.changeset/eslint-v10-peer-dep.md
+++ b/.changeset/eslint-v10-peer-dep.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/eslint-plugin-query": patch
+---
+
+fix(eslint-plugin-query): add ESLint v10 to peerDependencies and bump @typescript-eslint/utils to ^8.57.0

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -59,7 +59,7 @@
     "!src/__tests__"
   ],
   "dependencies": {
-    "@typescript-eslint/utils": "^8.48.0"
+    "@typescript-eslint/utils": "^8.57.0"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^8.48.0",


### PR DESCRIPTION
Adds ESLint v10 to the supported `peerDependencies` range for `@tanstack/eslint-plugin-query`.

ESLint v10 was released recently and the plugin is compatible — it doesn't use any of the removed/deprecated APIs (`FlatESLint`, `LegacyESLint`, `eslintrc` config format). All existing tests pass without changes.

Resolves #10141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended ESLint peer dependency support to include v10, enabling compatibility with the latest ESLint releases.
  * Updated a TypeScript ESLint utility dependency to a newer patch/minor version to align with tooling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->