### PR TITLE
test({react,preact}-query/useMutation): add 'throwOnError' false case tests

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -783,6 +783,83 @@ describe('useMutation', () => {
     consoleMock.mockRestore()
   })
 
+  it('should not throw an error when throwOnError is set to false', async () => {
+    function Page() {
+      const { mutate, error } = useMutation<string, Error>({
+        mutationFn: () =>
+          sleep(10).then(() => {
+            throw new Error('Expected mock error')
+          }),
+        throwOnError: false,
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+          <div>error: {error?.message ?? 'null'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
+  })
+
+  it('should not throw an error when throwOnError is a function that returns false', async () => {
+    function Page() {
+      const { mutate, error } = useMutation<string, Error>({
+        mutationFn: () =>
+          sleep(10).then(() => {
+            throw new Error('Expected mock error')
+          }),
+        throwOnError: () => false,
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+          <div>error: {error?.message ?? 'null'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
+  })
+
+  it('should not throw an error when throwOnError is not set', async () => {
+    function Page() {
+      const { mutate, error } = useMutation<string, Error>({
+        mutationFn: () =>
+          sleep(10).then(() => {
+            throw new Error('Expected mock error')
+          }),
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+          <div>error: {error?.message ?? 'null'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
+  })
+
   it('should pass meta to mutation', async () => {
     const errorMock = vi.fn()
     const successMock = vi.fn()

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -782,6 +782,83 @@ describe('useMutation', () => {
     consoleMock.mockRestore()
   })
 
+  it('should not throw an error when throwOnError is set to false', async () => {
+    function Page() {
+      const { mutate, error } = useMutation<string, Error>({
+        mutationFn: () =>
+          sleep(10).then(() => {
+            throw new Error('Expected mock error')
+          }),
+        throwOnError: false,
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+          <div>error: {error?.message ?? 'null'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
+  })
+
+  it('should not throw an error when throwOnError is a function that returns false', async () => {
+    function Page() {
+      const { mutate, error } = useMutation<string, Error>({
+        mutationFn: () =>
+          sleep(10).then(() => {
+            throw new Error('Expected mock error')
+          }),
+        throwOnError: () => false,
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+          <div>error: {error?.message ?? 'null'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
+  })
+
+  it('should not throw an error when throwOnError is not set', async () => {
+    function Page() {
+      const { mutate, error } = useMutation<string, Error>({
+        mutationFn: () =>
+          sleep(10).then(() => {
+            throw new Error('Expected mock error')
+          }),
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+          <div>error: {error?.message ?? 'null'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
+  })
+
   it('should pass meta to mutation', async () => {
     const errorMock = vi.fn()
     const successMock = vi.fn()


### PR DESCRIPTION
## 🎯 Changes

- Add 3 runtime tests for `useMutation` `throwOnError` false cases in both `react-query` and `preact-query`:
  - `should not throw an error when throwOnError is set to false`: explicitly set to `false`
  - `should not throw an error when throwOnError is a function that returns false`: function returning `false`
  - `should not throw an error when throwOnError is not set`: default value (`false`)
- Complements existing tests that verify `throwOnError: true` and `throwOnError: () => true` behavior

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for mutation error handling across preact and react query implementations. Tests validate that when mutations fail, errors are properly captured in the component state and displayed to users across multiple error throwing configurations—when disabled, when conditionally applied, or when the option is omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->