### PR TITLE
fix: preserve query behavior during hydration fetch

### DIFF
--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -273,10 +273,16 @@ export function hydrate(
         // Note that we need to call these even when data was synchronously
         // available, as we still need to set up the retryer
         query
-          .fetch(undefined, {
-            // RSC transformed promises are not thenable
-            initialPromise: Promise.resolve(promise).then(deserializeData),
-          })
+          .fetch(
+            // Preserve the query's behavior (e.g. infiniteQueryBehavior) so
+            // that when the streamed promise resolves, the data gets processed
+            // through the correct pipeline instead of being stored raw.
+            query.options.behavior ? { behavior: query.options.behavior } : undefined,
+            {
+              // RSC transformed promises are not thenable
+              initialPromise: Promise.resolve(promise).then(deserializeData),
+            },
+          )
           // Avoid unhandled promise rejections
           .catch(noop)
       }


### PR DESCRIPTION
When prefetchInfiniteQuery fails on the server and the promise gets streamed to the client, hydrate() calls query.fetch(undefined, { initialPromise }) which drops the behavior property. Without infiniteQueryBehavior set, the retried fetch stores the raw response instead of wrapping it in the expected { pages, pageParams } structure, causing "Cannot read properties of undefined (reading 'length')" on the client.

The fix passes the query's existing behavior through to the fetch call so infinite queries retain their data processing pipeline after hydration.

Fixes #8825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query hydration to properly apply configured query behaviors during initialization, ensuring streamed query results are processed through their intended behavior pipeline rather than stored as raw data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->