### PR TITLE
fix(eslint-plugin-query): use TypeFlags from typescript instead of hardcoded values

### DIFF
--- a/packages/eslint-plugin-query/src/rules/no-void-query-fn/no-void-query-fn.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-void-query-fn/no-void-query-fn.rule.ts
@@ -1,14 +1,10 @@
 import { ESLintUtils } from '@typescript-eslint/utils'
+import { TypeFlags } from 'typescript'
 import { ASTUtils } from '../../utils/ast-utils'
 import { detectTanstackQueryImports } from '../../utils/detect-react-query-imports'
 import { getDocsUrl } from '../../utils/get-docs-url'
 import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils'
 import type { ExtraRuleDocs } from '../../types'
-
-const TypeFlags = {
-  Void: 16384,
-  Undefined: 32768,
-} as const
 
 export const name = 'no-void-query-fn'
 


### PR DESCRIPTION
## Summary

Fixes #10461

The `no-void-query-fn` rule used hardcoded values for `TypeFlags.Void` (16384) and `TypeFlags.Undefined` (32768):

```ts
const TypeFlags = {
  Void: 16384,
  Undefined: 32768,
} as const
```

These internal TypeScript flag values were [reordered in TypeScript 6](https://github.com/microsoft/TypeScript/pull/63084), causing the bitwise check to test for `UniqueESSymbol | EnumLiteral` instead of `Void | Undefined`. This resulted in false positives when `queryFn` returns an enum member.

## Fix

Import `TypeFlags` directly from the `typescript` package (already listed as a peer dependency) instead of hardcoding the numeric values. This ensures correct behavior across all supported TypeScript versions (5.x and 6.x).

## Test

All 34 existing `no-void-query-fn` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal implementation in eslint-plugin-query to improve code maintainability with no visible user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->