### PR TITLE
fix(query-devtools): sanitize invalid browser locales

### DIFF
--- a/.changeset/safe-languages-wash.md
+++ b/.changeset/safe-languages-wash.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-devtools': patch
+---
+
+Sanitize invalid browser locale values before query devtools use them for locale-sensitive formatting.

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -15,12 +15,13 @@ import { clsx as cx } from 'clsx'
 import { TransitionGroup } from 'solid-transition-group'
 import { Key } from '@solid-primitives/keyed'
 import { createResizeObserver } from '@solid-primitives/resize-observer'
-import { DropdownMenu, RadioGroup } from '@kobalte/core'
+import { DropdownMenu, RadioGroup, useLocale } from '@kobalte/core'
 import { Portal } from 'solid-js/web'
 import { tokens } from './theme'
 import {
   convertRemToPixels,
   displayValue,
+  formatDateTime,
   getMutationStatusColor,
   getQueryStatusColor,
   getQueryStatusColorByLabel,
@@ -675,6 +676,7 @@ export const ContentView: Component<ContentViewProps> = (props) => {
   setupQueryCacheSubscription()
   setupMutationCacheSubscription()
   let containerRef!: HTMLDivElement
+  const locale = useLocale()
   const theme = useTheme()
   const css = useQueryDevtoolsContext().shadowDOMTarget
     ? goober.css.bind({ target: useQueryDevtoolsContext().shadowDOMTarget })
@@ -778,7 +780,7 @@ export const ContentView: Component<ContentViewProps> = (props) => {
                 item.options.mutationKey
                   ? JSON.stringify(item.options.mutationKey) + ' - '
                   : ''
-              }${new Date(item.state.submittedAt).toLocaleString()}`
+              }${formatDateTime(item.state.submittedAt, locale.locale())}`
               return rankItem(value, props.localStore.mutationFilter || '')
                 .passed
             })
@@ -1501,6 +1503,7 @@ const QueryRow: Component<{ query: Query }> = (props) => {
 }
 
 const MutationRow: Component<{ mutation: Mutation }> = (props) => {
+  const locale = useLocale()
   const theme = useTheme()
   const css = useQueryDevtoolsContext().shadowDOMTarget
     ? goober.css.bind({ target: useQueryDevtoolsContext().shadowDOMTarget })
@@ -1580,9 +1583,10 @@ const MutationRow: Component<{ mutation: Mutation }> = (props) => {
             styles().selectedQueryRow,
           'tsqd-query-row',
         )}
-        aria-label={`Mutation submitted at ${new Date(
+        aria-label={`Mutation submitted at ${formatDateTime(
           props.mutation.state.submittedAt,
-        ).toLocaleString()}`}
+          locale.locale(),
+        )}`}
       >
         <div
           class={cx(getObserverCountColorStyles(), 'tsqd-query-observer-count')}
@@ -1604,7 +1608,7 @@ const MutationRow: Component<{ mutation: Mutation }> = (props) => {
           <Show when={props.mutation.options.mutationKey}>
             {JSON.stringify(props.mutation.options.mutationKey)} -{' '}
           </Show>
-          {new Date(props.mutation.state.submittedAt).toLocaleString()}
+          {formatDateTime(props.mutation.state.submittedAt, locale.locale())}
         </code>
       </button>
     </Show>

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -22,6 +22,7 @@ import {
   convertRemToPixels,
   displayValue,
   formatDateTime,
+  formatTime,
   getMutationStatusColor,
   getQueryStatusColor,
   getQueryStatusColorByLabel,
@@ -1861,6 +1862,7 @@ const QueryStatus: Component<QueryStatusProps> = (props) => {
 }
 
 const QueryDetails = () => {
+  const locale = useLocale()
   const theme = useTheme()
   const css = useQueryDevtoolsContext().shadowDOMTarget
     ? goober.css.bind({ target: useQueryDevtoolsContext().shadowDOMTarget })
@@ -2053,7 +2055,7 @@ const QueryDetails = () => {
           <div class="tsqd-query-details-last-updated">
             <span>Last Updated:</span>
             <span>
-              {new Date(activeQueryState()!.dataUpdatedAt).toLocaleTimeString()}
+              {formatTime(activeQueryState()!.dataUpdatedAt, locale.locale())}
             </span>
           </div>
         </div>
@@ -2395,6 +2397,7 @@ const QueryDetails = () => {
 }
 
 const MutationDetails = () => {
+  const locale = useLocale()
   const theme = useTheme()
   const css = useQueryDevtoolsContext().shadowDOMTarget
     ? goober.css.bind({ target: useQueryDevtoolsContext().shadowDOMTarget })
@@ -2495,9 +2498,7 @@ const MutationDetails = () => {
           <div class="tsqd-query-details-last-updated">
             <span>Submitted At:</span>
             <span>
-              {new Date(
-                activeMutation()!.state.submittedAt,
-              ).toLocaleTimeString()}
+              {formatTime(activeMutation()!.state.submittedAt, locale.locale())}
             </span>
           </div>
         </div>

--- a/packages/query-devtools/src/DevtoolsComponent.tsx
+++ b/packages/query-devtools/src/DevtoolsComponent.tsx
@@ -1,7 +1,8 @@
 import { createLocalStorage } from '@solid-primitives/storage'
+import { I18nProvider } from '@kobalte/core'
 import { createMemo } from 'solid-js'
 import { Devtools } from './Devtools'
-import { getPreferredColorScheme } from './utils'
+import { createSafeLocale, getPreferredColorScheme } from './utils'
 import { THEME_PREFERENCE } from './constants'
 import { PiPProvider, QueryDevtoolsContext, ThemeContext } from './contexts'
 import type { Theme } from './contexts'
@@ -13,6 +14,7 @@ const DevtoolsComponent: DevtoolsComponentType = (props) => {
   })
 
   const colorScheme = getPreferredColorScheme()
+  const locale = createSafeLocale()
 
   const theme = createMemo(() => {
     const preference = (props.theme ||
@@ -26,7 +28,9 @@ const DevtoolsComponent: DevtoolsComponentType = (props) => {
     <QueryDevtoolsContext.Provider value={props}>
       <PiPProvider localStore={localStore} setLocalStore={setLocalStore}>
         <ThemeContext.Provider value={theme}>
-          <Devtools localStore={localStore} setLocalStore={setLocalStore} />
+          <I18nProvider locale={locale()}>
+            <Devtools localStore={localStore} setLocalStore={setLocalStore} />
+          </I18nProvider>
         </ThemeContext.Provider>
       </PiPProvider>
     </QueryDevtoolsContext.Provider>

--- a/packages/query-devtools/src/DevtoolsPanelComponent.tsx
+++ b/packages/query-devtools/src/DevtoolsPanelComponent.tsx
@@ -1,7 +1,8 @@
 import { createLocalStorage } from '@solid-primitives/storage'
+import { I18nProvider } from '@kobalte/core'
 import { createMemo } from 'solid-js'
 import { ContentView, ParentPanel } from './Devtools'
-import { getPreferredColorScheme } from './utils'
+import { createSafeLocale, getPreferredColorScheme } from './utils'
 import { THEME_PREFERENCE } from './constants'
 import { PiPProvider, QueryDevtoolsContext, ThemeContext } from './contexts'
 import type { Theme } from './contexts'
@@ -13,6 +14,7 @@ const DevtoolsPanelComponent: DevtoolsComponentType = (props) => {
   })
 
   const colorScheme = getPreferredColorScheme()
+  const locale = createSafeLocale()
 
   const theme = createMemo(() => {
     const preference = (props.theme ||
@@ -30,14 +32,16 @@ const DevtoolsPanelComponent: DevtoolsComponentType = (props) => {
         setLocalStore={setLocalStore}
       >
         <ThemeContext.Provider value={theme}>
-          <ParentPanel>
-            <ContentView
-              localStore={localStore}
-              setLocalStore={setLocalStore}
-              onClose={props.onClose}
-              showPanelViewOnly
-            />
-          </ParentPanel>
+          <I18nProvider locale={locale()}>
+            <ParentPanel>
+              <ContentView
+                localStore={localStore}
+                setLocalStore={setLocalStore}
+                onClose={props.onClose}
+                showPanelViewOnly
+              />
+            </ParentPanel>
+          </I18nProvider>
         </ThemeContext.Provider>
       </PiPProvider>
     </QueryDevtoolsContext.Provider>

--- a/packages/query-devtools/src/__tests__/locale.test.ts
+++ b/packages/query-devtools/src/__tests__/locale.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { formatDateTime, getPreferredLocale, sanitizeLocale } from '../utils'
+import {
+  formatDateTime,
+  formatTime,
+  getPreferredLocale,
+  sanitizeLocale,
+} from '../utils'
 
 describe('locale utils', () => {
   it('falls back to en-US when navigator.language is an invalid string', () => {
@@ -26,6 +31,15 @@ describe('locale utils', () => {
       value.toLocaleString('en-US'),
     )
     expect(() => formatDateTime(value, 'undefined')).not.toThrow()
+  })
+
+  it('sanitizes invalid locales before formatting times', () => {
+    const value = new Date('2024-01-02T03:04:05.000Z')
+
+    expect(formatTime(value, 'undefined')).toBe(
+      value.toLocaleTimeString('en-US'),
+    )
+    expect(() => formatTime(value, 'undefined')).not.toThrow()
   })
 
   it('falls back for empty locale values', () => {

--- a/packages/query-devtools/src/__tests__/locale.test.ts
+++ b/packages/query-devtools/src/__tests__/locale.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { formatDateTime, getPreferredLocale, sanitizeLocale } from '../utils'
+
+describe('locale utils', () => {
+  it('falls back to en-US when navigator.language is an invalid string', () => {
+    expect(
+      getPreferredLocale({
+        language: 'undefined',
+        userLanguage: 'undefined',
+      }),
+    ).toBe('en-US')
+  })
+
+  it('keeps valid locale tags unchanged', () => {
+    expect(
+      getPreferredLocale({
+        language: 'fr-FR',
+      }),
+    ).toBe('fr-FR')
+  })
+
+  it('sanitizes invalid locales before formatting dates', () => {
+    const value = new Date('2024-01-02T03:04:05.000Z')
+
+    expect(formatDateTime(value, 'undefined')).toBe(
+      value.toLocaleString('en-US'),
+    )
+    expect(() => formatDateTime(value, 'undefined')).not.toThrow()
+  })
+
+  it('falls back for empty locale values', () => {
+    expect(sanitizeLocale('')).toBe('en-US')
+    expect(sanitizeLocale('   ')).toBe('en-US')
+  })
+})

--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -3,6 +3,70 @@ import { createSignal, onCleanup, onMount } from 'solid-js'
 import type { Mutation, Query } from '@tanstack/query-core'
 import type { DevtoolsPosition } from './contexts'
 
+const DEFAULT_LOCALE = 'en-US'
+
+type NavigatorWithUserLanguage = {
+  language?: string
+  userLanguage?: string
+}
+
+export function sanitizeLocale(
+  locale: string | undefined,
+  fallback: string = DEFAULT_LOCALE,
+) {
+  if (typeof locale !== 'string') {
+    return fallback
+  }
+
+  const normalizedLocale = locale.trim()
+
+  if (!normalizedLocale) {
+    return fallback
+  }
+
+  try {
+    return (
+      Intl.DateTimeFormat.supportedLocalesOf([normalizedLocale])[0] || fallback
+    )
+  } catch {
+    return fallback
+  }
+}
+
+export function getPreferredLocale(
+  navigatorValue?: NavigatorWithUserLanguage,
+) {
+  return sanitizeLocale(
+    navigatorValue?.language || navigatorValue?.userLanguage,
+  )
+}
+
+export function createSafeLocale() {
+  const getLocale = () =>
+    getPreferredLocale(
+      typeof navigator === 'undefined'
+        ? undefined
+        : (navigator as NavigatorWithUserLanguage),
+    )
+
+  const [locale, setLocale] = createSignal(getLocale())
+
+  onMount(() => {
+    const updateLocale = () => {
+      setLocale(getLocale())
+    }
+
+    window.addEventListener('languagechange', updateLocale)
+    onCleanup(() => window.removeEventListener('languagechange', updateLocale))
+  })
+
+  return locale
+}
+
+export function formatDateTime(value: string | number | Date, locale?: string) {
+  return new Date(value).toLocaleString(sanitizeLocale(locale))
+}
+
 export function getQueryStatusLabel(query: Query) {
   return query.state.fetchStatus === 'fetching'
     ? 'fetching'

--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -67,6 +67,10 @@ export function formatDateTime(value: string | number | Date, locale?: string) {
   return new Date(value).toLocaleString(sanitizeLocale(locale))
 }
 
+export function formatTime(value: string | number | Date, locale?: string) {
+  return new Date(value).toLocaleTimeString(sanitizeLocale(locale))
+}
+
 export function getQueryStatusLabel(query: Query) {
   return query.state.fetchStatus === 'fetching'
     ? 'fetching'


### PR DESCRIPTION
## What
- sanitize invalid browser locale values before devtools formatting uses them
- wrap the query devtools UI in a Kobalte `I18nProvider` with the sanitized locale and route mutation date formatting through the sanitized locale helpers
- add regression tests for invalid `navigator.language` values like `"undefined"`
- add a patch changeset for `@tanstack/query-devtools`

## Why
- `@tanstack/query-devtools` can currently throw at runtime when the browser reports an invalid locale string, for example `navigator.language === "undefined"`
- the invalid locale can surface through bundled dependency locale resolution as well as devtools' own locale-sensitive date formatting paths

## How tested
- `npx nx run @tanstack/query-devtools:test:eslint`
- `npx nx run @tanstack/query-devtools:test:types`
- `npx nx run @tanstack/query-devtools:test:lib`
- `npx nx run @tanstack/query-devtools:build`
- `npx nx run @tanstack/query-devtools:test:build`
- manual repro against the linked issue reproduction app using Playwright-managed Chromium `145.0.7632.6` and Firefox `146.0.1`; verified the unfixed published packages throw and the patched local packages no longer do

Fixes #10286.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Devtools now uses an i18n-aware locale provider so timestamps display according to the current locale.
  * Date/time displays in mutation and query panels use consistent locale-aware formatting.

* **Bug Fixes**
  * Invalid or unsupported browser locales are sanitized and now safely fall back to English (US).

* **Tests**
  * Added tests covering locale selection, sanitization, and date/time formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->