### PR TITLE
test({react,preact,angular}-query/{queryOptions,infiniteQueryOptions,mutationOptions}): replace 'toStrictEqual' with 'toBe' and add type annotations

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/infinite-query-options.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/infinite-query-options.test.ts
@@ -12,6 +12,6 @@ describe('infiniteQueryOptions', () => {
       initialPageParam: null,
     }
 
-    expect(infiniteQueryOptions(object)).toStrictEqual(object)
+    expect(infiniteQueryOptions(object)).toBe(object)
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/mutation-options.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/mutation-options.test.ts
@@ -10,6 +10,7 @@ import {
   mutationOptions,
   provideTanStackQuery,
 } from '..'
+import type { CreateMutationOptions } from '../types'
 
 describe('mutationOptions', () => {
   let queryClient: QueryClient
@@ -30,20 +31,20 @@ describe('mutationOptions', () => {
   })
 
   it('should return the object received as a parameter without any modification (with mutationKey in mutationOptions)', () => {
-    const object = {
+    const object: CreateMutationOptions = {
       mutationKey: ['key'],
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the object received as a parameter without any modification (without mutationKey in mutationOptions)', () => {
-    const object = {
+    const object: CreateMutationOptions = {
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the number of fetching mutations when used with injectIsMutating (with mutationKey in mutationOptions)', async () => {

--- a/packages/angular-query-experimental/src/__tests__/query-options.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test.ts
@@ -9,6 +9,6 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve(5),
     } as const
 
-    expect(queryOptions(object)).toStrictEqual(object)
+    expect(queryOptions(object)).toBe(object)
   })
 })

--- a/packages/preact-query/src/__tests__/infiniteQueryOptions.test.tsx
+++ b/packages/preact-query/src/__tests__/infiniteQueryOptions.test.tsx
@@ -12,6 +12,6 @@ describe('infiniteQueryOptions', () => {
       initialPageParam: null,
     }
 
-    expect(infiniteQueryOptions(object)).toStrictEqual(object)
+    expect(infiniteQueryOptions(object)).toBe(object)
   })
 })

--- a/packages/preact-query/src/__tests__/mutationOptions.test.tsx
+++ b/packages/preact-query/src/__tests__/mutationOptions.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useIsMutating, useMutation, useMutationState } from '..'
 import { mutationOptions } from '../mutationOptions'
 import { renderWithClient } from './utils'
+import type { UseMutationOptions } from '../types'
 
 describe('mutationOptions', () => {
   beforeEach(() => {
@@ -18,20 +19,20 @@ describe('mutationOptions', () => {
   })
 
   it('should return the object received as a parameter without any modification (with mutationKey in mutationOptions)', () => {
-    const object = {
+    const object: UseMutationOptions = {
       mutationKey: ['key'],
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the object received as a parameter without any modification (without mutationKey in mutationOptions)', () => {
-    const object = {
+    const object: UseMutationOptions = {
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the number of fetching mutations when used with useIsMutating (with mutationKey in mutationOptions)', async () => {

--- a/packages/preact-query/src/__tests__/queryOptions.test.tsx
+++ b/packages/preact-query/src/__tests__/queryOptions.test.tsx
@@ -10,6 +10,6 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve(5),
     } as const
 
-    expect(queryOptions(object)).toStrictEqual(object)
+    expect(queryOptions(object)).toBe(object)
   })
 })

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test.tsx
@@ -12,6 +12,6 @@ describe('infiniteQueryOptions', () => {
       initialPageParam: null,
     }
 
-    expect(infiniteQueryOptions(object)).toStrictEqual(object)
+    expect(infiniteQueryOptions(object)).toBe(object)
   })
 })

--- a/packages/react-query/src/__tests__/mutationOptions.test.tsx
+++ b/packages/react-query/src/__tests__/mutationOptions.test.tsx
@@ -6,6 +6,7 @@ import { mutationOptions } from '../mutationOptions'
 import { useIsMutating, useMutation, useMutationState } from '..'
 import { renderWithClient } from './utils'
 import type { MutationState } from '@tanstack/query-core'
+import type { UseMutationOptions } from '../types'
 
 describe('mutationOptions', () => {
   beforeEach(() => {
@@ -17,20 +18,20 @@ describe('mutationOptions', () => {
   })
 
   it('should return the object received as a parameter without any modification (with mutationKey in mutationOptions)', () => {
-    const object = {
+    const object: UseMutationOptions = {
       mutationKey: ['key'],
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the object received as a parameter without any modification (without mutationKey in mutationOptions)', () => {
-    const object = {
+    const object: UseMutationOptions = {
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the number of fetching mutations when used with useIsMutating (with mutationKey in mutationOptions)', async () => {

--- a/packages/react-query/src/__tests__/queryOptions.test.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.test.tsx
@@ -9,6 +9,6 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve(5),
     } as const
 
-    expect(queryOptions(object)).toStrictEqual(object)
+    expect(queryOptions(object)).toBe(object)
   })
 })


### PR DESCRIPTION
## 🎯 Changes

- Replace `toStrictEqual` with `toBe` for identity function assertions in `queryOptions`, `infiniteQueryOptions`, and `mutationOptions` tests across `react-query`, `preact-query`, and `angular-query-experimental`
- Add explicit type annotations (`UseMutationOptions` / `CreateMutationOptions`) to `mutationOptions` test objects for consistency with `queryOptions` and `infiniteQueryOptions` tests

Since these options functions are identity functions that return the same reference, `toBe` (reference equality) is more precise than `toStrictEqual` (deep equality). This aligns with the change made in #10135 for `solid-query`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions across multiple packages to verify that option functions return consistent object references
  * Added explicit type annotations to test objects for enhanced type safety validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->