### PR TITLE
test({react,preact,solid}-query/useQueries): fix test description from 'useQuery' to 'useQueries'

### DIFF
--- a/packages/preact-query/src/__tests__/useQueries.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useQueries.test-d.tsx
@@ -62,7 +62,7 @@ describe('UseQueries config object overload', () => {
     expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
   })
 
-  it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQuery', () => {
+  it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQueries', () => {
     const query1 = queryOptions({
       queryKey: queryKey(),
       queryFn: () => Promise.resolve(1),

--- a/packages/react-query/src/__tests__/useQueries.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test-d.tsx
@@ -61,7 +61,7 @@ describe('UseQueries config object overload', () => {
     expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
   })
 
-  it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQuery', () => {
+  it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQueries', () => {
     const query1 = queryOptions({
       queryKey: queryKey(),
       queryFn: () => Promise.resolve(1),

--- a/packages/solid-query/src/__tests__/useQueries.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test-d.tsx
@@ -142,7 +142,7 @@ describe('useQueries', () => {
     expectTypeOf(queryResults[2].data).toEqualTypeOf<string | undefined>()
   })
 
-  it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQuery', () => {
+  it('should be possible to define a different TData than TQueryFnData using select with queryOptions spread into useQueries', () => {
     const query1 = queryOptions({
       queryKey: queryKey(),
       queryFn: () => Promise.resolve(1),


### PR DESCRIPTION
## 🎯 Changes

Fix typo in type test description: `useQuery` → `useQueries`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected test descriptions across multiple packages to accurately reference the APIs being tested, improving test documentation clarity without affecting any functional behavior or type assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->