### PR TITLE
test(svelte-query): extract 'queryClient' creation from Svelte components to test files

### DIFF
--- a/packages/svelte-query/tests/HydrationBoundary/BaseExample.svelte
+++ b/packages/svelte-query/tests/HydrationBoundary/BaseExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import {
     HydrationBoundary,
     createQuery,
@@ -8,14 +8,15 @@
   import type { DehydratedState } from '@tanstack/query-core'
 
   let {
+    queryClient,
     dehydratedState,
     queryFn,
   }: {
+    queryClient: QueryClient
     dehydratedState: DehydratedState
     queryFn: () => Promise<string>
   } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const query = createQuery(() => ({

--- a/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
+++ b/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
@@ -5,22 +5,25 @@ import { sleep } from '@tanstack/query-test-utils'
 import BaseExample from './BaseExample.svelte'
 
 describe('HydrationBoundary', () => {
+  let queryClient: QueryClient
   let stringifiedState: string
 
   beforeEach(async () => {
     vi.useFakeTimers()
-    const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
+    queryClient = new QueryClient()
+    const dehydrateClient = new QueryClient()
+    dehydrateClient.prefetchQuery({
       queryKey: ['string'],
       queryFn: () => sleep(10).then(() => 'stringCached'),
     })
     await vi.advanceTimersByTimeAsync(10)
-    const dehydrated = dehydrate(queryClient)
+    const dehydrated = dehydrate(dehydrateClient)
     stringifiedState = JSON.stringify(dehydrated)
-    queryClient.clear()
+    dehydrateClient.clear()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
@@ -29,6 +32,7 @@ describe('HydrationBoundary', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         dehydratedState,
         queryFn: () => sleep(20).then(() => 'string'),
       },

--- a/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
@@ -4,21 +4,24 @@ import { QueryClient } from '@tanstack/query-core'
 import BaseExample from './BaseExample.svelte'
 
 describe('QueryClientProvider', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
   test('Sets a specific cache for all queries to use', async () => {
-    const queryClient = new QueryClient()
     const queryCache = queryClient.getQueryCache()
 
     const rendered = render(BaseExample, {
       props: {
-        queryClient: queryClient,
+        queryClient,
       },
     })
 

--- a/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
@@ -8,7 +8,10 @@
   let {
     queryClient,
     states,
-  }: { queryClient: QueryClient; states: { value: Array<QueryObserverResult> } } = $props()
+  }: {
+    queryClient: QueryClient
+    states: { value: Array<QueryObserverResult> }
+  } = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import { untrack } from 'svelte'
-  import { QueryClient } from '@tanstack/query-core'
   import { queryKey, sleep } from '@tanstack/query-test-utils'
   import { createInfiniteQuery } from '../../src/index.js'
   import { setQueryClientContext } from '../../src/context.js'
-  import type { QueryObserverResult } from '@tanstack/query-core'
+  import type { QueryClient, QueryObserverResult } from '@tanstack/query-core'
 
-  let { states }: { states: { value: Array<QueryObserverResult> } } = $props()
+  let {
+    queryClient,
+    states,
+  }: { queryClient: QueryClient; states: { value: Array<QueryObserverResult> } } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const query = createInfiniteQuery(() => ({

--- a/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
@@ -8,7 +8,10 @@
   let {
     queryClient,
     states,
-  }: { queryClient: QueryClient; states: { value: Array<QueryObserverResult> } } = $props()
+  }: {
+    queryClient: QueryClient
+    states: { value: Array<QueryObserverResult> }
+  } = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import { untrack } from 'svelte'
-  import { QueryClient } from '@tanstack/query-core'
   import { createInfiniteQuery } from '../../src/index.js'
   import { setQueryClientContext } from '../../src/context.js'
-  import type { QueryObserverResult } from '@tanstack/query-core'
+  import type { QueryClient, QueryObserverResult } from '@tanstack/query-core'
   import { queryKey, sleep } from '@tanstack/query-test-utils'
 
-  let { states }: { states: { value: Array<QueryObserverResult> } } = $props()
+  let {
+    queryClient,
+    states,
+  }: { queryClient: QueryClient; states: { value: Array<QueryObserverResult> } } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const query = createInfiniteQuery(() => ({

--- a/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.svelte.test.ts
@@ -8,11 +8,15 @@ import ChangeClientExample from './ChangeClientExample.svelte'
 import type { QueryObserverResult } from '@tanstack/query-core'
 
 describe('createInfiniteQuery', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
@@ -21,6 +25,7 @@ describe('createInfiniteQuery', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         states,
       },
     })
@@ -110,6 +115,7 @@ describe('createInfiniteQuery', () => {
 
     const rendered = render(SelectExample, {
       props: {
+        queryClient,
         states,
       },
     })
@@ -131,8 +137,6 @@ describe('createInfiniteQuery', () => {
   })
 
   it('should be able to set new pages with the query client', async () => {
-    const queryClient = new QueryClient()
-
     const rendered = render(ChangeClientExample, {
       props: {
         queryClient,

--- a/packages/svelte-query/tests/createMutation/FailureExample.svelte
+++ b/packages/svelte-query/tests/createMutation/FailureExample.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import { createMutation, setQueryClientContext } from '../../src/index.js'
 
   let {
+    queryClient,
     mutationFn,
-  }: { mutationFn: (value: { count: number }) => Promise<{ count: number }> } =
-    $props()
+  }: {
+    queryClient: QueryClient
+    mutationFn: (value: { count: number }) => Promise<{ count: number }>
+  } = $props()
 
   let count = $state(0)
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const mutation = createMutation(() => ({ mutationFn }))

--- a/packages/svelte-query/tests/createMutation/OnSuccessExample.svelte
+++ b/packages/svelte-query/tests/createMutation/OnSuccessExample.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import { createMutation, setQueryClientContext } from '../../src/index.js'
   import { sleep } from '@tanstack/query-test-utils'
 
   type Props = {
+    queryClient: QueryClient
     onSuccessMock: any
     onSettledMock: any
   }
 
-  const { onSettledMock, onSuccessMock }: Props = $props()
+  const { queryClient, onSettledMock, onSuccessMock }: Props = $props()
 
   let count = $state(0)
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const mutation = createMutation(() => ({

--- a/packages/svelte-query/tests/createMutation/ResetExample.svelte
+++ b/packages/svelte-query/tests/createMutation/ResetExample.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import { createMutation, setQueryClientContext } from '../../src/index.js'
   import { sleep } from '@tanstack/query-test-utils'
 
-  const queryClient = new QueryClient()
+  let { queryClient }: { queryClient: QueryClient } = $props()
+
   setQueryClientContext(queryClient)
 
   const mutation = createMutation(() => ({

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -111,10 +111,10 @@ describe('createMutation', () => {
   test(
     'should recreate observer when queryClient changes',
     withEffectRoot(async () => {
-      const client1 = new QueryClient()
-      const client2 = new QueryClient()
+      const queryClient1 = new QueryClient()
+      const queryClient2 = new QueryClient()
 
-      let activeClient = $state(client1)
+      let activeClient = $state(queryClient1)
 
       const mutation = createMutation(
         () => ({
@@ -129,7 +129,7 @@ describe('createMutation', () => {
       expect(mutation.status).toBe('success')
       expect(mutation.data).toBe('first')
 
-      activeClient = client2
+      activeClient = queryClient2
       flushSync()
 
       expect(mutation.status).toBe('idle')

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -10,16 +10,22 @@ import OnSuccessExample from './OnSuccessExample.svelte'
 import FailureExample from './FailureExample.svelte'
 
 describe('createMutation', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
   test('Able to reset `error`', async () => {
-    const rendered = render(ResetExample)
+    const rendered = render(ResetExample, {
+      props: { queryClient },
+    })
 
     expect(rendered.queryByText('Error: undefined')).toBeInTheDocument()
 
@@ -38,6 +44,7 @@ describe('createMutation', () => {
 
     const rendered = render(OnSuccessExample, {
       props: {
+        queryClient,
         onSuccessMock,
         onSettledMock,
       },
@@ -75,6 +82,7 @@ describe('createMutation', () => {
 
     const rendered = render(FailureExample, {
       props: {
+        queryClient,
         mutationFn,
       },
     })
@@ -103,16 +111,16 @@ describe('createMutation', () => {
   test(
     'should recreate observer when queryClient changes',
     withEffectRoot(async () => {
-      const queryClient1 = new QueryClient()
-      const queryClient2 = new QueryClient()
+      const client1 = new QueryClient()
+      const client2 = new QueryClient()
 
-      let queryClient = $state(queryClient1)
+      let activeClient = $state(client1)
 
       const mutation = createMutation(
         () => ({
           mutationFn: (params: string) => sleep(10).then(() => params),
         }),
-        () => queryClient,
+        () => activeClient,
       )
 
       mutation.mutate('first')
@@ -121,7 +129,7 @@ describe('createMutation', () => {
       expect(mutation.status).toBe('success')
       expect(mutation.data).toBe('first')
 
-      queryClient = queryClient2
+      activeClient = client2
       flushSync()
 
       expect(mutation.status).toBe('idle')

--- a/packages/svelte-query/tests/createQueries/IsRestoringExample.svelte
+++ b/packages/svelte-query/tests/createQueries/IsRestoringExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import { queryKey } from '@tanstack/query-test-utils'
   import {
     setIsRestoringContext,
@@ -8,14 +8,15 @@
   import { createQueries } from '../../src/index.js'
 
   let {
+    queryClient,
     queryFn1,
     queryFn2,
   }: {
+    queryClient: QueryClient
     queryFn1: () => Promise<string>
     queryFn2: () => Promise<string>
   } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
   setIsRestoringContext({ current: true })
 

--- a/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
@@ -274,7 +274,7 @@ describe('createQueries', () => {
     const queryFn2 = vi.fn(() => sleep(10).then(() => 'data2'))
 
     const rendered = render(IsRestoringExample, {
-      props: { queryFn1, queryFn2 },
+      props: { queryClient, queryFn1, queryFn2 },
     })
 
     await vi.advanceTimersByTimeAsync(0)
@@ -305,7 +305,7 @@ describe('createQueries', () => {
     const queryFn2 = vi.fn(() => sleep(20).then(() => 'data2'))
 
     const rendered = render(IsRestoringExample, {
-      props: { queryFn1, queryFn2 },
+      props: { queryClient, queryFn1, queryFn2 },
     })
 
     await vi.advanceTimersByTimeAsync(0)

--- a/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
+++ b/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import { queryKey } from '@tanstack/query-test-utils'
   import {
     setIsRestoringContext,
@@ -8,12 +8,13 @@
   import { createQuery } from '../../src/index.js'
 
   let {
+    queryClient,
     queryFn,
   }: {
+    queryClient: QueryClient
     queryFn: () => Promise<string>
   } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
   setIsRestoringContext({ current: true })
 

--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -1924,7 +1924,7 @@ describe('createQuery', () => {
     const queryFn = vi.fn(() => sleep(10).then(() => 'data'))
 
     const rendered = render(IsRestoringExample, {
-      props: { queryFn },
+      props: { queryClient, queryFn },
     })
 
     await vi.advanceTimersByTimeAsync(0)

--- a/packages/svelte-query/tests/mutationOptions/BaseExample.svelte
+++ b/packages/svelte-query/tests/mutationOptions/BaseExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import {
     createMutation,
     setQueryClientContext,
@@ -14,16 +14,17 @@
   import type { MutationFilters } from '@tanstack/query-core'
 
   let {
+    queryClient,
     mutationOpts,
     isMutatingFilters,
     mutationStateOpts,
   }: {
+    queryClient: QueryClient
     mutationOpts: Accessor<CreateMutationOptions<string, Error, void, unknown>>
     isMutatingFilters?: MutationFilters
     mutationStateOpts?: MutationStateOptions
   } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const mutation = createMutation(mutationOpts)

--- a/packages/svelte-query/tests/mutationOptions/MultiExample.svelte
+++ b/packages/svelte-query/tests/mutationOptions/MultiExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import {
     createMutation,
     setQueryClientContext,
@@ -14,18 +14,19 @@
   import type { MutationFilters } from '@tanstack/query-core'
 
   let {
+    queryClient,
     mutationOpts1,
     mutationOpts2,
     isMutatingFilters,
     mutationStateOpts,
   }: {
+    queryClient: QueryClient
     mutationOpts1: Accessor<CreateMutationOptions<string, Error, void, unknown>>
     mutationOpts2: Accessor<CreateMutationOptions<string, Error, void, unknown>>
     isMutatingFilters?: MutationFilters
     mutationStateOpts?: MutationStateOptions
   } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const mutation1 = createMutation(mutationOpts1)

--- a/packages/svelte-query/tests/mutationOptions/mutationOptions.svelte.test.ts
+++ b/packages/svelte-query/tests/mutationOptions/mutationOptions.svelte.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
+import { QueryClient } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { mutationOptions } from '../../src/index.js'
 import BaseExample from './BaseExample.svelte'
 import MultiExample from './MultiExample.svelte'
 
 describe('mutationOptions', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
@@ -39,7 +44,7 @@ describe('mutationOptions', () => {
     })
 
     const rendered = render(BaseExample, {
-      props: { mutationOpts: () => mutationOpts },
+      props: { queryClient, mutationOpts: () => mutationOpts },
     })
 
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
@@ -57,7 +62,7 @@ describe('mutationOptions', () => {
     })
 
     const rendered = render(BaseExample, {
-      props: { mutationOpts: () => mutationOpts },
+      props: { queryClient, mutationOpts: () => mutationOpts },
     })
 
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
@@ -81,6 +86,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(MultiExample, {
       props: {
+        queryClient,
         mutationOpts1: () => mutationOpts1,
         mutationOpts2: () => mutationOpts2,
       },
@@ -108,6 +114,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(MultiExample, {
       props: {
+        queryClient,
         mutationOpts1: () => mutationOpts1,
         mutationOpts2: () => mutationOpts2,
         isMutatingFilters: { mutationKey: mutationOpts1.mutationKey },
@@ -133,6 +140,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         mutationOpts: () => mutationOpts,
         isMutatingFilters: { mutationKey: mutationOpts.mutationKey },
       },
@@ -153,7 +161,7 @@ describe('mutationOptions', () => {
     })
 
     const rendered = render(BaseExample, {
-      props: { mutationOpts: () => mutationOpts },
+      props: { queryClient, mutationOpts: () => mutationOpts },
     })
 
     expect(rendered.getByText('clientIsMutating: 0')).toBeInTheDocument()
@@ -177,6 +185,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(MultiExample, {
       props: {
+        queryClient,
         mutationOpts1: () => mutationOpts1,
         mutationOpts2: () => mutationOpts2,
       },
@@ -204,6 +213,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(MultiExample, {
       props: {
+        queryClient,
         mutationOpts1: () => mutationOpts1,
         mutationOpts2: () => mutationOpts2,
         isMutatingFilters: { mutationKey: mutationOpts1.mutationKey },
@@ -229,6 +239,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         mutationOpts: () => mutationOpts,
         mutationStateOpts: {
           filters: {
@@ -253,6 +264,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         mutationOpts: () => mutationOpts,
         mutationStateOpts: {
           filters: { status: 'success' },
@@ -279,6 +291,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(MultiExample, {
       props: {
+        queryClient,
         mutationOpts1: () => mutationOpts1,
         mutationOpts2: () => mutationOpts2,
         mutationStateOpts: {
@@ -309,6 +322,7 @@ describe('mutationOptions', () => {
 
     const rendered = render(MultiExample, {
       props: {
+        queryClient,
         mutationOpts1: () => mutationOpts1,
         mutationOpts2: () => mutationOpts2,
         mutationStateOpts: {

--- a/packages/svelte-query/tests/useIsFetching/BaseExample.svelte
+++ b/packages/svelte-query/tests/useIsFetching/BaseExample.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import { queryKey, sleep } from '@tanstack/query-test-utils'
   import { setQueryClientContext } from '../../src/context.js'
   import { createQuery, useIsFetching } from '../../src/index.js'
 
-  const queryClient = new QueryClient()
+  let { queryClient }: { queryClient: QueryClient } = $props()
+
   setQueryClientContext(queryClient)
 
   let ready = $state(false)

--- a/packages/svelte-query/tests/useIsFetching/useIsFetching.svelte.test.ts
+++ b/packages/svelte-query/tests/useIsFetching/useIsFetching.svelte.test.ts
@@ -1,18 +1,25 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
+import { QueryClient } from '@tanstack/query-core'
 import BaseExample from './BaseExample.svelte'
 
 describe('useIsFetching', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
   test('should update as queries start and stop fetching', async () => {
-    const rendered = render(BaseExample)
+    const rendered = render(BaseExample, {
+      props: { queryClient },
+    })
 
     expect(rendered.getByText('isFetching: 0')).toBeInTheDocument()
 

--- a/packages/svelte-query/tests/useIsMutating/BaseExample.svelte
+++ b/packages/svelte-query/tests/useIsMutating/BaseExample.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import { queryKey, sleep } from '@tanstack/query-test-utils'
   import { setQueryClientContext } from '../../src/context.js'
   import { createMutation, useIsMutating } from '../../src/index.js'
 
-  const queryClient = new QueryClient()
+  let { queryClient }: { queryClient: QueryClient } = $props()
+
   setQueryClientContext(queryClient)
 
   const mutation = createMutation(() => ({

--- a/packages/svelte-query/tests/useIsMutating/useIsMutating.svelte.test.ts
+++ b/packages/svelte-query/tests/useIsMutating/useIsMutating.svelte.test.ts
@@ -1,18 +1,25 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
+import { QueryClient } from '@tanstack/query-core'
 import BaseExample from './BaseExample.svelte'
 
 describe('useIsMutating', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
   test('should update as queries start and stop mutating', async () => {
-    const rendered = render(BaseExample)
+    const rendered = render(BaseExample, {
+      props: { queryClient },
+    })
 
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
 

--- a/packages/svelte-query/tests/useMutationState/BaseExample.svelte
+++ b/packages/svelte-query/tests/useMutationState/BaseExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import {
     createMutation,
     setQueryClientContext,
@@ -12,16 +12,17 @@
   } from '../../src/index.js'
 
   let {
+    queryClient,
     successMutationOpts,
     errorMutationOpts,
     mutationStateOpts,
   }: {
+    queryClient: QueryClient
     successMutationOpts: Accessor<CreateMutationOptions>
     errorMutationOpts: Accessor<CreateMutationOptions>
     mutationStateOpts?: MutationStateOptions | undefined
   } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const successMutation = createMutation(successMutationOpts)

--- a/packages/svelte-query/tests/useMutationState/SelectExample.svelte
+++ b/packages/svelte-query/tests/useMutationState/SelectExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { QueryClient } from '@tanstack/query-core'
+  import type { QueryClient } from '@tanstack/query-core'
   import {
     createMutation,
     setQueryClientContext,
@@ -12,14 +12,15 @@
   } from '../../src/index.js'
 
   let {
+    queryClient,
     mutationOpts,
     mutationStateOpts,
   }: {
+    queryClient: QueryClient
     mutationOpts: Accessor<CreateMutationOptions>
     mutationStateOpts: MutationStateOptions<any>
   } = $props()
 
-  const queryClient = new QueryClient()
   setQueryClientContext(queryClient)
 
   const mutation = createMutation(mutationOpts)

--- a/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
+++ b/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
+import { QueryClient } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import BaseExample from './BaseExample.svelte'
 import SelectExample from './SelectExample.svelte'
 import type { Mutation } from '@tanstack/query-core'
 
 describe('useMutationState', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    queryClient.clear()
     vi.useRealTimers()
   })
 
@@ -26,6 +31,7 @@ describe('useMutationState', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         successMutationOpts: () => ({
           mutationKey: successKey,
           mutationFn: successMutationFn,
@@ -60,6 +66,7 @@ describe('useMutationState', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         successMutationOpts: () => ({
           mutationKey: successKey,
           mutationFn: successMutationFn,
@@ -90,6 +97,7 @@ describe('useMutationState', () => {
 
     const rendered = render(SelectExample, {
       props: {
+        queryClient,
         mutationOpts: () => ({
           mutationKey,
           mutationFn: () => sleep(10).then(() => 'data'),
@@ -123,6 +131,7 @@ describe('useMutationState', () => {
 
     const rendered = render(BaseExample, {
       props: {
+        queryClient,
         successMutationOpts: () => ({
           mutationKey: successKey,
           mutationFn: successMutationFn,


### PR DESCRIPTION
## 🎯 Changes

- Extract `queryClient` creation from 14 Svelte test components to test files
  - Components now receive `queryClient` via `$props()` and call `setQueryClientContext(queryClient)`
  - Test files create `queryClient` in `beforeEach` and call `queryClient.clear()` in `afterEach`
- Unify `queryClient` lifecycle management across all svelte-query test files (`QueryClientProvider`, `createInfiniteQuery`, `createMutation`, `createQuery`, `createQueries`, `useIsFetching`, `useIsMutating`, `useMutationState`, `mutationOptions`, `HydrationBoundary`)
- Rename `let queryClient` to `let activeClient` in `createMutation` `withEffectRoot` test to avoid shadowing

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test component architecture by externalizing QueryClient lifecycle management, enabling better test isolation and reusability across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->