### PR TITLE
test(angular-query/injectIsRestoring): add tests for 'injectIsRestoring' and 'provideIsRestoring'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
@@ -1,10 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import { describe, expect, test } from 'vitest'
-import {
-  Injector,
-  provideZonelessChangeDetection,
-  signal,
-} from '@angular/core'
+import { Injector, provideZonelessChangeDetection, signal } from '@angular/core'
 import {
   QueryClient,
   injectIsRestoring,


### PR DESCRIPTION
## 🎯 Changes

Add tests for `injectIsRestoring` and `provideIsRestoring` in `angular-query-experimental`.

- Default value returns `false` when `provideIsRestoring` is not used
- Returns provided signal value when `provideIsRestoring` is used
- Works outside injection context when passing an `injector` option
- Throws `NG0203` error outside injection context

This improves `inject-is-restoring.ts` coverage from 83.33% to 100%.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for `injectIsRestoring` functionality, including default behavior, signal provision, injector context handling, and error scenarios in the angular-query-experimental package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->