### PR TITLE
test(solid-query/useQuery): add test for 'isRestoring' transition from true to false triggering refetch

### DIFF
--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -6203,6 +6203,7 @@ describe('useQuery', () => {
     await vi.advanceTimersByTimeAsync(10)
 
     expect(rendered.getByTestId('status')).toHaveTextContent('success')
+    expect(rendered.getByTestId('fetchStatus')).toHaveTextContent('idle')
     expect(rendered.getByTestId('data')).toHaveTextContent('data')
     expect(queryFn).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## 🎯 Changes

Add a test to cover the `isRestoring` signal transition (`true` → `false`) triggering a refetch in `useBaseQuery.ts` (lines 338-339).

The test verifies that:
- While `isRestoring` is `true`, the query stays in `pending` status with `idle` fetchStatus and does not call `queryFn`
- When `isRestoring` transitions to `false`, the query refetches and resolves to `success`

This mirrors the behavior of `PersistQueryClientProvider` in `solid-query-persist-client` (`src/PersistQueryClientProvider.tsx:20,33`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public API export for managing restoration state in queries.

* **Tests**
  * Added tests ensuring queries respect restoration state: no fetching during restoration, automatic refetch upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->