### PR TITLE
fix(examples): guard missing mount targets in solid examples

### DIFF
--- a/examples/solid/basic-graphql-request/src/index.tsx
+++ b/examples/solid/basic-graphql-request/src/index.tsx
@@ -170,4 +170,7 @@ function Post(props: { postId: number; setPostId: Setter<number> }) {
   )
 }
 
-render(() => <App />, document.getElementById('root') as HTMLElement)
+const root = document.getElementById('root')
+if (!root) throw new Error('Missing #root element')
+
+render(() => <App />, root)

--- a/examples/solid/basic/src/index.tsx
+++ b/examples/solid/basic/src/index.tsx
@@ -151,4 +151,7 @@ const App: Component = () => {
   )
 }
 
-render(() => <App />, document.getElementById('root') as HTMLElement)
+const root = document.getElementById('root')
+if (!root) throw new Error('Missing #root element')
+
+render(() => <App />, root)

--- a/examples/solid/default-query-function/src/index.tsx
+++ b/examples/solid/default-query-function/src/index.tsx
@@ -136,4 +136,7 @@ function Post(props: { postId: number; setPostId: Setter<number> }) {
   )
 }
 
-render(() => <App />, document.getElementById('root') as HTMLElement)
+const root = document.getElementById('root')
+if (!root) throw new Error('Missing #root element')
+
+render(() => <App />, root)

--- a/examples/solid/offline/src/index.tsx
+++ b/examples/solid/offline/src/index.tsx
@@ -5,11 +5,14 @@ import { worker } from './api'
 
 worker.start()
 
+const root = document.getElementById('root')
+if (!root) throw new Error('Missing #root element')
+
 render(
   () => (
     <div style={{ padding: '16px' }}>
       <App />
     </div>
   ),
-  document.getElementById('root')!,
+  root,
 )

--- a/examples/solid/simple/src/index.tsx
+++ b/examples/solid/simple/src/index.tsx
@@ -49,4 +49,7 @@ function Example() {
     </Switch>
   )
 }
-render(() => <App />, document.getElementById('root') as HTMLElement)
+const root = document.getElementById('root')
+if (!root) throw new Error('Missing #root element')
+
+render(() => <App />, root)

--- a/examples/solid/solid-start-streaming/src/entry-client.tsx
+++ b/examples/solid/solid-start-streaming/src/entry-client.tsx
@@ -1,4 +1,7 @@
 // @refresh reload
 import { mount, StartClient } from '@solidjs/start/client'
 
-mount(() => <StartClient />, document.getElementById('app')!)
+const app = document.getElementById('app')
+if (!app) throw new Error('Missing #app element')
+
+mount(() => <StartClient />, app)


### PR DESCRIPTION
## 🎯 Changes

**What**
Adds safety guards for Solid example mount targets before calling render() / mount().

**Why**
Several Solid examples used non-null assertions (!) or as HTMLElement casts on document.getElementById(...).

If the DOM element is missing or renamed, the example crashes at runtime with an unclear error. Since examples are frequently copied, adding explicit runtime guards improves reliability and developer experience.

Similar to #10144 (Svelte simple), this applies the same mount target guard pattern to the Solid examples.

**Changes**
Replaces getElementById(... )! and as HTMLElement with guarded lookups

Throws clear errors when #root or #app is missing

Passes the verified element into render() / mount()

**Scope**
Examples-only change. No package/runtime changes.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application initialization across example projects with explicit runtime validation of required DOM elements, ensuring clear error messages if the app container is missing rather than silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->