### PR TITLE
test({react,preact}-query/useSuspenseQueries): add test for not suspending when all queries have fresh cached data

### DIFF
--- a/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -908,4 +908,52 @@ describe('useSuspenseQueries 2', () => {
     expect(rendered.getByText('data1: data1')).toBeInTheDocument()
     expect(rendered.getByText('data2: data2')).toBeInTheDocument()
   })
+
+  it('should not suspend and not refetch when all queries have fresh cached data', () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    queryClient.setQueryData(key1, 'cached1')
+    queryClient.setQueryData(key2, 'cached2')
+
+    const queryFn1 = vi.fn(() => sleep(20).then(() => 'data1'))
+    const queryFn2 = vi.fn(() => sleep(10).then(() => 'data2'))
+
+    function Page() {
+      const [result1, result2] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: queryFn1,
+          },
+          {
+            queryKey: key2,
+            queryFn: queryFn2,
+          },
+        ],
+      })
+
+      return (
+        <div>
+          <div>data1: {result1.data}</div>
+          <div>data2: {result2.data}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <Suspense fallback={<div>loading</div>}>
+        <Page />
+      </Suspense>,
+    )
+
+    // No suspend, fresh cached data shown immediately
+    expect(rendered.getByText('data1: cached1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: cached2')).toBeInTheDocument()
+
+    // No background refetch because data is still fresh (within staleTime)
+    expect(queryFn1).toHaveBeenCalledTimes(0)
+    expect(queryFn2).toHaveBeenCalledTimes(0)
+  })
 })

--- a/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -886,4 +886,52 @@ describe('useSuspenseQueries 2', () => {
     expect(rendered.getByText('data1: data1')).toBeInTheDocument()
     expect(rendered.getByText('data2: data2')).toBeInTheDocument()
   })
+
+  it('should not suspend and not refetch when all queries have fresh cached data', () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    queryClient.setQueryData(key1, 'cached1')
+    queryClient.setQueryData(key2, 'cached2')
+
+    const queryFn1 = vi.fn(() => sleep(20).then(() => 'data1'))
+    const queryFn2 = vi.fn(() => sleep(10).then(() => 'data2'))
+
+    function Page() {
+      const [result1, result2] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: queryFn1,
+          },
+          {
+            queryKey: key2,
+            queryFn: queryFn2,
+          },
+        ],
+      })
+
+      return (
+        <div>
+          <div>data1: {result1.data}</div>
+          <div>data2: {result2.data}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <React.Suspense fallback={<div>loading</div>}>
+        <Page />
+      </React.Suspense>,
+    )
+
+    // No suspend, fresh cached data shown immediately
+    expect(rendered.getByText('data1: cached1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: cached2')).toBeInTheDocument()
+
+    // No background refetch because data is still fresh (within staleTime)
+    expect(queryFn1).toHaveBeenCalledTimes(0)
+    expect(queryFn2).toHaveBeenCalledTimes(0)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `useSuspenseQueries` does not suspend when all queries already have fresh cached data.

When all queries have cached data within `staleTime` (min 1000ms in suspense mode), the component should:
- Render immediately with cached data (no suspend)
- Not trigger any background refetch (`queryFn` not called)

Added to both `react-query` and `preact-query`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying that when queries have fresh cached data they render immediately without suspending and do not trigger background refetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->