### PR TITLE
test({react,preact}-query/useSuspenseQueries): add test for not suspending but refetching when all queries have stale cached data

### DIFF
--- a/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -956,4 +956,60 @@ describe('useSuspenseQueries 2', () => {
     expect(queryFn1).toHaveBeenCalledTimes(0)
     expect(queryFn2).toHaveBeenCalledTimes(0)
   })
+
+  it('should not suspend but refetch when all queries have stale cached data', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    queryClient.setQueryData(key1, 'cached1')
+    queryClient.setQueryData(key2, 'cached2')
+
+    // Advance past staleTime (min 1000ms in suspense) so data becomes stale before mount
+    vi.advanceTimersByTime(1000)
+
+    function Page() {
+      const [result1, result2] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(20).then(() => 'data1'),
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(10).then(() => 'data2'),
+          },
+        ],
+      })
+
+      return (
+        <div>
+          <div>data1: {result1.data}</div>
+          <div>data2: {result2.data}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <Suspense fallback={<div>loading</div>}>
+        <Page />
+      </Suspense>,
+    )
+
+    // No suspend, stale cached data shown immediately with background refetch started
+    expect(rendered.getByText('data1: cached1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: cached2')).toBeInTheDocument()
+
+    // key2 background refetch completes
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('data1: cached1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: data2')).toBeInTheDocument()
+
+    // key1 background refetch completes
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(rendered.getByText('data1: data1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: data2')).toBeInTheDocument()
+  })
 })

--- a/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -934,4 +934,60 @@ describe('useSuspenseQueries 2', () => {
     expect(queryFn1).toHaveBeenCalledTimes(0)
     expect(queryFn2).toHaveBeenCalledTimes(0)
   })
+
+  it('should not suspend but refetch when all queries have stale cached data', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    queryClient.setQueryData(key1, 'cached1')
+    queryClient.setQueryData(key2, 'cached2')
+
+    // Advance past staleTime (min 1000ms in suspense) so data becomes stale before mount
+    vi.advanceTimersByTime(1000)
+
+    function Page() {
+      const [result1, result2] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(20).then(() => 'data1'),
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(10).then(() => 'data2'),
+          },
+        ],
+      })
+
+      return (
+        <div>
+          <div>data1: {result1.data}</div>
+          <div>data2: {result2.data}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <React.Suspense fallback={<div>loading</div>}>
+        <Page />
+      </React.Suspense>,
+    )
+
+    // No suspend, stale cached data shown immediately with background refetch started
+    expect(rendered.getByText('data1: cached1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: cached2')).toBeInTheDocument()
+
+    // key2 background refetch completes
+    await act(() => vi.advanceTimersByTimeAsync(11))
+
+    expect(rendered.getByText('data1: cached1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: data2')).toBeInTheDocument()
+
+    // key1 background refetch completes
+    await act(() => vi.advanceTimersByTimeAsync(10))
+
+    expect(rendered.getByText('data1: data1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: data2')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add test for `useSuspenseQueries` verifying that when all queries have stale cached data, it does not suspend but shows cached data immediately and triggers background refetch.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests (Preact and React) verifying that when all queries start with stale cached data the UI immediately shows cached results without suspending, then performs timed background refetches that progressively update displayed data as each refresh completes. Tests exercise staged refresh ordering and assert UI updates occur without triggering a suspense state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->