### PR TITLE
test({react,preact}-query/useMutation): add 'mutate' callback override tests

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -365,6 +365,97 @@ describe('useMutation', () => {
     ])
   })
 
+  it('should be able to override the error callbacks when using mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: async (_text: string) =>
+          sleep(10).then(() => Promise.reject(new Error('oops'))),
+        onError: () => {
+          callbacks.push('useMutation.onError')
+        },
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onError: () => {
+                callbacks.push('mutate.onError')
+              },
+              onSettled: () => {
+                callbacks.push('mutate.onSettled')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onError',
+      'useMutation.onSettled',
+      'mutate.onError',
+      'mutate.onSettled',
+    ])
+  })
+
+  it('should be able to override the settled callbacks when using mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSuccess: () => {
+          callbacks.push('useMutation.onSuccess')
+        },
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onSuccess: () => {
+                callbacks.push('mutate.onSuccess')
+              },
+              onSettled: () => {
+                callbacks.push('mutate.onSettled')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSuccess',
+      'useMutation.onSettled',
+      'mutate.onSuccess',
+      'mutate.onSettled',
+    ])
+  })
+
   it('should be able to use mutation defaults', async () => {
     const key = queryKey()
 

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -364,6 +364,97 @@ describe('useMutation', () => {
     ])
   })
 
+  it('should be able to override the error callbacks when using mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: async (_text: string) =>
+          sleep(10).then(() => Promise.reject(new Error('oops'))),
+        onError: () => {
+          callbacks.push('useMutation.onError')
+        },
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onError: () => {
+                callbacks.push('mutate.onError')
+              },
+              onSettled: () => {
+                callbacks.push('mutate.onSettled')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onError',
+      'useMutation.onSettled',
+      'mutate.onError',
+      'mutate.onSettled',
+    ])
+  })
+
+  it('should be able to override the settled callbacks when using mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSuccess: () => {
+          callbacks.push('useMutation.onSuccess')
+        },
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onSuccess: () => {
+                callbacks.push('mutate.onSuccess')
+              },
+              onSettled: () => {
+                callbacks.push('mutate.onSettled')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSuccess',
+      'useMutation.onSettled',
+      'mutate.onSuccess',
+      'mutate.onSettled',
+    ])
+  })
+
   it('should be able to use mutation defaults', async () => {
     const key = queryKey()
 


### PR DESCRIPTION
## 🎯 Changes

- Add 2 runtime tests for `useMutation` `mutate` callback override in both `react-query` and `preact-query`:
  - `should be able to override the error callbacks when using mutate`: verifies `onError` and `onSettled` callbacks are called in order (useMutation → mutate)
  - `should be able to override the settled callbacks when using mutate`: verifies `onSuccess` and `onSettled` callbacks are called in order (useMutation → mutate)
- Complements existing tests that verify the same behavior with `mutateAsync` (line 266, 316)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `useMutation` callback execution order in both React Query and Preact Query, verifying correct callback sequencing for successful and failed mutations with per-call option overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->