### PR TITLE
fix(examples): guard missing mount target in preact simple example

### DIFF
--- a/examples/preact/simple/src/index.tsx
+++ b/examples/preact/simple/src/index.tsx
@@ -42,4 +42,7 @@ const Example = () => {
   )
 }
 
-render(<App />, document.getElementById('app'))
+const app = document.getElementById('app')
+if (!app) throw new Error('Missing #app element')
+
+render(<App />, app)


### PR DESCRIPTION
## 🎯 Changes

**What**
Adds a safety guard for the Preact simple example mount target before calling render().

**Why**
The example previously passed the mount target directly:
document.getElementById('app')

If the DOM element is missing or renamed, the example can fail at runtime with an unclear error. Since examples are frequently copied, adding an explicit guard improves reliability and developer experience.

**Changes**
- Adds a runtime check for the #app element
- Throws a clear error when the mount target is missing
- Passes the verified element into render()

**Scope**
Examples-only change. No package/runtime changes.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the example application to detect and report missing initialization elements, ensuring clearer error messages during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->