### PR TITLE
test(react-query/useSuspenseQuery): remove unnecessary 'act' from background refetch, 'refetchInterval', and post-unmount assertions

### DIFF
--- a/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -200,7 +200,7 @@ describe('useSuspenseQuery', () => {
 
     fireEvent.click(rendered.getByLabelText('toggle'))
     expect(rendered.queryByText('loading')).not.toBeInTheDocument()
-    await act(() => vi.advanceTimersByTimeAsync(10))
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.queryByText('rendered')).not.toBeInTheDocument()
     expect(queryCache.find({ queryKey: key })?.getObserversCount()).toBe(0)
   })
@@ -811,7 +811,7 @@ describe('useSuspenseQuery', () => {
     // refetch
     fireEvent.click(rendered.getByRole('button', { name: 'refetch' }))
     // we are now in error state but still have data to show
-    await act(() => vi.advanceTimersByTimeAsync(11))
+    await vi.advanceTimersByTimeAsync(11)
     expect(rendered.getByText('rendered data error')).toBeInTheDocument()
 
     consoleMock.mockRestore()
@@ -922,9 +922,9 @@ describe('useSuspenseQuery', () => {
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await act(() => vi.advanceTimersByTimeAsync(10))
     expect(rendered.getByText('count: 1')).toBeInTheDocument()
-    await act(() => vi.advanceTimersByTimeAsync(21))
+    await vi.advanceTimersByTimeAsync(21)
     expect(rendered.getByText('count: 2')).toBeInTheDocument()
-    await act(() => vi.advanceTimersByTimeAsync(21))
+    await vi.advanceTimersByTimeAsync(21)
     expect(rendered.getByText('count: 3')).toBeInTheDocument()
 
     expect(count).toBeGreaterThanOrEqual(3)


### PR DESCRIPTION
## 🎯 Changes

Remove 4 unnecessary `act` wrappers from `useSuspenseQuery.test.tsx` where suspend resolution is not involved:

- **Line 203**: Post-unmount timer — component already unmounted, only checking observer count
- **Line 814**: Background refetch via `refetch()` — component already has data displayed, refetch triggers `status` change without suspend
- **Lines 925, 927**: `refetchInterval` background refetch — data updates (`count: 1` → `2` → `3`) without suspend

`act` is only needed for suspend → resolve or suspend → error transitions. Background refetches and post-unmount assertions don't require `act`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized test execution flow for asynchronous timer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->