### PR TITLE
test(vue-query/mutationOptions): add shallow ref test for getter overload

### DIFF
--- a/packages/vue-query/src/__tests__/mutationOptions.test.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test.ts
@@ -700,4 +700,20 @@ describe('mutationOptions', () => {
     expect(data.value).toEqual({ nested: { count: 0 } })
     expect(isReactive(data.value?.nested)).toBe(false)
   })
+
+  it('should return data in a shallow ref when shallow is true (getter)', async () => {
+    const mutationOpts = mutationOptions(() => ({
+      mutationKey: ['key'],
+      mutationFn: () => sleep(10).then(() => ({ nested: { count: 0 } })),
+      shallow: true,
+    }))
+
+    const { mutate, data } = useMutation(mutationOpts)
+
+    mutate()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(data.value).toEqual({ nested: { count: 0 } })
+    expect(isReactive(data.value?.nested)).toBe(false)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add 1 runtime test for `mutationOptions` getter overload with `shallow: true`:
  - `should return data in a shallow ref when shallow is true (getter)`: verifies nested data is non-reactive when `shallow: true` is passed via getter

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify shallow reference handling in mutation options functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->