### PR TITLE
test(svelte-query): add 'assertType' and 'expectTypeOf' to type tests with no assertions

### DIFF
--- a/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
+++ b/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, test } from 'vitest'
+import { assertType, describe, expectTypeOf, test } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { createInfiniteQuery, infiniteQueryOptions } from '../src/index.js'
@@ -7,14 +7,16 @@ import type { InfiniteData } from '@tanstack/query-core'
 describe('infiniteQueryOptions', () => {
   test('Should not allow excess properties', () => {
     const key = queryKey()
-    infiniteQueryOptions({
-      queryKey: key,
-      queryFn: () => Promise.resolve('data'),
-      getNextPageParam: () => 1,
-      initialPageParam: 1,
-      // @ts-expect-error this is a good error, because stallTime does not exist!
-      stallTime: 1000,
-    })
+    assertType(
+      infiniteQueryOptions({
+        queryKey: key,
+        queryFn: () => Promise.resolve('data'),
+        getNextPageParam: () => 1,
+        initialPageParam: 1,
+        // @ts-expect-error this is a good error, because stallTime does not exist!
+        stallTime: 1000,
+      }),
+    )
   })
 
   test('Should infer types for callbacks', () => {

--- a/packages/svelte-query/tests/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, test } from 'vitest'
+import { assertType, describe, expectTypeOf, test } from 'vitest'
 import {
   QueriesObserver,
   QueryClient,
@@ -12,12 +12,14 @@ import type { QueryObserverResult } from '@tanstack/query-core'
 describe('queryOptions', () => {
   test('Should not allow excess properties', () => {
     const key = queryKey()
-    queryOptions({
-      queryKey: key,
-      queryFn: () => Promise.resolve(5),
-      // @ts-expect-error this is a good error, because stallTime does not exist!
-      stallTime: 1000,
-    })
+    assertType(
+      queryOptions({
+        queryKey: key,
+        queryFn: () => Promise.resolve(5),
+        // @ts-expect-error this is a good error, because stallTime does not exist!
+        stallTime: 1000,
+      }),
+    )
   })
 
   test('Should infer types for callbacks', () => {
@@ -193,7 +195,7 @@ describe('queryOptions', () => {
   })
 
   test('Should allow undefined response in initialData', () => {
-    return (id: string | null) =>
+    assertType((id: string | null) =>
       queryOptions({
         queryKey: ['todo', id],
         queryFn: () =>
@@ -208,6 +210,7 @@ describe('queryOptions', () => {
                 id,
                 title: 'Initial Data',
               },
-      })
+      }),
+    )
   })
 })

--- a/packages/svelte-query/tests/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions.test-d.ts
@@ -195,9 +195,10 @@ describe('queryOptions', () => {
   })
 
   test('Should allow undefined response in initialData', () => {
-    assertType((id: string | null) =>
+    const key = queryKey()
+    const options = (id: string | null) =>
       queryOptions({
-        queryKey: ['todo', id],
+        queryKey: [...key, id],
         queryFn: () =>
           Promise.resolve({
             id: '1',
@@ -210,7 +211,10 @@ describe('queryOptions', () => {
                 id,
                 title: 'Initial Data',
               },
-      }),
-    )
+      })
+
+    expectTypeOf(options(null).initialData).returns.toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add `assertType` to 2 type tests to make type validation explicitly expressed as test assertions:
  - `infiniteQueryOptions.test-d.ts`: "Should not allow excess properties"
  - `queryOptions.test-d.ts`: "Should not allow excess properties"
- Replace `assertType` with `expectTypeOf` for `initialData` type validation in `queryOptions.test-d.ts`:
  - "Should allow undefined response in initialData": validates `initialData` return type is `{ id: string; title: string } | undefined`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened type-level assertions in the test suite for query option behaviors by adopting explicit assertion checks.
  * Added an explicit assertion for the resolved initial-data type to prevent regressions.
  * No changes to public APIs or runtime behavior; purely test improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->