### PR TITLE
docs({solid,vue}-query/broadcastQueryClient): remove unnecessary 'replace' that doesn't match source content

### DIFF
--- a/docs/framework/solid/plugins/broadcastQueryClient.md
+++ b/docs/framework/solid/plugins/broadcastQueryClient.md
@@ -2,5 +2,4 @@
 id: broadcastQueryClient
 title: broadcastQueryClient (Experimental)
 ref: docs/framework/react/plugins/broadcastQueryClient.md
-replace: { 'react-query': 'vue-query' }
 ---

--- a/docs/framework/vue/plugins/broadcastQueryClient.md
+++ b/docs/framework/vue/plugins/broadcastQueryClient.md
@@ -2,5 +2,4 @@
 id: broadcastQueryClient
 title: broadcastQueryClient (Experimental)
 ref: docs/framework/react/plugins/broadcastQueryClient.md
-replace: { 'react-query': 'vue-query' }
 ---


### PR DESCRIPTION
## 🎯 Changes

Both `solid-query` and `vue-query` `broadcastQueryClient.md` docs had a `replace: { 'react-query': '...' }` pattern, but the referenced React source file (`docs/framework/react/plugins/broadcastQueryClient.md`) doesn't contain the string `react-query` anywhere — the package name is `@tanstack/query-broadcast-client-experimental`.

Additionally, the `solid-query` file had `'react-query': 'vue-query'` which was an incorrect value copied from the `vue-query` file.

This PR removes the unnecessary `replace` field from both files.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation metadata in the Solid and Vue plugin guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->