### PR TITLE
test({react,preact}-query/useMutation): add conditional handling and retry tests using 'mutate' callbacks

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -2027,12 +2027,16 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('message: success: submitted successfully')).toBeInTheDocument()
+    expect(
+      rendered.getByText('message: success: submitted successfully'),
+    ).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /submit fail/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('message: error: submission failed')).toBeInTheDocument()
+    expect(
+      rendered.getByText('message: error: submission failed'),
+    ).toBeInTheDocument()
   })
 
   it('should handle conditional error with retry using mutate', async () => {
@@ -2075,7 +2079,9 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('message: failed, retrying...')).toBeInTheDocument()
+    expect(
+      rendered.getByText('message: failed, retrying...'),
+    ).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
     await vi.advanceTimersByTimeAsync(11)

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -1979,4 +1979,107 @@ describe('useMutation', () => {
       rendered.getByText('result: error: create failed'),
     ).toBeInTheDocument()
   })
+
+  it('should handle conditional logic based on mutate success or failure', async () => {
+    function Page() {
+      const [message, setMessage] = useState<string>('idle')
+
+      const submitMutation = useMutation({
+        mutationFn: async (shouldFail: boolean) => {
+          await sleep(10)
+          if (shouldFail) {
+            throw new Error('submission failed')
+          }
+          return 'submitted successfully'
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={() =>
+              submitMutation.mutate(false, {
+                onSuccess: (result) => setMessage(`success: ${result}`),
+                onError: (error) => setMessage(`error: ${error.message}`),
+              })
+            }
+          >
+            submit
+          </button>
+          <button
+            onClick={() =>
+              submitMutation.mutate(true, {
+                onSuccess: (result) => setMessage(`success: ${result}`),
+                onError: (error) => setMessage(`error: ${error.message}`),
+              })
+            }
+          >
+            submit fail
+          </button>
+          <div>message: {message}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: success: submitted successfully')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /submit fail/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: error: submission failed')).toBeInTheDocument()
+  })
+
+  it('should handle conditional error with retry using mutate', async () => {
+    let attempt = 0
+
+    function Page() {
+      const [message, setMessage] = useState<string>('idle')
+
+      const submitMutation = useMutation({
+        mutationFn: async () => {
+          await sleep(10)
+          attempt++
+          if (attempt < 2) {
+            throw new Error('temporary failure')
+          }
+          return 'success'
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={() =>
+              submitMutation.mutate(undefined, {
+                onSuccess: (result) => setMessage(`result: ${result}`),
+                onError: () => setMessage('failed, retrying...'),
+              })
+            }
+          >
+            submit
+          </button>
+          <div>message: {message}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: failed, retrying...')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: result: success')).toBeInTheDocument()
+  })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1978,4 +1978,107 @@ describe('useMutation', () => {
       rendered.getByText('result: error: create failed'),
     ).toBeInTheDocument()
   })
+
+  it('should handle conditional logic based on mutate success or failure', async () => {
+    function Page() {
+      const [message, setMessage] = React.useState<string>('idle')
+
+      const submitMutation = useMutation({
+        mutationFn: async (shouldFail: boolean) => {
+          await sleep(10)
+          if (shouldFail) {
+            throw new Error('submission failed')
+          }
+          return 'submitted successfully'
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={() =>
+              submitMutation.mutate(false, {
+                onSuccess: (result) => setMessage(`success: ${result}`),
+                onError: (error) => setMessage(`error: ${error.message}`),
+              })
+            }
+          >
+            submit
+          </button>
+          <button
+            onClick={() =>
+              submitMutation.mutate(true, {
+                onSuccess: (result) => setMessage(`success: ${result}`),
+                onError: (error) => setMessage(`error: ${error.message}`),
+              })
+            }
+          >
+            submit fail
+          </button>
+          <div>message: {message}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: success: submitted successfully')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /submit fail/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: error: submission failed')).toBeInTheDocument()
+  })
+
+  it('should handle conditional error with retry using mutate', async () => {
+    let attempt = 0
+
+    function Page() {
+      const [message, setMessage] = React.useState<string>('idle')
+
+      const submitMutation = useMutation({
+        mutationFn: async () => {
+          await sleep(10)
+          attempt++
+          if (attempt < 2) {
+            throw new Error('temporary failure')
+          }
+          return 'success'
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={() =>
+              submitMutation.mutate(undefined, {
+                onSuccess: (result) => setMessage(`result: ${result}`),
+                onError: () => setMessage('failed, retrying...'),
+              })
+            }
+          >
+            submit
+          </button>
+          <div>message: {message}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: failed, retrying...')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('message: result: success')).toBeInTheDocument()
+  })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -2026,12 +2026,16 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('message: success: submitted successfully')).toBeInTheDocument()
+    expect(
+      rendered.getByText('message: success: submitted successfully'),
+    ).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /submit fail/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('message: error: submission failed')).toBeInTheDocument()
+    expect(
+      rendered.getByText('message: error: submission failed'),
+    ).toBeInTheDocument()
   })
 
   it('should handle conditional error with retry using mutate', async () => {
@@ -2074,7 +2078,9 @@ describe('useMutation', () => {
     fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
     await vi.advanceTimersByTimeAsync(11)
 
-    expect(rendered.getByText('message: failed, retrying...')).toBeInTheDocument()
+    expect(
+      rendered.getByText('message: failed, retrying...'),
+    ).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /submit/i }))
     await vi.advanceTimersByTimeAsync(11)


### PR DESCRIPTION
## 🎯 Changes

- Add 2 runtime tests for `useMutation` real-world scenarios using `mutate` callbacks in both `react-query` and `preact-query`:
  - `should handle conditional logic based on mutate success or failure`: uses `mutate` with `onSuccess`/`onError` callbacks to show success or error message based on mutation result
  - `should handle conditional error with retry using mutate`: first attempt fails with `onError` callback, user clicks again to retry and succeeds with `onSuccess` callback
- Uses `mutate` + callback pattern (TanStack Query recommended) instead of `mutateAsync` + `try/catch`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `useMutation` error and success handling with variable inputs and retry scenarios across Preact Query and React Query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->