### PR TITLE
test(svelte-query): replace inline props types with 'type Props', remove 'any', and add explicit generics

### DIFF
--- a/packages/svelte-query/tests/HydrationBoundary/BaseExample.svelte
+++ b/packages/svelte-query/tests/HydrationBoundary/BaseExample.svelte
@@ -7,15 +7,13 @@
   } from '../../src/index.js'
   import type { DehydratedState } from '@tanstack/query-core'
 
-  let {
-    queryClient,
-    dehydratedState,
-    queryFn,
-  }: {
+  type Props = {
     queryClient: QueryClient
     dehydratedState: DehydratedState
     queryFn: () => Promise<string>
-  } = $props()
+  }
+
+  let { queryClient, dehydratedState, queryFn }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/QueryClientProvider/BaseExample.svelte
+++ b/packages/svelte-query/tests/QueryClientProvider/BaseExample.svelte
@@ -3,7 +3,11 @@
   import QueryChild from './QueryChild.svelte'
   import type { QueryClient } from '@tanstack/query-core'
 
-  let { queryClient }: { queryClient: QueryClient } = $props()
+  type Props = {
+    queryClient: QueryClient
+  }
+
+  let { queryClient }: Props = $props()
 </script>
 
 <QueryClientProvider client={queryClient}>

--- a/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
@@ -5,13 +5,12 @@
   import { setQueryClientContext } from '../../src/context.js'
   import type { QueryClient, QueryObserverResult } from '@tanstack/query-core'
 
-  let {
-    queryClient,
-    states,
-  }: {
+  type Props = {
     queryClient: QueryClient
     states: { value: Array<QueryObserverResult> }
-  } = $props()
+  }
+
+  let { queryClient, states }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/createInfiniteQuery/ChangeClientExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/ChangeClientExample.svelte
@@ -4,7 +4,11 @@
   import { setQueryClientContext } from '../../src/context.js'
   import { sleep } from '@tanstack/query-test-utils'
 
-  let { queryClient }: { queryClient: QueryClient } = $props()
+  type Props = {
+    queryClient: QueryClient
+  }
+
+  let { queryClient }: Props = $props()
 
   const queryKey = ['test']
 

--- a/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
@@ -5,13 +5,12 @@
   import type { QueryClient, QueryObserverResult } from '@tanstack/query-core'
   import { queryKey, sleep } from '@tanstack/query-test-utils'
 
-  let {
-    queryClient,
-    states,
-  }: {
+  type Props = {
     queryClient: QueryClient
     states: { value: Array<QueryObserverResult> }
-  } = $props()
+  }
+
+  let { queryClient, states }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/createMutation/FailureExample.svelte
+++ b/packages/svelte-query/tests/createMutation/FailureExample.svelte
@@ -2,13 +2,12 @@
   import type { QueryClient } from '@tanstack/query-core'
   import { createMutation, setQueryClientContext } from '../../src/index.js'
 
-  let {
-    queryClient,
-    mutationFn,
-  }: {
+  type Props = {
     queryClient: QueryClient
     mutationFn: (value: { count: number }) => Promise<{ count: number }>
-  } = $props()
+  }
+
+  let { queryClient, mutationFn }: Props = $props()
 
   let count = $state(0)
 

--- a/packages/svelte-query/tests/createMutation/OnSuccessExample.svelte
+++ b/packages/svelte-query/tests/createMutation/OnSuccessExample.svelte
@@ -5,8 +5,8 @@
 
   type Props = {
     queryClient: QueryClient
-    onSuccessMock: any
-    onSettledMock: any
+    onSuccessMock: (data: number) => void
+    onSettledMock: (data: number | undefined) => void
   }
 
   const { queryClient, onSettledMock, onSuccessMock }: Props = $props()

--- a/packages/svelte-query/tests/createMutation/ResetExample.svelte
+++ b/packages/svelte-query/tests/createMutation/ResetExample.svelte
@@ -3,7 +3,11 @@
   import { createMutation, setQueryClientContext } from '../../src/index.js'
   import { sleep } from '@tanstack/query-test-utils'
 
-  let { queryClient }: { queryClient: QueryClient } = $props()
+  type Props = {
+    queryClient: QueryClient
+  }
+
+  let { queryClient }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/createQueries/IsRestoringExample.svelte
+++ b/packages/svelte-query/tests/createQueries/IsRestoringExample.svelte
@@ -7,15 +7,13 @@
   } from '../../src/context.js'
   import { createQueries } from '../../src/index.js'
 
-  let {
-    queryClient,
-    queryFn1,
-    queryFn2,
-  }: {
+  type Props = {
     queryClient: QueryClient
     queryFn1: () => Promise<string>
     queryFn2: () => Promise<string>
-  } = $props()
+  }
+
+  let { queryClient, queryFn1, queryFn2 }: Props = $props()
 
   setQueryClientContext(queryClient)
   setIsRestoringContext({ current: true })

--- a/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
+++ b/packages/svelte-query/tests/createQuery/IsRestoringExample.svelte
@@ -7,13 +7,12 @@
   } from '../../src/context.js'
   import { createQuery } from '../../src/index.js'
 
-  let {
-    queryClient,
-    queryFn,
-  }: {
+  type Props = {
     queryClient: QueryClient
     queryFn: () => Promise<string>
-  } = $props()
+  }
+
+  let { queryClient, queryFn }: Props = $props()
 
   setQueryClientContext(queryClient)
   setIsRestoringContext({ current: true })

--- a/packages/svelte-query/tests/mutationOptions/BaseExample.svelte
+++ b/packages/svelte-query/tests/mutationOptions/BaseExample.svelte
@@ -13,17 +13,19 @@
   } from '../../src/index.js'
   import type { MutationFilters } from '@tanstack/query-core'
 
+  type Props = {
+    queryClient: QueryClient
+    mutationOpts: Accessor<CreateMutationOptions<string>>
+    isMutatingFilters?: MutationFilters
+    mutationStateOpts?: MutationStateOptions
+  }
+
   let {
     queryClient,
     mutationOpts,
     isMutatingFilters,
     mutationStateOpts,
-  }: {
-    queryClient: QueryClient
-    mutationOpts: Accessor<CreateMutationOptions<string, Error, void, unknown>>
-    isMutatingFilters?: MutationFilters
-    mutationStateOpts?: MutationStateOptions
-  } = $props()
+  }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/mutationOptions/MultiExample.svelte
+++ b/packages/svelte-query/tests/mutationOptions/MultiExample.svelte
@@ -13,19 +13,21 @@
   } from '../../src/index.js'
   import type { MutationFilters } from '@tanstack/query-core'
 
+  type Props = {
+    queryClient: QueryClient
+    mutationOpts1: Accessor<CreateMutationOptions<string>>
+    mutationOpts2: Accessor<CreateMutationOptions<string>>
+    isMutatingFilters?: MutationFilters
+    mutationStateOpts?: MutationStateOptions
+  }
+
   let {
     queryClient,
     mutationOpts1,
     mutationOpts2,
     isMutatingFilters,
     mutationStateOpts,
-  }: {
-    queryClient: QueryClient
-    mutationOpts1: Accessor<CreateMutationOptions<string, Error, void, unknown>>
-    mutationOpts2: Accessor<CreateMutationOptions<string, Error, void, unknown>>
-    isMutatingFilters?: MutationFilters
-    mutationStateOpts?: MutationStateOptions
-  } = $props()
+  }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/useIsFetching/BaseExample.svelte
+++ b/packages/svelte-query/tests/useIsFetching/BaseExample.svelte
@@ -4,7 +4,11 @@
   import { setQueryClientContext } from '../../src/context.js'
   import { createQuery, useIsFetching } from '../../src/index.js'
 
-  let { queryClient }: { queryClient: QueryClient } = $props()
+  type Props = {
+    queryClient: QueryClient
+  }
+
+  let { queryClient }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/useIsMutating/BaseExample.svelte
+++ b/packages/svelte-query/tests/useIsMutating/BaseExample.svelte
@@ -4,7 +4,11 @@
   import { setQueryClientContext } from '../../src/context.js'
   import { createMutation, useIsMutating } from '../../src/index.js'
 
-  let { queryClient }: { queryClient: QueryClient } = $props()
+  type Props = {
+    queryClient: QueryClient
+  }
+
+  let { queryClient }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/useMutationState/BaseExample.svelte
+++ b/packages/svelte-query/tests/useMutationState/BaseExample.svelte
@@ -11,17 +11,19 @@
     MutationStateOptions,
   } from '../../src/index.js'
 
+  type Props = {
+    queryClient: QueryClient
+    successMutationOpts: Accessor<CreateMutationOptions<string>>
+    errorMutationOpts: Accessor<CreateMutationOptions<string>>
+    mutationStateOpts?: MutationStateOptions
+  }
+
   let {
     queryClient,
     successMutationOpts,
     errorMutationOpts,
     mutationStateOpts,
-  }: {
-    queryClient: QueryClient
-    successMutationOpts: Accessor<CreateMutationOptions>
-    errorMutationOpts: Accessor<CreateMutationOptions>
-    mutationStateOpts?: MutationStateOptions | undefined
-  } = $props()
+  }: Props = $props()
 
   setQueryClientContext(queryClient)
 

--- a/packages/svelte-query/tests/useMutationState/SelectExample.svelte
+++ b/packages/svelte-query/tests/useMutationState/SelectExample.svelte
@@ -11,15 +11,13 @@
     MutationStateOptions,
   } from '../../src/index.js'
 
-  let {
-    queryClient,
-    mutationOpts,
-    mutationStateOpts,
-  }: {
+  type Props = {
     queryClient: QueryClient
-    mutationOpts: Accessor<CreateMutationOptions>
-    mutationStateOpts: MutationStateOptions<any>
-  } = $props()
+    mutationOpts: Accessor<CreateMutationOptions<string>>
+    mutationStateOpts: MutationStateOptions<string>
+  }
+
+  let { queryClient, mutationOpts, mutationStateOpts }: Props = $props()
 
   setQueryClientContext(queryClient)
 


### PR DESCRIPTION
## 🎯 Changes

- Replace inline props types with `type Props` across 16 Svelte test components
- Remove `any` types:
  - `OnSuccessExample`: `onSuccessMock: any` → `(data: number) => void`, `onSettledMock: any` → `(data: number | undefined) => void`
  - `useMutationState/SelectExample`: `MutationStateOptions<any>` → `MutationStateOptions<string>`
- Add explicit generics to `CreateMutationOptions`:
  - `mutationOptions/BaseExample`, `MultiExample`: `CreateMutationOptions` → `CreateMutationOptions<string>`
  - `useMutationState/BaseExample`, `SelectExample`: `CreateMutationOptions` → `CreateMutationOptions<string>`
- Remove unnecessary `| undefined` from optional prop type in `useMutationState/BaseExample`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized and consolidated internal component type definitions across the test suite for improved code clarity and better maintainability.
  * Refined and enhanced type specifications for mutation and query operations in test examples, providing clearer and more accurate type information.
  * Updated generic type parameters in options objects to improve type safety and precision in test component implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->