### PR TITLE
test(vue-query/mutationOptions): add 'useMutationState' tests for getter overloads

### DIFF
--- a/packages/vue-query/src/__tests__/mutationOptions.test.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test.ts
@@ -564,6 +564,74 @@ describe('mutationOptions', () => {
     expect(states.value).toEqual(['data1'])
   })
 
+  it('should return mutation states when used with useMutationState (getter without mutationKey in mutationOptions)', async () => {
+    const mutationOpts = mutationOptions(() => ({
+      mutationFn: () => sleep(10).then(() => 'data'),
+    }))
+
+    const { mutate } = useMutation(mutationOpts)
+    const states = useMutationState({
+      filters: { status: 'success' },
+      select: (mutation) => mutation.state.data,
+    })
+
+    expect(states.value).toEqual([])
+
+    mutate()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(states.value).toEqual(['data'])
+  })
+
+  it('should return mutation states when used with useMutationState (getter)', async () => {
+    const mutationOpts1 = mutationOptions(() => ({
+      mutationKey: ['mutation'],
+      mutationFn: () => sleep(10).then(() => 'data1'),
+    }))
+    const mutationOpts2 = mutationOptions(() => ({
+      mutationFn: () => sleep(10).then(() => 'data2'),
+    }))
+
+    const { mutate: mutate1 } = useMutation(mutationOpts1)
+    const { mutate: mutate2 } = useMutation(mutationOpts2)
+    const states = useMutationState({
+      filters: { status: 'success' },
+      select: (mutation) => mutation.state.data,
+    })
+
+    expect(states.value).toEqual([])
+
+    mutate1()
+    mutate2()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(states.value).toEqual(['data1', 'data2'])
+  })
+
+  it('should return mutation states when used with useMutationState (getter, filter mutationOpts1.mutationKey)', async () => {
+    const mutationOpts1 = mutationOptions(() => ({
+      mutationKey: ['mutation'],
+      mutationFn: () => sleep(10).then(() => 'data1'),
+    }))
+    const mutationOpts2 = mutationOptions(() => ({
+      mutationFn: () => sleep(10).then(() => 'data2'),
+    }))
+
+    const resolvedOpts1 = mutationOpts1()
+
+    const { mutate: mutate1 } = useMutation(mutationOpts1)
+    const { mutate: mutate2 } = useMutation(mutationOpts2)
+    const states = useMutationState({
+      filters: { mutationKey: resolvedOpts1.mutationKey, status: 'success' },
+      select: (mutation) => mutation.state.data,
+    })
+
+    expect(states.value).toEqual([])
+
+    mutate1()
+    mutate2()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(states.value).toEqual(['data1'])
+  })
+
   it('should work with getter passed to mutationOptions when used with useIsMutating', async () => {
     const keyRef = ref('isMutatingGetter')
     const mutationOpts = mutationOptions(() => ({


### PR DESCRIPTION
## 🎯 Changes

- Add 3 runtime tests for `mutationOptions` getter overloads with `useMutationState`:
  - `should return mutation states when used with useMutationState (getter without mutationKey in mutationOptions)`
  - `should return mutation states when used with useMutationState (getter)`: multiple mutations with getter
  - `should return mutation states when used with useMutationState (getter, filter mutationOpts1.mutationKey)`: filter by `mutationKey` with getter

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added three new test cases validating mutation state behavior with getter-based options, covering scenarios with and without mutation keys, state filtering, and key resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->