### PR TITLE
test(preact-query/useSuspenseQueries): align cached data test with react-query to verify background refetch

### DIFF
--- a/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -867,11 +867,11 @@ describe('useSuspenseQueries 2', () => {
         queries: [
           {
             queryKey: key1,
-            queryFn: () => sleep(QUERY_DURATION).then(() => 'data1'),
+            queryFn: () => sleep(2000).then(() => 'data1'),
           },
           {
             queryKey: key2,
-            queryFn: () => sleep(QUERY_DURATION).then(() => 'data2'),
+            queryFn: () => sleep(1000).then(() => 'data2'),
           },
         ],
       })
@@ -893,9 +893,19 @@ describe('useSuspenseQueries 2', () => {
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
 
-    await vi.advanceTimersByTimeAsync(QUERY_DURATION)
+    // key2 resolves: suspend lifts, key1 shows cached data, key2 shows fresh data
+    await vi.advanceTimersByTimeAsync(1000)
 
     expect(rendered.getByText('data1: cached')).toBeInTheDocument()
+    expect(rendered.getByText('data2: data2')).toBeInTheDocument()
+
+    // key1 stale timer fires, triggering background refetch
+    await vi.advanceTimersByTimeAsync(1000)
+
+    // key1 background refetch completes: key1 updates to fresh data
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(rendered.getByText('data1: data1')).toBeInTheDocument()
     expect(rendered.getByText('data2: data2')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Align the `should only suspend queries that are pending when some already have cached data` test in preact-query with the react-query version (#10126).

Previously, the preact test used the same `QUERY_DURATION` for both queries and only verified the initial suspend/resolve. The updated test uses different durations for each query (matching react-query) and verifies that the background refetch completes and updates `key1` from `'cached'` to `'data1'`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for multi-query suspense scenarios with improved timing validation and background refetch simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->