### PR TITLE
docs(examples): fix nuxt3 README links and commands

### DIFF
--- a/examples/vue/nuxt3/README.md
+++ b/examples/vue/nuxt3/README.md
@@ -1,6 +1,6 @@
 # Nuxt 3 Minimal Starter
 
-We recommend to look at the [documentation](https://nuxt.com/docs/3.x/getting-started/introduction).
+We recommend looking at the [documentation](https://nuxt.com/docs/3.x/getting-started/introduction).
 
 ## Setup
 
@@ -26,4 +26,4 @@ Build the application for production:
 pnpm build
 ```
 
-Checkout the [deployment documentation](https://nuxt.com/docs/3.x/getting-started/deployment).
+Check out the [deployment documentation](https://nuxt.com/docs/3.x/getting-started/deployment).


### PR DESCRIPTION
## 🎯 Changes

**What**
Fixes outdated Nuxt documentation links and updates package manager commands in the examples/vue/nuxt3 README.

**Why**
The README referenced the old Nuxt documentation domain:

https://v3.nuxtjs.org

This domain now redirects and some pages (such as deployment docs) return a 404. Updating the links to the current Nuxt documentation ensures readers are directed to working resources.

The README also referenced yarn commands, while this repository uses pnpm (packageManager: pnpm@10.24.0). Updating the commands keeps the example consistent with the repo standard.

**Changes**

- Update Nuxt documentation link → https://nuxt.com/docs/3.x/getting-started/introduction
- Update deployment documentation link → https://nuxt.com/docs/3.x/getting-started/deployment
- Replace yarn install, yarn dev, yarn build with pnpm install, pnpm dev, pnpm build

**Scope**
Docs-only change. No package/runtime changes.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Nuxt documentation links to the current 3.x site (getting started and deployment pages).
  * Replaced yarn with pnpm in installation, development, and build commands for the example project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->