### PR TITLE
fix(examples): guard missing mount targets in react examples

### DIFF
--- a/examples/react/basic/src/index.tsx
+++ b/examples/react/basic/src/index.tsx
@@ -157,5 +157,6 @@ function App() {
   )
 }
 
-const rootElement = document.getElementById('root') as HTMLElement
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Missing #root element')
 ReactDOM.createRoot(rootElement).render(<App />)

--- a/examples/react/rick-morty/src/index.tsx
+++ b/examples/react/rick-morty/src/index.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom/client'
 import App from './App'
 
-const rootElement = document.getElementById('root') as HTMLElement
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Missing #root element')
 ReactDOM.createRoot(rootElement).render(<App />)

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -45,5 +45,6 @@ function Example() {
   )
 }
 
-const rootElement = document.getElementById('root') as HTMLElement
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Missing #root element')
 ReactDOM.createRoot(rootElement).render(<App />)

--- a/examples/react/star-wars/src/index.tsx
+++ b/examples/react/star-wars/src/index.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom/client'
 import App from './App'
 
-const rootElement = document.getElementById('root') as HTMLElement
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Missing #root element')
 ReactDOM.createRoot(rootElement).render(<App />)


### PR DESCRIPTION
## 🎯 Changes

**What**
Adds safety guards for mount targets in several React examples before calling ReactDOM.createRoot().

**Why**
These examples previously used unsafe patterns such as:

document.getElementById('root') as HTMLElement

If the DOM element is missing or renamed, the example can crash at runtime with an unclear error. Since examples are frequently copied, adding explicit runtime guards improves reliability and developer experience.

**Changes**

- Replaces getElementById('root') as HTMLElement with guarded lookups
- Throws a clear error when the #root mount target is missing
- Passes the verified element into ReactDOM.createRoot()

**Scope**
Examples-only change. No package/runtime changes.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across React example applications. Added explicit validation to ensure the required HTML root element exists at startup, with a clear error message displayed immediately if it's missing. This prevents silent failures and enhances the debugging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->