### PR TITLE
test(query-core/queriesObserver): add test for returning cached combined result when nothing has changed

### DIFF
--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -633,6 +633,32 @@ describe('queriesObserver', () => {
     trackResultSpy.mockRestore()
   })
 
+  test('should return cached combined result when nothing has changed', () => {
+    const combine = vi.fn((results: Array<QueryObserverResult>) => ({
+      count: results.length,
+    }))
+
+    const key = queryKey()
+    const queryFn = vi.fn().mockReturnValue(1)
+
+    const queries = [{ queryKey: key, queryFn }]
+
+    const observer = new QueriesObserver<{ count: number }>(
+      queryClient,
+      queries,
+      { combine },
+    )
+
+    const [raw1, getCombined1] = observer.getOptimisticResult(queries, combine)
+    const combined1 = getCombined1(raw1)
+
+    const [raw2, getCombined2] = observer.getOptimisticResult(queries, combine)
+    const combined2 = getCombined2(raw2)
+
+    // Same combine, same queries → cached result returned
+    expect(combined1).toBe(combined2)
+  })
+
   test('should track properties on all observers when trackResult is called', () => {
     const key1 = queryKey()
     const key2 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `#combineResult` returns the cached `#combinedResult` without recalculating when none of the conditions (`!#combinedResult`, `#result !== #lastResult`, `queryHashesChanged`, `combine !== #lastCombine`) are met.

This covers the else path of the if block in `#combineResult`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query observer caching behavior to verify that combined results are properly cached and reused when the same parameters are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->