### PR TITLE
test(query-core/queriesObserver): add test for skipping 'trackResult' when 'notifyOnChangeProps' is set

### DIFF
--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -609,6 +609,30 @@ describe('queriesObserver', () => {
     expect(combined.count).toBe(1)
   })
 
+  test('should return observer result directly when notifyOnChangeProps is set', () => {
+    const key = queryKey()
+    const queryFn = vi.fn().mockReturnValue(1)
+
+    const observer = new QueriesObserver(queryClient, [
+      { queryKey: key, queryFn, notifyOnChangeProps: ['data'] },
+    ])
+
+    const trackResultSpy = vi.spyOn(QueryObserver.prototype, 'trackResult')
+
+    const [, , trackResult] = observer.getOptimisticResult(
+      [{ queryKey: key, queryFn, notifyOnChangeProps: ['data'] }],
+      undefined,
+    )
+
+    const trackedResults = trackResult()
+
+    expect(trackedResults).toHaveLength(1)
+    // trackResult should NOT be called when notifyOnChangeProps is set
+    expect(trackResultSpy).not.toHaveBeenCalled()
+
+    trackResultSpy.mockRestore()
+  })
+
   test('should track properties on all observers when trackResult is called', () => {
     const key1 = queryKey()
     const key2 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `#trackResult` returns the observer result directly (without calling `trackResult`) when `notifyOnChangeProps` is set on the query options.

This covers the else branch of `!notifyOnChangeProps ? trackResult(...) : observerResult` in `#trackResult`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for query observer optimization behavior to ensure accurate result tracking under specific notification conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->