### PR TITLE
test({react,preact}-query/useMutation): add chained 'mutateAsync' tests for sequential mutation calls

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -1893,4 +1893,89 @@ describe('useMutation', () => {
       rendered.getByText('data: custom client, status: success'),
     ).toBeInTheDocument()
   })
+
+  it('should be able to chain mutateAsync calls sequentially', async () => {
+    function Page() {
+      const [result, setResult] = useState<string>('idle')
+
+      const createUserMutation = useMutation({
+        mutationFn: (name: string) =>
+          sleep(10).then(() => ({ id: '1', name })),
+      })
+
+      const updateProfileMutation = useMutation({
+        mutationFn: (userId: string) =>
+          sleep(10).then(() => `profile updated for ${userId}`),
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              const user = await createUserMutation.mutateAsync('John')
+              const profile = await updateProfileMutation.mutateAsync(user.id)
+              setResult(profile)
+            }}
+          >
+            chain
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /chain/i }))
+    await vi.advanceTimersByTimeAsync(10)
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: profile updated for 1'),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle error in chained mutateAsync calls', async () => {
+    function Page() {
+      const [result, setResult] = useState<string>('idle')
+
+      const createUserMutation = useMutation({
+        mutationFn: (_name: string) =>
+          sleep(10).then<{ id: string }>(() => {
+            throw new Error('create failed')
+          }),
+      })
+
+      const updateProfileMutation = useMutation({
+        mutationFn: (userId: string) =>
+          sleep(10).then(() => `profile updated for ${userId}`),
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              try {
+                const user = await createUserMutation.mutateAsync('John')
+                const profile = await updateProfileMutation.mutateAsync(user.id)
+                setResult(profile)
+              } catch (error) {
+                setResult(`error: ${(error as Error).message}`)
+              }
+            }}
+          >
+            chain
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /chain/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('result: error: create failed')).toBeInTheDocument()
+  })
 })

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -1899,8 +1899,7 @@ describe('useMutation', () => {
       const [result, setResult] = useState<string>('idle')
 
       const createUserMutation = useMutation({
-        mutationFn: (name: string) =>
-          sleep(10).then(() => ({ id: '1', name })),
+        mutationFn: (name: string) => sleep(10).then(() => ({ id: '1', name })),
       })
 
       const updateProfileMutation = useMutation({
@@ -1976,6 +1975,8 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /chain/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('result: error: create failed')).toBeInTheDocument()
+    expect(
+      rendered.getByText('result: error: create failed'),
+    ).toBeInTheDocument()
   })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1898,8 +1898,7 @@ describe('useMutation', () => {
       const [result, setResult] = React.useState<string>('idle')
 
       const createUserMutation = useMutation({
-        mutationFn: (name: string) =>
-          sleep(10).then(() => ({ id: '1', name })),
+        mutationFn: (name: string) => sleep(10).then(() => ({ id: '1', name })),
       })
 
       const updateProfileMutation = useMutation({
@@ -1975,6 +1974,8 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /chain/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('result: error: create failed')).toBeInTheDocument()
+    expect(
+      rendered.getByText('result: error: create failed'),
+    ).toBeInTheDocument()
   })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1892,4 +1892,89 @@ describe('useMutation', () => {
       rendered.getByText('data: custom client, status: success'),
     ).toBeInTheDocument()
   })
+
+  it('should be able to chain mutateAsync calls sequentially', async () => {
+    function Page() {
+      const [result, setResult] = React.useState<string>('idle')
+
+      const createUserMutation = useMutation({
+        mutationFn: (name: string) =>
+          sleep(10).then(() => ({ id: '1', name })),
+      })
+
+      const updateProfileMutation = useMutation({
+        mutationFn: (userId: string) =>
+          sleep(10).then(() => `profile updated for ${userId}`),
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              const user = await createUserMutation.mutateAsync('John')
+              const profile = await updateProfileMutation.mutateAsync(user.id)
+              setResult(profile)
+            }}
+          >
+            chain
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /chain/i }))
+    await vi.advanceTimersByTimeAsync(10)
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: profile updated for 1'),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle error in chained mutateAsync calls', async () => {
+    function Page() {
+      const [result, setResult] = React.useState<string>('idle')
+
+      const createUserMutation = useMutation({
+        mutationFn: (_name: string) =>
+          sleep(10).then<{ id: string }>(() => {
+            throw new Error('create failed')
+          }),
+      })
+
+      const updateProfileMutation = useMutation({
+        mutationFn: (userId: string) =>
+          sleep(10).then(() => `profile updated for ${userId}`),
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              try {
+                const user = await createUserMutation.mutateAsync('John')
+                const profile = await updateProfileMutation.mutateAsync(user.id)
+                setResult(profile)
+              } catch (error) {
+                setResult(`error: ${(error as Error).message}`)
+              }
+            }}
+          >
+            chain
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /chain/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('result: error: create failed')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add 2 runtime tests for chained `mutateAsync` calls in both `react-query` and `preact-query`:
  - `should be able to chain mutateAsync calls sequentially`: first mutation creates a user, second mutation updates profile using the created user's ID
  - `should handle error in chained mutateAsync calls`: first mutation fails, error is caught in `try/catch`, second mutation is not executed
- Uses `fireEvent.click` with `async/await` pattern matching real user flow

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for sequential `mutateAsync` execution and error handling scenarios in mutation chains across both preact-query and react-query packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->