### PR TITLE
test(svelte-query/createInfiniteQuery): remove unused 'svelte-ignore state_snapshot_uncloneable' comments

### DIFF
--- a/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/BaseExample.svelte
@@ -23,7 +23,6 @@
 
   $effect(() => {
     // @ts-expect-error
-    // svelte-ignore state_snapshot_uncloneable
     states.value = [...untrack(() => states.value), $state.snapshot(query)]
   })
 </script>

--- a/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
+++ b/packages/svelte-query/tests/createInfiniteQuery/SelectExample.svelte
@@ -27,7 +27,6 @@
 
   $effect(() => {
     // @ts-expect-error
-    // svelte-ignore state_snapshot_uncloneable
     states.value = [...untrack(() => states.value), $state.snapshot(query)]
   })
 </script>


### PR DESCRIPTION
## 🎯 Changes

- Remove unused `// svelte-ignore state_snapshot_uncloneable` comments from `BaseExample.svelte` and `SelectExample.svelte`
  - The warning is no longer triggered, making the svelte-ignore comment unnecessary
  - `// @ts-expect-error` is retained as the `Snapshot` type mismatch with `QueryObserverResult` is a known Svelte limitation

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed internal compiler directives from test files to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->