### PR TITLE
fix(svelte-query): handle multi-item createQueries removals

### DIFF
--- a/.changeset/green-peaches-yawn.md
+++ b/.changeset/green-peaches-yawn.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/svelte-query': patch
+---
+
+Fix `createQueries` when a reactive query list removes multiple items in one update.

--- a/packages/svelte-query/src/containers.svelte.ts
+++ b/packages/svelte-query/src/containers.svelte.ts
@@ -88,7 +88,10 @@ export function createRawRef<T extends {} | Array<unknown>>(
     const existingKeys = Object.keys(out)
     const newKeys = Object.keys(newValue)
     const keysToRemove = existingKeys.filter((key) => !newKeys.includes(key))
-    for (const key of keysToRemove) {
+    const keysToDelete = Array.isArray(out)
+      ? [...keysToRemove].reverse()
+      : keysToRemove
+    for (const key of keysToDelete) {
       // @ts-expect-error
       delete out[key]
     }

--- a/packages/svelte-query/src/containers.svelte.ts
+++ b/packages/svelte-query/src/containers.svelte.ts
@@ -84,6 +84,9 @@ export function createRawRef<T extends {} | Array<unknown>>(
     },
   })
 
+  /**
+   * Replaces the proxy-backed top-level keys in place while preserving the original reference.
+   */
   function update(newValue: T) {
     const existingKeys = Object.keys(out)
     const newKeys = Object.keys(newValue)

--- a/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/svelte'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient, createQueries } from '../../src/index.js'
-import { promiseWithResolvers, withEffectRoot } from '../utils.svelte.js'
+import { promiseWithResolvers, ref, withEffectRoot } from '../utils.svelte.js'
 import IsRestoring from './IsRestoring.svelte'
 import type { CreateQueryResult } from '../../src/index.js'
 
@@ -163,6 +163,32 @@ describe('createQueries', () => {
         combined: true,
         res: 'first result,second result',
       })
+    }),
+  )
+
+  it(
+    'should handle removing multiple queries in a single update',
+    withEffectRoot(async () => {
+      const filters = ref([1, 2, 3, 4])
+
+      const results = createQueries(
+        () => ({
+          queries: filters.value.map((filter) => ({
+            queryKey: ['filter', filter],
+            queryFn: () => filter,
+          })),
+        }),
+        () => queryClient,
+      )
+
+      await vi.waitFor(() =>
+        expect(results.map((result) => result.data)).toEqual([1, 2, 3, 4]),
+      )
+
+      filters.value = filters.value.slice(0, 2)
+
+      await vi.waitFor(() => expect(results).toHaveLength(2))
+      expect(results.map((result) => result.data)).toEqual([1, 2])
     }),
   )
 


### PR DESCRIPTION
## Summary
- delete proxy-backed array result entries from the tail first so `createQueries` can shrink by multiple items in one reactive update
- keep the proxy reference stable while removing array entries in reverse order
- add a regression test for shrinking a reactive query list from four entries to two
- add a patch changeset for `@tanstack/svelte-query`

## Testing
- `corepack pnpm --filter @tanstack/svelte-query exec vitest run tests/createQueries/createQueries.svelte.test.ts`
- `corepack pnpm exec prettier --check .changeset/green-peaches-yawn.md packages/svelte-query/src/containers.svelte.ts packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts`
- `corepack pnpm exec eslint --concurrency=auto -c eslint.config.js packages/svelte-query/src/containers.svelte.ts packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts`
- `git diff --check origin/main...HEAD`

Fixes #10341.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where removing multiple items from a reactive query list in a single update could cause unexpected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->