### PR TITLE
fix(vue-query): preserve `queryOptions` object type to avoid property loss

### DIFF
--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -9,9 +9,15 @@ export function queryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
+  TOptions extends DefinedInitialQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey
+  > = DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 >(
-  options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  options: TOptions,
+): TOptions & {
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 
@@ -20,9 +26,15 @@ export function queryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
+  TOptions extends UndefinedInitialQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey
+  > = UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 >(
-  options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  options: TOptions,
+): TOptions & {
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }
 


### PR DESCRIPTION
## 🎯 Changes

Fixes #7892

There's a discrepancy between the return type of `queryOptions` in vue-query and react-query. When wrapping the options via `queryOptions`, properties like `queryFn` are lost on the returned type because `UndefinedInitialQueryOptions` is evaluated as a `MaybeRef<...>` union.

This fix introduces `TOptions` as a generic parameter that extends the base options, ensuring that the literal object passed in is preserved in the return type without being collapsed into the ref union.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Query option types now preserve more precise type information, improving IDE autocomplete accuracy and type validation. Developers benefit from better type hints and earlier error detection when configuring and using queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->