### PR TITLE
test(vue-query/useMutation): add test for outside scope warning in development mode

### DIFF
--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -390,15 +390,18 @@ describe('useMutation', () => {
     vi.stubEnv('NODE_ENV', 'development')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    useMutation({
-      mutationFn: (params: string) => sleep(0).then(() => params),
-    })
+    try {
+      useMutation({
+        mutationFn: (params: string) => sleep(0).then(() => params),
+      })
 
-    vi.unstubAllEnvs()
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      'vue-query composable like "useQuery()" should only be used inside a "setup()" function or a running effect scope. They might otherwise lead to memory leaks.',
-    )
+      expect(warnSpy).toHaveBeenCalledWith(
+        'vue-query composable like "useQuery()" should only be used inside a "setup()" function or a running effect scope. They might otherwise lead to memory leaks.',
+      )
+    } finally {
+      warnSpy.mockRestore()
+      vi.unstubAllEnvs()
+    }
   })
 
   describe('throwOnError', () => {


### PR DESCRIPTION
## 🎯 Changes

- Add test to verify that `useMutation` warns when used outside of a `setup()` function or running effect scope in development mode.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to verify a development-mode warning is emitted when a mutation hook is used outside of a setup context, ensuring consistent warning messages in dev builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->