### PR TITLE
feat(query-core): add enforceQueryGcTime query client option

### DIFF
--- a/.changeset/warm-windows-kiss.md
+++ b/.changeset/warm-windows-kiss.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/query-core': minor
+---
+
+Add `enforceQueryGcTime` to `QueryClientConfig` to force `gcTime` for all queries created by a client.
+
+When provided, this value overrides `gcTime` from:
+- `defaultOptions.queries`
+- `setQueryDefaults`
+- per-query options passed to query methods

--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -64,6 +64,21 @@ Its available methods are:
   - Optional
   - Define defaults for all queries and mutations using this queryClient.
   - You can also define defaults to be used for [hydration](../framework/react/reference/hydration.md)
+- `enforceQueryGcTime?: number`
+  - Optional
+  - Forces `gcTime` for every query created by this client, including calls that provide `gcTime` per-query or via `setQueryDefaults`.
+  - Useful when you need a strict retention policy, for example to keep all query data in cache with `Infinity`.
+
+```tsx
+const queryClient = new QueryClient({
+  enforceQueryGcTime: Infinity,
+  defaultOptions: {
+    queries: {
+      gcTime: 60 * 1000, // ignored because enforceQueryGcTime takes precedence
+    },
+  },
+})
+```
 
 ## `queryClient.fetchQuery`
 

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -145,6 +145,47 @@ describe('queryClient', () => {
   })
 
   describe('defaultQueryOptions', () => {
+    test('should enforce gcTime from QueryClient config', () => {
+      const key = queryKey()
+      const testClient = new QueryClient({
+        enforceQueryGcTime: Infinity,
+      })
+
+      expect(
+        testClient.defaultQueryOptions({ queryKey: key, gcTime: 10 }).gcTime,
+      ).toBe(Infinity)
+    })
+
+    test('should enforce gcTime over matching query defaults', () => {
+      const key = queryKey()
+      const testClient = new QueryClient({
+        enforceQueryGcTime: Infinity,
+      })
+
+      testClient.setQueryDefaults(key, { gcTime: 10 })
+
+      expect(testClient.defaultQueryOptions({ queryKey: key }).gcTime).toBe(
+        Infinity,
+      )
+    })
+
+    test('should enforce gcTime when query is added to cache', async () => {
+      const key = queryKey()
+      const testClient = new QueryClient({
+        enforceQueryGcTime: Infinity,
+      })
+
+      await testClient.prefetchQuery({
+        queryKey: key,
+        queryFn: () => Promise.resolve('data'),
+        gcTime: 10,
+      })
+
+      expect(
+        testClient.getQueryCache().find({ queryKey: key })?.options.gcTime,
+      ).toBe(Infinity)
+    })
+
     test('should default networkMode when persister is present', () => {
       expect(
         new QueryClient({

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -62,6 +62,7 @@ export class QueryClient {
   #queryCache: QueryCache
   #mutationCache: MutationCache
   #defaultOptions: DefaultOptions
+  #enforceQueryGcTime: number | undefined
   #queryDefaults: Map<string, QueryDefaults>
   #mutationDefaults: Map<string, MutationDefaults>
   #mountCount: number
@@ -72,6 +73,7 @@ export class QueryClient {
     this.#queryCache = config.queryCache || new QueryCache()
     this.#mutationCache = config.mutationCache || new MutationCache()
     this.#defaultOptions = config.defaultOptions || {}
+    this.#enforceQueryGcTime = config.enforceQueryGcTime
     this.#queryDefaults = new Map()
     this.#mutationDefaults = new Map()
     this.#mountCount = 0
@@ -591,6 +593,10 @@ export class QueryClient {
       ...this.getQueryDefaults(options.queryKey),
       ...options,
       _defaulted: true,
+    }
+
+    if (this.#enforceQueryGcTime !== undefined) {
+      defaultedOptions.gcTime = this.#enforceQueryGcTime
     }
 
     if (!defaultedOptions.queryHash) {

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -1356,6 +1356,11 @@ export interface QueryClientConfig {
   queryCache?: QueryCache
   mutationCache?: MutationCache
   defaultOptions?: DefaultOptions
+  /**
+   * Force all queries created by this client to use the same gcTime.
+   * This overrides gcTime set globally, per key or per query call.
+   */
+  enforceQueryGcTime?: number
 }
 
 export interface DefaultOptions<TError = DefaultError> {


### PR DESCRIPTION
## Discustion

https://github.com/TanStack/query/discussions/10555

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `enforceQueryGcTime` option to QueryClient configuration, allowing developers to enforce a single garbage collection time across all queries, overriding per-query or global settings.

* **Documentation**
  * Updated QueryClient reference documentation with the new `enforceQueryGcTime` configuration option and usage examples.

* **Tests**
  * Added test coverage for `enforceQueryGcTime` behavior and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->