### PR TITLE
test(solid-query/useQuery): add test for string 'reconcile' option maintaining referential equality

### DIFF
--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -1091,12 +1091,20 @@ describe('useQuery', () => {
     ))
 
     await vi.advanceTimersByTimeAsync(10)
-    expect(rendered.getByText('Data: [{"id":"1","done":false},{"id":"2","done":false}]')).toBeInTheDocument()
+    expect(
+      rendered.getByText(
+        'Data: [{"id":"1","done":false},{"id":"2","done":false}]',
+      ),
+    ).toBeInTheDocument()
     expect(states).toHaveLength(1)
 
     fireEvent.click(rendered.getByRole('button', { name: /refetch/i }))
     await vi.advanceTimersByTimeAsync(10)
-    expect(rendered.getByText('Data: [{"id":"1","done":false},{"id":"2","done":true}]')).toBeInTheDocument()
+    expect(
+      rendered.getByText(
+        'Data: [{"id":"1","done":false},{"id":"2","done":true}]',
+      ),
+    ).toBeInTheDocument()
 
     // reconcile by 'id' updates in-place, so the array reference stays the same
     // and the effect is not triggered again


### PR DESCRIPTION
## 🎯 Changes

Add a test to cover the string `reconcile` option path in `reconcileFn` (`useBaseQuery.ts`, lines 41-59).

The test verifies that when `reconcile: 'id'` is used:
- After refetch with changed data (`id: '2'` done: `false` → `true`), Solid's `reconcile` updates items in-place
- The array reference stays the same, so `createEffect` is not triggered again (`states` stays at length 1)

The existing test (`should share equal data structures between query results`) covers the function callback path (`reconcile: (oldData, newData) => ...`, lines 37-39), but the string key path (lines 41-59) was previously uncovered.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for data reconciliation behavior to ensure data references remain stable during updates and re-fetches do not cause unnecessary re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->