### PR TITLE
test(vue-query/mutationOptions): add reactive 'mutationKey' test for getter overload

### DIFF
--- a/packages/vue-query/src/__tests__/mutationOptions.test.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isReactive, ref } from 'vue-demi'
-import { sleep } from '@tanstack/query-test-utils'
+import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
 import { useIsMutating, useMutationState } from '../useMutationState'
 import { useQueryClient } from '../useQueryClient'
@@ -715,5 +715,39 @@ describe('mutationOptions', () => {
 
     expect(data.value).toEqual({ nested: { count: 0 } })
     expect(isReactive(data.value?.nested)).toBe(false)
+  })
+
+  it('should reactively update mutationKey when ref changes in getter', async () => {
+    const key = queryKey()
+    const keyRef = ref('key01')
+    const fnMock = vi.fn((params: string) => sleep(10).then(() => params))
+    const mutationOpts = mutationOptions(() => ({
+      mutationKey: [...key, keyRef.value],
+      mutationFn: fnMock,
+    }))
+
+    const mutation = useMutation(mutationOpts)
+
+    mutation.mutate('data')
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fnMock).toHaveBeenCalledTimes(1)
+    expect(fnMock).toHaveBeenNthCalledWith(
+      1,
+      'data',
+      expect.objectContaining({ mutationKey: [...key, 'key01'] }),
+    )
+
+    keyRef.value = 'key02'
+    await vi.advanceTimersByTimeAsync(0)
+    mutation.mutate('data')
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fnMock).toHaveBeenCalledTimes(2)
+    expect(fnMock).toHaveBeenNthCalledWith(
+      2,
+      'data',
+      expect.objectContaining({ mutationKey: [...key, 'key02'] }),
+    )
   })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add reactive `mutationKey` test for `mutationOptions` getter overload:
  - `should reactively update mutationKey when ref changes in getter`: verifies that when a ref used inside `mutationOptions(() => ({ mutationKey: [...key, keyRef.value] }))` changes, the mutation picks up the updated key

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for reactive mutation key behavior with Vue refs, ensuring proper updates across mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->