### PR TITLE
test(vue-query/mutationOptions): add identity tests for getter overloads

### DIFF
--- a/packages/vue-query/src/__tests__/mutationOptions.test.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test.ts
@@ -35,6 +35,25 @@ describe('mutationOptions', () => {
     expect(mutationOptions(object)).toStrictEqual(object)
   })
 
+  it('should return the getter received as a parameter without any modification (with mutationKey in mutationOptions)', () => {
+    const getter = () =>
+      ({
+        mutationKey: ['key'],
+        mutationFn: () => sleep(10).then(() => 5),
+      }) as const
+
+    expect(mutationOptions(getter)).toBe(getter)
+  })
+
+  it('should return the getter received as a parameter without any modification (without mutationKey in mutationOptions)', () => {
+    const getter = () =>
+      ({
+        mutationFn: () => sleep(10).then(() => 5),
+      }) as const
+
+    expect(mutationOptions(getter)).toBe(getter)
+  })
+
   it('should return the number of fetching mutations when used with useIsMutating (with mutationKey in mutationOptions)', async () => {
     const isMutatingArray: Array<number> = []
     const mutationOpts = mutationOptions({


### PR DESCRIPTION
## 🎯 Changes

- Add 2 identity tests for `mutationOptions` getter overloads:
  - `should return the getter received as a parameter without any modification (with mutationKey in mutationOptions)`: verifies `mutationOptions(getter)` returns the same function reference using `toBe`
  - `should return the getter received as a parameter without any modification (without mutationKey in mutationOptions)`: same without `mutationKey`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage to verify mutation options behavior with and without mutation keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->