### PR TITLE
test({react,preact}-query/useMutation): add single callback tests for 'onSuccess', 'onError', and 'onSettled'

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -295,10 +295,7 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onSuccess',
-      'mutate.onSuccess',
-    ])
+    expect(callbacks).toEqual(['useMutation.onSuccess', 'mutate.onSuccess'])
   })
 
   it('should be able to call `onError` callback after failed mutate', async () => {
@@ -335,10 +332,7 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onError',
-      'mutate.onError',
-    ])
+    expect(callbacks).toEqual(['useMutation.onError', 'mutate.onError'])
   })
 
   it('should be able to call `onSettled` callback after mutate', async () => {
@@ -372,10 +366,7 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onSettled',
-      'mutate.onSettled',
-    ])
+    expect(callbacks).toEqual(['useMutation.onSettled', 'mutate.onSettled'])
   })
 
   it('should be able to override the useMutation success callbacks', async () => {

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -264,6 +264,120 @@ describe('useMutation', () => {
     )
   })
 
+  it('should be able to call `onSuccess` callback after successful mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSuccess: () => {
+          callbacks.push('useMutation.onSuccess')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onSuccess: () => {
+                callbacks.push('mutate.onSuccess')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSuccess',
+      'mutate.onSuccess',
+    ])
+  })
+
+  it('should be able to call `onError` callback after failed mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw new Error('oops')
+          }),
+        onError: () => {
+          callbacks.push('useMutation.onError')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onError: () => {
+                callbacks.push('mutate.onError')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onError',
+      'mutate.onError',
+    ])
+  })
+
+  it('should be able to call `onSettled` callback after mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onSettled: () => {
+                callbacks.push('mutate.onSettled')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSettled',
+      'mutate.onSettled',
+    ])
+  })
+
   it('should be able to override the useMutation success callbacks', async () => {
     const callbacks: Array<string> = []
 

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -294,10 +294,7 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onSuccess',
-      'mutate.onSuccess',
-    ])
+    expect(callbacks).toEqual(['useMutation.onSuccess', 'mutate.onSuccess'])
   })
 
   it('should be able to call `onError` callback after failed mutate', async () => {
@@ -334,10 +331,7 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onError',
-      'mutate.onError',
-    ])
+    expect(callbacks).toEqual(['useMutation.onError', 'mutate.onError'])
   })
 
   it('should be able to call `onSettled` callback after mutate', async () => {
@@ -371,10 +365,7 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onSettled',
-      'mutate.onSettled',
-    ])
+    expect(callbacks).toEqual(['useMutation.onSettled', 'mutate.onSettled'])
   })
 
   it('should be able to override the useMutation success callbacks', async () => {

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -263,6 +263,120 @@ describe('useMutation', () => {
     )
   })
 
+  it('should be able to call `onSuccess` callback after successful mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSuccess: () => {
+          callbacks.push('useMutation.onSuccess')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onSuccess: () => {
+                callbacks.push('mutate.onSuccess')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSuccess',
+      'mutate.onSuccess',
+    ])
+  })
+
+  it('should be able to call `onError` callback after failed mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw new Error('oops')
+          }),
+        onError: () => {
+          callbacks.push('useMutation.onError')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onError: () => {
+                callbacks.push('mutate.onError')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onError',
+      'mutate.onError',
+    ])
+  })
+
+  it('should be able to call `onSettled` callback after mutate', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('todo', {
+              onSettled: () => {
+                callbacks.push('mutate.onSettled')
+              },
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSettled',
+      'mutate.onSettled',
+    ])
+  })
+
   it('should be able to override the useMutation success callbacks', async () => {
     const callbacks: Array<string> = []
 


### PR DESCRIPTION
## 🎯 Changes

- Add 3 runtime tests for `useMutation` single callback cases in both `react-query` and `preact-query`:
  - `should be able to call 'onSuccess' callback after successful mutate`: only `onSuccess` callback at both useMutation and mutate level
  - `should be able to call 'onError' callback after failed mutate`: only `onError` callback at both levels
  - `should be able to call 'onSettled' callback after mutate`: only `onSettled` callback at both levels
- Complements existing tests that verify multiple callbacks together (`onSuccess` + `onSettled`, `onError` + `onSettled`)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced test coverage for `useMutation` hook by adding callback invocation ordering tests to verify library-level callbacks execute before per-call callbacks for success, error, and settled scenarios across both React and Preact implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->