### PR TITLE
test(vue-query/useIsFetching): add test for outside scope warning in development mode

### DIFF
--- a/packages/vue-query/src/__tests__/useIsFetching.test.ts
+++ b/packages/vue-query/src/__tests__/useIsFetching.test.ts
@@ -103,12 +103,15 @@ describe('useIsFetching', () => {
     vi.stubEnv('NODE_ENV', 'development')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    useIsFetching()
+    try {
+      useIsFetching()
 
-    vi.unstubAllEnvs()
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      'vue-query composable like "useQuery()" should only be used inside a "setup()" function or a running effect scope. They might otherwise lead to memory leaks.',
-    )
+      expect(warnSpy).toHaveBeenCalledWith(
+        'vue-query composable like "useQuery()" should only be used inside a "setup()" function or a running effect scope. They might otherwise lead to memory leaks.',
+      )
+    } finally {
+      warnSpy.mockRestore()
+      vi.unstubAllEnvs()
+    }
   })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add test to verify that `useIsFetching` warns when used outside of a `setup()` function or running effect scope in development mode.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test to verify that a development-mode warning is triggered when a composable is used outside its intended context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->