### PR TITLE
test({react,preact}-query/useMutation): add parallel 'mutateAsync' tests with 'Promise.all' and 'Promise.allSettled'

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -2241,7 +2241,9 @@ describe('useMutation', () => {
     await vi.advanceTimersByTimeAsync(11)
 
     expect(
-      rendered.getByText('result: uploaded: file1, uploaded: file2, uploaded: file3'),
+      rendered.getByText(
+        'result: uploaded: file1, uploaded: file2, uploaded: file3',
+      ),
     ).toBeInTheDocument()
   })
 
@@ -2319,7 +2321,9 @@ describe('useMutation', () => {
               ])
               const summary = results
                 .map((r) =>
-                  r.status === 'fulfilled' ? r.value : `error: ${r.reason.message}`,
+                  r.status === 'fulfilled'
+                    ? r.value
+                    : `error: ${r.reason.message}`,
                 )
                 .join(', ')
               setResult(summary)
@@ -2338,7 +2342,9 @@ describe('useMutation', () => {
     await vi.advanceTimersByTimeAsync(11)
 
     expect(
-      rendered.getByText('result: uploaded: file1, error: upload failed, uploaded: file3'),
+      rendered.getByText(
+        'result: uploaded: file1, error: upload failed, uploaded: file3',
+      ),
     ).toBeInTheDocument()
   })
 })

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -2207,4 +2207,138 @@ describe('useMutation', () => {
     expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
     expect(rendered.getByText('message: rollback')).toBeInTheDocument()
   })
+
+  it('should be able to run multiple mutateAsync calls in parallel with Promise.all', async () => {
+    function Page() {
+      const [result, setResult] = useState<string>('idle')
+
+      const { mutateAsync } = useMutation({
+        mutationFn: (file: string) => sleep(10).then(() => `uploaded: ${file}`),
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              const results = await Promise.all([
+                mutateAsync('file1'),
+                mutateAsync('file2'),
+                mutateAsync('file3'),
+              ])
+              setResult(results.join(', '))
+            }}
+          >
+            upload all
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: uploaded: file1, uploaded: file2, uploaded: file3'),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle Promise.all rejection when one parallel mutateAsync call fails', async () => {
+    function Page() {
+      const [result, setResult] = useState<string>('idle')
+
+      const { mutateAsync } = useMutation({
+        mutationFn: async (file: string) => {
+          await sleep(10)
+          if (file === 'file2') {
+            throw new Error('upload failed')
+          }
+          return `uploaded: ${file}`
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              try {
+                const results = await Promise.all([
+                  mutateAsync('file1'),
+                  mutateAsync('file2'),
+                  mutateAsync('file3'),
+                ])
+                setResult(results.join(', '))
+              } catch (error) {
+                setResult(`error: ${(error as Error).message}`)
+              }
+            }}
+          >
+            upload all
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: error: upload failed'),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle partial failure in parallel mutateAsync calls with Promise.allSettled', async () => {
+    function Page() {
+      const [result, setResult] = useState<string>('idle')
+
+      const { mutateAsync } = useMutation({
+        mutationFn: async (file: string) => {
+          await sleep(10)
+          if (file === 'file2') {
+            throw new Error('upload failed')
+          }
+          return `uploaded: ${file}`
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              const results = await Promise.allSettled([
+                mutateAsync('file1'),
+                mutateAsync('file2'),
+                mutateAsync('file3'),
+              ])
+              const summary = results
+                .map((r) =>
+                  r.status === 'fulfilled' ? r.value : `error: ${r.reason.message}`,
+                )
+                .join(', ')
+              setResult(summary)
+            }}
+          >
+            upload all
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: uploaded: file1, error: upload failed, uploaded: file3'),
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -2240,7 +2240,9 @@ describe('useMutation', () => {
     await vi.advanceTimersByTimeAsync(11)
 
     expect(
-      rendered.getByText('result: uploaded: file1, uploaded: file2, uploaded: file3'),
+      rendered.getByText(
+        'result: uploaded: file1, uploaded: file2, uploaded: file3',
+      ),
     ).toBeInTheDocument()
   })
 
@@ -2318,7 +2320,9 @@ describe('useMutation', () => {
               ])
               const summary = results
                 .map((r) =>
-                  r.status === 'fulfilled' ? r.value : `error: ${r.reason.message}`,
+                  r.status === 'fulfilled'
+                    ? r.value
+                    : `error: ${r.reason.message}`,
                 )
                 .join(', ')
               setResult(summary)
@@ -2337,7 +2341,9 @@ describe('useMutation', () => {
     await vi.advanceTimersByTimeAsync(11)
 
     expect(
-      rendered.getByText('result: uploaded: file1, error: upload failed, uploaded: file3'),
+      rendered.getByText(
+        'result: uploaded: file1, error: upload failed, uploaded: file3',
+      ),
     ).toBeInTheDocument()
   })
 })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -2206,4 +2206,138 @@ describe('useMutation', () => {
     expect(rendered.getByText('items: item1, item2, item3')).toBeInTheDocument()
     expect(rendered.getByText('message: rollback')).toBeInTheDocument()
   })
+
+  it('should be able to run multiple mutateAsync calls in parallel with Promise.all', async () => {
+    function Page() {
+      const [result, setResult] = React.useState<string>('idle')
+
+      const { mutateAsync } = useMutation({
+        mutationFn: (file: string) => sleep(10).then(() => `uploaded: ${file}`),
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              const results = await Promise.all([
+                mutateAsync('file1'),
+                mutateAsync('file2'),
+                mutateAsync('file3'),
+              ])
+              setResult(results.join(', '))
+            }}
+          >
+            upload all
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: uploaded: file1, uploaded: file2, uploaded: file3'),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle Promise.all rejection when one parallel mutateAsync call fails', async () => {
+    function Page() {
+      const [result, setResult] = React.useState<string>('idle')
+
+      const { mutateAsync } = useMutation({
+        mutationFn: async (file: string) => {
+          await sleep(10)
+          if (file === 'file2') {
+            throw new Error('upload failed')
+          }
+          return `uploaded: ${file}`
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              try {
+                const results = await Promise.all([
+                  mutateAsync('file1'),
+                  mutateAsync('file2'),
+                  mutateAsync('file3'),
+                ])
+                setResult(results.join(', '))
+              } catch (error) {
+                setResult(`error: ${(error as Error).message}`)
+              }
+            }}
+          >
+            upload all
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: error: upload failed'),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle partial failure in parallel mutateAsync calls with Promise.allSettled', async () => {
+    function Page() {
+      const [result, setResult] = React.useState<string>('idle')
+
+      const { mutateAsync } = useMutation({
+        mutationFn: async (file: string) => {
+          await sleep(10)
+          if (file === 'file2') {
+            throw new Error('upload failed')
+          }
+          return `uploaded: ${file}`
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
+          <button
+            onClick={async () => {
+              const results = await Promise.allSettled([
+                mutateAsync('file1'),
+                mutateAsync('file2'),
+                mutateAsync('file3'),
+              ])
+              const summary = results
+                .map((r) =>
+                  r.status === 'fulfilled' ? r.value : `error: ${r.reason.message}`,
+                )
+                .join(', ')
+              setResult(summary)
+            }}
+          >
+            upload all
+          </button>
+          <div>result: {result}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: uploaded: file1, error: upload failed, uploaded: file3'),
+    ).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add 3 parallel `mutateAsync` tests to both `react-query` and `preact-query`:

- `Promise.all` with all successful parallel calls
- `Promise.all` rejection when one parallel call fails (try/catch)
- `Promise.allSettled` with partial failure handling

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for concurrent mutation handling in both Preact Query and React Query packages.
  * Added test cases verifying successful parallel mutation execution and result aggregation.
  * Added test cases for error handling in concurrent operations.
  * Added test cases for partial failure scenarios with mixed success and error outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->