### PR TITLE
fix(query-devtools): remove experimentalDts to prevent solid-js type leak

### DIFF
--- a/.changeset/fix-solid-js-type-leak.md
+++ b/.changeset/fix-solid-js-type-leak.md
@@ -1,0 +1,9 @@
+---
+"@tanstack/query-devtools": patch
+---
+
+Fix solid-js types leaking into bundled .d.ts file
+
+Remove `experimentalDts: true` and `delete tsup_option.dts` from tsup.config.ts to prevent solid-js internal types from being exposed to React projects. Reverts to rollup-plugin-dts which correctly treats solid-js as external.
+
+Fixes #10421

--- a/packages/query-devtools/tsup.config.ts
+++ b/packages/query-devtools/tsup.config.ts
@@ -16,8 +16,6 @@ export default defineConfig(() => {
 
   tsup_options.forEach((tsup_option) => {
     tsup_option.outDir = 'build'
-    tsup_option.experimentalDts = true
-    delete tsup_option.dts
   })
 
   return tsup_options


### PR DESCRIPTION
Fixes #10421

Remove `experimentalDts: true` from `packages/query-devtools/tsup.config.ts` to prevent internal solid-js types from being exposed in the bundled `.d.ts` file, which causes TypeScript errors in React projects.

---

## Problem

When using `@tanstack/react-query-devtools` (v5.96.2+) in a React project, running `tsc` produces errors for solid-js types:

```
error TS2307: Cannot find module 'solid-js' or its corresponding type declarations.
error TS2307: Cannot find module '@solid-primitives/storage' or its corresponding type declarations.
```

This occurs despite solid-js not being a dependency of React projects.

### Root Cause

PR #10253 ("ref: ts cutoff") introduced `experimentalDts: true` across tsup configurations to improve TypeScript version support (5.4+). However:

1. `experimentalDts: true` uses `@microsoft/api-extractor` for deeper type analysis
2. api-extractor traces JSX type references through `jsxImportSource: "solid-js"` setting
3. The resulting bundled `.d.ts` file includes `import { JSX } from 'solid-js'`
4. React projects don't have solid-js installed → TypeScript error

**Note:** This is not intended as criticism of PR #10253. That PR had valid goals (TypeScript modernization) but didn't account for framework-neutral packages exposing internal implementation details.

---

## Solution

Revert to `rollup-plugin-dts` (the previous `dts: true` approach) by removing the two lines added in PR #10253:

```typescript
// Before
tsup_options.forEach((tsup_option) => {
  tsup_option.outDir = 'build'
  tsup_option.experimentalDts = true   // ← Remove
  delete tsup_option.dts               // ← Remove
})

// After
tsup_options.forEach((tsup_option) => {
  tsup_option.outDir = 'build'
})
```

### Why This Works

- `rollup-plugin-dts` treats external packages (solid-js) as `external` during bundling
- solid-js types are not included in the final `.d.ts` file
- Public API types (TanstackQueryDevtools, DevtoolsButtonPosition, etc.) are preserved
- Reverts to the behavior of v5.91.3 where this issue did not exist

---

## 🎯 Changes

**File Modified:**
- `packages/query-devtools/tsup.config.ts` (2 lines removed)

**File Added:**
- `.changeset/fix-solid-js-type-leak.md` (changeset entry for patch release)

---

## ✅ Testing

**Build Verification:**
```bash
# Build succeeds
pnpm --filter @tanstack/query-devtools build

# Verify solid-js is not in bundled .d.ts
grep "solid-js\|solid-primitives" packages/query-devtools/build/index.d.ts
# → No output (success)

# Verify public API types are present
grep "TanstackQueryDevtools\|DevtoolsButtonPosition\|Theme" packages/query-devtools/build/index.d.ts
# → Types found (success)
```

**React Project Type Check:**
```bash
# React project with @tanstack/react-query-devtools
npx tsc --noEmit
# → No errors (previously showed 6 solid-js errors)
```

**Test Results:**
- ✅ Existing test suite passes (npx nx run @tanstack/query-devtools:test:lib)
- ✅ Build validation passes (pnpm run test:build)
- ✅ Multi-version TypeScript validation passes (test:types:ts54~ts60)

---

## 📝 Changeset

A changeset has been created for automatic version management:

```
Package: @tanstack/query-devtools
Type: patch
Description: Fix solid-js types leaking into bundled .d.ts file
```

---

## 🚀 Release Impact

- **Affected Package:** @tanstack/query-devtools
- **Impact Level:** Patch (bug fix)
- **Breaking Changes:** None
- **Migration Required:** No (fixes broken type checking)
- **Consumers Affected:** All React projects using @tanstack/react-query-devtools (v5.96.2+)

---

## 📚 Related Issues

- **Issue #10421:** Cannot find module 'solid-js' when typechecking with '@tanstack/query-devtools'
- **Related PR #10253:** TypeScript version cutoff (introduced the issue)
- **Related PR #10358:** Fixed vite/tsup type leak (adds confidence that rollup-plugin-dts is safe)

---

## 💬 Additional Context

### Why Not Update query-devtools To Use solid-query-devtools Approach?

`@tanstack/solid-query-devtools` also has `experimentalDts: true` but doesn't have this issue because:
- It's a **SolidJS-specific** package
- Consumers always have solid-js installed
- Exposing solid-js types is expected and correct

`@tanstack/query-devtools` is different:
- **Framework-neutral** implementation (SolidJS internally, but generic public API)
- Used in React, Vue, Svelte, Angular projects
- Internal implementation details must be hidden from consumers

---

## Checklist

- [x] Read and followed CONTRIBUTING.md guidelines
- [x] Tested locally with `pnpm --filter @tanstack/query-devtools build`
- [x] Verified no solid-js references in bundled .d.ts
- [x] Verified public API types are preserved
- [x] Tested React project type checking
- [x] Created changeset with `pnpm changeset`
- [x] Commit follows conventional commit format: `fix(query-devtools): ...`

---

## Author Notes

This is my first contribution to TanStack/query. I've thoroughly verified the fix works in a real React project scenario and doesn't break existing functionality. I'm ready for any requested changes or clarifications during review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript type definitions that were incorrectly including framework-specific types in React consumer packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->