### PR TITLE
test(query-core/queriesObserver): add test for 'trackResult' property tracking synchronization across all observers

### DIFF
--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -524,7 +524,7 @@ describe('queriesObserver', () => {
 
     const trackPropSpy = vi.spyOn(QueryObserver.prototype, 'trackProp')
 
-    const [, getCombinedResult, trackResult] = observer.getOptimisticResult(
+    const [, , trackResult] = observer.getOptimisticResult(
       [
         { queryKey: key1, queryFn: queryFn1 },
         { queryKey: key2, queryFn: queryFn2 },
@@ -533,9 +533,8 @@ describe('queriesObserver', () => {
     )
 
     const trackedResults = trackResult()
-    const combinedResult = getCombinedResult(trackedResults)
 
-    expect(combinedResult).toHaveLength(2)
+    expect(trackedResults).toHaveLength(2)
 
     // Accessing a property on the first result should trigger trackProp on all observers
     void trackedResults[0]!.status


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `trackResult` synchronizes property tracking across all observers in `QueriesObserver`.

When a property (e.g., `status`) is accessed on one tracked result, `trackProp` is called on all observers — 1 direct call from the accessed observer's proxy + 2 synchronized calls from `onPropTracked` callback (one per observer).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify property-tracking behavior across multiple observers during query operations, ensuring consistent tracking when observer results are accessed. The new checks are present in multiple scenarios to improve confidence in observer synchronization and result tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->