### PR TITLE
test(solid-query/useQuery): add test for refetching query when 'queryClient' changes

### DIFF
--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -40,7 +40,7 @@ import type {
   UseQueryResult,
 } from '..'
 import type { Mock } from 'vitest'
-import type { Accessor, JSX } from 'solid-js'
+import type { JSX } from 'solid-js'
 
 describe('useQuery', () => {
   const queryCache = new QueryCache()
@@ -6191,7 +6191,7 @@ describe('useQuery', () => {
       .fn()
       .mockImplementation(() => sleep(10).then(() => 'data'))
 
-    function Page(props: { client: Accessor<QueryClient> }) {
+    function Page(props: { client: () => QueryClient }) {
       const query = useQuery(
         () => ({
           queryKey: key,


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that when `queryClient` changes, the query refetches with the new client. Covers `useBaseQuery.ts` lines 317-327 where the client signal change triggers observer re-creation and re-subscription.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying that switching between different query client instances triggers refetches, preserves separate per-client caches, and updates UI status correctly; a duplicate of this test was added in a second location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->