### PR TITLE
test(svelte-query/HydrationBoundary): add test for hydrating queries to the cache on context

### DIFF
--- a/packages/svelte-query/tests/HydrationBoundary/BaseExample.svelte
+++ b/packages/svelte-query/tests/HydrationBoundary/BaseExample.svelte
@@ -8,15 +8,14 @@
   import type { DehydratedState } from '@tanstack/query-core'
 
   let {
-    queryClient,
     dehydratedState,
     queryFn,
   }: {
-    queryClient: QueryClient
     dehydratedState: DehydratedState
     queryFn: () => Promise<string>
   } = $props()
 
+  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const query = createQuery(() => ({
@@ -25,6 +24,10 @@
   }))
 </script>
 
-<HydrationBoundary state={dehydratedState} options={undefined} queryClient={undefined}>
+<HydrationBoundary
+  state={dehydratedState}
+  options={undefined}
+  queryClient={undefined}
+>
   <div>data: {query.data ?? 'undefined'}</div>
 </HydrationBoundary>

--- a/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
+++ b/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
@@ -26,11 +26,9 @@ describe('HydrationBoundary', () => {
 
   it('should hydrate queries to the cache on context', async () => {
     const dehydratedState = JSON.parse(stringifiedState)
-    const queryClient = new QueryClient()
 
     const rendered = render(BaseExample, {
       props: {
-        queryClient,
         dehydratedState,
         queryFn: () => sleep(20).then(() => 'string'),
       },
@@ -39,6 +37,5 @@ describe('HydrationBoundary', () => {
     expect(rendered.getByText('data: stringCached')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(21)
     expect(rendered.getByText('data: string')).toBeInTheDocument()
-    queryClient.clear()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add a test for `HydrationBoundary` that verifies hydrated queries are available in the cache on context, improving coverage for `HydrationBoundary.svelte` (0% → 100%) and `useHydrate.ts` (0% → 100%).

The test follows the same pattern as the react-query `HydrationBoundary.test.tsx` `'should hydrate queries to the cache on context'` test case.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering hydration/dehydration flows for query state, verifying initial hydrated values and subsequent updates.

* **Documentation**
  * Added an example Svelte component demonstrating how to use a hydration boundary with dehydrated query state and client initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->