### PR TITLE
docs(solid-query): add 'mutationOptions' to config.json navigation

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1125,6 +1125,10 @@
               "to": "framework/solid/reference/infiniteQueryOptions"
             },
             {
+              "label": "mutationOptions",
+              "to": "framework/solid/reference/mutationOptions"
+            },
+            {
               "label": "hydration",
               "to": "framework/solid/reference/hydration"
             }


### PR DESCRIPTION
## 🎯 Changes

- Add `mutationOptions` navigation entry to `docs/config.json` for solid-query
  - The reference page (`docs/framework/solid/reference/mutationOptions.md`) was added in #10138 but was missing from the navigation config

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).