### PR TITLE
Ensure query-devtools lists Solid peer dependencies

### DIFF
--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -62,6 +62,17 @@
     "src",
     "!src/__tests__"
   ],
+  "peerDependencies": {
+    "@kobalte/core": "^0.13.4",
+    "@solid-primitives/keyed": "^1.2.2",
+    "@solid-primitives/resize-observer": "^2.0.26",
+    "@solid-primitives/storage": "^1.3.11",
+    "@tanstack/match-sorter-utils": "^8.19.4",
+    "clsx": "^2.1.1",
+    "goober": "^2.1.16",
+    "solid-js": "^1.9.7",
+    "solid-transition-group": "^0.2.3"
+  },
   "devDependencies": {
     "@kobalte/core": "^0.13.4",
     "@solid-primitives/keyed": "^1.2.2",

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -10,9 +10,10 @@ import {
   createSignal,
   on,
   onCleanup,
+  useContext,
 } from 'solid-js'
 import { createStore, reconcile, unwrap } from 'solid-js/store'
-import { useQueryClient } from './QueryClientProvider'
+import { QueryClientContext } from './QueryClientProvider'
 import { useIsRestoring } from './isRestoring'
 import type { UseBaseQueryOptions } from './types'
 import type { Accessor, Signal } from 'solid-js'
@@ -115,7 +116,17 @@ export function useBaseQuery<
 ) {
   type ResourceData = QueryObserverResult<TData, TError>
 
-  const client = createMemo(() => useQueryClient(queryClient?.()))
+  const queryClientFromContext = useContext(QueryClientContext)
+  const client = createMemo(() => {
+    const clientFromOptions = queryClient?.()
+    if (clientFromOptions) {
+      return clientFromOptions
+    }
+    if (!queryClientFromContext) {
+      throw new Error('No QueryClient set, use QueryClientProvider to set one')
+    }
+    return queryClientFromContext()
+  })
   const isRestoring = useIsRestoring()
   // There are times when we run a query on the server but the resource is never read
   // This could lead to times when the queryObserver is unsubscribed before the resource has loaded


### PR DESCRIPTION
## Summary
- add the Solid runtime dependencies as peers for @tanstack/query-devtools so TypeScript consumers can resolve solid-js and its primitives
- keep the existing devDependencies so the package still builds locally

## Testing
- pnpm --filter @tanstack/query-devtools test:types:tscurrent *(fails: tsc cannot resolve @tanstack/query-test-utils inside this workspace)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added peer dependency specifications to the query devtools package to ensure compatibility with the Solid.js ecosystem.

* **Behavior Change**
  * Query client resolution now prefers an explicitly provided client and falls back to context; a clear runtime error is thrown if no client is available, improving configuration feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->