### PR TITLE
test(vue-query/queryOptions): add runtime test for identity function

### DIFF
--- a/packages/vue-query/src/__tests__/queryOptions.test.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { queryOptions } from '../queryOptions'
+import type { UseQueryOptions } from '../useQuery'
+
+describe('queryOptions', () => {
+  it('should return the object received as a parameter without any modification.', () => {
+    const object: UseQueryOptions = {
+      queryKey: ['key'],
+      queryFn: () => Promise.resolve(5),
+    } as const
+
+    expect(queryOptions(object)).toBe(object)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add a runtime test for `queryOptions` in vue-query to verify it returns the same object reference without modification (identity function behavior).

This aligns vue-query with existing tests in react-query, preact-query, solid-query, and svelte-query (0aec57559).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for queryOptions functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->