### PR TITLE
test({react,preact}-query/useMutation): add optimistic update tests with success and rollback on error

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -2088,4 +2088,123 @@ describe('useMutation', () => {
 
     expect(rendered.getByText('message: result: success')).toBeInTheDocument()
   })
+
+  it('should support optimistic update on success', async () => {
+    function Page() {
+      const [items, setItems] = useState<Array<string>>([
+        'item1',
+        'item2',
+        'item3',
+      ])
+
+      const [successMessage, setSuccessMessage] = useState<string>('')
+
+      const deleteMutation = useMutation({
+        mutationFn: (item: string) => sleep(10).then(() => item),
+        onMutate: (item) => {
+          const previousItems = [...items]
+          setItems((prev) => prev.filter((i) => i !== item))
+          return { previousItems }
+        },
+        onSuccess: (deletedItem) => {
+          setSuccessMessage(`deleted: ${deletedItem}`)
+        },
+        onError: (_error, _item, context) => {
+          if (context?.previousItems) {
+            setItems(context.previousItems)
+          }
+        },
+      })
+
+      return (
+        <div>
+          {items.map((item) => (
+            <button key={item} onClick={() => deleteMutation.mutate(item)}>
+              delete {item}
+            </button>
+          ))}
+          <div>items: {items.join(', ')}</div>
+          <div>success: {successMessage || 'none'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
+    expect(rendered.getByText('success: none')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /delete item2/i }))
+
+    // optimistic update: item2 removed immediately
+    expect(rendered.getByText('items: item1, item3')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    // success: item2 stays removed and onSuccess called
+    expect(rendered.getByText('items: item1, item3')).toBeInTheDocument()
+    expect(rendered.getByText('success: deleted: item2')).toBeInTheDocument()
+  })
+
+  it('should support optimistic update and rollback on error', async () => {
+    function Page() {
+      const [items, setItems] = useState<Array<string>>([
+        'item1',
+        'item2',
+        'item3',
+      ])
+
+      const [message, setMessage] = useState<string>('')
+
+      const deleteMutation = useMutation({
+        mutationFn: (item: string) =>
+          sleep(10).then(() => {
+            throw new Error(`Failed to delete ${item}`)
+          }),
+        onMutate: (item) => {
+          const previousItems = [...items]
+          setItems((prev) => prev.filter((i) => i !== item))
+          return { previousItems }
+        },
+        onSuccess: (deletedItem) => {
+          setMessage(`deleted: ${deletedItem}`)
+        },
+        onError: (_error, _item, context) => {
+          setMessage('rollback')
+          if (context?.previousItems) {
+            setItems(context.previousItems)
+          }
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          {items.map((item) => (
+            <button key={item} onClick={() => deleteMutation.mutate(item)}>
+              delete {item}
+            </button>
+          ))}
+          <div>items: {items.join(', ')}</div>
+          <div>message: {message || 'none'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
+    expect(rendered.getByText('message: none')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /delete item2/i }))
+
+    // optimistic update: item2 removed immediately
+    expect(rendered.getByText('items: item1, item3')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    // rollback: item2 restored after error, onSuccess not called
+    expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
+    expect(rendered.getByText('message: rollback')).toBeInTheDocument()
+  })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -2087,4 +2087,123 @@ describe('useMutation', () => {
 
     expect(rendered.getByText('message: result: success')).toBeInTheDocument()
   })
+
+  it('should support optimistic update on success', async () => {
+    function Page() {
+      const [items, setItems] = React.useState<Array<string>>([
+        'item1',
+        'item2',
+        'item3',
+      ])
+
+      const [successMessage, setSuccessMessage] = React.useState<string>('')
+
+      const deleteMutation = useMutation({
+        mutationFn: (item: string) => sleep(10).then(() => item),
+        onMutate: (item) => {
+          const previousItems = [...items]
+          setItems((prev) => prev.filter((i) => i !== item))
+          return { previousItems }
+        },
+        onSuccess: (deletedItem) => {
+          setSuccessMessage(`deleted: ${deletedItem}`)
+        },
+        onError: (_error, _item, context) => {
+          if (context?.previousItems) {
+            setItems(context.previousItems)
+          }
+        },
+      })
+
+      return (
+        <div>
+          {items.map((item) => (
+            <button key={item} onClick={() => deleteMutation.mutate(item)}>
+              delete {item}
+            </button>
+          ))}
+          <div>items: {items.join(', ')}</div>
+          <div>success: {successMessage || 'none'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
+    expect(rendered.getByText('success: none')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /delete item2/i }))
+
+    // optimistic update: item2 removed immediately
+    expect(rendered.getByText('items: item1, item3')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    // success: item2 stays removed and onSuccess called
+    expect(rendered.getByText('items: item1, item3')).toBeInTheDocument()
+    expect(rendered.getByText('success: deleted: item2')).toBeInTheDocument()
+  })
+
+  it('should support optimistic update and rollback on error', async () => {
+    function Page() {
+      const [items, setItems] = React.useState<Array<string>>([
+        'item1',
+        'item2',
+        'item3',
+      ])
+
+      const [message, setMessage] = React.useState<string>('')
+
+      const deleteMutation = useMutation({
+        mutationFn: (item: string) =>
+          sleep(10).then(() => {
+            throw new Error(`Failed to delete ${item}`)
+          }),
+        onMutate: (item) => {
+          const previousItems = [...items]
+          setItems((prev) => prev.filter((i) => i !== item))
+          return { previousItems }
+        },
+        onSuccess: (deletedItem) => {
+          setMessage(`deleted: ${deletedItem}`)
+        },
+        onError: (_error, _item, context) => {
+          setMessage('rollback')
+          if (context?.previousItems) {
+            setItems(context.previousItems)
+          }
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          {items.map((item) => (
+            <button key={item} onClick={() => deleteMutation.mutate(item)}>
+              delete {item}
+            </button>
+          ))}
+          <div>items: {items.join(', ')}</div>
+          <div>message: {message || 'none'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
+    expect(rendered.getByText('message: none')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: /delete item2/i }))
+
+    // optimistic update: item2 removed immediately
+    expect(rendered.getByText('items: item1, item3')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    // rollback: item2 restored after error, onSuccess not called
+    expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
+    expect(rendered.getByText('message: rollback')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

- Add 2 runtime tests for `useMutation` optimistic update pattern in both `react-query` and `preact-query`:
  - `should support optimistic update on success`: `onMutate` removes item from UI immediately, mutation succeeds, `onSuccess` confirms deletion
  - `should support optimistic update and rollback on error`: `onMutate` removes item from UI immediately, mutation fails, `onError` restores previous state using context (not `onSuccess`)
- Both tests verify `onMutate` → context → `onSuccess`/`onError` callback flow with `onSuccess` included for completeness

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for optimistic deletion behavior in mutation flows, verifying immediate UI removal on mutate and confirmation on success.
  * Added tests for error paths that validate rollback/restoration of state and appropriate error messaging when mutations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->