### PR TITLE
test(vue-query/useQueries): add test for outside scope warning in development mode

### DIFF
--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -369,6 +369,29 @@ describe('useQueries', () => {
     expect(fetchFn).toHaveBeenCalledTimes(6)
   })
 
+  test('should warn when used outside of setup function in development mode', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      useQueries({
+        queries: [
+          {
+            queryKey: ['outsideScope'],
+            queryFn: () => sleep(0).then(() => 'data'),
+          },
+        ],
+      })
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'vue-query composable like "useQuery()" should only be used inside a "setup()" function or a running effect scope. They might otherwise lead to memory leaks.',
+      )
+    } finally {
+      warnSpy.mockRestore()
+      vi.unstubAllEnvs()
+    }
+  })
+
   test('should work with options getter and be reactive', async () => {
     const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')


### PR DESCRIPTION
## 🎯 Changes

Add test for `useQueries` outside scope warning in development mode, covering `useQueries.ts` lines 254-259.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to validate warning behavior when using `useQueries` outside of proper execution scopes in development mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->