### PR TITLE
test(query-core/mutationCache): add test for deleting scope when removing the only mutation in that scope

### DIFF
--- a/packages/query-core/src/__tests__/mutationCache.test.tsx
+++ b/packages/query-core/src/__tests__/mutationCache.test.tsx
@@ -467,5 +467,21 @@ describe('mutationCache', () => {
       expect(testCache.getAll()).toHaveLength(1)
       expect(testCache.getAll()).toEqual([mutation2])
     })
+
+    test('should delete scope when removing the only mutation in that scope', () => {
+      const testCache = new MutationCache()
+      const testClient = new QueryClient({ mutationCache: testCache })
+
+      const mutation = testCache.build(testClient, {
+        scope: { id: 'scope1' },
+        mutationFn: () => Promise.resolve('data'),
+      })
+
+      expect(testCache.getAll()).toHaveLength(1)
+
+      testCache.remove(mutation)
+
+      expect(testCache.getAll()).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `MutationCache.remove` deletes the scope entry when removing the only mutation in that scope.

This improves `mutationCache.ts` statement coverage (96.72% → 100%) by covering the `else if` branch at lines 148-149.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for MutationCache scope and mutation removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->