### PR TITLE
test(angular-query/injectMutation): add test for 'throwOnError' with 'mutate'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -412,6 +412,28 @@ describe('injectMutation', () => {
       expect(boundaryFn).toHaveBeenCalledTimes(1)
       expect(boundaryFn).toHaveBeenCalledWith(err)
     })
+
+    test('should throw when throwOnError is true and mutate is used', async () => {
+      const { mutate } = TestBed.runInInjectionContext(() => {
+        return injectMutation(() => ({
+          mutationKey: ['fake'],
+          mutationFn: () => {
+            return Promise.reject(
+              new Error('Expected mock error. All is well!'),
+            )
+          },
+          throwOnError: true,
+        }))
+      })
+
+      TestBed.tick()
+
+      mutate()
+
+      await expect(vi.advanceTimersByTimeAsync(0)).rejects.toThrow(
+        'Expected mock error. All is well!',
+      )
+    })
   })
 
   test('should throw when throwOnError is true', async () => {


### PR DESCRIPTION
## 🎯 Changes

Add test for `throwOnError: true` with `mutate()` (non-async) in `injectMutation`.

Existing tests only covered `throwOnError` with `mutateAsync`, which handles errors via Promise rejection. This test covers the subscriber callback path (lines 152-153) where the error is emitted via `ngZone.onError` and thrown directly.

This improves `inject-mutation.ts` coverage from 96% to 100%.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for mutation error handling behavior with the throwOnError option enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->