### PR TITLE
test(query-core/queryObserver): add test for skipping refetch when 'retryOnMount' is false and query is in error state

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1402,6 +1402,42 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
+  test('should not refetch on mount when retryOnMount is false and query is in error state', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn(() => Promise.reject('error'))
+
+    // First observer causes query to fail
+    const firstObserver = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn,
+      retry: false,
+    })
+    const unsubscribeFirst = firstObserver.subscribe(vi.fn())
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(queryClient.getQueryState(key)?.status).toBe('error')
+
+    unsubscribeFirst()
+
+    // New observer with retryOnMount: false should not refetch
+    const secondObserver = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn,
+      retry: false,
+      retryOnMount: false,
+    })
+    const unsubscribeSecond = secondObserver.subscribe(vi.fn())
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    // queryFn should still have been called only once (no refetch)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+
+    unsubscribeSecond()
+  })
+
   test('should reject promise when experimental_prefetchInRender is disabled and thenable is pending', async () => {
     const key = queryKey()
     const queryClient2 = new QueryClient({


### PR DESCRIPTION
## 🎯 Changes

Add a test to verify that `QueryObserver` does not refetch on mount when `retryOnMount: false` is set and the query is already in `error` state.

This covers the `options.retryOnMount === false` branch in `shouldLoadOnMount` (queryObserver.ts:755).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query observer behavior to ensure queries do not re-execute upon remounting when retry and retryOnMount are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->