### PR TITLE
ci: issues permissions for changeset preview

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,7 @@ env:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   test:


### PR DESCRIPTION
the changeset preview can't post in the PR the expected bumps - it's because it lacks issues write access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow permissions to enhance issue management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->