### PR TITLE
test(vue-query/mutationOptions): add type tests for getter overloads

### DIFF
--- a/packages/vue-query/src/__tests__/mutationOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test-d.ts
@@ -295,5 +295,4 @@ describe('mutationOptions', () => {
     )
     expectTypeOf(mutation.data.value).toEqualTypeOf<string | undefined>()
   })
-
 })

--- a/packages/vue-query/src/__tests__/mutationOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test-d.ts
@@ -243,4 +243,57 @@ describe('mutationOptions', () => {
     const resolved = options()
     expectTypeOf(resolved.mutationFn).not.toBeUndefined()
   })
+
+  it('should error if mutationFn return type mismatches TData (getter)', () => {
+    assertType(
+      mutationOptions<number>(() => ({
+        // @ts-expect-error this is a good error, because return type is string, not number
+        mutationFn: async () => Promise.resolve('wrong return'),
+      })),
+    )
+  })
+
+  it('should infer all types when not explicitly provided (getter)', () => {
+    expectTypeOf(
+      mutationOptions(() => ({
+        mutationFn: (id: string) => Promise.resolve(id.length),
+        mutationKey: ['key'],
+        onSuccess: (data) => {
+          expectTypeOf(data).toEqualTypeOf<number>()
+        },
+      })),
+    ).toEqualTypeOf<
+      () => WithRequired<
+        MutationOptions<number, DefaultError, string, unknown>,
+        'mutationKey'
+      >
+    >()
+    expectTypeOf(
+      mutationOptions(() => ({
+        mutationFn: (id: string) => Promise.resolve(id.length),
+        onSuccess: (data) => {
+          expectTypeOf(data).toEqualTypeOf<number>()
+        },
+      })),
+    ).toEqualTypeOf<
+      () => Omit<
+        MutationOptions<number, DefaultError, string, unknown>,
+        'mutationKey'
+      >
+    >()
+  })
+
+  it('should work when used with useMutation (getter)', () => {
+    const mutation = useMutation(
+      mutationOptions(() => ({
+        mutationKey: ['key'],
+        mutationFn: () => Promise.resolve('data'),
+        onSuccess: (data) => {
+          expectTypeOf(data).toEqualTypeOf<string>()
+        },
+      })),
+    )
+    expectTypeOf(mutation.data.value).toEqualTypeOf<string | undefined>()
+  })
+
 })


### PR DESCRIPTION
## 🎯 Changes

- Add 3 type tests for `mutationOptions` getter overloads:
  - `should error if mutationFn return type mismatches TData (getter)`: verifies `@ts-expect-error` works correctly with getter overloads
  - `should infer all types when not explicitly provided (getter)`: verifies return type is `() => WithRequired<...>` / `() => Omit<...>`
  - `should work when used with useMutation (getter)`: verifies getter can be passed directly to `useMutation`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced TypeScript type validation for mutation options, improving compile-time type safety verification for getter overload patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->