### PR TITLE
test(svelte-query/{queryOptions,infiniteQueryOptions}): flatten test directories that don't require '.svelte' component files

### DIFF
--- a/packages/svelte-query/tests/infiniteQueryOptions.svelte.test.ts
+++ b/packages/svelte-query/tests/infiniteQueryOptions.svelte.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { infiniteQueryOptions } from '../../src/index.js'
-import type { CreateInfiniteQueryOptions } from '../../src/types.js'
+import { infiniteQueryOptions } from '../src/index.js'
+import type { CreateInfiniteQueryOptions } from '../src/types.js'
 
 describe('infiniteQueryOptions', () => {
   it('should return the object received as a parameter without any modification.', () => {

--- a/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
+++ b/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, test } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
-import { createInfiniteQuery, infiniteQueryOptions } from '../../src/index.js'
+import { createInfiniteQuery, infiniteQueryOptions } from '../src/index.js'
 import type { InfiniteData } from '@tanstack/query-core'
 
 describe('queryOptions', () => {

--- a/packages/svelte-query/tests/queryOptions.svelte.test.ts
+++ b/packages/svelte-query/tests/queryOptions.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { queryOptions } from '../../src/index.js'
+import { queryOptions } from '../src/index.js'
 
 describe('queryOptions', () => {
   it('should return the object received as a parameter without any modification.', () => {

--- a/packages/svelte-query/tests/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions.test-d.ts
@@ -5,7 +5,7 @@ import {
   dataTagSymbol,
   skipToken,
 } from '@tanstack/query-core'
-import { createQueries, queryOptions } from '../../src/index.js'
+import { createQueries, queryOptions } from '../src/index.js'
 import type { QueryObserverResult } from '@tanstack/query-core'
 
 describe('queryOptions', () => {


### PR DESCRIPTION
## 🎯 Changes

Move `queryOptions` and `infiniteQueryOptions` test files from subdirectories to `tests/` root, since they don't require `.svelte` component files.

Other test directories (e.g., `createMutation/`, `useMutationState/`, `useIsFetching/`) need `.svelte` component files because they use `setContext`/`getContext` for sharing `QueryClient` across multiple hooks. These two directories only contain pure unit tests and type tests, so the subdirectory structure is unnecessary.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test file module resolution paths to align with project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->