### PR TITLE
test(query-core/queryObserver): add test for not tracking error prop when 'throwOnError' is not set

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1368,6 +1368,40 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
+  test('should not track error prop when throwOnError is not set', async () => {
+    const key = queryKey()
+    const results: Array<QueryObserverResult> = []
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => Promise.reject('error'),
+      retry: false,
+    })
+
+    const trackedResult = observer.trackResult(
+      observer.getCurrentResult(),
+      (prop) => {
+        if (prop === 'data') {
+          observer.trackProp(prop)
+        }
+      },
+    )
+
+    trackedResult.data
+
+    const unsubscribe = observer.subscribe((result) => {
+      results.push(result)
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Without throwOnError, `error` is not auto-added to trackedProps.
+    // Since only `data` is tracked and it did not change (stayed undefined),
+    // the listener is not invoked even though `error` prop changed.
+    expect(results.length).toBe(0)
+
+    unsubscribe()
+  })
+
   test('should reject promise when experimental_prefetchInRender is disabled and thenable is pending', async () => {
     const key = queryKey()
     const queryClient2 = new QueryClient({


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `error` prop is not auto-added to `trackedProps` when `throwOnError` is not set.

This covers the else branch of `if (this.options.throwOnError)` in `queryObserver.ts` — complementing the existing `should track error prop when throwOnError is true` test that covers the if branch.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test verifying `QueryObserver` behavior when error tracking is not enabled and only the `data` property is manually tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->