### PR TITLE
test(vue-query/mutationOptions): add 'queryClient.isMutating' tests for getter overloads

### DIFF
--- a/packages/vue-query/src/__tests__/mutationOptions.test.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test.ts
@@ -350,6 +350,135 @@ describe('mutationOptions', () => {
     unsubscribe()
   })
 
+  it('should return the number of fetching mutations when used with queryClient.isMutating (getter with mutationKey in mutationOptions)', async () => {
+    const isMutatingArray: Array<number> = []
+    const queryClient = useQueryClient()
+    const mutationOpts = mutationOptions(() => ({
+      mutationKey: ['mutation'],
+      mutationFn: () => sleep(500).then(() => 'data'),
+    }))
+
+    const { mutate } = useMutation(mutationOpts)
+
+    const resolvedOpts = mutationOpts()
+
+    const mutationCache = queryClient.getMutationCache()
+    const unsubscribe = mutationCache.subscribe(() => {
+      isMutatingArray.push(queryClient.isMutating(resolvedOpts))
+    })
+
+    isMutatingArray.push(queryClient.isMutating(resolvedOpts))
+
+    mutate()
+    await vi.advanceTimersByTimeAsync(0)
+    // Use Math.max because subscribe callback count is implementation-dependent
+    expect(Math.max(...isMutatingArray)).toEqual(1)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(isMutatingArray[isMutatingArray.length - 1]).toEqual(0)
+
+    unsubscribe()
+  })
+
+  it('should return the number of fetching mutations when used with queryClient.isMutating (getter without mutationKey in mutationOptions)', async () => {
+    const isMutatingArray: Array<number> = []
+    const queryClient = useQueryClient()
+    const mutationOpts = mutationOptions(() => ({
+      mutationFn: () => sleep(500).then(() => 'data'),
+    }))
+
+    const { mutate } = useMutation(mutationOpts)
+
+    const mutationCache = queryClient.getMutationCache()
+    const unsubscribe = mutationCache.subscribe(() => {
+      isMutatingArray.push(queryClient.isMutating())
+    })
+
+    isMutatingArray.push(queryClient.isMutating())
+
+    mutate()
+    await vi.advanceTimersByTimeAsync(0)
+    // Use Math.max because subscribe callback count is implementation-dependent
+    expect(Math.max(...isMutatingArray)).toEqual(1)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(isMutatingArray[isMutatingArray.length - 1]).toEqual(0)
+
+    unsubscribe()
+  })
+
+  it('should return the number of fetching mutations when used with queryClient.isMutating (getter)', async () => {
+    const isMutatingArray: Array<number> = []
+    const queryClient = useQueryClient()
+    const mutationOpts1 = mutationOptions(() => ({
+      mutationKey: ['mutation'],
+      mutationFn: () => sleep(500).then(() => 'data1'),
+    }))
+    const mutationOpts2 = mutationOptions(() => ({
+      mutationFn: () => sleep(500).then(() => 'data2'),
+    }))
+
+    const { mutate: mutate1 } = useMutation(mutationOpts1)
+    const { mutate: mutate2 } = useMutation(mutationOpts2)
+
+    const mutationCache = queryClient.getMutationCache()
+    const unsubscribe = mutationCache.subscribe(() => {
+      isMutatingArray.push(queryClient.isMutating())
+    })
+
+    isMutatingArray.push(queryClient.isMutating())
+
+    mutate1()
+    mutate2()
+    await vi.advanceTimersByTimeAsync(0)
+    // Use Math.max because subscribe callback count is implementation-dependent
+    expect(Math.max(...isMutatingArray)).toEqual(2)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(isMutatingArray[isMutatingArray.length - 1]).toEqual(0)
+
+    unsubscribe()
+  })
+
+  it('should return the number of fetching mutations when used with queryClient.isMutating (getter, filter mutationOpts1.mutationKey)', async () => {
+    const isMutatingArray: Array<number> = []
+    const queryClient = useQueryClient()
+    const mutationOpts1 = mutationOptions(() => ({
+      mutationKey: ['mutation'],
+      mutationFn: () => sleep(500).then(() => 'data1'),
+    }))
+    const mutationOpts2 = mutationOptions(() => ({
+      mutationFn: () => sleep(500).then(() => 'data2'),
+    }))
+
+    const resolvedOpts1 = mutationOpts1()
+
+    const { mutate: mutate1 } = useMutation(mutationOpts1)
+    const { mutate: mutate2 } = useMutation(mutationOpts2)
+
+    const mutationCache = queryClient.getMutationCache()
+    const unsubscribe = mutationCache.subscribe(() => {
+      isMutatingArray.push(
+        queryClient.isMutating({
+          mutationKey: resolvedOpts1.mutationKey,
+        }),
+      )
+    })
+
+    isMutatingArray.push(
+      queryClient.isMutating({
+        mutationKey: resolvedOpts1.mutationKey,
+      }),
+    )
+
+    mutate1()
+    mutate2()
+    await vi.advanceTimersByTimeAsync(0)
+    // Use Math.max because subscribe callback count is implementation-dependent
+    expect(Math.max(...isMutatingArray)).toEqual(1)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(isMutatingArray[isMutatingArray.length - 1]).toEqual(0)
+
+    unsubscribe()
+  })
+
   it('should return mutation states when used with useMutationState (with mutationKey in mutationOptions)', async () => {
     const mutationOpts = mutationOptions({
       mutationKey: ['mutation'],


### PR DESCRIPTION
## 🎯 Changes

- Add 4 runtime tests for `mutationOptions` getter overloads with `queryClient.isMutating`:
  - `should return the number of fetching mutations when used with queryClient.isMutating (getter with mutationKey in mutationOptions)`
  - `should return the number of fetching mutations when used with queryClient.isMutating (getter without mutationKey in mutationOptions)`
  - `should return the number of fetching mutations when used with queryClient.isMutating (getter)`: multiple mutations with getter
  - `should return the number of fetching mutations when used with queryClient.isMutating (getter, filter mutationOpts1.mutationKey)`: filter by `mutationKey` with getter

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added four test cases validating mutation state tracking and reporting behavior across various usage scenarios, including mutations with and without keys, concurrent execution, filtering by keys, and verification of correct state reporting during active mutations and proper cleanup after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->