### PR TITLE
test(angular-query-experimental/injectQueries): add test for not fetching when 'isRestoring' is true

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -82,48 +82,50 @@ describe('injectQueries', () => {
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
   })
 
-  it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
-    const key1 = queryKey()
-    const key2 = queryKey()
-    const queryFn1 = vi.fn().mockImplementation(() => sleep(10).then(() => 1))
-    const queryFn2 = vi.fn().mockImplementation(() => sleep(10).then(() => 2))
+  describe('isRestoring', () => {
+    it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
+      const key1 = queryKey()
+      const key2 = queryKey()
+      const queryFn1 = vi.fn().mockImplementation(() => sleep(10).then(() => 1))
+      const queryFn2 = vi.fn().mockImplementation(() => sleep(10).then(() => 2))
 
-    TestBed.resetTestingModule()
-    TestBed.configureTestingModule({
-      providers: [
-        provideZonelessChangeDetection(),
-        provideTanStackQuery(queryClient),
-        provideIsRestoring(signal(true).asReadonly()),
-      ],
-    })
-
-    const queries = TestBed.runInInjectionContext(() =>
-      injectQueries(() => ({
-        queries: [
-          { queryKey: key1, queryFn: queryFn1 },
-          { queryKey: key2, queryFn: queryFn2 },
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          provideTanStackQuery(queryClient),
+          provideIsRestoring(signal(true).asReadonly()),
         ],
-      })),
-    )
+      })
 
-    await vi.advanceTimersByTimeAsync(0)
-    expect(queries()[0].status()).toBe('pending')
-    expect(queries()[0].fetchStatus()).toBe('idle')
-    expect(queries()[0].data()).toBeUndefined()
-    expect(queries()[1].status()).toBe('pending')
-    expect(queries()[1].fetchStatus()).toBe('idle')
-    expect(queries()[1].data()).toBeUndefined()
-    expect(queryFn1).toHaveBeenCalledTimes(0)
-    expect(queryFn2).toHaveBeenCalledTimes(0)
+      const queries = TestBed.runInInjectionContext(() =>
+        injectQueries(() => ({
+          queries: [
+            { queryKey: key1, queryFn: queryFn1 },
+            { queryKey: key2, queryFn: queryFn2 },
+          ],
+        })),
+      )
 
-    await vi.advanceTimersByTimeAsync(11)
-    expect(queries()[0].status()).toBe('pending')
-    expect(queries()[0].fetchStatus()).toBe('idle')
-    expect(queries()[0].data()).toBeUndefined()
-    expect(queries()[1].status()).toBe('pending')
-    expect(queries()[1].fetchStatus()).toBe('idle')
-    expect(queries()[1].data()).toBeUndefined()
-    expect(queryFn1).toHaveBeenCalledTimes(0)
-    expect(queryFn2).toHaveBeenCalledTimes(0)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(queries()[0].status()).toBe('pending')
+      expect(queries()[0].fetchStatus()).toBe('idle')
+      expect(queries()[0].data()).toBeUndefined()
+      expect(queries()[1].status()).toBe('pending')
+      expect(queries()[1].fetchStatus()).toBe('idle')
+      expect(queries()[1].data()).toBeUndefined()
+      expect(queryFn1).toHaveBeenCalledTimes(0)
+      expect(queryFn2).toHaveBeenCalledTimes(0)
+
+      await vi.advanceTimersByTimeAsync(11)
+      expect(queries()[0].status()).toBe('pending')
+      expect(queries()[0].fetchStatus()).toBe('idle')
+      expect(queries()[0].data()).toBeUndefined()
+      expect(queries()[1].status()).toBe('pending')
+      expect(queries()[1].fetchStatus()).toBe('idle')
+      expect(queries()[1].data()).toBeUndefined()
+      expect(queryFn1).toHaveBeenCalledTimes(0)
+      expect(queryFn2).toHaveBeenCalledTimes(0)
+    })
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -3,11 +3,12 @@ import {
   Component,
   effect,
   provideZonelessChangeDetection,
+  signal,
 } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import { render } from '@testing-library/angular'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryClient, provideTanStackQuery } from '..'
+import { QueryClient, provideIsRestoring, provideTanStackQuery } from '..'
 import { injectQueries } from '../inject-queries'
 
 let queryClient: QueryClient
@@ -79,5 +80,50 @@ describe('injectQueries', () => {
     expect(results[0]).toMatchObject([{ data: undefined }, { data: undefined }])
     expect(results[1]).toMatchObject([{ data: 1 }, { data: undefined }])
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
+  })
+
+  it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+    const queryFn1 = vi.fn().mockImplementation(() => sleep(10).then(() => 1))
+    const queryFn2 = vi.fn().mockImplementation(() => sleep(10).then(() => 2))
+
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideTanStackQuery(queryClient),
+        provideIsRestoring(signal(true).asReadonly()),
+      ],
+    })
+
+    const queries = TestBed.runInInjectionContext(() =>
+      injectQueries(() => ({
+        queries: [
+          { queryKey: key1, queryFn: queryFn1 },
+          { queryKey: key2, queryFn: queryFn2 },
+        ],
+      })),
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queries()[0].status()).toBe('pending')
+    expect(queries()[0].fetchStatus()).toBe('idle')
+    expect(queries()[0].data()).toBeUndefined()
+    expect(queries()[1].status()).toBe('pending')
+    expect(queries()[1].fetchStatus()).toBe('idle')
+    expect(queries()[1].data()).toBeUndefined()
+    expect(queryFn1).toHaveBeenCalledTimes(0)
+    expect(queryFn2).toHaveBeenCalledTimes(0)
+
+    await vi.advanceTimersByTimeAsync(11)
+    expect(queries()[0].status()).toBe('pending')
+    expect(queries()[0].fetchStatus()).toBe('idle')
+    expect(queries()[0].data()).toBeUndefined()
+    expect(queries()[1].status()).toBe('pending')
+    expect(queries()[1].fetchStatus()).toBe('idle')
+    expect(queries()[1].data()).toBeUndefined()
+    expect(queryFn1).toHaveBeenCalledTimes(0)
+    expect(queryFn2).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add a test verifying that `injectQueries` does not fetch during the restoring period when `isRestoring` is `true`, matching the existing pattern in `injectQuery` tests.

This covers the `isRestoring() ? () => undefined : ...` branch in `inject-queries.ts`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for restoration state: added test setup support for an "is restoring" signal and new tests confirming queries remain pending, do not run their fetch functions, and preserve idle/fetch statuses while restoration is active, preventing premature execution during restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->