### PR TITLE
test(svelte-query/createQuery): add test for not fetching when 'isRestoring' is true

### DIFF
--- a/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
+++ b/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { QueryClient } from '@tanstack/query-core'
+  import { setIsRestoringContext } from '../../src/context.js'
+  import { createQuery } from '../../src/index.js'
+
+  let {
+    queryFn,
+  }: {
+    queryFn: () => Promise<string>
+  } = $props()
+
+  const queryClient = new QueryClient()
+
+  setIsRestoringContext({ current: true })
+
+  const query = createQuery(
+    () => ({
+      queryKey: ['restoring'],
+      queryFn,
+    }),
+    () => queryClient,
+  )
+</script>
+
+<div>
+  <div data-testid="status">{query.status}</div>
+  <div data-testid="fetchStatus">{query.fetchStatus}</div>
+  <div data-testid="data">{query.data ?? 'undefined'}</div>
+</div>

--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/svelte'
+import { sleep } from '@tanstack/query-test-utils'
+import IsRestoringExample from './IsRestoringExample.svelte'
+
+describe('createQuery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
+    const queryFn = vi.fn(() => sleep(10).then(() => 'data'))
+
+    const rendered = render(IsRestoringExample, {
+      props: { queryFn },
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(rendered.getByTestId('status')).toHaveTextContent('pending')
+    expect(rendered.getByTestId('fetchStatus')).toHaveTextContent('idle')
+    expect(rendered.getByTestId('data')).toHaveTextContent('undefined')
+    expect(queryFn).toHaveBeenCalledTimes(0)
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByTestId('status')).toHaveTextContent('pending')
+    expect(rendered.getByTestId('fetchStatus')).toHaveTextContent('idle')
+    expect(rendered.getByTestId('data')).toHaveTextContent('undefined')
+    expect(queryFn).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

- Add test to verify that `createQuery` does not fetch queries during the restoring period when `isRestoring` is true
- Add `IsRestoringExample.svelte` component that sets `isRestoring` context via `setIsRestoringContext`
- Matches the existing `createQueries` test pattern from #10382

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the isRestoring behavior in query creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->