### PR TITLE
test(svelte-query): replace hardcoded query keys with 'queryKey()' in Svelte test components

### DIFF
--- a/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte'
   import { QueryClient } from '@tanstack/query-core'
-  import { sleep } from '@tanstack/query-test-utils'
+  import { queryKey, sleep } from '@tanstack/query-test-utils'
   import { createInfiniteQuery } from '../../src/index.js'
   import type { QueryObserverResult } from '@tanstack/query-core'
 
@@ -11,7 +11,7 @@
 
   const query = createInfiniteQuery(
     () => ({
-      queryKey: ['test'],
+      queryKey: queryKey(),
       queryFn: ({ pageParam }) => sleep(10).then(() => pageParam),
       getNextPageParam: (lastPage) => lastPage + 1,
       initialPageParam: 0,

--- a/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
@@ -3,7 +3,7 @@
   import { QueryClient } from '@tanstack/query-core'
   import { createInfiniteQuery } from '../../src/index.js'
   import type { QueryObserverResult } from '@tanstack/query-core'
-  import { sleep } from '@tanstack/query-test-utils'
+  import { queryKey, sleep } from '@tanstack/query-test-utils'
 
   let { states }: { states: { value: Array<QueryObserverResult> } } = $props()
 
@@ -11,7 +11,7 @@
 
   const query = createInfiniteQuery(
     () => ({
-      queryKey: ['test'],
+      queryKey: queryKey(),
       queryFn: () => sleep(10).then(() => ({ count: 1 })),
       select: (data) => ({
         pages: data.pages.map((x) => `count: ${x.count}`),

--- a/packages/svelte-query/tests/createQueries/IsRestoringExample.svelte
+++ b/packages/svelte-query/tests/createQueries/IsRestoringExample.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { QueryClient } from '@tanstack/query-core'
+  import { queryKey } from '@tanstack/query-test-utils'
   import { setIsRestoringContext } from '../../src/context.js'
   import { createQueries } from '../../src/index.js'
 
@@ -18,8 +19,8 @@
   const result = createQueries(
     () => ({
       queries: [
-        { queryKey: ['restoring-1'], queryFn: queryFn1 },
-        { queryKey: ['restoring-2'], queryFn: queryFn2 },
+        { queryKey: queryKey(), queryFn: queryFn1 },
+        { queryKey: queryKey(), queryFn: queryFn2 },
       ],
     }),
     () => queryClient,

--- a/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
+++ b/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { QueryClient } from '@tanstack/query-core'
+  import { queryKey } from '@tanstack/query-test-utils'
   import { setIsRestoringContext } from '../../src/context.js'
   import { createQuery } from '../../src/index.js'
 
@@ -15,7 +16,7 @@
 
   const query = createQuery(
     () => ({
-      queryKey: ['restoring'],
+      queryKey: queryKey(),
       queryFn,
     }),
     () => queryClient,

--- a/packages/svelte-query/tests/useIsFetching/Query.svelte
+++ b/packages/svelte-query/tests/useIsFetching/Query.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { createQuery } from '../../src/index.js'
-  import { sleep } from '@tanstack/query-test-utils'
+  import { queryKey, sleep } from '@tanstack/query-test-utils'
 
   let ready = $state(false)
 
   const query = createQuery(() => ({
-    queryKey: ['test'],
+    queryKey: queryKey(),
     queryFn: () => sleep(10).then(() => 'test'),
     enabled: ready,
   }))

--- a/packages/svelte-query/tests/useIsMutating/Query.svelte
+++ b/packages/svelte-query/tests/useIsMutating/Query.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { createMutation } from '../../src/index.js'
-  import { sleep } from '@tanstack/query-test-utils'
+  import { queryKey, sleep } from '@tanstack/query-test-utils'
 
   const mutation = createMutation(() => ({
-    mutationKey: ['mutation-1'],
+    mutationKey: queryKey(),
     mutationFn: () => sleep(10).then(() => 'data'),
   }))
 </script>


### PR DESCRIPTION
## 🎯 Changes

- Replace hardcoded query/mutation keys with `queryKey()` utility in Svelte test component files (`.svelte`)
- Applied to `createQueries/IsRestoringExample.svelte`, `createInfiniteQuery/BaseExample.svelte`, `createInfiniteQuery/SelectExample.svelte`, `createQuery/IsRestoringExample.svelte`, `useIsFetching/Query.svelte`, `useIsMutating/Query.svelte`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test query key configurations to use centralized key generation across multiple test examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->