### PR TITLE
test(vue-query/useMutation): add test for 'throw' from error watcher when 'throwOnError' returns true

### DIFF
--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -402,5 +402,27 @@ describe('useMutation', () => {
       expect(boundaryFn).toHaveBeenCalledTimes(1)
       expect(boundaryFn).toHaveBeenCalledWith(err)
     })
+
+    test('should throw from error watcher when throwOnError returns true', async () => {
+      const throwOnErrorFn = vi.fn().mockReturnValue(true)
+      const { mutate } = useMutation({
+        mutationFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+        throwOnError: throwOnErrorFn,
+      })
+
+      mutate()
+
+      // Suppress the Unhandled Rejection caused by watcher throw in Vue 3
+      const rejectionHandler = () => {}
+      process.on('unhandledRejection', rejectionHandler)
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      process.off('unhandledRejection', rejectionHandler)
+
+      expect(throwOnErrorFn).toHaveBeenCalledTimes(1)
+      expect(throwOnErrorFn).toHaveBeenCalledWith(Error('Some error'))
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add test for the `throw` path in `useMutation`'s error watcher when `throwOnError` returns `true`.

The existing `throwOnError` test only covers when the callback returns a falsy value (no throw). This test covers the branch where `throwOnError` returns `true`, causing the error watcher to throw. A `process.on('unhandledRejection')` handler is used to suppress the Unhandled Rejection caused by Vue 3's watcher throw behavior.

Coverage: `useMutation.ts` Stmts 87.5% → 91.66%

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for error handling behavior in mutations to improve code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->