### PR TITLE
test(vue-query/queryClient): add test for 'ensureQueryData' ref unwrapping

### DIFF
--- a/packages/vue-query/src/__tests__/queryClient.test.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test.ts
@@ -83,6 +83,22 @@ describe('QueryCache', () => {
     })
   })
 
+  describe('ensureQueryData', () => {
+    test('should properly unwrap parameter', () => {
+      const queryClient = new QueryClient()
+
+      queryClient.ensureQueryData({
+        queryKey: queryKeyRef,
+        queryFn: fn,
+      })
+
+      expect(QueryClientOrigin.prototype.ensureQueryData).toBeCalledWith({
+        queryKey: queryKeyUnref,
+        queryFn: fn,
+      })
+    })
+  })
+
   describe('getQueriesData', () => {
     test('should properly unwrap queryKey param', () => {
       const queryClient = new QueryClient()


### PR DESCRIPTION
## 🎯 Changes

Add a missing test for `ensureQueryData` to verify that Vue `ref` parameters are properly unwrapped before being passed to the parent `QueryClient`.

All other `QueryClient` methods already had ref unwrapping tests — `ensureQueryData` was the only one missing.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the ensureQueryData method to ensure consistent parameter handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->