### PR TITLE
test({react,preact}-query): add type tests for 'useMutation'

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test-d.tsx
@@ -1,0 +1,138 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { QueryClient } from '@tanstack/query-core'
+import { useMutation } from '../useMutation'
+import type { DefaultError } from '@tanstack/query-core'
+import type { UseMutationResult } from '../types'
+
+describe('useMutation', () => {
+  it('should infer TData from mutationFn return type', () => {
+    const mutation = useMutation({
+      mutationFn: () => Promise.resolve('data'),
+    })
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.error).toEqualTypeOf<DefaultError | null>()
+  })
+
+  it('should infer TVariables from mutationFn parameter', () => {
+    const mutation = useMutation({
+      mutationFn: (vars: { id: string }) => Promise.resolve(vars.id),
+    })
+
+    expectTypeOf(mutation.mutate).toBeCallableWith({ id: '1' })
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+  })
+
+  it('should infer TOnMutateResult from onMutate return type', () => {
+    useMutation({
+      mutationFn: () => Promise.resolve('data'),
+      onMutate: () => {
+        return { token: 'abc' }
+      },
+      onSuccess: (_data, _variables, onMutateResult) => {
+        expectTypeOf(onMutateResult).toEqualTypeOf<{ token: string }>()
+      },
+      onError: (_error, _variables, onMutateResult) => {
+        expectTypeOf(onMutateResult).toEqualTypeOf<
+          { token: string } | undefined
+        >()
+      },
+    })
+  })
+
+  it('should allow explicit generic types', () => {
+    const mutation = useMutation<string, Error, { id: number }>({
+      mutationFn: (vars) => {
+        expectTypeOf(vars).toEqualTypeOf<{ id: number }>()
+        return Promise.resolve('result')
+      },
+    })
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.error).toEqualTypeOf<Error | null>()
+  })
+
+  it('should return correct UseMutationResult type', () => {
+    const mutation = useMutation({
+      mutationFn: () => Promise.resolve(42),
+    })
+
+    expectTypeOf(mutation).toEqualTypeOf<
+      UseMutationResult<number, DefaultError, void, unknown>
+    >()
+  })
+
+  it('should type mutateAsync with correct return type', () => {
+    const mutation = useMutation({
+      mutationFn: (id: string) => Promise.resolve(id.length),
+    })
+
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith('test')
+    expectTypeOf(mutation.mutateAsync('test')).toEqualTypeOf<Promise<number>>()
+  })
+
+  it('should default TVariables to void when mutationFn has no parameters', () => {
+    const mutation = useMutation({
+      mutationFn: () => Promise.resolve('data'),
+    })
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+  })
+
+  it('should infer custom TError type', () => {
+    class CustomError extends Error {
+      code: number
+      constructor(code: number) {
+        super()
+        this.code = code
+      }
+    }
+
+    const mutation = useMutation<string, CustomError>({
+      mutationFn: () => Promise.resolve('data'),
+    })
+
+    expectTypeOf(mutation.error).toEqualTypeOf<CustomError | null>()
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+  })
+
+  it('should infer types for onSettled callback', () => {
+    useMutation({
+      mutationFn: () => Promise.resolve(42),
+      onSettled: (data, error, _variables, _onMutateResult) => {
+        expectTypeOf(data).toEqualTypeOf<number | undefined>()
+        expectTypeOf(error).toEqualTypeOf<DefaultError | null>()
+      },
+    })
+  })
+
+  it('should infer custom TError in onError callback', () => {
+    class CustomError extends Error {
+      code: number
+      constructor(code: number) {
+        super()
+        this.code = code
+      }
+    }
+
+    useMutation<string, CustomError>({
+      mutationFn: () => Promise.resolve('data'),
+      onError: (error) => {
+        expectTypeOf(error).toEqualTypeOf<CustomError>()
+      },
+    })
+  })
+
+  it('should accept queryClient as second argument', () => {
+    const queryClient = new QueryClient()
+
+    const mutation = useMutation(
+      {
+        mutationFn: () => Promise.resolve('data'),
+      },
+      queryClient,
+    )
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+  })
+})

--- a/packages/react-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test-d.tsx
@@ -1,0 +1,138 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { QueryClient } from '@tanstack/query-core'
+import { useMutation } from '../useMutation'
+import type { DefaultError } from '@tanstack/query-core'
+import type { UseMutationResult } from '../types'
+
+describe('useMutation', () => {
+  it('should infer TData from mutationFn return type', () => {
+    const mutation = useMutation({
+      mutationFn: () => Promise.resolve('data'),
+    })
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.error).toEqualTypeOf<DefaultError | null>()
+  })
+
+  it('should infer TVariables from mutationFn parameter', () => {
+    const mutation = useMutation({
+      mutationFn: (vars: { id: string }) => Promise.resolve(vars.id),
+    })
+
+    expectTypeOf(mutation.mutate).toBeCallableWith({ id: '1' })
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+  })
+
+  it('should infer TOnMutateResult from onMutate return type', () => {
+    useMutation({
+      mutationFn: () => Promise.resolve('data'),
+      onMutate: () => {
+        return { token: 'abc' }
+      },
+      onSuccess: (_data, _variables, onMutateResult) => {
+        expectTypeOf(onMutateResult).toEqualTypeOf<{ token: string }>()
+      },
+      onError: (_error, _variables, onMutateResult) => {
+        expectTypeOf(onMutateResult).toEqualTypeOf<
+          { token: string } | undefined
+        >()
+      },
+    })
+  })
+
+  it('should allow explicit generic types', () => {
+    const mutation = useMutation<string, Error, { id: number }>({
+      mutationFn: (vars) => {
+        expectTypeOf(vars).toEqualTypeOf<{ id: number }>()
+        return Promise.resolve('result')
+      },
+    })
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.error).toEqualTypeOf<Error | null>()
+  })
+
+  it('should return correct UseMutationResult type', () => {
+    const mutation = useMutation({
+      mutationFn: () => Promise.resolve(42),
+    })
+
+    expectTypeOf(mutation).toEqualTypeOf<
+      UseMutationResult<number, DefaultError, void, unknown>
+    >()
+  })
+
+  it('should type mutateAsync with correct return type', () => {
+    const mutation = useMutation({
+      mutationFn: (id: string) => Promise.resolve(id.length),
+    })
+
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith('test')
+    expectTypeOf(mutation.mutateAsync('test')).toEqualTypeOf<Promise<number>>()
+  })
+
+  it('should default TVariables to void when mutationFn has no parameters', () => {
+    const mutation = useMutation({
+      mutationFn: () => Promise.resolve('data'),
+    })
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+  })
+
+  it('should infer custom TError type', () => {
+    class CustomError extends Error {
+      code: number
+      constructor(code: number) {
+        super()
+        this.code = code
+      }
+    }
+
+    const mutation = useMutation<string, CustomError>({
+      mutationFn: () => Promise.resolve('data'),
+    })
+
+    expectTypeOf(mutation.error).toEqualTypeOf<CustomError | null>()
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+  })
+
+  it('should infer types for onSettled callback', () => {
+    useMutation({
+      mutationFn: () => Promise.resolve(42),
+      onSettled: (data, error, _variables, _onMutateResult) => {
+        expectTypeOf(data).toEqualTypeOf<number | undefined>()
+        expectTypeOf(error).toEqualTypeOf<DefaultError | null>()
+      },
+    })
+  })
+
+  it('should infer custom TError in onError callback', () => {
+    class CustomError extends Error {
+      code: number
+      constructor(code: number) {
+        super()
+        this.code = code
+      }
+    }
+
+    useMutation<string, CustomError>({
+      mutationFn: () => Promise.resolve('data'),
+      onError: (error) => {
+        expectTypeOf(error).toEqualTypeOf<CustomError>()
+      },
+    })
+  })
+
+  it('should accept queryClient as second argument', () => {
+    const queryClient = new QueryClient()
+
+    const mutation = useMutation(
+      {
+        mutationFn: () => Promise.resolve('data'),
+      },
+      queryClient,
+    )
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

- Add 11 type tests for `useMutation` in both `react-query` and `preact-query` (identical signatures), covering all 4 generic parameters:
  - `TData`: inference from `mutationFn` return type, explicit generic
  - `TError`: default `DefaultError`, custom error type, `onError`/`onSettled` callbacks
  - `TVariables`: inference from `mutationFn` parameter, default `void`
  - `TOnMutateResult`: inference from `onMutate` return type, `onSuccess`/`onError` callbacks
  - Return type: `UseMutationResult`, `mutate`, `mutateAsync`
  - `queryClient` as optional second argument

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added TypeScript type-validation tests for the useMutation hook in both React and Preact packages, verifying generic type inference (data, variables, error), explicit generics, mutate/mutateAsync signatures, onMutate/onSuccess/onError/onSettled callback typings, error-defaulting/custom errors, and overload behavior with an optional client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->