### PR TITLE
test(query-core/queriesObserver): add test for 'combineResult' fallback when called without raw argument

### DIFF
--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -586,6 +586,29 @@ describe('queriesObserver', () => {
     expect(combined2.total).toBe(8)
   })
 
+  test('should use fallback result when combineResult is called without raw argument', () => {
+    const combine = vi.fn((results: Array<QueryObserverResult>) => ({
+      count: results.length,
+    }))
+
+    const key = queryKey()
+    const queryFn = vi.fn().mockReturnValue(1)
+
+    const observer = new QueriesObserver<{ count: number }>(
+      queryClient,
+      [{ queryKey: key, queryFn }],
+      { combine },
+    )
+
+    const [, getCombined] = observer.getOptimisticResult(
+      [{ queryKey: key, queryFn }],
+      combine,
+    )
+    const combined = getCombined()
+
+    expect(combined.count).toBe(1)
+  })
+
   test('should track properties on all observers when trackResult is called', () => {
     const key1 = queryKey()
     const key2 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that the `combineResult` function (returned by `getOptimisticResult`) falls back to the pre-computed `result` when called without a raw argument.

This covers the fallback path of `r ?? result` in `getOptimisticResult`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for query observer combined functionality. Added verification that the combined result feature operates correctly with the observer's default fallback behavior when invoked without explicit arguments, ensuring consistent and reliable query aggregation across diverse usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->