### PR TITLE
fix(react-query): add experimental_prefetchInRender support to useQueries

### DIFF
--- a/.changeset/fix-use-queries-prefetch-in-render.md
+++ b/.changeset/fix-use-queries-prefetch-in-render.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Add experimental_prefetchInRender support to useQueries so that React.use(promise) resolves correctly

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -4,6 +4,7 @@ import * as React from 'react'
 import {
   QueriesObserver,
   QueryObserver,
+  isServer,
   noop,
   notifyManager,
 } from '@tanstack/query-core'
@@ -19,6 +20,7 @@ import {
   ensureSuspenseTimers,
   fetchOptimistic,
   shouldSuspend,
+  willFetch,
 } from './suspense'
 import type {
   DefinedUseQueryResult,
@@ -322,6 +324,33 @@ export function useQueries<
 
   if (firstSingleResultWhichShouldThrow?.error) {
     throw firstSingleResultWhichShouldThrow.error
+  }
+
+  // Handle experimental_prefetchInRender for each query that has it enabled
+  if (!isServer) {
+    const observers = observer.getObservers()
+    optimisticResult.forEach((result, index) => {
+      const opts = defaultedQueries[index]
+      if (
+        opts?.experimental_prefetchInRender &&
+        willFetch(result, isRestoring)
+      ) {
+        const queryObserver = observers[index]
+        const query = client
+          .getQueryCache()
+          .get(opts.queryHash)
+
+        const promise = !query?.state.dataUpdateCount
+          ? // New cache entry: fetch immediately to ensure .promise is resolved even if the component is unmounted
+            fetchOptimistic(opts, queryObserver!, errorResetBoundary)
+          : // Existing cache entry: subscribe to the "cache promise" to finalize the currentThenable once data comes in
+            query?.promise
+
+        promise?.catch(noop).finally(() => {
+          queryObserver?.updateResult()
+        })
+      }
+    })
   }
 
   return getCombinedResult(trackResult())


### PR DESCRIPTION
## Problem

`experimental_prefetchInRender` works with `useQuery` but not with `useQueries`. When using `React.use(promise)` with `useQueries`, the component never finishes loading because the promise never resolves.

```tsx
const query = queryOptions({
  queryKey: ['foo'],
  queryFn: async () => [],
  experimental_prefetchInRender: true,
});

// ✅ Works with useQuery
const { promise } = useQuery(query);
React.use(promise);

// ❌ Never finishes loading with useQueries
const [{ promise }] = useQueries({ queries: [query] });
React.use(promise);
```

## Root Cause

`useBaseQuery` implements `experimental_prefetchInRender` by detecting when a query will fetch and either:
1. Triggering an optimistic fetch for new cache entries, or
2. Subscribing to the existing cache promise

When the promise resolves, it calls `observer.updateResult()` which finalizes the `currentThenable`.

`useQueries` was missing this logic entirely — the `experimental_prefetchInRender` option was ignored.

## Fix

Added the same prefetch-in-render logic to `useQueries`, iterating over each query's result and options to handle the `experimental_prefetchInRender` flag individually. For each query that will fetch and has the option enabled:

- New cache entries trigger `fetchOptimistic()` immediately
- Existing cache entries subscribe to the query's cache promise
- On promise resolution, `observer.updateResult()` is called to finalize the thenable

Closes #9988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side support for experimental prefetch-on-render optimization, improving data loading and responsiveness when rendering queries.

* **Chores**
  * Added release changeset documenting the patch and the new prefetch-on-render behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->