### PR TITLE
test(vue-query/useMutationState): split 'useMutationState' tests into separate file from 'useIsMutating.test.ts'

### DIFF
--- a/packages/vue-query/src/__tests__/useIsMutating.test.ts
+++ b/packages/vue-query/src/__tests__/useIsMutating.test.ts
@@ -1,9 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { onScopeDispose, reactive, ref } from 'vue-demi'
 import { sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
-import { useIsMutating, useMutationState } from '../useMutationState'
-import { useQueryClient } from '../useQueryClient'
+import { useIsMutating } from '../useMutationState'
 import type { MockedFunction } from 'vitest'
 
 vi.mock('../useQueryClient')
@@ -108,77 +107,5 @@ describe('useIsMutating', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(isMutating.value).toStrictEqual(1)
-  })
-})
-
-describe('useMutationState', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('should return variables after calling mutate 1', () => {
-    const mutationKey = ['mutation']
-    const variables = 'foo123'
-
-    const { mutate } = useMutation({
-      mutationKey: mutationKey,
-      mutationFn: (params: string) => sleep(0).then(() => params),
-    })
-
-    mutate(variables)
-
-    const mutationState = useMutationState({
-      filters: { mutationKey, status: 'pending' },
-      select: (mutation) => mutation.state.variables,
-    })
-
-    expect(mutationState.value).toEqual([variables])
-  })
-
-  it('should return variables after calling mutate 2', () => {
-    const queryClient = useQueryClient()
-    queryClient.clear()
-    const mutationKey = ['mutation']
-    const variables = 'bar234'
-
-    const { mutate } = useMutation({
-      mutationKey: mutationKey,
-      mutationFn: (params: string) => sleep(0).then(() => params),
-    })
-
-    mutate(variables)
-
-    const mutationState = useMutationState()
-
-    expect(mutationState.value[0]?.variables).toEqual(variables)
-  })
-
-  it('should work with options getter and be reactive', async () => {
-    const keyRef = ref('useMutationStateGetter2')
-    const variables = 'foo123'
-
-    const { mutate } = useMutation({
-      mutationKey: ['useMutationStateGetter'],
-      mutationFn: (params: string) => sleep(10).then(() => params),
-    })
-
-    mutate(variables)
-
-    const mutationState = useMutationState(() => ({
-      filters: { mutationKey: [keyRef.value], status: 'pending' },
-      select: (mutation) => mutation.state.variables,
-    }))
-
-    expect(mutationState.value).toEqual([])
-
-    keyRef.value = 'useMutationStateGetter'
-
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(mutationState.value).toEqual([variables])
   })
 })

--- a/packages/vue-query/src/__tests__/useMutationState.test.ts
+++ b/packages/vue-query/src/__tests__/useMutationState.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue-demi'
+import { sleep } from '@tanstack/query-test-utils'
+import { useMutation } from '../useMutation'
+import { useMutationState } from '../useMutationState'
+import { useQueryClient } from '../useQueryClient'
+
+vi.mock('../useQueryClient')
+
+describe('useMutationState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should return variables after calling mutate 1', () => {
+    const mutationKey = ['mutation']
+    const variables = 'foo123'
+
+    const { mutate } = useMutation({
+      mutationKey: mutationKey,
+      mutationFn: (params: string) => sleep(0).then(() => params),
+    })
+
+    mutate(variables)
+
+    const mutationState = useMutationState({
+      filters: { mutationKey, status: 'pending' },
+      select: (mutation) => mutation.state.variables,
+    })
+
+    expect(mutationState.value).toEqual([variables])
+  })
+
+  it('should return variables after calling mutate 2', () => {
+    const queryClient = useQueryClient()
+    queryClient.clear()
+    const mutationKey = ['mutation']
+    const variables = 'bar234'
+
+    const { mutate } = useMutation({
+      mutationKey: mutationKey,
+      mutationFn: (params: string) => sleep(0).then(() => params),
+    })
+
+    mutate(variables)
+
+    const mutationState = useMutationState()
+
+    expect(mutationState.value[0]?.variables).toEqual(variables)
+  })
+
+  it('should work with options getter and be reactive', async () => {
+    const keyRef = ref('useMutationStateGetter2')
+    const variables = 'foo123'
+
+    const { mutate } = useMutation({
+      mutationKey: ['useMutationStateGetter'],
+      mutationFn: (params: string) => sleep(10).then(() => params),
+    })
+
+    mutate(variables)
+
+    const mutationState = useMutationState(() => ({
+      filters: { mutationKey: [keyRef.value], status: 'pending' },
+      select: (mutation) => mutation.state.variables,
+    }))
+
+    expect(mutationState.value).toEqual([])
+
+    keyRef.value = 'useMutationStateGetter'
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mutationState.value).toEqual([variables])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

- Split `useMutationState` tests from `useIsMutating.test.ts` into a dedicated `useMutationState.test.ts` file, aligning with the test file structure used in other packages (react-query, preact-query, solid-query, svelte-query).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for mutation state behavior and reactivity.
  * Refactored test organization for improved focus and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->