### PR TITLE
test(query-core/queriesObserver): add test for recalculating combined result when 'combine' function changes

### DIFF
--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -552,6 +552,40 @@ describe('queriesObserver', () => {
     expect(newCombined.keys).toEqual(['pending'])
   })
 
+  test('should recalculate combined result when combine function changes', () => {
+    const combine1 = vi.fn((results: Array<QueryObserverResult>) => ({
+      total: results.length,
+    }))
+    const combine2 = vi.fn((results: Array<QueryObserverResult>) => ({
+      total: results.length * 4,
+    }))
+
+    const key1 = queryKey()
+    const key2 = queryKey()
+    const queryFn1 = vi.fn().mockReturnValue(1)
+    const queryFn2 = vi.fn().mockReturnValue(2)
+
+    const queries = [
+      { queryKey: key1, queryFn: queryFn1 },
+      { queryKey: key2, queryFn: queryFn2 },
+    ]
+
+    const observer = new QueriesObserver<{ total: number }>(
+      queryClient,
+      queries,
+      { combine: combine1 },
+    )
+
+    const [raw1, getCombined1] = observer.getOptimisticResult(queries, combine1)
+    const combined1 = getCombined1(raw1)
+
+    const [raw2, getCombined2] = observer.getOptimisticResult(queries, combine2)
+    const combined2 = getCombined2(raw2)
+
+    expect(combined1.total).toBe(2)
+    expect(combined2.total).toBe(8)
+  })
+
   test('should track properties on all observers when trackResult is called', () => {
     const key1 = queryKey()
     const key2 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `QueriesObserver` recalculates the combined result when the `combine` function reference changes, instead of returning the cached result.

This covers the `combine !== this.#lastCombine` branch in `#combineResult`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test ensuring a single query observer recalculates combined results when the combine function changes. Verifies optimistic results update from the initial to the new combine logic (totals change accordingly), preventing reuse of prior derived values and ensuring correct recomputation behavior. Strengthens coverage for derived-result handling and cache-invalidation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->