### PR TITLE
docs(react-native): fix example to include initial state

### DIFF
--- a/docs/framework/react/react-native.md
+++ b/docs/framework/react/react-native.md
@@ -41,14 +41,23 @@ import { onlineManager } from '@tanstack/react-query'
 import * as Network from 'expo-network'
 
 onlineManager.setEventListener((setOnline) => {
-  Network.getNetworkStateAsync().then((state) => {
+  let initialised = false
+
+  const eventSubscription = Network.addNetworkStateListener((state) => {
+    initialised = true
     setOnline(!!state.isConnected)
   })
 
-  const eventSubscription = Network.addNetworkStateListener((state) => {
-    setOnline(!!state.isConnected)
-  })
-  
+  Network.getNetworkStateAsync()
+    .then((state) => {
+      if (!initialised) {
+        setOnline(!!state.isConnected)
+      }
+    })
+    .catch(() => {
+      // getNetworkStateAsync can reject on some platforms/SDK versions
+    })
+
   return eventSubscription.remove
 })
 ```


### PR DESCRIPTION
## 🎯 Changes

`expo-network` does not emit the current state immediately upon subscription. This causes onlineManager to default to "online" on cold starts, even if the device is actually offline. So we need to explicitly call `Network.getNetworkStateAsync()` to initialize the state correctly before setting up the listener.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated React Native framework docs to describe faster, immediate network-state detection during setup so the app knows online/offline status promptly and reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->