### PR TITLE
test(query-core/queryObserver): add test for rejecting promise when 'experimental_prefetchInRender' is disabled

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1378,6 +1378,31 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
+  test('should reject promise when experimental_prefetchInRender is disabled and thenable is pending', async () => {
+    const key = queryKey()
+    const queryClient2 = new QueryClient({
+      defaultOptions: {
+        queries: {
+          experimental_prefetchInRender: false,
+        },
+      },
+    })
+    const observer = new QueryObserver(queryClient2, {
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+      enabled: false,
+    })
+
+    const result = observer.getCurrentResult()
+    const tracked = observer.trackResult(result)
+
+    await expect(tracked.promise).rejects.toThrow(
+      'experimental_prefetchInRender feature flag is not enabled',
+    )
+
+    queryClient2.clear()
+  })
+
   test('should not refetchOnMount when set to "always" when staleTime is Static', async () => {
     const key = queryKey()
     const queryFn = vi.fn(() => 'data')


### PR DESCRIPTION
## 🎯 Changes

Add a test for `queryObserver.ts` lines 272-277 — `trackResult` rejecting the pending thenable when `experimental_prefetchInRender` is disabled and `.promise` is accessed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying that when the experimental prefetch feature is disabled, in-flight thenables are rejected with a clear, specific error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->