### PR TITLE
test(react-query/useSuspenseInfiniteQuery): add test for basic suspend and resolve states

### DIFF
--- a/packages/react-query/src/__tests__/useSuspenseInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseInfiniteQuery.test.tsx
@@ -25,9 +25,8 @@ describe('useSuspenseInfiniteQuery', () => {
 
   it('should return the correct states for a successful infinite query', async () => {
     const key = queryKey()
-    const states: Array<
-      UseSuspenseInfiniteQueryResult<InfiniteData<number>>
-    > = []
+    const states: Array<UseSuspenseInfiniteQueryResult<InfiniteData<number>>> =
+      []
 
     function Page() {
       const [multiplier, setMultiplier] = React.useState(1)


### PR DESCRIPTION
## 🎯 Changes

Add a basic suspend → resolve test for `useSuspenseInfiniteQuery` that verifies:

- Suspense fallback is shown while the query is pending
- Data (`pages`, `pageParams`) and `status: 'success'` are correct after resolve
- Re-suspends and resolves correctly when the query key changes

This follows the same pattern as the existing test in `useSuspenseQuery.test.tsx`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for infinite query functionality, verifying correct behavior across the complete query lifecycle including initial loading states, successful data rendering, pagination for additional pages, dynamic parameter changes, and validation of returned data structures and pagination markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->