### PR TITLE
test(svelte-query): unify all test descriptions with 'should'

### DIFF
--- a/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
@@ -16,7 +16,7 @@ describe('QueryClientProvider', () => {
     vi.useRealTimers()
   })
 
-  test('Sets a specific cache for all queries to use', async () => {
+  test('should set a specific cache for all queries to use', async () => {
     const queryCache = queryClient.getQueryCache()
 
     const rendered = render(BaseExample, {

--- a/packages/svelte-query/tests/context/context.svelte.test.ts
+++ b/packages/svelte-query/tests/context/context.svelte.test.ts
@@ -4,7 +4,7 @@ import { getIsRestoringContext } from '../../src/index.js'
 import BaseExample from './BaseExample.svelte'
 
 describe('getQueryClientContext', () => {
-  test('Throw when called without a client in context', () => {
+  test('should throw when called without a client in context', () => {
     expect(() => render(BaseExample)).toThrow(
       'No QueryClient was found in Svelte context. Did you forget to wrap your component with QueryClientProvider?',
     )
@@ -12,7 +12,7 @@ describe('getQueryClientContext', () => {
 })
 
 describe('getIsRestoringContext', () => {
-  test('Do not throw when called outside of a component', () => {
+  test('should not throw when called outside of a component', () => {
     expect(() => getIsRestoringContext()).not.toThrow()
   })
 })

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -22,7 +22,7 @@ describe('createMutation', () => {
     vi.useRealTimers()
   })
 
-  test('Able to reset `error`', async () => {
+  test('should be able to reset `error`', async () => {
     const rendered = render(ResetExample, {
       props: { queryClient },
     })
@@ -38,7 +38,7 @@ describe('createMutation', () => {
     expect(rendered.getByText('Error: undefined')).toBeInTheDocument()
   })
 
-  test('Able to call `onSuccess` and `onSettled` after each successful mutate', async () => {
+  test('should be able to call `onSuccess` and `onSettled` after each successful mutate', async () => {
     const onSuccessMock = vi.fn()
     const onSettledMock = vi.fn()
 
@@ -69,7 +69,7 @@ describe('createMutation', () => {
     expect(onSettledMock).toHaveBeenNthCalledWith(3, 3)
   })
 
-  test('Set correct values for `failureReason` and `failureCount` on multiple mutate calls', async () => {
+  test('should set correct values for `failureReason` and `failureCount` on multiple mutate calls', async () => {
     type Value = { count: number }
 
     const mutationFn = vi.fn<(value: Value) => Promise<Value>>()

--- a/packages/svelte-query/tests/createQueries/createQueries.test-d.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.test-d.ts
@@ -43,7 +43,7 @@ describe('createQueries', () => {
     >()
   })
 
-  it('handles type parameter - tuple of tuples', () => {
+  it('should handle type parameter - tuple of tuples', () => {
     const queryClient = new QueryClient()
     const key1 = queryKey()
     const key2 = queryKey()
@@ -158,7 +158,7 @@ describe('createQueries', () => {
     )
   })
 
-  it('handles type parameter - tuple of objects', () => {
+  it('should handle type parameter - tuple of objects', () => {
     const queryClient = new QueryClient()
     const key1 = queryKey()
     const key2 = queryKey()
@@ -315,7 +315,7 @@ describe('createQueries', () => {
     )
   })
 
-  it('handles array literal without type parameter to infer result type', () => {
+  it('should handle array literal without type parameter to infer result type', () => {
     const queryClient = new QueryClient()
     const key1 = queryKey()
     const key2 = queryKey()
@@ -562,7 +562,7 @@ describe('createQueries', () => {
     )
   })
 
-  it('handles strongly typed queryFn factories and createQueries wrappers', () => {
+  it('should handle strongly typed queryFn factories and createQueries wrappers', () => {
     const queryClient = new QueryClient()
 
     // QueryKey + queryFn factory

--- a/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
+++ b/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
@@ -5,7 +5,7 @@ import { createInfiniteQuery, infiniteQueryOptions } from '../src/index.js'
 import type { InfiniteData } from '@tanstack/query-core'
 
 describe('infiniteQueryOptions', () => {
-  test('Should not allow excess properties', () => {
+  test('should not allow excess properties', () => {
     const key = queryKey()
     assertType(
       infiniteQueryOptions({
@@ -19,7 +19,7 @@ describe('infiniteQueryOptions', () => {
     )
   })
 
-  test('Should infer types for callbacks', () => {
+  test('should infer types for callbacks', () => {
     const key = queryKey()
     infiniteQueryOptions({
       queryKey: key,
@@ -33,7 +33,7 @@ describe('infiniteQueryOptions', () => {
     })
   })
 
-  test('Should work when passed to createInfiniteQuery', () => {
+  test('should work when passed to createInfiniteQuery', () => {
     const key = queryKey()
     const options = infiniteQueryOptions({
       queryKey: key,
@@ -50,7 +50,7 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
-  test('Should work when passed to fetchInfiniteQuery', async () => {
+  test('should work when passed to fetchInfiniteQuery', async () => {
     const key = queryKey()
     const options = infiniteQueryOptions({
       queryKey: key,

--- a/packages/svelte-query/tests/mutationOptions/mutationOptions.test-d.ts
+++ b/packages/svelte-query/tests/mutationOptions/mutationOptions.test-d.ts
@@ -19,7 +19,7 @@ import type {
 } from '../../src/types.js'
 
 describe('mutationOptions', () => {
-  test('Should not allow excess properties', () => {
+  test('should not allow excess properties', () => {
     const key = queryKey()
 
     // @ts-expect-error this is a good error, because onMutates does not exist!
@@ -33,7 +33,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('Should infer types for callbacks', () => {
+  test('should infer types for callbacks', () => {
     const key = queryKey()
 
     mutationOptions({
@@ -45,7 +45,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('Should infer types for onError callback', () => {
+  test('should infer types for onError callback', () => {
     const key = queryKey()
 
     mutationOptions({
@@ -59,7 +59,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('Should infer types for variables', () => {
+  test('should infer types for variables', () => {
     const key = queryKey()
 
     mutationOptions<number, DefaultError, { id: string }>({
@@ -71,7 +71,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('Should infer result type correctly', () => {
+  test('should infer result type correctly', () => {
     const key = queryKey()
 
     mutationOptions<number, DefaultError, void, { name: string }>({
@@ -86,7 +86,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('Should infer context type correctly', () => {
+  test('should infer context type correctly', () => {
     const key = queryKey()
 
     mutationOptions<number>({
@@ -110,7 +110,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('Should error if mutationFn return type mismatches TData', () => {
+  test('should error if mutationFn return type mismatches TData', () => {
     assertType(
       mutationOptions<number>({
         // @ts-expect-error this is a good error, because return type is string, not number
@@ -119,7 +119,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('Should allow mutationKey to be omitted', () => {
+  test('should allow mutationKey to be omitted', () => {
     return mutationOptions({
       mutationFn: () => Promise.resolve(123),
       onSuccess: (data) => {
@@ -128,7 +128,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('Should infer all types when not explicitly provided', () => {
+  test('should infer all types when not explicitly provided', () => {
     const key = queryKey()
 
     expectTypeOf(
@@ -157,7 +157,7 @@ describe('mutationOptions', () => {
     >()
   })
 
-  test('Should work when used with createMutation', () => {
+  test('should work when used with createMutation', () => {
     const key = queryKey()
 
     const mutation = createMutation(() =>
@@ -184,7 +184,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('Should work when used with useIsMutating', () => {
+  test('should work when used with useIsMutating', () => {
     const key = queryKey()
 
     const isMutating = useIsMutating(
@@ -203,7 +203,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('Should work when used with queryClient.isMutating', () => {
+  test('should work when used with queryClient.isMutating', () => {
     const key = queryKey()
     const queryClient = new QueryClient()
 
@@ -223,7 +223,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('Should work when used with useMutationState', () => {
+  test('should work when used with useMutationState', () => {
     const key = queryKey()
 
     const mutationState = useMutationState({

--- a/packages/svelte-query/tests/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions.test-d.ts
@@ -10,7 +10,7 @@ import { createQueries, queryOptions } from '../src/index.js'
 import type { QueryObserverResult } from '@tanstack/query-core'
 
 describe('queryOptions', () => {
-  test('Should not allow excess properties', () => {
+  test('should not allow excess properties', () => {
     const key = queryKey()
     assertType(
       queryOptions({
@@ -22,7 +22,7 @@ describe('queryOptions', () => {
     )
   })
 
-  test('Should infer types for callbacks', () => {
+  test('should infer types for callbacks', () => {
     const key = queryKey()
     queryOptions({
       queryKey: key,
@@ -34,7 +34,7 @@ describe('queryOptions', () => {
     })
   })
 
-  test('Should work when passed to fetchQuery', async () => {
+  test('should work when passed to fetchQuery', async () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -45,7 +45,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number>()
   })
 
-  test('Should work when passed to createQueries', () => {
+  test('should work when passed to createQueries', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -59,7 +59,7 @@ describe('queryOptions', () => {
     expectTypeOf(queries[0].data).toEqualTypeOf<number | undefined>()
   })
 
-  test('Should tag the queryKey with the result type of the QueryFn', () => {
+  test('should tag the queryKey with the result type of the QueryFn', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -69,7 +69,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<number>()
   })
 
-  test('Should tag the queryKey even if no promise is returned', () => {
+  test('should tag the queryKey even if no promise is returned', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -79,7 +79,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<number>()
   })
 
-  test('Should tag the queryKey with unknown if there is no queryFn', () => {
+  test('should tag the queryKey with unknown if there is no queryFn', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -88,7 +88,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<unknown>()
   })
 
-  test('Should tag the queryKey with the result type of the QueryFn if select is used', () => {
+  test('should tag the queryKey with the result type of the QueryFn if select is used', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -99,7 +99,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<number>()
   })
 
-  test('Should return the proper type when passed to getQueryData', () => {
+  test('should return the proper type when passed to getQueryData', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -111,7 +111,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('Should return the proper type when passed to getQueryState', () => {
+  test('should return the proper type when passed to getQueryState', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -123,7 +123,7 @@ describe('queryOptions', () => {
     expectTypeOf(state?.data).toEqualTypeOf<number | undefined>()
   })
 
-  test('Should properly type updaterFn when passed to setQueryData', () => {
+  test('should properly type updaterFn when passed to setQueryData', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -138,7 +138,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('Should properly type value when passed to setQueryData', () => {
+  test('should properly type value when passed to setQueryData', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -156,7 +156,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('Should infer even if there is a conditional skipToken', () => {
+  test('should infer even if there is a conditional skipToken', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -168,7 +168,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('Should infer to unknown if we disable a query with just a skipToken', () => {
+  test('should infer to unknown if we disable a query with just a skipToken', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -180,7 +180,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<unknown>()
   })
 
-  test('Should return the proper type when passed to QueriesObserver', () => {
+  test('should return the proper type when passed to QueriesObserver', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -194,7 +194,7 @@ describe('queryOptions', () => {
     >()
   })
 
-  test('Should allow undefined response in initialData', () => {
+  test('should allow undefined response in initialData', () => {
     const key = queryKey()
     const options = (id: string | null) =>
       queryOptions({

--- a/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
+++ b/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
@@ -19,7 +19,7 @@ describe('useMutationState', () => {
     vi.useRealTimers()
   })
 
-  test('Run few mutation functions and check from useMutationState', async () => {
+  test('should run few mutation functions and check from useMutationState', async () => {
     const successKey = queryKey()
     const errorKey = queryKey()
     const successMutationFn = vi.fn(() => sleep(10).then(() => 'data'))
@@ -54,7 +54,7 @@ describe('useMutationState', () => {
     expect(rendered.getByText('Data: ["success","error"]')).toBeInTheDocument()
   })
 
-  test('Can select specific type of mutation ( i.e: error only )', async () => {
+  test('should select specific type of mutation ( i.e: error only )', async () => {
     const successKey = queryKey()
     const errorKey = queryKey()
     const successMutationFn = vi.fn(() => sleep(10).then(() => 'data'))
@@ -119,7 +119,7 @@ describe('useMutationState', () => {
     expect(rendered.getByText('Variables: ["success"]')).toBeInTheDocument()
   })
 
-  test('Can select specific mutation using mutation key', async () => {
+  test('should select specific mutation using mutation key', async () => {
     const successKey = queryKey()
     const errorKey = queryKey()
     const successMutationFn = vi.fn(() => sleep(10).then(() => 'data'))


### PR DESCRIPTION
## 🎯 Changes

- Unify all test descriptions to start with `should` across 8 svelte-query test files
  - `Should` → `should` (lowercase): `queryOptions.test-d.ts`, `infiniteQueryOptions.test-d.ts`, `mutationOptions.test-d.ts`
  - `Able to` → `should be able to`: `createMutation.svelte.test.ts`
  - `Set correct` → `should set correct`: `createMutation.svelte.test.ts`
  - `Sets` → `should set`: `QueryClientProvider.svelte.test.ts`
  - `Throw` → `should throw`, `Do not throw` → `should not throw`: `context.svelte.test.ts`
  - `Run` → `should run`, `Can select` → `should select`: `useMutationState.svelte.test.ts`
  - `handles` → `should handle`: `createQueries.test-d.ts`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test naming conventions across test suites to follow consistent "should..." phrasing for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->