### PR TITLE
docs: fix Preact hydration nav link

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1249,7 +1249,7 @@
             },
             {
               "label": "hydration",
-              "to": "framework/react/reference/functions/HydrationBoundary"
+              "to": "framework/preact/reference/functions/HydrationBoundary"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- fix the Preact API reference hydration nav entry in docs/config.json
- point it to ramework/preact/reference/functions/HydrationBoundary, which exists in this repo
- avoid the current broken link to the non-existent React path

## Validation
- Get-Content 'docs/config.json' -Raw | ConvertFrom-Json
- verified docs/framework/preact/reference/functions/HydrationBoundary.md exists
- git diff --check

## Notes
This is a small docs/navigation fix discovered while investigating docs link issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected API reference documentation to ensure HydrationBoundary references point to the appropriate framework implementation across both React and Preact documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->