### PR TITLE
test(svelte-query/createMutation): add test for recreating observer when 'queryClient' changes

### DIFF
--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { flushSync } from 'svelte'
 import { fireEvent, render } from '@testing-library/svelte'
+import { QueryClient } from '@tanstack/query-core'
 import { sleep } from '@tanstack/query-test-utils'
+import { createMutation } from '../../src/index.js'
+import { withEffectRoot } from '../utils.svelte.js'
 import ResetExample from './ResetExample.svelte'
 import OnSuccessExample from './OnSuccessExample.svelte'
 import FailureExample from './FailureExample.svelte'
@@ -95,4 +99,33 @@ describe('createMutation', () => {
     expect(rendered.getByText('Failure Count: 0')).toBeInTheDocument()
     expect(rendered.getByText('Failure Reason: undefined')).toBeInTheDocument()
   })
+
+  test(
+    'should recreate observer when queryClient changes',
+    withEffectRoot(async () => {
+      const queryClient1 = new QueryClient()
+      const queryClient2 = new QueryClient()
+
+      let queryClient = $state(queryClient1)
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (params: string) => sleep(10).then(() => params),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutate('first')
+      await vi.advanceTimersByTimeAsync(11)
+
+      expect(mutation.status).toBe('success')
+      expect(mutation.data).toBe('first')
+
+      queryClient = queryClient2
+      flushSync()
+
+      expect(mutation.status).toBe('idle')
+      expect(mutation.data).toBeUndefined()
+    }),
+  )
 })


### PR DESCRIPTION
## 🎯 Changes

Add a test for `createMutation` to verify that the `MutationObserver` is recreated when the provided `queryClient` changes at runtime.

This covers `createMutation.svelte.ts` lines 41 and 61 (`watchChanges` callbacks for client/observer changes), improving line coverage from 89.47% to 100%.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case verifying mutation observer recreation and state reset when the underlying query client changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->