### PR TITLE
test(svelte-query/createInfiniteQuery): add type tests for page params, 'initialData', 'select', and 'Accessor<QueryClient>'

### DIFF
--- a/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.test-d.ts
+++ b/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.test-d.ts
@@ -1,0 +1,209 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { QueryClient } from '@tanstack/query-core'
+import { queryKey } from '@tanstack/query-test-utils'
+import { createInfiniteQuery } from '../../src/index.js'
+import type { InfiniteData } from '@tanstack/query-core'
+
+describe('createInfiniteQuery', () => {
+  describe('pageParam', () => {
+    it('initialPageParam should define type of param passed to queryFunctionContext', () => {
+      createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          expectTypeOf(pageParam).toEqualTypeOf<number>()
+        },
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+      }))
+    })
+
+    it('direction should be passed to queryFn of createInfiniteQuery', () => {
+      createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ direction }) => {
+          expectTypeOf(direction).toEqualTypeOf<'forward' | 'backward'>()
+        },
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+      }))
+    })
+
+    it('initialPageParam should define type of param passed to queryFunctionContext for fetchInfiniteQuery', () => {
+      const queryClient = new QueryClient()
+      queryClient.fetchInfiniteQuery({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          expectTypeOf(pageParam).toEqualTypeOf<number>()
+        },
+        initialPageParam: 1,
+      })
+    })
+
+    it('initialPageParam should define type of param passed to queryFunctionContext for prefetchInfiniteQuery', () => {
+      const queryClient = new QueryClient()
+      queryClient.prefetchInfiniteQuery({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          expectTypeOf(pageParam).toEqualTypeOf<number>()
+        },
+        initialPageParam: 1,
+      })
+    })
+  })
+
+  describe('initialData', () => {
+    it('TData should have undefined in the union even when initialData is provided', () => {
+      const { data } = createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          return pageParam * 5
+        },
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+        initialData: { pages: [5], pageParams: [1] },
+      }))
+
+      // TODO: Order of generics prevents pageParams to be typed correctly. Using `unknown` for now
+      expectTypeOf(data).toEqualTypeOf<
+        InfiniteData<number, unknown> | undefined
+      >()
+    })
+
+    it('TData should have undefined in the union when initialData is NOT provided', () => {
+      const { data } = createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          return pageParam * 5
+        },
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+      }))
+
+      expectTypeOf(data).toEqualTypeOf<
+        InfiniteData<number, unknown> | undefined
+      >()
+    })
+  })
+
+  describe('select', () => {
+    it('should still return paginated data if no select result', () => {
+      const infiniteQuery = createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          return pageParam * 5
+        },
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+      }))
+
+      // TODO: Order of generics prevents pageParams to be typed correctly. Using `unknown` for now
+      expectTypeOf(infiniteQuery.data).toEqualTypeOf<
+        InfiniteData<number, unknown> | undefined
+      >()
+    })
+
+    it('should be able to transform data to arbitrary result', () => {
+      const infiniteQuery = createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          return pageParam * 5
+        },
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+        select: (data) => {
+          expectTypeOf(data).toEqualTypeOf<InfiniteData<number, number>>()
+          return 'selected' as const
+        },
+      }))
+
+      expectTypeOf(infiniteQuery.data).toEqualTypeOf<'selected' | undefined>()
+    })
+  })
+
+  describe('getNextPageParam / getPreviousPageParam', () => {
+    it('should get typed params', () => {
+      const infiniteQuery = createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          return String(pageParam)
+        },
+        initialPageParam: 1,
+        getNextPageParam: (
+          lastPage,
+          allPages,
+          lastPageParam,
+          allPageParams,
+        ) => {
+          expectTypeOf(lastPage).toEqualTypeOf<string>()
+          expectTypeOf(allPages).toEqualTypeOf<Array<string>>()
+          expectTypeOf(lastPageParam).toEqualTypeOf<number>()
+          expectTypeOf(allPageParams).toEqualTypeOf<Array<number>>()
+          return undefined
+        },
+        getPreviousPageParam: (
+          firstPage,
+          allPages,
+          firstPageParam,
+          allPageParams,
+        ) => {
+          expectTypeOf(firstPage).toEqualTypeOf<string>()
+          expectTypeOf(allPages).toEqualTypeOf<Array<string>>()
+          expectTypeOf(firstPageParam).toEqualTypeOf<number>()
+          expectTypeOf(allPageParams).toEqualTypeOf<Array<number>>()
+          return undefined
+        },
+      }))
+
+      // TODO: Order of generics prevents pageParams to be typed correctly. Using `unknown` for now
+      expectTypeOf(infiniteQuery.data).toEqualTypeOf<
+        InfiniteData<string, unknown> | undefined
+      >()
+    })
+  })
+
+  describe('error booleans', () => {
+    it('should not be permanently `false`', () => {
+      const {
+        isFetchNextPageError,
+        isFetchPreviousPageError,
+        isLoadingError,
+        isRefetchError,
+      } = createInfiniteQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }) => {
+          return pageParam * 5
+        },
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+      }))
+
+      expectTypeOf(isFetchNextPageError).toEqualTypeOf<boolean>()
+      expectTypeOf(isFetchPreviousPageError).toEqualTypeOf<boolean>()
+      expectTypeOf(isLoadingError).toEqualTypeOf<boolean>()
+      expectTypeOf(isRefetchError).toEqualTypeOf<boolean>()
+    })
+  })
+
+  describe('queryClient', () => {
+    it('should accept queryClient as second argument', () => {
+      const queryClient = new QueryClient()
+
+      const infiniteQuery = createInfiniteQuery(
+        () => ({
+          queryKey: queryKey(),
+          queryFn: ({ pageParam }) => {
+            return pageParam * 5
+          },
+          initialPageParam: 1,
+          getNextPageParam: () => undefined,
+        }),
+        () => queryClient,
+      )
+
+      // TODO: Order of generics prevents pageParams to be typed correctly. Using `unknown` for now
+      expectTypeOf(infiniteQuery.data).toEqualTypeOf<
+        InfiniteData<number, unknown> | undefined
+      >()
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add type tests for `createInfiniteQuery` in `svelte-query`, covering:

- `pageParam` and `direction` type inference in `queryFn`
- `fetchInfiniteQuery` / `prefetchInfiniteQuery` page param types
- `initialData` type inference (always includes `undefined` — no `DefinedInitialDataInfiniteOptions` overload)
- `select` data transformation
- `getNextPageParam` / `getPreviousPageParam` typed params
- Error booleans (`isFetchNextPageError`, `isFetchPreviousPageError`, `isLoadingError`, `isRefetchError`)
- `Accessor<QueryClient>` second argument

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added type declaration tests for infinite query functionality to ensure correct type inference across pagination and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->