### PR TITLE
test({react,preact}-query/useMutation): add single callback tests for 'mutateAsync'

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -369,6 +369,113 @@ describe('useMutation', () => {
     expect(callbacks).toEqual(['useMutation.onSettled', 'mutate.onSettled'])
   })
 
+  it('should be able to call `onSuccess` callback after successful mutateAsync', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutateAsync } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSuccess: () => {
+          callbacks.push('useMutation.onSuccess')
+        },
+      })
+
+      useEffect(() => {
+        setActTimeout(async () => {
+          await mutateAsync('todo', {
+            onSuccess: () => {
+              callbacks.push('mutateAsync.onSuccess')
+            },
+          })
+        }, 0)
+      }, [mutateAsync])
+
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSuccess',
+      'mutateAsync.onSuccess',
+    ])
+  })
+
+  it('should be able to call `onError` callback after failed mutateAsync', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutateAsync } = useMutation({
+        mutationFn: async (_text: string) =>
+          sleep(10).then(() => {
+            throw new Error('oops')
+          }),
+        onError: () => {
+          callbacks.push('useMutation.onError')
+        },
+      })
+
+      useEffect(() => {
+        setActTimeout(async () => {
+          try {
+            await mutateAsync('todo', {
+              onError: () => {
+                callbacks.push('mutateAsync.onError')
+              },
+            })
+          } catch {}
+        }, 0)
+      }, [mutateAsync])
+
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onError',
+      'mutateAsync.onError',
+    ])
+  })
+
+  it('should be able to call `onSettled` callback after mutateAsync', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutateAsync } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      useEffect(() => {
+        setActTimeout(async () => {
+          await mutateAsync('todo', {
+            onSettled: () => {
+              callbacks.push('mutateAsync.onSettled')
+            },
+          })
+        }, 0)
+      }, [mutateAsync])
+
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSettled',
+      'mutateAsync.onSettled',
+    ])
+  })
+
   it('should be able to override the useMutation success callbacks', async () => {
     const callbacks: Array<string> = []
 

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -436,10 +436,7 @@ describe('useMutation', () => {
 
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onError',
-      'mutateAsync.onError',
-    ])
+    expect(callbacks).toEqual(['useMutation.onError', 'mutateAsync.onError'])
   })
 
   it('should be able to call `onSettled` callback after mutateAsync', async () => {

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -435,10 +435,7 @@ describe('useMutation', () => {
 
     await vi.advanceTimersByTimeAsync(10)
 
-    expect(callbacks).toEqual([
-      'useMutation.onError',
-      'mutateAsync.onError',
-    ])
+    expect(callbacks).toEqual(['useMutation.onError', 'mutateAsync.onError'])
   })
 
   it('should be able to call `onSettled` callback after mutateAsync', async () => {

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -368,6 +368,113 @@ describe('useMutation', () => {
     expect(callbacks).toEqual(['useMutation.onSettled', 'mutate.onSettled'])
   })
 
+  it('should be able to call `onSuccess` callback after successful mutateAsync', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutateAsync } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSuccess: () => {
+          callbacks.push('useMutation.onSuccess')
+        },
+      })
+
+      React.useEffect(() => {
+        setActTimeout(async () => {
+          await mutateAsync('todo', {
+            onSuccess: () => {
+              callbacks.push('mutateAsync.onSuccess')
+            },
+          })
+        }, 0)
+      }, [mutateAsync])
+
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSuccess',
+      'mutateAsync.onSuccess',
+    ])
+  })
+
+  it('should be able to call `onError` callback after failed mutateAsync', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutateAsync } = useMutation({
+        mutationFn: async (_text: string) =>
+          sleep(10).then(() => {
+            throw new Error('oops')
+          }),
+        onError: () => {
+          callbacks.push('useMutation.onError')
+        },
+      })
+
+      React.useEffect(() => {
+        setActTimeout(async () => {
+          try {
+            await mutateAsync('todo', {
+              onError: () => {
+                callbacks.push('mutateAsync.onError')
+              },
+            })
+          } catch {}
+        }, 0)
+      }, [mutateAsync])
+
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onError',
+      'mutateAsync.onError',
+    ])
+  })
+
+  it('should be able to call `onSettled` callback after mutateAsync', async () => {
+    const callbacks: Array<string> = []
+
+    function Page() {
+      const { mutateAsync } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSettled: () => {
+          callbacks.push('useMutation.onSettled')
+        },
+      })
+
+      React.useEffect(() => {
+        setActTimeout(async () => {
+          await mutateAsync('todo', {
+            onSettled: () => {
+              callbacks.push('mutateAsync.onSettled')
+            },
+          })
+        }, 0)
+      }, [mutateAsync])
+
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(callbacks).toEqual([
+      'useMutation.onSettled',
+      'mutateAsync.onSettled',
+    ])
+  })
+
   it('should be able to override the useMutation success callbacks', async () => {
     const callbacks: Array<string> = []
 


### PR DESCRIPTION
## 🎯 Changes

- Add 3 runtime tests for `useMutation` single callback cases with `mutateAsync` in both `react-query` and `preact-query`:
  - `should be able to call 'onSuccess' callback after successful mutateAsync`
  - `should be able to call 'onError' callback after failed mutateAsync`
  - `should be able to call 'onSettled' callback after mutateAsync`
- Complements existing single callback tests for `mutate` (#10487) and multi-callback override tests

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for asynchronous mutation callbacks in both react-query and preact-query packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->