### PR TITLE
test(svelte-query/useMutationState): add type tests for default 'MutationState' and 'select' inference

### DIFF
--- a/packages/svelte-query/tests/useMutationState/useMutationState.test-d.ts
+++ b/packages/svelte-query/tests/useMutationState/useMutationState.test-d.ts
@@ -1,0 +1,24 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { useMutationState } from '../../src/index.js'
+import type { MutationState, MutationStatus } from '@tanstack/query-core'
+
+describe('useMutationState', () => {
+  it('should default to MutationState', () => {
+    const result = useMutationState({
+      filters: { status: 'pending' },
+    })
+
+    expectTypeOf(result).toEqualTypeOf<
+      Array<MutationState<unknown, Error, unknown, unknown>>
+    >()
+  })
+
+  it('should infer with select', () => {
+    const result = useMutationState({
+      filters: { status: 'pending' },
+      select: (mutation) => mutation.state.status,
+    })
+
+    expectTypeOf(result).toEqualTypeOf<Array<MutationStatus>>()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add type tests for `useMutationState` in `svelte-query`, covering:

- Default return type (`Array<MutationState>`) when no `select` is provided
- `TResult` inference from `select` callback

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added type declaration tests for `useMutationState` to ensure proper TypeScript type inference with and without filter options and select functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->