### PR TITLE
fix(vue-query-devtools): only register cleanup after mount

### DIFF
--- a/.changeset/khaki-coats-divide.md
+++ b/.changeset/khaki-coats-divide.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query-devtools': patch
+---
+
+Fix Vue SSR devtools cleanup by only registering `unmount()` after `mount()` has run.

--- a/packages/vue-query-devtools/src/devtools.vue
+++ b/packages/vue-query-devtools/src/devtools.vue
@@ -33,10 +33,9 @@ watchEffect(() => {
 
 onMounted(() => {
   devtools.mount(div.value as HTMLElement)
-})
-
-onScopeDispose(() => {
-  devtools.unmount()
+  onScopeDispose(() => {
+    devtools.unmount()
+  })
 })
 </script>
 

--- a/packages/vue-query-devtools/src/devtoolsPanel.vue
+++ b/packages/vue-query-devtools/src/devtoolsPanel.vue
@@ -38,10 +38,9 @@ watchEffect(() => {
 
 onMounted(() => {
   devtools.mount(div.value as HTMLElement)
-})
-
-onScopeDispose(() => {
-  devtools.unmount()
+  onScopeDispose(() => {
+    devtools.unmount()
+  })
 })
 </script>
 


### PR DESCRIPTION
  ## 🎯 Changes

  Fix SSR cleanup handling in `@tanstack/vue-query-devtools` by only registering `devtools.unmount()`
  after `devtools.mount()` has actually run.

  Previously, the Vue devtools wrapper registered cleanup in `onScopeDispose()` during setup, while
  `mount()` only happened in `onMounted()`. In Vue SSR, `onMounted()` does not run on the server, but

  This change ensures cleanup is only registered after mount in:
  - `packages/vue-query-devtools/src/devtools.vue`
  - `packages/vue-query-devtools/src/devtoolsPanel.vue`

  A changeset was also added for `@tanstack/vue-query-devtools`.

  Closes #10374

  - [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/
  main/CONTRIBUTING.md).
  - [ ] I have tested this code locally with `pnpm run test:pr`.

  ## 🚀 Release Impact

  - [x] This change affects published code, and I have generated a [changeset](https://github.com/
  changesets/changesets/blob/main/docs/adding-a-changeset.md).
  - [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Vue SSR devtools cleanup where shutdown operations are now properly registered after component mount, resolving lifecycle timing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->