### PR TITLE
refactor(preact-query/useQueries): remove unreachable 'willFetch' branch in suspense promise collection

### DIFF
--- a/.changeset/remove-unreachable-willfetch-preact.md
+++ b/.changeset/remove-unreachable-willfetch-preact.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query': patch
+---
+
+refactor(preact-query/useQueries): remove unreachable 'willFetch' branch in suspense promise collection

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -29,7 +29,6 @@ import {
   ensureSuspenseTimers,
   fetchOptimistic,
   shouldSuspend,
-  willFetch,
 } from './suspense'
 import type {
   DefinedUseQueryResult,
@@ -292,13 +291,9 @@ export function useQueries<
     ? optimisticResult.flatMap((result, index) => {
         const opts = defaultedQueries[index]
 
-        if (opts) {
+        if (opts && shouldSuspend(opts, result)) {
           const queryObserver = new QueryObserver(client, opts)
-          if (shouldSuspend(opts, result)) {
-            return fetchOptimistic(opts, queryObserver, errorResetBoundary)
-          } else if (willFetch(result, isRestoring)) {
-            void fetchOptimistic(opts, queryObserver, errorResetBoundary)
-          }
+          return fetchOptimistic(opts, queryObserver, errorResetBoundary)
         }
         return []
       })


### PR DESCRIPTION
## 🎯 Changes

Apply the same refactoring from #10082 to `preact-query`. Remove the unreachable `willFetch` branch in `useQueries.ts` suspense promise collection, since `shouldSuspend` already covers the only reachable case.

- Remove `willFetch` import from `suspense`
- Simplify the suspense promise flatMap logic by combining `opts` and `shouldSuspend` checks

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unreachable code paths and streamlined internal query logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->