### PR TITLE
test(vue-query/useQuery): add test for outside scope warning in development mode

### DIFF
--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -465,16 +465,19 @@ describe('useQuery', () => {
       vi.stubEnv('NODE_ENV', 'development')
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-      useQuery({
-        queryKey: ['outsideScope'],
-        queryFn: () => sleep(0).then(() => 'data'),
-      })
+      try {
+        useQuery({
+          queryKey: ['outsideScope'],
+          queryFn: () => sleep(0).then(() => 'data'),
+        })
 
-      vi.unstubAllEnvs()
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        'vue-query composable like "useQuery()" should only be used inside a "setup()" function or a running effect scope. They might otherwise lead to memory leaks.',
-      )
+        expect(warnSpy).toHaveBeenCalledWith(
+          'vue-query composable like "useQuery()" should only be used inside a "setup()" function or a running effect scope. They might otherwise lead to memory leaks.',
+        )
+      } finally {
+        warnSpy.mockRestore()
+        vi.unstubAllEnvs()
+      }
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

Add a test to cover the development-mode warning in `useBaseQuery` (lines 74-79) when `useQuery` is called outside of a Vue `setup()` function or `effectScope`.

Uses `vi.stubEnv('NODE_ENV', 'development')` to temporarily enable the dev-only code path and verifies `console.warn` is called with the expected message.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering the development-mode warning for using query hooks outside a valid setup scope; checks are included in multiple contexts to ensure consistent warnings.

---

Note: These are test-only changes focused on developer diagnostics; no user-facing behavior or features were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->