### PR TITLE
test({react,preact}-query/useSuspenseQueries): add test for suspending when the faster query already has data

### DIFF
--- a/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -856,7 +856,7 @@ describe('useSuspenseQueries 2', () => {
     process.env.NODE_ENV = envCopy
   })
 
-  it('should only suspend queries that are pending when some queries already have data', async () => {
+  it('should only suspend queries that are pending when the slower query already has data', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -904,6 +904,59 @@ describe('useSuspenseQueries 2', () => {
 
     // key1 background refetch completes: key1 updates to fresh data
     await vi.advanceTimersByTimeAsync(2000)
+
+    expect(rendered.getByText('data1: data1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: data2')).toBeInTheDocument()
+  })
+
+  it('should only suspend queries that are pending when the faster query already has data', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    queryClient.setQueryData(key2, 'cached')
+
+    function Page() {
+      const [result1, result2] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(2000).then(() => 'data1'),
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(1000).then(() => 'data2'),
+          },
+        ],
+      })
+
+      return (
+        <div>
+          <div>data1: {result1.data}</div>
+          <div>data2: {result2.data}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <Suspense fallback={<div>loading</div>}>
+        <Page />
+      </Suspense>,
+    )
+
+    expect(rendered.getByText('loading')).toBeInTheDocument()
+
+    // key1 resolves: suspend lifts, key1 shows fresh data, key2 shows cached data
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(rendered.getByText('data1: data1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: cached')).toBeInTheDocument()
+
+    // key2 stale timer fires, triggering background refetch
+    await vi.advanceTimersByTimeAsync(1000)
+
+    // key2 background refetch completes: key2 updates to fresh data
+    await vi.advanceTimersByTimeAsync(1000)
 
     expect(rendered.getByText('data1: data1')).toBeInTheDocument()
     expect(rendered.getByText('data2: data2')).toBeInTheDocument()

--- a/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -834,7 +834,7 @@ describe('useSuspenseQueries 2', () => {
     process.env.NODE_ENV = envCopy
   })
 
-  it('should only suspend queries that are pending when some queries already have data', async () => {
+  it('should only suspend queries that are pending when the slower query already has data', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -882,6 +882,59 @@ describe('useSuspenseQueries 2', () => {
 
     // key1 background refetch completes: key1 updates to fresh data
     await act(() => vi.advanceTimersByTimeAsync(2000))
+
+    expect(rendered.getByText('data1: data1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: data2')).toBeInTheDocument()
+  })
+
+  it('should only suspend queries that are pending when the faster query already has data', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    queryClient.setQueryData(key2, 'cached')
+
+    function Page() {
+      const [result1, result2] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(2000).then(() => 'data1'),
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(1000).then(() => 'data2'),
+          },
+        ],
+      })
+
+      return (
+        <div>
+          <div>data1: {result1.data}</div>
+          <div>data2: {result2.data}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <React.Suspense fallback={<div>loading</div>}>
+        <Page />
+      </React.Suspense>,
+    )
+
+    expect(rendered.getByText('loading')).toBeInTheDocument()
+
+    // key1 resolves: suspend lifts, key1 shows fresh data, key2 shows cached data
+    await act(() => vi.advanceTimersByTimeAsync(2000))
+
+    expect(rendered.getByText('data1: data1')).toBeInTheDocument()
+    expect(rendered.getByText('data2: cached')).toBeInTheDocument()
+
+    // key2 stale timer fires, triggering background refetch
+    await act(() => vi.advanceTimersByTimeAsync(1000))
+
+    // key2 background refetch completes: key2 updates to fresh data
+    await act(() => vi.advanceTimersByTimeAsync(1000))
 
     expect(rendered.getByText('data1: data1')).toBeInTheDocument()
     expect(rendered.getByText('data2: data2')).toBeInTheDocument()


### PR DESCRIPTION
## 🎯 Changes

Add test case for `useSuspenseQueries` where the cached query is the faster one (key2) instead of the slower one (key1).

The existing `should only suspend queries that are pending when the slower query already has data` test covers key1(cached, `sleep(2000)`) + key2(no cache, `sleep(1000)`). This new test covers the opposite: key1(no cache, `sleep(2000)`) + key2(cached, `sleep(1000)`), verifying that stale timer and background refetch timing behave correctly when the cached query's stale timer expires before suspend lifts.

Also renamed existing test description from `...when some queries already have data` to `...when the slower query already has data` for clarity.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Renamed existing test case for improved clarity on query timing scenarios
  * Added comprehensive test coverage validating behavior when queries have different data states (cached vs. pending), including background refetch scenarios in both preact-query and react-query packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->