### PR TITLE
test(*): migrate 'test' to 'it' and enforce 'vitest/consistent-test-it' rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,10 @@ export default [
     plugins: { vitest },
     rules: {
       ...vitest.configs.recommended.rules,
+      'vitest/consistent-test-it': [
+        'error',
+        { fn: 'it', withinDescribe: 'it' },
+      ],
       'vitest/no-standalone-expect': [
         'error',
         {

--- a/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, expectTypeOf, it, test } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient, dataTagSymbol } from '@tanstack/query-core'
 import { infiniteQueryOptions } from '../infinite-query-options'
@@ -139,7 +139,7 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
-  test('should not be allowed to be passed to non-infinite query functions', () => {
+  it('should not be allowed to be passed to non-infinite query functions', () => {
     const key = queryKey()
     const queryClient = new QueryClient()
     const options = infiniteQueryOptions({
@@ -166,7 +166,7 @@ describe('infiniteQueryOptions', () => {
     )
   })
 
-  test('allow optional initialData function', () => {
+  it('allow optional initialData function', () => {
     const key = queryKey()
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
@@ -185,7 +185,7 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
-  test('allow optional initialData object', () => {
+  it('allow optional initialData object', () => {
     const key = queryKey()
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({

--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test-d.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { afterEach, beforeEach, describe, expectTypeOf, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expectTypeOf, it, vi } from 'vitest'
 import { provideZonelessChangeDetection } from '@angular/core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient, injectInfiniteQuery, provideTanStackQuery } from '..'
@@ -23,7 +23,7 @@ describe('injectInfiniteQuery', () => {
     vi.useRealTimers()
   })
 
-  test('should narrow type after isSuccess', () => {
+  it('should narrow type after isSuccess', () => {
     const key = queryKey()
     const query = TestBed.runInInjectionContext(() => {
       return injectInfiniteQuery(() => ({

--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Injector, provideZonelessChangeDetection } from '@angular/core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient, injectInfiniteQuery, provideTanStackQuery } from '..'
@@ -23,7 +23,7 @@ describe('injectInfiniteQuery', () => {
     vi.useRealTimers()
   })
 
-  test('should properly execute infinite query', async () => {
+  it('should properly execute infinite query', async () => {
     const key = queryKey()
     const query = TestBed.runInInjectionContext(() => {
       return injectInfiniteQuery(() => ({
@@ -64,7 +64,7 @@ describe('injectInfiniteQuery', () => {
   })
 
   describe('injection context', () => {
-    test('throws NG0203 with descriptive error outside injection context', () => {
+    it('throws NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()
       expect(() => {
         injectInfiniteQuery(() => ({
@@ -77,7 +77,7 @@ describe('injectInfiniteQuery', () => {
       }).toThrow(/NG0203(.*?)injectInfiniteQuery/)
     })
 
-    test('can be used outside injection context when passing an injector', () => {
+    it('can be used outside injection context when passing an injector', () => {
       const key = queryKey()
       const query = injectInfiniteQuery(
         () => ({

--- a/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Injector, provideZonelessChangeDetection } from '@angular/core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
@@ -28,7 +28,7 @@ describe('injectIsFetching', () => {
     vi.useRealTimers()
   })
 
-  test('Returns number of fetching queries', async () => {
+  it('Returns number of fetching queries', async () => {
     const key = queryKey()
     const isFetching = TestBed.runInInjectionContext(() => {
       injectQuery(() => ({
@@ -46,13 +46,13 @@ describe('injectIsFetching', () => {
   })
 
   describe('injection context', () => {
-    test('throws NG0203 with descriptive error outside injection context', () => {
+    it('throws NG0203 with descriptive error outside injection context', () => {
       expect(() => {
         injectIsFetching()
       }).toThrow(/NG0203(.*?)injectIsFetching/)
     })
 
-    test('can be used outside injection context when passing an injector', () => {
+    it('can be used outside injection context when passing an injector', () => {
       expect(
         injectIsFetching(undefined, {
           injector: TestBed.inject(Injector),

--- a/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TestBed } from '@angular/core/testing'
 import { Injector, provideZonelessChangeDetection } from '@angular/core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
@@ -28,7 +28,7 @@ describe('injectIsMutating', () => {
     vi.useRealTimers()
   })
 
-  test('should properly return isMutating state', async () => {
+  it('should properly return isMutating state', async () => {
     const key = queryKey()
     const [mutation, isMutating] = TestBed.runInInjectionContext(() => [
       injectMutation(() => ({
@@ -52,13 +52,13 @@ describe('injectIsMutating', () => {
   })
 
   describe('injection context', () => {
-    test('throws NG0203 with descriptive error outside injection context', () => {
+    it('throws NG0203 with descriptive error outside injection context', () => {
       expect(() => {
         injectIsMutating()
       }).toThrow(/NG0203(.*?)injectIsMutating/)
     })
 
-    test('can be used outside injection context when passing an injector', () => {
+    it('can be used outside injection context when passing an injector', () => {
       expect(
         injectIsMutating(undefined, {
           injector: TestBed.inject(Injector),

--- a/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { Injector, provideZonelessChangeDetection, signal } from '@angular/core'
 import {
   QueryClient,
@@ -11,7 +11,7 @@ import {
 describe('injectIsRestoring', () => {
   let queryClient: QueryClient
 
-  test('returns false by default when provideIsRestoring is not used', () => {
+  it('returns false by default when provideIsRestoring is not used', () => {
     queryClient = new QueryClient()
 
     TestBed.configureTestingModule({
@@ -28,7 +28,7 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(false)
   })
 
-  test('returns provided signal value when provideIsRestoring is used', () => {
+  it('returns provided signal value when provideIsRestoring is used', () => {
     queryClient = new QueryClient()
     const restoringSignal = signal(true)
 
@@ -47,7 +47,7 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(true)
   })
 
-  test('can be used outside injection context when passing an injector', () => {
+  it('can be used outside injection context when passing an injector', () => {
     queryClient = new QueryClient()
 
     TestBed.configureTestingModule({
@@ -64,7 +64,7 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(false)
   })
 
-  test('throws NG0203 with descriptive error outside injection context', () => {
+  it('throws NG0203 with descriptive error outside injection context', () => {
     expect(() => {
       injectIsRestoring()
     }).toThrow(/NG0203(.*?)injectIsRestoring/)

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
@@ -6,7 +6,7 @@ import {
   signal,
 } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { By } from '@angular/platform-browser'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
@@ -36,7 +36,7 @@ describe('injectMutationState', () => {
   })
 
   describe('injectMutationState', () => {
-    test('should return variables after calling mutate 1', () => {
+    it('should return variables after calling mutate 1', () => {
       const mutationKey = queryKey()
       const variables = 'foo123'
 
@@ -59,7 +59,7 @@ describe('injectMutationState', () => {
       expect(mutationState()).toEqual([variables])
     })
 
-    test('reactive options should update injectMutationState', () => {
+    it('reactive options should update injectMutationState', () => {
       const mutationKey1 = queryKey()
       const mutationKey2 = queryKey()
       const variables1 = 'foo123'
@@ -96,7 +96,7 @@ describe('injectMutationState', () => {
       expect(mutationState()).toEqual([variables2])
     })
 
-    test('should return variables after calling mutate 2', () => {
+    it('should return variables after calling mutate 2', () => {
       queryClient.clear()
       const mutationKey = queryKey()
       const variables = 'bar234'
@@ -117,7 +117,7 @@ describe('injectMutationState', () => {
       expect(mutationState()[0]?.variables).toEqual(variables)
     })
 
-    test('should support required signal inputs', async () => {
+    it('should support required signal inputs', async () => {
       queryClient.clear()
       const fakeName = 'name1'
       const mutationKey1 = ['fake', fakeName]
@@ -179,13 +179,13 @@ describe('injectMutationState', () => {
     })
 
     describe('injection context', () => {
-      test('throws NG0203 with descriptive error outside injection context', () => {
+      it('throws NG0203 with descriptive error outside injection context', () => {
         expect(() => {
           injectMutationState()
         }).toThrow(/NG0203(.*?)injectMutationState/)
       })
 
-      test('can be used outside injection context when passing an injector', () => {
+      it('can be used outside injection context when passing an injector', () => {
         const injector = TestBed.inject(Injector)
         expect(
           injectMutationState(undefined, {

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
@@ -1,11 +1,11 @@
-import { describe, expectTypeOf, test } from 'vitest'
+import { describe, expectTypeOf, it } from 'vitest'
 import { sleep } from '@tanstack/query-test-utils'
 import { injectMutation } from '..'
 import type { Signal } from '@angular/core'
 
 describe('injectMutation', () => {
   describe('Discriminated union return type', () => {
-    test('data should be possibly undefined by default', () => {
+    it('data should be possibly undefined by default', () => {
       const mutation = injectMutation(() => ({
         mutationFn: () => sleep(0).then(() => 'string'),
       }))
@@ -13,7 +13,7 @@ describe('injectMutation', () => {
       expectTypeOf(mutation.data).toEqualTypeOf<Signal<string | undefined>>()
     })
 
-    test('data should be defined when mutation is success', () => {
+    it('data should be defined when mutation is success', () => {
       const mutation = injectMutation(() => ({
         mutationFn: () => sleep(0).then(() => 'string'),
       }))
@@ -23,7 +23,7 @@ describe('injectMutation', () => {
       }
     })
 
-    test('error should be null when mutation is success', () => {
+    it('error should be null when mutation is success', () => {
       const mutation = injectMutation(() => ({
         mutationFn: () => sleep(0).then(() => 'string'),
       }))
@@ -33,7 +33,7 @@ describe('injectMutation', () => {
       }
     })
 
-    test('data should be undefined when mutation is pending', () => {
+    it('data should be undefined when mutation is pending', () => {
       const mutation = injectMutation(() => ({
         mutationFn: () => sleep(0).then(() => 'string'),
       }))
@@ -43,7 +43,7 @@ describe('injectMutation', () => {
       }
     })
 
-    test('error should be defined when mutation is error', () => {
+    it('error should be defined when mutation is error', () => {
       const mutation = injectMutation(() => ({
         mutationFn: () => sleep(0).then(() => 'string'),
       }))
@@ -53,7 +53,7 @@ describe('injectMutation', () => {
       }
     })
 
-    test('should narrow variables', () => {
+    it('should narrow variables', () => {
       const mutation = injectMutation(() => ({
         mutationFn: (_variables: string) => sleep(0).then(() => 'string'),
       }))

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { By } from '@angular/platform-browser'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient, injectMutation, provideTanStackQuery } from '..'
@@ -31,7 +31,7 @@ describe('injectMutation', () => {
     vi.useRealTimers()
   })
 
-  test('should be in idle state initially', () => {
+  it('should be in idle state initially', () => {
     const mutation = TestBed.runInInjectionContext(() => {
       return injectMutation(() => ({
         mutationFn: (params) => sleep(0).then(() => params),
@@ -46,7 +46,7 @@ describe('injectMutation', () => {
     })
   })
 
-  test('should change state after invoking mutate', async () => {
+  it('should change state after invoking mutate', async () => {
     const result = 'Mock data'
 
     const mutation = TestBed.runInInjectionContext(() => {
@@ -70,7 +70,7 @@ describe('injectMutation', () => {
     })
   })
 
-  test('should return error when request fails', async () => {
+  it('should return error when request fails', async () => {
     const mutation = TestBed.runInInjectionContext(() => {
       return injectMutation(() => ({
         mutationFn: () =>
@@ -92,7 +92,7 @@ describe('injectMutation', () => {
     })
   })
 
-  test('should return data when request succeeds', async () => {
+  it('should return data when request succeeds', async () => {
     const result = 'Mock data'
     const mutation = TestBed.runInInjectionContext(() => {
       return injectMutation(() => ({
@@ -114,7 +114,7 @@ describe('injectMutation', () => {
     })
   })
 
-  test('reactive options should update mutation', () => {
+  it('reactive options should update mutation', () => {
     const mutationCache = queryClient.getMutationCache()
     // Signal will be updated before the mutation is called
     // this test confirms that the mutation uses the updated value
@@ -137,7 +137,7 @@ describe('injectMutation', () => {
     expect(mutations?.options.mutationKey).toEqual(key2)
   })
 
-  test('should reset state after invoking mutation.reset', async () => {
+  it('should reset state after invoking mutation.reset', async () => {
     const mutation = TestBed.runInInjectionContext(() => {
       return injectMutation(() => ({
         mutationFn: () =>
@@ -170,7 +170,7 @@ describe('injectMutation', () => {
       vi.clearAllMocks()
     })
 
-    test('should call onMutate when passed as an option', async () => {
+    it('should call onMutate when passed as an option', async () => {
       const onMutate = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -186,7 +186,7 @@ describe('injectMutation', () => {
       expect(onMutate).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onError when passed as an option', async () => {
+    it('should call onError when passed as an option', async () => {
       const onError = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -203,7 +203,7 @@ describe('injectMutation', () => {
       expect(onError).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSuccess when passed as an option', async () => {
+    it('should call onSuccess when passed as an option', async () => {
       const onSuccess = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -219,7 +219,7 @@ describe('injectMutation', () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSettled when passed as an option', async () => {
+    it('should call onSettled when passed as an option', async () => {
       const onSettled = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -235,7 +235,7 @@ describe('injectMutation', () => {
       expect(onSettled).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onError when passed as an argument of mutate function', async () => {
+    it('should call onError when passed as an argument of mutate function', async () => {
       const onError = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -251,7 +251,7 @@ describe('injectMutation', () => {
       expect(onError).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSuccess when passed as an argument of mutate function', async () => {
+    it('should call onSuccess when passed as an argument of mutate function', async () => {
       const onSuccess = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -266,7 +266,7 @@ describe('injectMutation', () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSettled when passed as an argument of mutate function', async () => {
+    it('should call onSettled when passed as an argument of mutate function', async () => {
       const onSettled = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -281,7 +281,7 @@ describe('injectMutation', () => {
       expect(onSettled).toHaveBeenCalledTimes(1)
     })
 
-    test('should fire both onSettled functions', async () => {
+    it('should fire both onSettled functions', async () => {
       const onSettled = vi.fn()
       const onSettledOnFunction = vi.fn()
       const mutation = TestBed.runInInjectionContext(() => {
@@ -300,7 +300,7 @@ describe('injectMutation', () => {
     })
   })
 
-  test('should support required signal inputs', async () => {
+  it('should support required signal inputs', async () => {
     const mutationCache = queryClient.getMutationCache()
 
     @Component({
@@ -340,7 +340,7 @@ describe('injectMutation', () => {
     expect(mutation!.options.mutationKey).toStrictEqual(['fake', 'value'])
   })
 
-  test('should update options on required signal input change', async () => {
+  it('should update options on required signal input change', async () => {
     const mutationCache = queryClient.getMutationCache()
 
     @Component({
@@ -392,7 +392,7 @@ describe('injectMutation', () => {
   })
 
   describe('throwOnError', () => {
-    test('should evaluate throwOnError when mutation is expected to throw', async () => {
+    it('should evaluate throwOnError when mutation is expected to throw', async () => {
       const key = queryKey()
       const err = new Error('Expected mock error. All is well!')
       const boundaryFn = vi.fn()
@@ -416,7 +416,7 @@ describe('injectMutation', () => {
       expect(boundaryFn).toHaveBeenCalledWith(err)
     })
 
-    test('should throw when throwOnError is true and mutate is used', async () => {
+    it('should throw when throwOnError is true and mutate is used', async () => {
       const key = queryKey()
       const { mutate } = TestBed.runInInjectionContext(() => {
         return injectMutation(() => ({
@@ -440,7 +440,7 @@ describe('injectMutation', () => {
     })
   })
 
-  test('should throw when throwOnError is true', async () => {
+  it('should throw when throwOnError is true', async () => {
     const key = queryKey()
     const err = new Error('Expected mock error. All is well!')
     const { mutateAsync } = TestBed.runInInjectionContext(() => {
@@ -456,7 +456,7 @@ describe('injectMutation', () => {
     await expect(() => mutateAsync()).rejects.toThrow(err)
   })
 
-  test('should throw when throwOnError function returns true', async () => {
+  it('should throw when throwOnError function returns true', async () => {
     const key = queryKey()
     const err = new Error('Expected mock error. All is well!')
     const { mutateAsync } = TestBed.runInInjectionContext(() => {
@@ -473,7 +473,7 @@ describe('injectMutation', () => {
   })
 
   describe('injection context', () => {
-    test('throws NG0203 with descriptive error outside injection context', () => {
+    it('throws NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()
       expect(() => {
         injectMutation(() => ({
@@ -483,7 +483,7 @@ describe('injectMutation', () => {
       }).toThrow(/NG0203(.*?)injectMutation/)
     })
 
-    test('can be used outside injection context when passing an injector', () => {
+    it('can be used outside injection context when passing an injector', () => {
       const key = queryKey()
       expect(() => {
         injectMutation(
@@ -498,7 +498,7 @@ describe('injectMutation', () => {
       }).not.toThrow()
     })
 
-    test('should complete mutation before whenStable() resolves', async () => {
+    it('should complete mutation before whenStable() resolves', async () => {
       const app = TestBed.inject(ApplicationRef)
       let mutationStarted = false
       let mutationCompleted = false
@@ -535,7 +535,7 @@ describe('injectMutation', () => {
       expect(mutation.data()).toBe('processed: test')
     })
 
-    test('should handle synchronous mutation with retry', async () => {
+    it('should handle synchronous mutation with retry', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [
@@ -585,7 +585,7 @@ describe('injectMutation', () => {
       expect(attemptCount).toBe(3) // Initial + 2 retries
     })
 
-    test('should handle multiple synchronous mutations on same key', async () => {
+    it('should handle multiple synchronous mutations on same key', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [
@@ -639,7 +639,7 @@ describe('injectMutation', () => {
       expect(callCount).toBe(2)
     })
 
-    test('should handle synchronous mutation with optimistic updates', async () => {
+    it('should handle synchronous mutation with optimistic updates', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [
@@ -691,7 +691,7 @@ describe('injectMutation', () => {
       expect(queryClient.getQueryData(testQueryKey)).toBe('final: test')
     })
 
-    test('should handle synchronous mutation cancellation', async () => {
+    it('should handle synchronous mutation cancellation', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it, test } from 'vitest'
+import { describe, expectTypeOf, it } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { injectQuery, queryOptions } from '..'
 import type { Signal } from '@angular/core'
@@ -133,7 +133,7 @@ describe('injectQuery', () => {
   })
 
   describe('Discriminated union return type', () => {
-    test('data should be possibly undefined by default', () => {
+    it('data should be possibly undefined by default', () => {
       const key = queryKey()
       const query = injectQuery(() => ({
         queryKey: key,
@@ -143,7 +143,7 @@ describe('injectQuery', () => {
       expectTypeOf(query.data).toEqualTypeOf<Signal<string | undefined>>()
     })
 
-    test('data should be defined when query is success', () => {
+    it('data should be defined when query is success', () => {
       const key = queryKey()
       const query = injectQuery(() => ({
         queryKey: key,
@@ -155,7 +155,7 @@ describe('injectQuery', () => {
       }
     })
 
-    test('error should be null when query is success', () => {
+    it('error should be null when query is success', () => {
       const key = queryKey()
       const query = injectQuery(() => ({
         queryKey: key,
@@ -167,7 +167,7 @@ describe('injectQuery', () => {
       }
     })
 
-    test('data should be undefined when query is pending', () => {
+    it('data should be undefined when query is pending', () => {
       const key = queryKey()
       const query = injectQuery(() => ({
         queryKey: key,
@@ -179,7 +179,7 @@ describe('injectQuery', () => {
       }
     })
 
-    test('error should be defined when query is error', () => {
+    it('error should be defined when query is error', () => {
       const key = queryKey()
       const query = injectQuery(() => ({
         queryKey: key,

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -20,7 +20,7 @@ import {
   describe,
   expect,
   expectTypeOf,
-  test,
+  it,
   vi,
 } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
@@ -54,7 +54,7 @@ describe('injectQuery', () => {
     vi.useRealTimers()
   })
 
-  test('should return the correct types', () => {
+  it('should return the correct types', () => {
     const key = queryKey()
     // unspecified query function should default to unknown
     const noQueryFn = TestBed.runInInjectionContext(() =>
@@ -266,7 +266,7 @@ describe('injectQuery', () => {
     >()
   })
 
-  test('should return pending status initially', () => {
+  it('should return pending status initially', () => {
     const key = queryKey()
     const query = TestBed.runInInjectionContext(() => {
       return injectQuery(() => ({
@@ -282,7 +282,7 @@ describe('injectQuery', () => {
     expect(query.isFetched()).toBe(false)
   })
 
-  test('should resolve to success and update signal: injectQuery()', async () => {
+  it('should resolve to success and update signal: injectQuery()', async () => {
     const key = queryKey()
     const query = TestBed.runInInjectionContext(() => {
       return injectQuery(() => ({
@@ -300,7 +300,7 @@ describe('injectQuery', () => {
     expect(query.isSuccess()).toBe(true)
   })
 
-  test('should reject and update signal', async () => {
+  it('should reject and update signal', async () => {
     const key = queryKey()
     const query = TestBed.runInInjectionContext(() => {
       return injectQuery(() => ({
@@ -322,7 +322,7 @@ describe('injectQuery', () => {
     expect(query.failureReason()).toMatchObject({ message: 'Some error' })
   })
 
-  test('should update query on options contained signal change', async () => {
+  it('should update query on options contained signal change', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const key = signal(key1)
@@ -354,7 +354,7 @@ describe('injectQuery', () => {
     })
   })
 
-  test('should only run query once enabled signal is set to true', async () => {
+  it('should only run query once enabled signal is set to true', async () => {
     const key = queryKey()
     const spy = vi.fn(() => sleep(10).then(() => 'Some data'))
     const enabled = signal(false)
@@ -377,7 +377,7 @@ describe('injectQuery', () => {
     expect(query.status()).toBe('success')
   })
 
-  test('should properly execute dependent queries', async () => {
+  it('should properly execute dependent queries', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -421,7 +421,7 @@ describe('injectQuery', () => {
     )
   })
 
-  test('should use the current value for the queryKey when refetch is called', async () => {
+  it('should use the current value for the queryKey when refetch is called', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
     const keySignal = signal('key11')
@@ -462,7 +462,7 @@ describe('injectQuery', () => {
   })
 
   describe('throwOnError', () => {
-    test('should evaluate throwOnError when query is expected to throw', async () => {
+    it('should evaluate throwOnError when query is expected to throw', async () => {
       const key = queryKey()
       const boundaryFn = vi.fn()
       TestBed.runInInjectionContext(() => {
@@ -485,7 +485,7 @@ describe('injectQuery', () => {
       )
     })
 
-    test('should throw when throwOnError is true', async () => {
+    it('should throw when throwOnError is true', async () => {
       const key = queryKey()
       TestBed.runInInjectionContext(() => {
         return injectQuery(() => ({
@@ -499,7 +499,7 @@ describe('injectQuery', () => {
       await expect(vi.runAllTimersAsync()).rejects.toThrow('Some error')
     })
 
-    test('should throw when throwOnError function returns true', async () => {
+    it('should throw when throwOnError function returns true', async () => {
       const key = queryKey()
       TestBed.runInInjectionContext(() => {
         return injectQuery(() => ({
@@ -514,7 +514,7 @@ describe('injectQuery', () => {
     })
   })
 
-  test('should set state to error when queryFn returns reject promise', async () => {
+  it('should set state to error when queryFn returns reject promise', async () => {
     const key = queryKey()
     const query = TestBed.runInInjectionContext(() => {
       return injectQuery(() => ({
@@ -532,7 +532,7 @@ describe('injectQuery', () => {
     expect(query.status()).toBe('error')
   })
 
-  test('should render with required signal inputs', async () => {
+  it('should render with required signal inputs', async () => {
     @Component({
       selector: 'app-fake',
       template: `{{ query.data() }}`,
@@ -560,7 +560,7 @@ describe('injectQuery', () => {
   })
 
   describe('isRestoring', () => {
-    test('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
+    it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
       const key = queryKey()
       const queryFn = vi
         .fn()
@@ -597,7 +597,7 @@ describe('injectQuery', () => {
   })
 
   describe('injection context', () => {
-    test('throws NG0203 with descriptive error outside injection context', () => {
+    it('throws NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()
       expect(() => {
         injectQuery(() => ({
@@ -607,7 +607,7 @@ describe('injectQuery', () => {
       }).toThrow(/NG0203(.*?)injectQuery/)
     })
 
-    test('can be used outside injection context when passing an injector', () => {
+    it('can be used outside injection context when passing an injector', () => {
       const key = queryKey()
       const query = injectQuery(
         () => ({
@@ -622,7 +622,7 @@ describe('injectQuery', () => {
       expect(query.status()).toBe('pending')
     })
 
-    test('should complete queries before whenStable() resolves', async () => {
+    it('should complete queries before whenStable() resolves', async () => {
       const key = queryKey()
       const app = TestBed.inject(ApplicationRef)
 
@@ -644,7 +644,7 @@ describe('injectQuery', () => {
       expect(query.data()).toBe('test data')
     })
 
-    test('should complete HttpClient-based queries before whenStable() resolves', async () => {
+    it('should complete HttpClient-based queries before whenStable() resolves', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [
@@ -690,7 +690,7 @@ describe('injectQuery', () => {
       httpTestingController.verify()
     })
 
-    test('should handle synchronous queryFn with staleTime', async () => {
+    it('should handle synchronous queryFn with staleTime', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [
@@ -734,7 +734,7 @@ describe('injectQuery', () => {
       expect(callCount).toBe(2)
     })
 
-    test('should handle enabled/disabled transitions with synchronous queryFn', async () => {
+    it('should handle enabled/disabled transitions with synchronous queryFn', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [
@@ -776,7 +776,7 @@ describe('injectQuery', () => {
       expect(callCount).toBe(1)
     })
 
-    test('should handle query invalidation with synchronous data', async () => {
+    it('should handle query invalidation with synchronous data', async () => {
       TestBed.resetTestingModule()
       TestBed.configureTestingModule({
         providers: [

--- a/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
@@ -9,7 +9,7 @@ import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { lastValueFrom } from 'rxjs'
 import {
@@ -52,7 +52,7 @@ describe('PendingTasks Integration', () => {
   })
 
   describe('Synchronous Resolution', () => {
-    test('should handle synchronous queryFn with whenStable()', async () => {
+    it('should handle synchronous queryFn with whenStable()', async () => {
       const app = TestBed.inject(ApplicationRef)
 
       const key = queryKey()
@@ -78,7 +78,7 @@ describe('PendingTasks Integration', () => {
       expect(query.data()).toBe('instant-data')
     })
 
-    test('should handle synchronous error with whenStable()', async () => {
+    it('should handle synchronous error with whenStable()', async () => {
       const app = TestBed.inject(ApplicationRef)
 
       const key = queryKey()
@@ -101,7 +101,7 @@ describe('PendingTasks Integration', () => {
       expect(query.error()).toEqual(new Error('instant-error'))
     })
 
-    test('should handle synchronous mutationFn with whenStable()', async () => {
+    it('should handle synchronous mutationFn with whenStable()', async () => {
       const app = TestBed.inject(ApplicationRef)
       let mutationFnCalled = false
 
@@ -129,7 +129,7 @@ describe('PendingTasks Integration', () => {
       expect(mutation.data()).toBe('processed: test')
     })
 
-    test('should handle synchronous mutation error with whenStable()', async () => {
+    it('should handle synchronous mutation error with whenStable()', async () => {
       const app = TestBed.inject(ApplicationRef)
 
       const mutation = TestBed.runInInjectionContext(() =>
@@ -156,7 +156,7 @@ describe('PendingTasks Integration', () => {
   })
 
   describe('Race Conditions', () => {
-    test('should handle query that completes during initial subscription', async () => {
+    it('should handle query that completes during initial subscription', async () => {
       const key = queryKey()
       const app = TestBed.inject(ApplicationRef)
       let resolveQuery: (value: string) => void
@@ -184,7 +184,7 @@ describe('PendingTasks Integration', () => {
       expect(query.data()).toBe('race-data')
     })
 
-    test('should handle rapid refetches without task leaks', async () => {
+    it('should handle rapid refetches without task leaks', async () => {
       const app = TestBed.inject(ApplicationRef)
       let callCount = 0
 
@@ -213,7 +213,7 @@ describe('PendingTasks Integration', () => {
       expect(query.data()).toMatch(/^data-\d+$/)
     })
 
-    test('should keep PendingTasks active while query retry is paused offline', async () => {
+    it('should keep PendingTasks active while query retry is paused offline', async () => {
       const app = TestBed.inject(ApplicationRef)
       let attempt = 0
 
@@ -297,7 +297,7 @@ describe('PendingTasks Integration', () => {
       }))
     }
 
-    test('should cleanup pending tasks when component with active query is destroyed', async () => {
+    it('should cleanup pending tasks when component with active query is destroyed', async () => {
       const app = TestBed.inject(ApplicationRef)
       const fixture = TestBed.createComponent(TestComponent)
 
@@ -314,7 +314,7 @@ describe('PendingTasks Integration', () => {
       await expect(stablePromise).resolves.toEqual(undefined)
     })
 
-    test('should cleanup pending tasks when component with active mutation is destroyed', async () => {
+    it('should cleanup pending tasks when component with active mutation is destroyed', async () => {
       const app = TestBed.inject(ApplicationRef)
       const fixture = TestBed.createComponent(TestComponent)
 
@@ -332,7 +332,7 @@ describe('PendingTasks Integration', () => {
   })
 
   describe('Concurrent Operations', () => {
-    test('should handle multiple queries running simultaneously', async () => {
+    it('should handle multiple queries running simultaneously', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const key3 = queryKey()
@@ -377,7 +377,7 @@ describe('PendingTasks Integration', () => {
       expect(query3.data()).toBe('instant-data')
     })
 
-    test('should handle multiple mutations running simultaneously', async () => {
+    it('should handle multiple mutations running simultaneously', async () => {
       const app = TestBed.inject(ApplicationRef)
 
       const mutation1 = TestBed.runInInjectionContext(() =>
@@ -423,7 +423,7 @@ describe('PendingTasks Integration', () => {
       expect(mutation3.data()).toBe('processed-3: test3')
     })
 
-    test('should handle mixed queries and mutations', async () => {
+    it('should handle mixed queries and mutations', async () => {
       const app = TestBed.inject(ApplicationRef)
 
       const key = queryKey()
@@ -469,7 +469,7 @@ describe('PendingTasks Integration', () => {
       })
     })
 
-    test('should handle multiple HttpClient requests with lastValueFrom', async () => {
+    it('should handle multiple HttpClient requests with lastValueFrom', async () => {
       const app = TestBed.inject(ApplicationRef)
       const httpClient = TestBed.inject(HttpClient)
       const httpTestingController = TestBed.inject(HttpTestingController)
@@ -514,7 +514,7 @@ describe('PendingTasks Integration', () => {
       httpTestingController.verify()
     })
 
-    test('should handle HttpClient request cancellation', async () => {
+    it('should handle HttpClient request cancellation', async () => {
       const app = TestBed.inject(ApplicationRef)
       const httpClient = TestBed.inject(HttpClient)
       const httpTestingController = TestBed.inject(HttpTestingController)
@@ -548,7 +548,7 @@ describe('PendingTasks Integration', () => {
   })
 
   describe('Edge Cases', () => {
-    test('should handle query cancellation mid-flight', async () => {
+    it('should handle query cancellation mid-flight', async () => {
       const key = queryKey()
       const app = TestBed.inject(ApplicationRef)
 
@@ -578,7 +578,7 @@ describe('PendingTasks Integration', () => {
       expect(query.fetchStatus()).toBe('idle')
     })
 
-    test('should handle query retry and pending task tracking', async () => {
+    it('should handle query retry and pending task tracking', async () => {
       const app = TestBed.inject(ApplicationRef)
       let attemptCount = 0
 
@@ -607,7 +607,7 @@ describe('PendingTasks Integration', () => {
       expect(attemptCount).toBe(3) // Initial + 2 retries
     })
 
-    test('should handle mutation with optimistic updates', async () => {
+    it('should handle mutation with optimistic updates', async () => {
       const app = TestBed.inject(ApplicationRef)
       const testQueryKey = queryKey()
 

--- a/packages/angular-query-experimental/src/__tests__/provide-query-client.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/provide-query-client.test.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { InjectionToken, provideZonelessChangeDetection } from '@angular/core'
 import { QueryClient } from '@tanstack/query-core'
 import { provideQueryClient } from '../providers'
 
 describe('provideQueryClient', () => {
-  test('should provide a QueryClient instance directly', () => {
+  it('should provide a QueryClient instance directly', () => {
     const queryClient = new QueryClient()
 
     TestBed.configureTestingModule({
@@ -19,7 +19,7 @@ describe('provideQueryClient', () => {
     expect(providedQueryClient).toBe(queryClient)
   })
 
-  test('should provide a QueryClient instance using an InjectionToken', () => {
+  it('should provide a QueryClient instance using an InjectionToken', () => {
     const queryClient = new QueryClient()
     const CUSTOM_QUERY_CLIENT = new InjectionToken<QueryClient>('', {
       factory: () => queryClient,

--- a/packages/angular-query-experimental/src/__tests__/provide-tanstack-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/provide-tanstack-query.test.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { InjectionToken, provideZonelessChangeDetection } from '@angular/core'
 import { QueryClient } from '@tanstack/query-core'
 import { provideTanStackQuery } from '../providers'
 
 describe('provideTanStackQuery', () => {
-  test('should provide a QueryClient instance directly', () => {
+  it('should provide a QueryClient instance directly', () => {
     const queryClient = new QueryClient()
 
     TestBed.configureTestingModule({
@@ -19,7 +19,7 @@ describe('provideTanStackQuery', () => {
     expect(providedQueryClient).toBe(queryClient)
   })
 
-  test('should provide a QueryClient instance using an InjectionToken', () => {
+  it('should provide a QueryClient instance using an InjectionToken', () => {
     const queryClient = new QueryClient()
     const CUSTOM_QUERY_CLIENT = new InjectionToken<QueryClient>('', {
       factory: () => queryClient,

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -1,14 +1,14 @@
-import { assertType, describe, expectTypeOf, test } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient, dataTagSymbol, injectQuery, queryOptions } from '..'
 import type { Signal } from '@angular/core'
 
 describe('queryOptions', () => {
-  test('should not allow excess properties', () => {
+  it('should not allow excess properties', () => {
     expectTypeOf(queryOptions).parameter(0).not.toHaveProperty('stallTime')
   })
 
-  test('should infer types for callbacks', () => {
+  it('should infer types for callbacks', () => {
     const key = queryKey()
     queryOptions({
       queryKey: key,
@@ -20,7 +20,7 @@ describe('queryOptions', () => {
     })
   })
 
-  test('should allow undefined response in initialData', () => {
+  it('should allow undefined response in initialData', () => {
     const key = queryKey()
     const options = (id: string | null) =>
       queryOptions({
@@ -45,7 +45,7 @@ describe('queryOptions', () => {
   })
 })
 
-test('should work when passed to injectQuery', () => {
+it('should work when passed to injectQuery', () => {
   const key = queryKey()
   const options = queryOptions({
     queryKey: key,
@@ -56,7 +56,7 @@ test('should work when passed to injectQuery', () => {
   expectTypeOf(data).toEqualTypeOf<Signal<number | undefined>>()
 })
 
-test('should work when passed to fetchQuery', () => {
+it('should work when passed to fetchQuery', () => {
   const key = queryKey()
   const options = queryOptions({
     queryKey: key,
@@ -67,7 +67,7 @@ test('should work when passed to fetchQuery', () => {
   assertType<Promise<number>>(data)
 })
 
-test('should tag the queryKey with the result type of the QueryFn', () => {
+it('should tag the queryKey with the result type of the QueryFn', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
     queryKey: key,
@@ -76,7 +76,7 @@ test('should tag the queryKey with the result type of the QueryFn', () => {
   assertType<number>(tagged[dataTagSymbol])
 })
 
-test('should tag the queryKey even if no promise is returned', () => {
+it('should tag the queryKey even if no promise is returned', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
     queryKey: key,
@@ -85,7 +85,7 @@ test('should tag the queryKey even if no promise is returned', () => {
   assertType<number>(tagged[dataTagSymbol])
 })
 
-test('should tag the queryKey with unknown if there is no queryFn', () => {
+it('should tag the queryKey with unknown if there is no queryFn', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
     queryKey: key,
@@ -94,7 +94,7 @@ test('should tag the queryKey with unknown if there is no queryFn', () => {
   assertType<unknown>(tagged[dataTagSymbol])
 })
 
-test('should tag the queryKey with the result type of the QueryFn if select is used', () => {
+it('should tag the queryKey with the result type of the QueryFn if select is used', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
     queryKey: key,
@@ -105,7 +105,7 @@ test('should tag the queryKey with the result type of the QueryFn if select is u
   assertType<number>(tagged[dataTagSymbol])
 })
 
-test('should return the proper type when passed to getQueryData', () => {
+it('should return the proper type when passed to getQueryData', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
     queryKey: key,
@@ -118,7 +118,7 @@ test('should return the proper type when passed to getQueryData', () => {
   expectTypeOf(data).toEqualTypeOf<number | undefined>()
 })
 
-test('should properly type updaterFn when passed to setQueryData', () => {
+it('should properly type updaterFn when passed to setQueryData', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
     queryKey: key,
@@ -134,7 +134,7 @@ test('should properly type updaterFn when passed to setQueryData', () => {
   expectTypeOf(data).toEqualTypeOf<number | undefined>()
 })
 
-test('should properly type value when passed to setQueryData', () => {
+it('should properly type value when passed to setQueryData', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
     queryKey: key,

--- a/packages/angular-query-experimental/src/__tests__/signal-proxy.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/signal-proxy.test.ts
@@ -1,27 +1,27 @@
 import { isSignal, signal } from '@angular/core'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { signalProxy } from '../signal-proxy'
 
 describe('signalProxy', () => {
   const inputSignal = signal({ fn: () => 'bar', baz: 'qux' })
   const proxy = signalProxy(inputSignal)
 
-  test('should have computed fields', () => {
+  it('should have computed fields', () => {
     expect(proxy.baz()).toEqual('qux')
     expect(isSignal(proxy.baz)).toBe(true)
   })
 
-  test('should pass through functions as-is', () => {
+  it('should pass through functions as-is', () => {
     expect(proxy.fn()).toEqual('bar')
     expect(isSignal(proxy.fn)).toBe(false)
   })
 
-  test('supports "in" operator', () => {
+  it('supports "in" operator', () => {
     expect('baz' in proxy).toBe(true)
     expect('foo' in proxy).toBe(false)
   })
 
-  test('supports "Object.keys"', () => {
+  it('supports "Object.keys"', () => {
     expect(Object.keys(proxy)).toEqual(['fn', 'baz'])
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/with-devtools.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/with-devtools.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { TestBed } from '@angular/core/testing'
 import {
@@ -62,7 +62,7 @@ describe('withDevtools feature', () => {
     TestBed.resetTestingModule()
   })
 
-  test.each([
+  it.each([
     {
       description: 'should load devtools in development mode',
       isDevMode: true,

--- a/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
+++ b/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   QueryClient,
   injectQuery,
@@ -62,7 +62,7 @@ const createMockErrorPersister = (
 }
 
 describe('withPersistQueryClient', () => {
-  test('restores cache from persister', async () => {
+  it('restores cache from persister', async () => {
     const key = queryKey()
     const states: Array<{
       status: string
@@ -146,11 +146,11 @@ describe('withPersistQueryClient', () => {
     })
   })
 
-  test.todo(
+  it.todo(
     '(Once injectQueries is functional) verify that injectQueries transitions to an idle state',
   )
 
-  test('should show initialData while restoring', async () => {
+  it('should show initialData while restoring', async () => {
     const key = queryKey()
     const states: Array<{
       status: string
@@ -238,7 +238,7 @@ describe('withPersistQueryClient', () => {
     })
   })
 
-  test('should not refetch after restoring when data is fresh', async () => {
+  it('should not refetch after restoring when data is fresh', async () => {
     const key = queryKey()
     const states: Array<{
       status: string
@@ -321,7 +321,7 @@ describe('withPersistQueryClient', () => {
     })
   })
 
-  test('should call onSuccess after successful restoring', async () => {
+  it('should call onSuccess after successful restoring', async () => {
     const key = queryKey()
     const queryClient = new QueryClient()
     queryClient.prefetchQuery({
@@ -377,7 +377,7 @@ describe('withPersistQueryClient', () => {
     expect(rendered.getByText('fetched')).toBeInTheDocument()
   })
 
-  test('should remove cache after non-successful restoring', async () => {
+  it('should remove cache after non-successful restoring', async () => {
     const key = queryKey()
     const onErrorMock = vi
       .spyOn(console, 'error')

--- a/packages/eslint-plugin-query/src/__tests__/sort-data-by-order.utils.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/sort-data-by-order.utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { sortDataByOrder } from '../utils/sort-data-by-order'
 
 describe('create-route-property-order utils', () => {
@@ -68,7 +68,7 @@ describe('create-route-property-order utils', () => {
         expected: [{ key: 'd' }, { key: 'a' }, { key: 'b' }, { key: 'c' }],
       },
     ] as const
-    test.each(testCases)(
+    it.each(testCases)(
       '$data $orderArray $key $expected',
       ({ data, orderArray, key, expected }) => {
         const sortedData = sortDataByOrder(data, orderArray, key)

--- a/packages/eslint-plugin-query/src/__tests__/test-utils.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/test-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   expectArrayEqualIgnoreOrder,
   generateInterleavedCombinations,
@@ -32,7 +32,7 @@ describe('test-utils', () => {
         expected: [['a']],
       },
     ]
-    test.each(testCases)('$input $expected', ({ input, expected }) => {
+    it.each(testCases)('$input $expected', ({ input, expected }) => {
       const permutations = generatePermutations(input)
       expect(permutations).toEqual(expected)
     })
@@ -71,7 +71,7 @@ describe('test-utils', () => {
         minLength: 0,
       },
     ]
-    test.each(testCases)(
+    it.each(testCases)(
       '$input $minLength $expected',
       ({ input, minLength, expected }) => {
         const combinations = generatePartialCombinations(input, minLength)
@@ -93,12 +93,9 @@ describe('test-utils', () => {
         ],
       },
     ]
-    test.each(testCases)(
-      '$input $expected',
-      ({ data, additional, expected }) => {
-        const combinations = generateInterleavedCombinations(data, additional)
-        expectArrayEqualIgnoreOrder(combinations, expected)
-      },
-    )
+    it.each(testCases)('$input $expected', ({ data, additional, expected }) => {
+      const combinations = generateInterleavedCombinations(data, additional)
+      expectArrayEqualIgnoreOrder(combinations, expected)
+    })
   })
 })

--- a/packages/preact-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/preact-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -11,7 +11,7 @@ import { notifyManager } from '../../../query-core/src'
 import { act, cleanup, render } from '@testing-library/preact'
 import type { UseQueryResult } from '../../../preact-query/src'
 import { QueryClient, useQuery } from '../../../preact-query/src'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, vi, it } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 
 import { PersistQueryClientProvider } from './testPersistProvider'
@@ -48,7 +48,7 @@ describe('PersistQueryClientProvider (preact)', () => {
     vi.useRealTimers()
   })
 
-  test('restores cache from persister and refetches', async () => {
+  it('restores cache from persister and refetches', async () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -61,7 +61,7 @@ export const HydrationBoundary = ({
       // State is supplied from the outside and we might as well fail
       // gracefully if it has the wrong shape, so while we type `queries`
       // as required, we still provide a fallback.
-       
+
       const queries = state.queries || []
 
       const newQueries: DehydratedState['queries'] = []

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -61,7 +61,7 @@ export const HydrationBoundary = ({
       // State is supplied from the outside and we might as well fail
       // gracefully if it has the wrong shape, so while we type `queries`
       // as required, we still provide a fallback.
-
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const queries = state.queries || []
 
       const newQueries: DehydratedState['queries'] = []

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -61,7 +61,7 @@ export const HydrationBoundary = ({
       // State is supplied from the outside and we might as well fail
       // gracefully if it has the wrong shape, so while we type `queries`
       // as required, we still provide a fallback.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+       
       const queries = state.queries || []
 
       const newQueries: DehydratedState['queries'] = []

--- a/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
@@ -3,7 +3,7 @@ import type { hydrate } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { render } from '@testing-library/preact'
 import { Suspense, startTransition } from 'preact/compat'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, vi, it } from 'vitest'
 
 import {
   HydrationBoundary,
@@ -35,7 +35,7 @@ describe('Preact hydration', () => {
     vi.useRealTimers()
   })
 
-  test('should hydrate queries to the cache on context', async () => {
+  it('should hydrate queries to the cache on context', async () => {
     const dehydratedState = JSON.parse(stringifiedState)
     const queryClient = new QueryClient()
 
@@ -65,7 +65,7 @@ describe('Preact hydration', () => {
     queryClient.clear()
   })
 
-  test('should hydrate queries to the cache on custom context', async () => {
+  it('should hydrate queries to the cache on custom context', async () => {
     const queryClientInner = new QueryClient()
     const queryClientOuter = new QueryClient()
 
@@ -102,7 +102,7 @@ describe('Preact hydration', () => {
   })
 
   describe('PreactQueryCacheProvider with hydration support', () => {
-    test('should hydrate new queries if queries change', async () => {
+    it('should hydrate new queries if queries change', async () => {
       const dehydratedState = JSON.parse(stringifiedState)
       const queryClient = new QueryClient()
 
@@ -173,7 +173,7 @@ describe('Preact hydration', () => {
     // remounted, I didn't change tabs etc?).
     // Any queries that does not exist in the cache yet can still be hydrated
     // since they don't have any observers on the current page that would update.
-    test('should hydrate new but not existing queries if transition is aborted', async () => {
+    it('should hydrate new but not existing queries if transition is aborted', async () => {
       const initialDehydratedState = JSON.parse(stringifiedState)
       const queryClient = new QueryClient()
 
@@ -266,7 +266,7 @@ describe('Preact hydration', () => {
       queryClient.clear()
     })
 
-    test('should hydrate queries to new cache if cache changes', async () => {
+    it('should hydrate queries to new cache if cache changes', async () => {
       const dehydratedState = JSON.parse(stringifiedState)
       const queryClient = new QueryClient()
 
@@ -311,7 +311,7 @@ describe('Preact hydration', () => {
     })
   })
 
-  test('should not hydrate queries if state is null', async () => {
+  it('should not hydrate queries if state is null', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -339,7 +339,7 @@ describe('Preact hydration', () => {
     queryClient.clear()
   })
 
-  test('should not hydrate queries if state is undefined', async () => {
+  it('should not hydrate queries if state is undefined', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -363,7 +363,7 @@ describe('Preact hydration', () => {
     queryClient.clear()
   })
 
-  test('should not hydrate queries if state is not an object', async () => {
+  it('should not hydrate queries if state is not an object', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -387,7 +387,7 @@ describe('Preact hydration', () => {
     queryClient.clear()
   })
 
-  test('should handle state without queries property gracefully', async () => {
+  it('should handle state without queries property gracefully', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -412,7 +412,7 @@ describe('Preact hydration', () => {
   })
 
   // https://github.com/TanStack/query/issues/8677
-  test('should not infinite loop when hydrating promises that resolve to errors', async () => {
+  it('should not infinite loop when hydrating promises that resolve to errors', async () => {
     const originalHydrate = coreModule.hydrate
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
     let hydrationCount = 0

--- a/packages/preact-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/preact-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,6 +1,6 @@
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { render } from '@testing-library/preact'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, vi, it } from 'vitest'
 
 import {
   QueryCache,
@@ -19,7 +19,7 @@ describe('QueryClientProvider', () => {
     vi.useRealTimers()
   })
 
-  test('sets a specific cache for all queries to use', async () => {
+  it('sets a specific cache for all queries to use', async () => {
     const key = queryKey()
 
     const queryCache = new QueryCache()
@@ -50,7 +50,7 @@ describe('QueryClientProvider', () => {
     expect(queryCache.find({ queryKey: key })).toBeDefined()
   })
 
-  test('allows multiple caches to be partitioned', async () => {
+  it('allows multiple caches to be partitioned', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -106,7 +106,7 @@ describe('QueryClientProvider', () => {
     expect(queryCache2.find({ queryKey: key2 })).toBeDefined()
   })
 
-  test("uses defaultOptions for queries when they don't provide their own config", async () => {
+  it("uses defaultOptions for queries when they don't provide their own config", async () => {
     const key = queryKey()
 
     const queryCache = new QueryCache()
@@ -146,7 +146,7 @@ describe('QueryClientProvider', () => {
   })
 
   describe('useQueryClient', () => {
-    test('should throw an error if no query client has been set', () => {
+    it('should throw an error if no query client has been set', () => {
       const consoleMock = vi
         .spyOn(console, 'error')
         .mockImplementation(() => undefined)

--- a/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -5,7 +5,7 @@ import type {
   InitialDataFunction,
 } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
-import { assertType, describe, expectTypeOf, it, test } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
 import { useInfiniteQuery } from '../useInfiniteQuery'
@@ -155,7 +155,7 @@ describe('infiniteQueryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<InfiniteData<string, unknown>>()
   })
 
-  test('should not be allowed to be passed to non-infinite query functions', () => {
+  it('should not be allowed to be passed to non-infinite query functions', () => {
     const queryClient = new QueryClient()
     const options = infiniteQueryOptions({
       queryKey: queryKey(),
@@ -181,7 +181,7 @@ describe('infiniteQueryOptions', () => {
     )
   })
 
-  test('allow optional initialData function', () => {
+  it('allow optional initialData function', () => {
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
       queryKey: queryKey(),
@@ -199,7 +199,7 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
-  test('allow optional initialData object', () => {
+  it('allow optional initialData object', () => {
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
       queryKey: queryKey(),

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from 'preact/hooks'
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Mock } from 'vitest'
 
 import {
@@ -3911,7 +3911,7 @@ describe('useQuery', () => {
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/360
-  test('should init to status:pending, fetchStatus:idle when enabled is false', async () => {
+  it('should init to status:pending, fetchStatus:idle when enabled is false', async () => {
     const key = queryKey()
 
     function Page() {
@@ -3936,7 +3936,7 @@ describe('useQuery', () => {
     expect(rendered.getByText('status: pending, idle')).toBeInTheDocument()
   })
 
-  test('should not schedule garbage collection, if gcTimeout is set to `Infinity`', async () => {
+  it('should not schedule garbage collection, if gcTimeout is set to `Infinity`', async () => {
     const key = queryKey()
 
     function Page() {
@@ -3959,7 +3959,7 @@ describe('useQuery', () => {
     expect(setTimeoutSpy).not.toHaveBeenCalled()
   })
 
-  test('should schedule garbage collection, if gcTimeout is not set to infinity', async () => {
+  it('should schedule garbage collection, if gcTimeout is not set to infinity', async () => {
     const key = queryKey()
 
     function Page() {

--- a/packages/preact-query/src/utils.ts
+++ b/packages/preact-query/src/utils.ts
@@ -56,7 +56,7 @@ function didSnapshotChange(inst: {
   try {
     const nextValue = latestGetSnapshot()
     return !Object.is(prevValue, nextValue)
-    // eslint-disable-next-line no-unused-vars
+     
   } catch (_error) {
     return true
   }

--- a/packages/preact-query/src/utils.ts
+++ b/packages/preact-query/src/utils.ts
@@ -56,7 +56,6 @@ function didSnapshotChange(inst: {
   try {
     const nextValue = latestGetSnapshot()
     return !Object.is(prevValue, nextValue)
-     
   } catch (_error) {
     return true
   }

--- a/packages/preact-query/src/utils.ts
+++ b/packages/preact-query/src/utils.ts
@@ -56,6 +56,7 @@ function didSnapshotChange(inst: {
   try {
     const nextValue = latestGetSnapshot()
     return !Object.is(prevValue, nextValue)
+    // eslint-disable-next-line no-unused-vars
   } catch (_error) {
     return true
   }

--- a/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
+++ b/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { sleep } from '@tanstack/query-test-utils'
 import { asyncThrottle } from '../asyncThrottle'
 
@@ -11,7 +11,7 @@ describe('asyncThrottle', () => {
     vi.useRealTimers()
   })
 
-  test('basic', async () => {
+  it('basic', async () => {
     const interval = 10
     const execTimeStamps: Array<number> = []
     const mockFunc = vi.fn(
@@ -44,7 +44,7 @@ describe('asyncThrottle', () => {
     )
   })
 
-  test('Bug #3331 case 1: Special timing', async () => {
+  it('Bug #3331 case 1: Special timing', async () => {
     const interval = 1000
     const execTimeStamps: Array<number> = []
     const mockFunc = vi.fn(
@@ -76,7 +76,7 @@ describe('asyncThrottle', () => {
     )
   })
 
-  test('Bug #3331 case 2: "func" execution time is greater than the interval.', async () => {
+  it('Bug #3331 case 2: "func" execution time is greater than the interval.', async () => {
     const interval = 1000
     const execTimeStamps: Array<number> = []
     const mockFunc = vi.fn(
@@ -106,7 +106,7 @@ describe('asyncThrottle', () => {
     )
   })
 
-  test('"func" throw error not break next invoke', async () => {
+  it('"func" throw error not break next invoke', async () => {
     const interval = 10
 
     const mockFunc = vi.fn(
@@ -130,7 +130,7 @@ describe('asyncThrottle', () => {
     expect(mockFunc.mock.calls[1]?.[0]).toBe(2)
   })
 
-  test('"onError" should be called when "func" throw error', () => {
+  it('"onError" should be called when "func" throw error', () => {
     const err = new Error('error')
     const handleError = (e: unknown) => {
       expect(e).toBe(err)
@@ -145,7 +145,7 @@ describe('asyncThrottle', () => {
     testFunc()
   })
 
-  test('should throw error when "func" is not a function', () => {
+  it('should throw error when "func" is not a function', () => {
     expect(() => asyncThrottle(1 as any)).toThrow()
   })
 })

--- a/packages/query-core/src/__tests__/environmentManager.test.tsx
+++ b/packages/query-core/src/__tests__/environmentManager.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { environmentManager, isServer } from '..'
 
 describe('environmentManager', () => {
@@ -6,11 +6,11 @@ describe('environmentManager', () => {
     environmentManager.setIsServer(() => isServer)
   })
 
-  test('should use the default isServer detection', () => {
+  it('should use the default isServer detection', () => {
     expect(environmentManager.isServer()).toBe(isServer)
   })
 
-  test('should allow overriding isServer globally', () => {
+  it('should allow overriding isServer globally', () => {
     environmentManager.setIsServer(() => true)
     expect(environmentManager.isServer()).toBe(true)
 
@@ -18,7 +18,7 @@ describe('environmentManager', () => {
     expect(environmentManager.isServer()).toBe(false)
   })
 
-  test('should allow overriding isServer with a function', () => {
+  it('should allow overriding isServer with a function', () => {
     let server = true
     environmentManager.setIsServer(() => server)
     expect(environmentManager.isServer()).toBe(true)

--- a/packages/query-core/src/__tests__/focusManager.test.tsx
+++ b/packages/query-core/src/__tests__/focusManager.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FocusManager } from '../focusManager'
 
 describe('focusManager', () => {
@@ -53,7 +53,7 @@ describe('focusManager', () => {
     globalThis.document = document
   })
 
-  test('cleanup (removeEventListener) should not be called if window is not defined', () => {
+  it('cleanup (removeEventListener) should not be called if window is not defined', () => {
     const windowSpy = vi.spyOn(globalThis, 'window', 'get')
     windowSpy.mockImplementation(
       () => undefined as unknown as Window & typeof globalThis,
@@ -76,7 +76,7 @@ describe('focusManager', () => {
     windowSpy.mockRestore()
   })
 
-  test('cleanup (removeEventListener) should not be called if window.addEventListener is not defined', () => {
+  it('cleanup (removeEventListener) should not be called if window.addEventListener is not defined', () => {
     const { addEventListener } = globalThis.window
 
     // @ts-expect-error
@@ -113,7 +113,7 @@ describe('focusManager', () => {
     unsubscribeSpy.mockRestore()
   })
 
-  test('should call removeEventListener when last listener unsubscribes', () => {
+  it('should call removeEventListener when last listener unsubscribes', () => {
     const addEventListenerSpy = vi.spyOn(globalThis.window, 'addEventListener')
 
     const removeEventListenerSpy = vi.spyOn(
@@ -131,7 +131,7 @@ describe('focusManager', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledTimes(1) // visibilitychange event
   })
 
-  test('should keep setup function even if last listener unsubscribes', () => {
+  it('should keep setup function even if last listener unsubscribes', () => {
     const setupSpy = vi.fn().mockImplementation(() => () => undefined)
 
     focusManager.setEventListener(setupSpy)
@@ -149,7 +149,7 @@ describe('focusManager', () => {
     unsubscribe2()
   })
 
-  test('should call listeners when setFocused is called', () => {
+  it('should call listeners when setFocused is called', () => {
     const listener = vi.fn()
 
     focusManager.subscribe(listener)

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { QueryCache } from '../queryCache'
@@ -15,7 +15,7 @@ describe('dehydration and rehydration', () => {
     vi.useRealTimers()
   })
 
-  test('should work with serializable values', async () => {
+  it('should work with serializable values', async () => {
     const stringKey = queryKey()
     const numberKey = queryKey()
     const booleanKey = queryKey()
@@ -113,7 +113,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should not dehydrate queries if dehydrateQueries is set to false', async () => {
+  it('should not dehydrate queries if dehydrateQueries is set to false', async () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
@@ -132,7 +132,7 @@ describe('dehydration and rehydration', () => {
     queryClient.clear()
   })
 
-  test('should use the garbage collection time from the client', async () => {
+  it('should use the garbage collection time from the client', async () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
@@ -161,7 +161,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should be able to provide default options for the hydrated queries', async () => {
+  it('should be able to provide default options for the hydrated queries', async () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
@@ -183,7 +183,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should respect query defaultOptions specified on the QueryClient', async () => {
+  it('should respect query defaultOptions specified on the QueryClient', async () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({
@@ -217,7 +217,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should respect mutation defaultOptions specified on the QueryClient', async () => {
+  it('should respect mutation defaultOptions specified on the QueryClient', async () => {
     const key = queryKey()
     const mutationCache = new MutationCache()
     const queryClient = new QueryClient({
@@ -256,7 +256,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should work with complex keys', async () => {
+  it('should work with complex keys', async () => {
     const key = queryKey()
     const complexKey = [...key, { key: ['string'], key2: 0 }]
     const queryCache = new QueryCache()
@@ -294,7 +294,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should only hydrate successful queries by default', async () => {
+  it('should only hydrate successful queries by default', async () => {
     const successKey = queryKey()
     const loadingKey = queryKey()
     const errorKey = queryKey()
@@ -339,7 +339,7 @@ describe('dehydration and rehydration', () => {
     consoleMock.mockRestore()
   })
 
-  test('should filter queries via dehydrateQuery', async () => {
+  it('should filter queries via dehydrateQuery', async () => {
     const stringKey = queryKey()
     const numberKey = queryKey()
     const queryCache = new QueryCache()
@@ -379,7 +379,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should not overwrite query in cache if hydrated query is older', async () => {
+  it('should not overwrite query in cache if hydrated query is older', async () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
@@ -413,7 +413,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should overwrite query in cache if hydrated query is newer', async () => {
+  it('should overwrite query in cache if hydrated query is newer', async () => {
     const key = queryKey()
     const hydrationCache = new QueryCache()
     const hydrationClient = new QueryClient({ queryCache: hydrationCache })
@@ -449,7 +449,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should be able to dehydrate mutations and continue on hydration', async () => {
+  it('should be able to dehydrate mutations and continue on hydration', async () => {
     const key = queryKey()
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
@@ -538,7 +538,7 @@ describe('dehydration and rehydration', () => {
     onlineMock.mockRestore()
   })
 
-  test('should not dehydrate mutations if dehydrateMutations is set to false', async () => {
+  it('should not dehydrate mutations if dehydrateMutations is set to false', async () => {
     const key = queryKey()
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
@@ -573,7 +573,7 @@ describe('dehydration and rehydration', () => {
     consoleMock.mockRestore()
   })
 
-  test('should not dehydrate mutation if mutation state is set to pause', async () => {
+  it('should not dehydrate mutation if mutation state is set to pause', async () => {
     const key = queryKey()
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
@@ -609,7 +609,7 @@ describe('dehydration and rehydration', () => {
     consoleMock.mockRestore()
   })
 
-  test('should not hydrate if the hydratedState is null or is not an object', () => {
+  it('should not hydrate if the hydratedState is null or is not an object', () => {
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
 
@@ -619,7 +619,7 @@ describe('dehydration and rehydration', () => {
     queryClient.clear()
   })
 
-  test('should support hydratedState with undefined queries and mutations', () => {
+  it('should support hydratedState with undefined queries and mutations', () => {
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
 
@@ -629,7 +629,7 @@ describe('dehydration and rehydration', () => {
     queryClient.clear()
   })
 
-  test('should set the fetchStatus to idle when creating a query with dehydrate', async () => {
+  it('should set the fetchStatus to idle when creating a query with dehydrate', async () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
@@ -675,7 +675,7 @@ describe('dehydration and rehydration', () => {
     )
   })
 
-  test('should dehydrate and hydrate meta for queries', async () => {
+  it('should dehydrate and hydrate meta for queries', async () => {
     const metaKey = queryKey()
     const noMetaKey = queryKey()
     const queryCache = new QueryCache()
@@ -733,7 +733,7 @@ describe('dehydration and rehydration', () => {
     )
   })
 
-  test('should dehydrate and hydrate meta for mutations', async () => {
+  it('should dehydrate and hydrate meta for mutations', async () => {
     const metaKey = queryKey()
     const noMetaKey = queryKey()
     const mutationCache = new MutationCache()
@@ -794,7 +794,7 @@ describe('dehydration and rehydration', () => {
     )
   })
 
-  test('should not change fetchStatus when updating a query with dehydrate', async () => {
+  it('should not change fetchStatus when updating a query with dehydrate', async () => {
     const key = queryKey()
     const queryClient = new QueryClient()
 
@@ -831,7 +831,7 @@ describe('dehydration and rehydration', () => {
     )
   })
 
-  test('should dehydrate and hydrate mutation scopes', () => {
+  it('should dehydrate and hydrate mutation scopes', () => {
     const key = queryKey()
     const queryClient = new QueryClient()
     const onlineMock = mockOnlineManagerIsOnline(false)
@@ -866,7 +866,7 @@ describe('dehydration and rehydration', () => {
     onlineMock.mockRestore()
   })
 
-  test('should dehydrate promises for pending queries', async () => {
+  it('should dehydrate promises for pending queries', async () => {
     const successKey = queryKey()
     const pendingKey = queryKey()
     const queryCache = new QueryCache()
@@ -894,7 +894,7 @@ describe('dehydration and rehydration', () => {
     queryClient.clear()
   })
 
-  test('should hydrate promises even without observers', async () => {
+  it('should hydrate promises even without observers', async () => {
     const successKey = queryKey()
     const pendingKey = queryKey()
     const queryCache = new QueryCache()
@@ -960,7 +960,7 @@ describe('dehydration and rehydration', () => {
     })
   })
 
-  test('should transform promise result', async () => {
+  it('should transform promise result', async () => {
     const key = queryKey()
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -995,7 +995,7 @@ describe('dehydration and rehydration', () => {
     queryClient.clear()
   })
 
-  test('should transform query data if promise is already resolved', async () => {
+  it('should transform query data if promise is already resolved', async () => {
     const key = queryKey()
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -1029,7 +1029,7 @@ describe('dehydration and rehydration', () => {
     queryClient.clear()
   })
 
-  test('should overwrite query in cache if hydrated query is newer (with transformation)', async () => {
+  it('should overwrite query in cache if hydrated query is newer (with transformation)', async () => {
     const key = queryKey()
     const hydrationClient = new QueryClient({
       defaultOptions: {
@@ -1075,7 +1075,7 @@ describe('dehydration and rehydration', () => {
     hydrationClient.clear()
   })
 
-  test('should overwrite query in cache if hydrated query is newer (with promise)', async () => {
+  it('should overwrite query in cache if hydrated query is newer (with promise)', async () => {
     const key = queryKey()
     // --- server ---
 
@@ -1111,7 +1111,7 @@ describe('dehydration and rehydration', () => {
     serverQueryClient.clear()
   })
 
-  test('should not overwrite query in cache if existing query is newer (with promise)', async () => {
+  it('should not overwrite query in cache if existing query is newer (with promise)', async () => {
     const key = queryKey()
     // --- server ---
 
@@ -1159,7 +1159,7 @@ describe('dehydration and rehydration', () => {
     serverQueryClient.clear()
   })
 
-  test('should overwrite data when a new promise is streamed in', async () => {
+  it('should overwrite data when a new promise is streamed in', async () => {
     const key = queryKey()
     const serializeDataMock = vi.fn((data: any) => data)
     const deserializeDataMock = vi.fn((data: any) => data)
@@ -1234,7 +1234,7 @@ describe('dehydration and rehydration', () => {
     serverQueryClient.clear()
   })
 
-  test('should not redact errors when shouldRedactErrors returns false', async () => {
+  it('should not redact errors when shouldRedactErrors returns false', async () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({
@@ -1264,7 +1264,7 @@ describe('dehydration and rehydration', () => {
     await promise
   })
 
-  test('should handle errors in promises for pending queries', async () => {
+  it('should handle errors in promises for pending queries', async () => {
     const key = queryKey()
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
@@ -1296,7 +1296,7 @@ describe('dehydration and rehydration', () => {
     consoleMock.mockRestore()
   })
 
-  test('should log error in development environment when redacting errors', async () => {
+  it('should log error in development environment when redacting errors', async () => {
     const key = queryKey()
     const originalNodeEnv = process.env.NODE_ENV
     process.env.NODE_ENV = 'development'
@@ -1347,7 +1347,7 @@ describe('dehydration and rehydration', () => {
   // What can end up happening otherwise is that the content is visible from the
   // server, but the client renders a Suspense fallback, only to immediately show
   // the data again.
-  test('should rehydrate synchronous thenable immediately', async () => {
+  it('should rehydrate synchronous thenable immediately', async () => {
     const key = queryKey()
     // --- server ---
 

--- a/packages/query-core/src/__tests__/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/__tests__/infiniteQueryBehavior.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { CancelledError, InfiniteQueryObserver, QueryClient } from '..'
 import type { InfiniteData, InfiniteQueryObserverResult, QueryCache } from '..'
@@ -19,7 +19,7 @@ describe('InfiniteQueryBehavior', () => {
     vi.useRealTimers()
   })
 
-  test('should throw an error if the queryFn is not defined', async () => {
+  it('should throw an error if the queryFn is not defined', async () => {
     const key = queryKey()
 
     const observer = new InfiniteQueryObserver(queryClient, {
@@ -47,7 +47,7 @@ describe('InfiniteQueryBehavior', () => {
     unsubscribe()
   })
 
-  test('should apply the maxPages option to limit the number of pages', async () => {
+  it('should apply the maxPages option to limit the number of pages', async () => {
     const key = queryKey()
     let abortSignal: AbortSignal | null = null
 
@@ -195,7 +195,7 @@ describe('InfiniteQueryBehavior', () => {
     unsubscribe()
   })
 
-  test('should support query cancellation', async () => {
+  it('should support query cancellation', async () => {
     const key = queryKey()
     let abortSignal: AbortSignal | null = null
 
@@ -247,7 +247,7 @@ describe('InfiniteQueryBehavior', () => {
     unsubscribe()
   })
 
-  test('should not refetch pages if the query is cancelled', async () => {
+  it('should not refetch pages if the query is cancelled', async () => {
     const key = queryKey()
     let abortSignal: AbortSignal | null = null
 
@@ -332,7 +332,7 @@ describe('InfiniteQueryBehavior', () => {
     unsubscribe()
   })
 
-  test('should not enter an infinite loop when a page errors while retry is on #8046', async () => {
+  it('should not enter an infinite loop when a page errors while retry is on #8046', async () => {
     let errorCount = 0
     const key = queryKey()
 
@@ -406,7 +406,7 @@ describe('InfiniteQueryBehavior', () => {
     expect(reFetchedData.data?.pageParams).toEqual([1, 2, 3])
   })
 
-  test('should fetch even if initialPageParam is null', async () => {
+  it('should fetch even if initialPageParam is null', async () => {
     const key = queryKey()
 
     const observer = new InfiniteQueryObserver(queryClient, {
@@ -433,7 +433,7 @@ describe('InfiniteQueryBehavior', () => {
     unsubscribe()
   })
 
-  test('should not fetch next page when getNextPageParam returns null', async () => {
+  it('should not fetch next page when getNextPageParam returns null', async () => {
     const key = queryKey()
 
     const observer = new InfiniteQueryObserver(queryClient, {
@@ -467,7 +467,7 @@ describe('InfiniteQueryBehavior', () => {
     unsubscribe()
   })
 
-  test('should use persister when provided', async () => {
+  it('should use persister when provided', async () => {
     const key = queryKey()
 
     const persisterSpy = vi.fn().mockImplementation(async (fn) => {

--- a/packages/query-core/src/__tests__/infiniteQueryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/infiniteQueryObserver.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { InfiniteQueryObserver, QueryClient } from '..'
 import type {
@@ -20,7 +20,7 @@ describe('InfiniteQueryObserver', () => {
     vi.useRealTimers()
   })
 
-  test('should be able to fetch an infinite query with selector', async () => {
+  it('should be able to fetch an infinite query with selector', async () => {
     const key = queryKey()
     const observer = new InfiniteQueryObserver(queryClient, {
       queryKey: key,
@@ -43,7 +43,7 @@ describe('InfiniteQueryObserver', () => {
     })
   })
 
-  test('should pass the meta option to the queryFn', async () => {
+  it('should pass the meta option to the queryFn', async () => {
     const meta = {
       it: 'works',
     }
@@ -73,7 +73,7 @@ describe('InfiniteQueryObserver', () => {
     expect(queryFn).toBeCalledWith(expect.objectContaining({ meta }))
   })
 
-  test('should make getNextPageParam and getPreviousPageParam receive current pageParams', async () => {
+  it('should make getNextPageParam and getPreviousPageParam receive current pageParams', async () => {
     const key = queryKey()
     let single: Array<string> = []
     let all: Array<string> = []
@@ -112,7 +112,7 @@ describe('InfiniteQueryObserver', () => {
     expect(all).toEqual(['next0', 'next0,1', 'prev0,1'])
   })
 
-  test('should not invoke getNextPageParam and getPreviousPageParam on empty pages', () => {
+  it('should not invoke getNextPageParam and getPreviousPageParam on empty pages', () => {
     const key = queryKey()
 
     const getNextPageParam = vi.fn()
@@ -143,7 +143,7 @@ describe('InfiniteQueryObserver', () => {
     unsubscribe()
   })
 
-  test('should stop refetching if undefined is returned from getNextPageParam', async () => {
+  it('should stop refetching if undefined is returned from getNextPageParam', async () => {
     const key = queryKey()
     let next: number | undefined = 2
     const queryFn = vi.fn<(...args: Array<any>) => any>(({ pageParam }) =>
@@ -175,7 +175,7 @@ describe('InfiniteQueryObserver', () => {
     expect(observer.getCurrentResult().hasNextPage).toBe(false)
   })
 
-  test('should stop refetching if null is returned from getNextPageParam', async () => {
+  it('should stop refetching if null is returned from getNextPageParam', async () => {
     const key = queryKey()
     let next: number | null = 2
     const queryFn = vi.fn<(...args: Array<any>) => any>(({ pageParam }) =>
@@ -207,7 +207,7 @@ describe('InfiniteQueryObserver', () => {
     expect(observer.getCurrentResult().hasNextPage).toBe(false)
   })
 
-  test('should set infinite query behavior via getOptimisticResult and return the initial state', () => {
+  it('should set infinite query behavior via getOptimisticResult and return the initial state', () => {
     const key = queryKey()
     const observer = new InfiniteQueryObserver(queryClient, {
       queryKey: key,

--- a/packages/query-core/src/__tests__/mutationCache.test.tsx
+++ b/packages/query-core/src/__tests__/mutationCache.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { MutationCache, MutationObserver, QueryClient } from '..'
 import { executeMutation } from './utils'
@@ -13,7 +13,7 @@ describe('mutationCache', () => {
   })
 
   describe('MutationCacheConfig error callbacks', () => {
-    test('should call onError and onSettled when a mutation errors', async () => {
+    it('should call onError and onSettled when a mutation errors', async () => {
       const key = queryKey()
       const onError = vi.fn()
       const onSuccess = vi.fn()
@@ -63,7 +63,7 @@ describe('mutationCache', () => {
       )
     })
 
-    test('should be awaited', async () => {
+    it('should be awaited', async () => {
       const key = queryKey()
       const states: Array<number> = []
       const onError = () =>
@@ -106,7 +106,7 @@ describe('mutationCache', () => {
   })
 
   describe('MutationCacheConfig success callbacks', () => {
-    test('should call onSuccess and onSettled when a mutation is successful', async () => {
+    it('should call onSuccess and onSettled when a mutation is successful', async () => {
       const key = queryKey()
       const onError = vi.fn()
       const onSuccess = vi.fn()
@@ -155,7 +155,7 @@ describe('mutationCache', () => {
       )
     })
 
-    test('should be awaited', async () => {
+    it('should be awaited', async () => {
       const key = queryKey()
       const states: Array<number> = []
       const onSuccess = () =>
@@ -196,7 +196,7 @@ describe('mutationCache', () => {
   })
 
   describe('MutationCacheConfig.onMutate', () => {
-    test('should be called before a mutation executes', () => {
+    it('should be called before a mutation executes', () => {
       const key = queryKey()
       const onMutate = vi.fn()
       const testCache = new MutationCache({ onMutate })
@@ -221,7 +221,7 @@ describe('mutationCache', () => {
       })
     })
 
-    test('should be awaited', async () => {
+    it('should be awaited', async () => {
       const key = queryKey()
       const states: Array<number> = []
       const onMutate = () =>
@@ -250,7 +250,7 @@ describe('mutationCache', () => {
       expect(states).toEqual([1, 2, 3, 4])
     })
 
-    test('options.onMutate should run synchronously when mutationCache.config.onMutate is not defined', () => {
+    it('options.onMutate should run synchronously when mutationCache.config.onMutate is not defined', () => {
       const key = queryKey()
       const states: Array<string> = []
 
@@ -276,7 +276,7 @@ describe('mutationCache', () => {
   })
 
   describe('find', () => {
-    test('should filter correctly', () => {
+    it('should filter correctly', () => {
       const testCache = new MutationCache()
       const testClient = new QueryClient({ mutationCache: testCache })
       const key = ['mutation', 'vars']
@@ -306,7 +306,7 @@ describe('mutationCache', () => {
   })
 
   describe('findAll', () => {
-    test('should filter correctly', () => {
+    it('should filter correctly', () => {
       const testCache = new MutationCache()
       const testClient = new QueryClient({ mutationCache: testCache })
 
@@ -351,7 +351,7 @@ describe('mutationCache', () => {
   })
 
   describe('garbage collection', () => {
-    test('should remove unused mutations after gcTime has elapsed', async () => {
+    it('should remove unused mutations after gcTime has elapsed', async () => {
       const testCache = new MutationCache()
       const testClient = new QueryClient({ mutationCache: testCache })
       const onSuccess = vi.fn()
@@ -375,7 +375,7 @@ describe('mutationCache', () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
 
-    test('should not remove mutations if there are active observers', async () => {
+    it('should not remove mutations if there are active observers', async () => {
       const queryClient = new QueryClient()
       const observer = new MutationObserver(queryClient, {
         gcTime: 10,
@@ -400,7 +400,7 @@ describe('mutationCache', () => {
       expect(queryClient.getMutationCache().getAll()).toHaveLength(0)
     })
 
-    test('should be garbage collected later when unsubscribed and mutation is pending', async () => {
+    it('should be garbage collected later when unsubscribed and mutation is pending', async () => {
       const queryClient = new QueryClient()
       const onSuccess = vi.fn()
       const observer = new MutationObserver(queryClient, {
@@ -426,7 +426,7 @@ describe('mutationCache', () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
 
-    test('should call callbacks even with gcTime 0 and mutation still pending', async () => {
+    it('should call callbacks even with gcTime 0 and mutation still pending', async () => {
       const queryClient = new QueryClient()
       const onSuccess = vi.fn()
       const observer = new MutationObserver(queryClient, {
@@ -447,7 +447,7 @@ describe('mutationCache', () => {
   })
 
   describe('remove', () => {
-    test('should remove only the target mutation from scope when multiple scoped mutations exist', () => {
+    it('should remove only the target mutation from scope when multiple scoped mutations exist', () => {
       const testCache = new MutationCache()
       const testClient = new QueryClient({ mutationCache: testCache })
 
@@ -468,7 +468,7 @@ describe('mutationCache', () => {
       expect(testCache.getAll()).toEqual([mutation2])
     })
 
-    test('should delete scope when removing the only mutation in that scope', () => {
+    it('should delete scope when removing the only mutation in that scope', () => {
       const testCache = new MutationCache()
       const testClient = new QueryClient({ mutationCache: testCache })
 
@@ -484,7 +484,7 @@ describe('mutationCache', () => {
       expect(testCache.getAll()).toHaveLength(0)
     })
 
-    test('should still notify removal when removing a mutation that does not exist in the cache', () => {
+    it('should still notify removal when removing a mutation that does not exist in the cache', () => {
       const testCache = new MutationCache()
       const testClient = new QueryClient({ mutationCache: testCache })
 

--- a/packages/query-core/src/__tests__/mutationObserver.test.tsx
+++ b/packages/query-core/src/__tests__/mutationObserver.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { MutationObserver, QueryClient } from '..'
 
@@ -16,7 +16,7 @@ describe('mutationObserver', () => {
     vi.useRealTimers()
   })
 
-  test('onUnsubscribe should not remove the current mutation observer if there is still a subscription', async () => {
+  it('onUnsubscribe should not remove the current mutation observer if there is still a subscription', async () => {
     const mutation = new MutationObserver(queryClient, {
       mutationFn: (text: string) => sleep(20).then(() => text),
     })
@@ -41,7 +41,7 @@ describe('mutationObserver', () => {
     unsubscribe2()
   })
 
-  test('unsubscribe should remove observer to trigger GC', async () => {
+  it('unsubscribe should remove observer to trigger GC', async () => {
     const mutation = new MutationObserver(queryClient, {
       mutationFn: (text: string) => sleep(5).then(() => text),
       gcTime: 10,
@@ -62,7 +62,7 @@ describe('mutationObserver', () => {
     expect(queryClient.getMutationCache().findAll()).toHaveLength(0)
   })
 
-  test('reset should remove observer to trigger GC', async () => {
+  it('reset should remove observer to trigger GC', async () => {
     const mutation = new MutationObserver(queryClient, {
       mutationFn: (text: string) => sleep(5).then(() => text),
       gcTime: 10,
@@ -85,7 +85,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('changing mutation keys should reset the observer', async () => {
+  it('changing mutation keys should reset the observer', async () => {
     const key = queryKey()
     const mutation = new MutationObserver(queryClient, {
       mutationKey: [...key, '1'],
@@ -115,7 +115,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('changing mutation keys should not affect already existing mutations', async () => {
+  it('changing mutation keys should not affect already existing mutations', async () => {
     const key = queryKey()
     const mutationObserver = new MutationObserver(queryClient, {
       mutationKey: [...key, '1'],
@@ -156,7 +156,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('changing mutation meta should not affect successful mutations', async () => {
+  it('changing mutation meta should not affect successful mutations', async () => {
     const mutationObserver = new MutationObserver(queryClient, {
       meta: { a: 1 },
       mutationFn: (text: string) => sleep(5).then(() => text),
@@ -192,7 +192,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('mutation cache should have different meta when updated between mutations', async () => {
+  it('mutation cache should have different meta when updated between mutations', async () => {
     const mutationFn = (text: string) => sleep(5).then(() => text)
     const mutationObserver = new MutationObserver(queryClient, {
       meta: { a: 1 },
@@ -233,7 +233,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('changing mutation meta should not affect rejected mutations', async () => {
+  it('changing mutation meta should not affect rejected mutations', async () => {
     const mutationObserver = new MutationObserver(queryClient, {
       meta: { a: 1 },
       mutationFn: (_: string) =>
@@ -268,7 +268,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('changing mutation meta should affect pending mutations', async () => {
+  it('changing mutation meta should affect pending mutations', async () => {
     const mutationObserver = new MutationObserver(queryClient, {
       meta: { a: 1 },
       mutationFn: (text: string) => sleep(20).then(() => text),
@@ -301,7 +301,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('mutation callbacks should be called in correct order with correct arguments for success case', async () => {
+  it('mutation callbacks should be called in correct order with correct arguments for success case', async () => {
     const onSuccess = vi.fn()
     const onSettled = vi.fn()
 
@@ -341,7 +341,7 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
-  test('mutation callbacks should be called in correct order with correct arguments for error case', async () => {
+  it('mutation callbacks should be called in correct order with correct arguments for error case', async () => {
     const onError = vi.fn()
     const onSettled = vi.fn()
 
@@ -385,7 +385,7 @@ describe('mutationObserver', () => {
   })
 
   describe('erroneous mutation callback', () => {
-    test('onSuccess and onSettled is transferred to different execution context where it is reported', async ({
+    it('onSuccess and onSettled is transferred to different execution context where it is reported', async ({
       onTestFinished,
     }) => {
       const unhandledRejectionFn = vi.fn()
@@ -429,7 +429,7 @@ describe('mutationObserver', () => {
       unsubscribe()
     })
 
-    test('onError and onSettled is transferred to different execution context where it is reported', async ({
+    it('onError and onSettled is transferred to different execution context where it is reported', async ({
       onTestFinished,
     }) => {
       const unhandledRejectionFn = vi.fn()
@@ -477,7 +477,7 @@ describe('mutationObserver', () => {
     })
   })
 
-  test('should not notify cache when setOptions is called with same options', () => {
+  it('should not notify cache when setOptions is called with same options', () => {
     const mutationObserver = new MutationObserver(queryClient, {
       mutationFn: (text: string) => Promise.resolve(text),
     })

--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -1,5 +1,5 @@
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MutationCache, QueryClient } from '..'
 import { MutationObserver } from '../mutationObserver'
 import { executeMutation } from './utils'
@@ -19,7 +19,7 @@ describe('mutations', () => {
     vi.useRealTimers()
   })
 
-  test('mutate should accept null values', async () => {
+  it('mutate should accept null values', async () => {
     let variables
 
     const mutation = new MutationObserver(queryClient, {
@@ -35,7 +35,7 @@ describe('mutations', () => {
     expect(variables).toBe(null)
   })
 
-  test('setMutationDefaults should be able to set defaults', async () => {
+  it('setMutationDefaults should be able to set defaults', async () => {
     const key = queryKey()
     const fn = vi.fn()
 
@@ -60,7 +60,7 @@ describe('mutations', () => {
     })
   })
 
-  test('mutation should set correct success states', async () => {
+  it('mutation should set correct success states', async () => {
     const mutation = new MutationObserver(queryClient, {
       mutationFn: (text: string) => sleep(10).then(() => text),
       onMutate: (text) => text,
@@ -153,7 +153,7 @@ describe('mutations', () => {
     })
   })
 
-  test('mutation should set correct error states', async () => {
+  it('mutation should set correct error states', async () => {
     const mutation = new MutationObserver(queryClient, {
       mutationFn: (_: string) =>
         sleep(20).then(() => Promise.reject(new Error('err'))),
@@ -251,7 +251,7 @@ describe('mutations', () => {
     })
   })
 
-  test('should be able to restore a mutation', async () => {
+  it('should be able to restore a mutation', async () => {
     const key = queryKey()
 
     const onMutate = vi.fn()
@@ -331,7 +331,7 @@ describe('mutations', () => {
     expect(onSettled).toHaveBeenCalled()
   })
 
-  test('addObserver should not add an existing observer', () => {
+  it('addObserver should not add an existing observer', () => {
     const mutationCache = queryClient.getMutationCache()
     const observer = new MutationObserver(queryClient, {})
     const currentMutation = mutationCache.build(queryClient, {})
@@ -351,7 +351,7 @@ describe('mutations', () => {
     unsubscribe()
   })
 
-  test('mutate should throw an error if no mutationFn found', async () => {
+  it('mutate should throw an error if no mutationFn found', async () => {
     const mutation = new MutationObserver(queryClient, {
       mutationFn: undefined,
       retry: false,
@@ -366,7 +366,7 @@ describe('mutations', () => {
     expect(error).toEqual(new Error('No mutationFn found'))
   })
 
-  test('mutate update the mutation state even without an active subscription 1', async () => {
+  it('mutate update the mutation state even without an active subscription 1', async () => {
     const onSuccess = vi.fn()
     const onSettled = vi.fn()
 
@@ -384,7 +384,7 @@ describe('mutations', () => {
     expect(onSettled).not.toHaveBeenCalled()
   })
 
-  test('mutate update the mutation state even without an active subscription 2', async () => {
+  it('mutate update the mutation state even without an active subscription 2', async () => {
     const onSuccess = vi.fn()
     const onSettled = vi.fn()
 
@@ -402,7 +402,7 @@ describe('mutations', () => {
     expect(onSettled).not.toHaveBeenCalled()
   })
 
-  test('mutation callbacks should see updated options', async () => {
+  it('mutation callbacks should see updated options', async () => {
     const onSuccess = vi.fn()
 
     const mutation = new MutationObserver(queryClient, {
@@ -428,7 +428,7 @@ describe('mutations', () => {
   })
 
   describe('scoped mutations', () => {
-    test('mutations in the same scope should run in serial', async () => {
+    it('mutations in the same scope should run in serial', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
 
@@ -493,7 +493,7 @@ describe('mutations', () => {
     })
   })
 
-  test('mutations without scope should run in parallel', async () => {
+  it('mutations without scope should run in parallel', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -537,7 +537,7 @@ describe('mutations', () => {
     ])
   })
 
-  test('each scope should run in parallel, serial within scope', async () => {
+  it('each scope should run in parallel, serial within scope', async () => {
     const results: Array<string> = []
 
     executeMutation(
@@ -619,7 +619,7 @@ describe('mutations', () => {
   })
 
   describe('callback return types', () => {
-    test('should handle all sync callback patterns', async () => {
+    it('should handle all sync callback patterns', async () => {
       const key = queryKey()
       const results: Array<string> = []
 
@@ -657,7 +657,7 @@ describe('mutations', () => {
       ])
     })
 
-    test('should handle all async callback patterns', async () => {
+    it('should handle all async callback patterns', async () => {
       const key = queryKey()
       const results: Array<string> = []
 
@@ -695,7 +695,7 @@ describe('mutations', () => {
       ])
     })
 
-    test('should handle Promise.all() and Promise.allSettled() patterns', async () => {
+    it('should handle Promise.all() and Promise.allSettled() patterns', async () => {
       const key = queryKey()
       const results: Array<string> = []
 
@@ -736,7 +736,7 @@ describe('mutations', () => {
       ])
     })
 
-    test('should handle mixed sync/async patterns and return value isolation', async () => {
+    it('should handle mixed sync/async patterns and return value isolation', async () => {
       const key = queryKey()
       const results: Array<string> = []
 
@@ -783,7 +783,7 @@ describe('mutations', () => {
       ])
     })
 
-    test('should handle error cases with all callback patterns', async () => {
+    it('should handle error cases with all callback patterns', async () => {
       const key = queryKey()
       const results: Array<string> = []
 
@@ -838,7 +838,7 @@ describe('mutations', () => {
   })
 
   describe('erroneous mutation callback', () => {
-    test('error by global onSuccess triggers onError callback', async () => {
+    it('error by global onSuccess triggers onError callback', async () => {
       const newMutationError = new Error('mutation-error')
 
       queryClient = new QueryClient({
@@ -896,7 +896,7 @@ describe('mutations', () => {
       expect(mutationError).toEqual(newMutationError)
     })
 
-    test('error by mutations onSuccess triggers onError callback', async () => {
+    it('error by mutations onSuccess triggers onError callback', async () => {
       const key = queryKey()
       const results: Array<string> = []
 
@@ -946,7 +946,7 @@ describe('mutations', () => {
       expect(mutationError).toEqual(newMutationError)
     })
 
-    test('error by global onSettled triggers onError callback, calling global onSettled callback twice', async ({
+    it('error by global onSettled triggers onError callback, calling global onSettled callback twice', async ({
       onTestFinished,
     }) => {
       const newMutationError = new Error('mutation-error')
@@ -1020,7 +1020,7 @@ describe('mutations', () => {
       expect(mutationError).toEqual(newMutationError)
     })
 
-    test('error by mutations onSettled triggers onError callback, calling both onSettled callbacks twice', async ({
+    it('error by mutations onSettled triggers onError callback, calling both onSettled callbacks twice', async ({
       onTestFinished,
     }) => {
       const unhandledRejectionFn = vi.fn()
@@ -1084,7 +1084,7 @@ describe('mutations', () => {
       expect(mutationError).toEqual(newMutationError)
     })
 
-    test('errors by onError and consecutive onSettled callbacks are transferred to different execution context where it are reported', async ({
+    it('errors by onError and consecutive onSettled callbacks are transferred to different execution context where it are reported', async ({
       onTestFinished,
     }) => {
       const unhandledRejectionFn = vi.fn()
@@ -1166,7 +1166,7 @@ describe('mutations', () => {
     })
   })
 
-  test('should not remove mutation when one observer is removed but another still exists', async () => {
+  it('should not remove mutation when one observer is removed but another still exists', async () => {
     const observer1 = new MutationObserver(queryClient, {
       gcTime: 10,
       mutationFn: () => sleep(10).then(() => 'data'),

--- a/packages/query-core/src/__tests__/onlineManager.test.tsx
+++ b/packages/query-core/src/__tests__/onlineManager.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OnlineManager } from '../onlineManager'
 
 describe('onlineManager', () => {
@@ -13,7 +13,7 @@ describe('onlineManager', () => {
     vi.useRealTimers()
   })
 
-  test('isOnline should return true if navigator is undefined', () => {
+  it('isOnline should return true if navigator is undefined', () => {
     const navigatorSpy = vi.spyOn(globalThis, 'navigator', 'get')
 
     // Force navigator to be undefined
@@ -24,7 +24,7 @@ describe('onlineManager', () => {
     navigatorSpy.mockRestore()
   })
 
-  test('isOnline should return true if navigator.onLine is true', () => {
+  it('isOnline should return true if navigator.onLine is true', () => {
     const navigatorSpy = vi.spyOn(navigator, 'onLine', 'get')
     navigatorSpy.mockImplementation(() => true)
 
@@ -33,7 +33,7 @@ describe('onlineManager', () => {
     navigatorSpy.mockRestore()
   })
 
-  test('setEventListener should use online boolean arg', () => {
+  it('setEventListener should use online boolean arg', () => {
     let count = 0
 
     const setup = (setOnline: (online: boolean) => void) => {
@@ -51,7 +51,7 @@ describe('onlineManager', () => {
     expect(onlineManager.isOnline()).toBeFalsy()
   })
 
-  test('setEventListener should call previous remove handler when replacing an event listener', () => {
+  it('setEventListener should call previous remove handler when replacing an event listener', () => {
     const remove1Spy = vi.fn()
     const remove2Spy = vi.fn()
 
@@ -62,7 +62,7 @@ describe('onlineManager', () => {
     expect(remove2Spy).not.toHaveBeenCalled()
   })
 
-  test('cleanup (removeEventListener) should not be called if window is not defined', () => {
+  it('cleanup (removeEventListener) should not be called if window is not defined', () => {
     const windowSpy = vi.spyOn(globalThis, 'window', 'get')
     windowSpy.mockImplementation(
       () => undefined as unknown as Window & typeof globalThis,
@@ -79,7 +79,7 @@ describe('onlineManager', () => {
     windowSpy.mockRestore()
   })
 
-  test('cleanup (removeEventListener) should not be called if window.addEventListener is not defined', () => {
+  it('cleanup (removeEventListener) should not be called if window.addEventListener is not defined', () => {
     const { addEventListener } = globalThis.window
 
     // @ts-expect-error
@@ -96,7 +96,7 @@ describe('onlineManager', () => {
     globalThis.window.addEventListener = addEventListener
   })
 
-  test('it should replace default window listener when a new event listener is set', () => {
+  it('should replace default window listener when a new event listener is set', () => {
     const addEventListenerSpy = vi.spyOn(globalThis.window, 'addEventListener')
 
     const removeEventListenerSpy = vi.spyOn(
@@ -121,7 +121,7 @@ describe('onlineManager', () => {
     removeEventListenerSpy.mockRestore()
   })
 
-  test('should call removeEventListener when last listener unsubscribes', () => {
+  it('should call removeEventListener when last listener unsubscribes', () => {
     const addEventListenerSpy = vi.spyOn(globalThis.window, 'addEventListener')
 
     const removeEventListenerSpy = vi.spyOn(
@@ -139,7 +139,7 @@ describe('onlineManager', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledTimes(2) // online + offline
   })
 
-  test('should keep setup function even if last listener unsubscribes', () => {
+  it('should keep setup function even if last listener unsubscribes', () => {
     const setupSpy = vi.fn().mockImplementation(() => () => undefined)
 
     onlineManager.setEventListener(setupSpy)
@@ -157,7 +157,7 @@ describe('onlineManager', () => {
     unsubscribe2()
   })
 
-  test('should call listeners when setOnline is called', () => {
+  it('should call listeners when setOnline is called', () => {
     const listener = vi.fn()
 
     onlineManager.subscribe(listener)

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueriesObserver, QueryClient, QueryObserver } from '..'
 import type { QueryObserverResult } from '..'
@@ -17,7 +17,7 @@ describe('queriesObserver', () => {
     vi.useRealTimers()
   })
 
-  test('should return an array with all query results', async () => {
+  it('should return an array with all query results', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -38,7 +38,7 @@ describe('queriesObserver', () => {
     expect(observerResult).toMatchObject([{ data: 1 }, { data: 2 }])
   })
 
-  test('should return current queries via getQueries', async () => {
+  it('should return current queries via getQueries', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -60,7 +60,7 @@ describe('queriesObserver', () => {
     unsubscribe()
   })
 
-  test('should update when a query updates', async () => {
+  it('should update when a query updates', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -106,7 +106,7 @@ describe('queriesObserver', () => {
     ])
   })
 
-  test('should return current observers via getObservers', async () => {
+  it('should return current observers via getObservers', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -128,7 +128,7 @@ describe('queriesObserver', () => {
     unsubscribe()
   })
 
-  test('should update when a query is removed', async () => {
+  it('should update when a query is removed', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -177,7 +177,7 @@ describe('queriesObserver', () => {
     expect(results[5]).toMatchObject([{ status: 'success', data: 2 }])
   })
 
-  test('should update when a query changed position', async () => {
+  it('should update when a query changed position', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -227,7 +227,7 @@ describe('queriesObserver', () => {
     ])
   })
 
-  test('should not update when nothing has changed', async () => {
+  it('should not update when nothing has changed', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -273,7 +273,7 @@ describe('queriesObserver', () => {
     ])
   })
 
-  test('should trigger all fetches when subscribed', () => {
+  it('should trigger all fetches when subscribed', () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -291,7 +291,7 @@ describe('queriesObserver', () => {
     expect(queryFn2).toHaveBeenCalledTimes(1)
   })
 
-  test('should not destroy the observer if there is still a subscription', async () => {
+  it('should not destroy the observer if there is still a subscription', async () => {
     const key1 = queryKey()
     const observer = new QueriesObserver(queryClient, [
       {
@@ -319,7 +319,7 @@ describe('queriesObserver', () => {
     unsubscribe2()
   })
 
-  test('should handle duplicate query keys in different positions', async () => {
+  it('should handle duplicate query keys in different positions', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -389,7 +389,7 @@ describe('queriesObserver', () => {
     expect(queryFn2).toHaveBeenCalledTimes(1)
   })
 
-  test('should notify when results change during early return', async () => {
+  it('should notify when results change during early return', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = vi.fn().mockReturnValue(1)
@@ -436,7 +436,7 @@ describe('queriesObserver', () => {
     ])
   })
 
-  test('should update combined result when queries are added with stable combine reference', () => {
+  it('should update combined result when queries are added with stable combine reference', () => {
     const combine = vi.fn((results: Array<QueryObserverResult>) => ({
       count: results.length,
       results,
@@ -473,7 +473,7 @@ describe('queriesObserver', () => {
     expect(newCombined.count).toBe(2)
   })
 
-  test('should handle queries being removed with stable combine reference', () => {
+  it('should handle queries being removed with stable combine reference', () => {
     const combine = vi.fn((results: Array<QueryObserverResult>) => ({
       count: results.length,
       results,
@@ -517,7 +517,7 @@ describe('queriesObserver', () => {
     expect(newCombined.count).toBe(1)
   })
 
-  test('should update combined result when queries are replaced with different ones (same length)', () => {
+  it('should update combined result when queries are replaced with different ones (same length)', () => {
     const combine = vi.fn((results: Array<QueryObserverResult>) => ({
       keys: results.map((r) => r.status),
       results,
@@ -552,7 +552,7 @@ describe('queriesObserver', () => {
     expect(newCombined.keys).toEqual(['pending'])
   })
 
-  test('should recalculate combined result when combine function changes', () => {
+  it('should recalculate combined result when combine function changes', () => {
     const combine1 = vi.fn((results: Array<QueryObserverResult>) => ({
       total: results.length,
     }))
@@ -586,7 +586,7 @@ describe('queriesObserver', () => {
     expect(combined2.total).toBe(8)
   })
 
-  test('should use fallback result when combineResult is called without raw argument', () => {
+  it('should use fallback result when combineResult is called without raw argument', () => {
     const combine = vi.fn((results: Array<QueryObserverResult>) => ({
       count: results.length,
     }))
@@ -609,7 +609,7 @@ describe('queriesObserver', () => {
     expect(combined.count).toBe(1)
   })
 
-  test('should return observer result directly when notifyOnChangeProps is set', () => {
+  it('should return observer result directly when notifyOnChangeProps is set', () => {
     const key = queryKey()
     const queryFn = vi.fn().mockReturnValue(1)
 
@@ -633,7 +633,7 @@ describe('queriesObserver', () => {
     trackResultSpy.mockRestore()
   })
 
-  test('should return cached combined result when nothing has changed', () => {
+  it('should return cached combined result when nothing has changed', () => {
     const combine = vi.fn((results: Array<QueryObserverResult>) => ({
       count: results.length,
     }))
@@ -659,7 +659,7 @@ describe('queriesObserver', () => {
     expect(combined1).toBe(combined2)
   })
 
-  test('should track properties on all observers when trackResult is called', () => {
+  it('should track properties on all observers when trackResult is called', () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryFn1 = () => 'data1'
@@ -695,7 +695,7 @@ describe('queriesObserver', () => {
     trackPropSpy.mockRestore()
   })
 
-  test('should subscribe to new observers when a query is added while subscribed', async () => {
+  it('should subscribe to new observers when a query is added while subscribed', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const key3 = queryKey()

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   mockVisibilityState,
   queryKey,
@@ -37,7 +37,7 @@ describe('query', () => {
     vi.useRealTimers()
   })
 
-  test('should use the longest garbage collection time it has seen', async () => {
+  it('should use the longest garbage collection time it has seen', async () => {
     const key = queryKey()
     await queryClient.prefetchQuery({
       queryKey: key,
@@ -231,7 +231,7 @@ describe('query', () => {
     onlineMock.mockRestore()
   })
 
-  test('should not throw a CancelledError when fetchQuery is in progress and the last observer unsubscribes when AbortSignal is consumed', async () => {
+  it('should not throw a CancelledError when fetchQuery is in progress and the last observer unsubscribes when AbortSignal is consumed', async () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -264,7 +264,7 @@ describe('query', () => {
     expect(queryCache.find({ queryKey: key })?.state.data).toBe('data')
   })
 
-  test('should provide context to queryFn', () => {
+  it('should provide context to queryFn', () => {
     const key = queryKey()
 
     const queryFn = vi
@@ -286,7 +286,7 @@ describe('query', () => {
     expect(args.client).toEqual(queryClient)
   })
 
-  test('should continue if cancellation is not supported and signal is not consumed', async () => {
+  it('should continue if cancellation is not supported and signal is not consumed', async () => {
     const key = queryKey()
 
     queryClient.prefetchQuery({
@@ -315,7 +315,7 @@ describe('query', () => {
     })
   })
 
-  test('should not continue when last observer unsubscribed if the signal was consumed', async () => {
+  it('should not continue when last observer unsubscribed if the signal was consumed', async () => {
     const key = queryKey()
 
     queryClient.prefetchQuery({
@@ -345,7 +345,7 @@ describe('query', () => {
     })
   })
 
-  test('should provide an AbortSignal to the queryFn that provides info about the cancellation state', async () => {
+  it('should provide an AbortSignal to the queryFn that provides info about the cancellation state', async () => {
     const key = queryKey()
 
     const queryFn =
@@ -397,7 +397,7 @@ describe('query', () => {
     expect(error).toBeInstanceOf(CancelledError)
   })
 
-  test('should not continue if explicitly cancelled', async () => {
+  it('should not continue if explicitly cancelled', async () => {
     const key = queryKey()
 
     const queryFn = vi.fn<(...args: Array<unknown>) => unknown>()
@@ -429,7 +429,7 @@ describe('query', () => {
     expect(error).toBeInstanceOf(CancelledError)
   })
 
-  test('should not error if reset while pending', async () => {
+  it('should not error if reset while pending', async () => {
     const key = queryKey()
 
     const queryFn = vi.fn<(...args: Array<unknown>) => unknown>()
@@ -473,7 +473,7 @@ describe('query', () => {
     expect(error).toBeInstanceOf(CancelledError)
   })
 
-  test('should reset to default state when created from hydration', async () => {
+  it('should reset to default state when created from hydration', async () => {
     const key = queryKey()
     const client = new QueryClient()
     await client.prefetchQuery({
@@ -494,7 +494,7 @@ describe('query', () => {
     expect(hydrationClient.getQueryData(key)).toBe(undefined)
   })
 
-  test('should be able to refetch a cancelled query', async () => {
+  it('should be able to refetch a cancelled query', async () => {
     const key = queryKey()
 
     const queryFn = vi.fn<(...args: Array<unknown>) => unknown>()
@@ -516,7 +516,7 @@ describe('query', () => {
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
 
-  test('cancelling a resolved query should not have any effect', async () => {
+  it('cancelling a resolved query should not have any effect', async () => {
     const key = queryKey()
     await queryClient.prefetchQuery({
       queryKey: key,
@@ -528,7 +528,7 @@ describe('query', () => {
     expect(query.state.data).toBe('data')
   })
 
-  test('cancelling a rejected query should not have any effect', async () => {
+  it('cancelling a rejected query should not have any effect', async () => {
     const key = queryKey()
     const error = new Error('error')
 
@@ -544,7 +544,7 @@ describe('query', () => {
     expect(query.state.error).not.toBeInstanceOf(CancelledError)
   })
 
-  test('the previous query status should be kept when refetching', async () => {
+  it('the previous query status should be kept when refetching', async () => {
     const key = queryKey()
 
     await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
@@ -569,7 +569,7 @@ describe('query', () => {
     expect(query.state.status).toBe('error')
   })
 
-  test('queries with gcTime 0 should be removed immediately after unsubscribing', async () => {
+  it('queries with gcTime 0 should be removed immediately after unsubscribing', async () => {
     const key = queryKey()
     let count = 0
     const observer = new QueryObserver(queryClient, {
@@ -594,7 +594,7 @@ describe('query', () => {
     expect(count).toBe(1)
   })
 
-  test('should be garbage collected when unsubscribed to', async () => {
+  it('should be garbage collected when unsubscribed to', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -610,7 +610,7 @@ describe('query', () => {
     expect(queryCache.find({ queryKey: key })).toBeUndefined()
   })
 
-  test('should be garbage collected later when unsubscribed and query is fetching', async () => {
+  it('should be garbage collected later when unsubscribed and query is fetching', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -629,7 +629,7 @@ describe('query', () => {
     expect(queryCache.find({ queryKey: key })).toBeUndefined()
   })
 
-  test('should not be garbage collected unless there are no subscribers', async () => {
+  it('should not be garbage collected unless there are no subscribers', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -648,7 +648,7 @@ describe('query', () => {
     expect(queryCache.find({ queryKey: key })).toBeDefined()
   })
 
-  test('should return proper count of observers', () => {
+  it('should return proper count of observers', () => {
     const key = queryKey()
     const options = { queryKey: key, queryFn: () => 'data' }
     const observer = new QueryObserver(queryClient, options)
@@ -673,7 +673,7 @@ describe('query', () => {
     expect(query?.getObserversCount()).toEqual(0)
   })
 
-  test('stores meta object in query', async () => {
+  it('stores meta object in query', async () => {
     const meta = {
       it: 'works',
     }
@@ -692,7 +692,7 @@ describe('query', () => {
     expect(query.options.meta).toBe(meta)
   })
 
-  test('updates meta object on change', async () => {
+  it('updates meta object on change', async () => {
     const meta = {
       it: 'works',
     }
@@ -710,7 +710,7 @@ describe('query', () => {
     expect(query.options.meta).toBeUndefined()
   })
 
-  test('can use default meta', async () => {
+  it('can use default meta', async () => {
     const meta = {
       it: 'works',
     }
@@ -727,7 +727,7 @@ describe('query', () => {
     expect(query.meta).toBe(meta)
   })
 
-  test('provides meta object inside query function', async () => {
+  it('provides meta object inside query function', async () => {
     const meta = {
       it: 'works',
     }
@@ -745,7 +745,7 @@ describe('query', () => {
     )
   })
 
-  test('should refetch the observer when online method is called', () => {
+  it('should refetch the observer when online method is called', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -764,7 +764,7 @@ describe('query', () => {
     refetchSpy.mockRestore()
   })
 
-  test('should not add an existing observer', async () => {
+  it('should not add an existing observer', async () => {
     const key = queryKey()
 
     await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
@@ -783,7 +783,7 @@ describe('query', () => {
     expect(query.getObserversCount()).toEqual(1)
   })
 
-  test('should not try to remove an observer that does not exist', async () => {
+  it('should not try to remove an observer that does not exist', async () => {
     const key = queryKey()
 
     await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
@@ -800,7 +800,7 @@ describe('query', () => {
     notifySpy.mockRestore()
   })
 
-  test('should not change state on invalidate() if already invalidated', async () => {
+  it('should not change state on invalidate() if already invalidated', async () => {
     const key = queryKey()
 
     await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
@@ -816,7 +816,7 @@ describe('query', () => {
     expect(query.state).toBe(previousState)
   })
 
-  test('fetch should not dispatch "fetch" query is already fetching', async () => {
+  it('fetch should not dispatch "fetch" query is already fetching', async () => {
     const key = queryKey()
 
     const queryFn = () => sleep(10).then(() => 'data')
@@ -849,7 +849,7 @@ describe('query', () => {
     unsubscribe()
   })
 
-  test('fetch should throw an error if the queryFn is not defined', async () => {
+  it('fetch should throw an error if the queryFn is not defined', async () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -869,7 +869,7 @@ describe('query', () => {
     unsubscribe()
   })
 
-  test('fetch should dispatch an error if the queryFn returns undefined', async () => {
+  it('fetch should dispatch an error if the queryFn returns undefined', async () => {
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
     const key = queryKey()
@@ -923,7 +923,7 @@ describe('query', () => {
     resetIsServer()
   })
 
-  test('constructor should call initialDataUpdatedAt if defined as a function', async () => {
+  it('constructor should call initialDataUpdatedAt if defined as a function', async () => {
     const key = queryKey()
 
     const initialDataUpdatedAtSpy = vi.fn()
@@ -938,7 +938,7 @@ describe('query', () => {
     expect(initialDataUpdatedAtSpy).toHaveBeenCalled()
   })
 
-  test('should work with initialDataUpdatedAt set to zero', async () => {
+  it('should work with initialDataUpdatedAt set to zero', async () => {
     const key = queryKey()
 
     await queryClient.prefetchQuery({
@@ -956,7 +956,7 @@ describe('query', () => {
     })
   })
 
-  test('queries should be garbage collected even if they never fetched', async () => {
+  it('queries should be garbage collected even if they never fetched', async () => {
     const key = queryKey()
 
     queryClient.setQueryDefaults(key, { gcTime: 10 })
@@ -979,7 +979,7 @@ describe('query', () => {
     unsubscribe()
   })
 
-  test('should always revert to idle state (#5968)', async () => {
+  it('should always revert to idle state (#5968)', async () => {
     let mockedData = [1]
 
     const key = queryKey()
@@ -1043,7 +1043,7 @@ describe('query', () => {
     expect(spy).toHaveBeenCalledWith('1 - 2')
   })
 
-  test('should not reject a promise when silently cancelled in the background', async () => {
+  it('should not reject a promise when silently cancelled in the background', async () => {
     const key = queryKey()
 
     let x = 0
@@ -1141,7 +1141,7 @@ describe('query', () => {
     expect(query.state.status).toBe('error')
   })
 
-  test('should use persister if provided', async () => {
+  it('should use persister if provided', async () => {
     const key = queryKey()
 
     await queryClient.prefetchQuery({
@@ -1154,7 +1154,7 @@ describe('query', () => {
     expect(query.state.data).toBe('persisted data')
   })
 
-  test('should use queryFn from observer if not provided in options', async () => {
+  it('should use queryFn from observer if not provided in options', async () => {
     const key = queryKey()
     const queryFn = () => Promise.resolve('data')
     const observer = new QueryObserver(queryClient, {
@@ -1176,7 +1176,7 @@ describe('query', () => {
     expect(query.options.queryFn).toBe(queryFn)
   })
 
-  test('should log error when queryKey is not an array', async () => {
+  it('should log error when queryKey is not an array', async () => {
     const consoleMock = vi.spyOn(console, 'error')
     const key: unknown = 'string-key'
 
@@ -1192,7 +1192,7 @@ describe('query', () => {
     consoleMock.mockRestore()
   })
 
-  test('should call initialData function when it is a function', () => {
+  it('should call initialData function when it is a function', () => {
     const key = queryKey()
     const initialDataFn = vi.fn(() => 'initial data')
 
@@ -1210,7 +1210,7 @@ describe('query', () => {
     expect(query.state.data).toBe('initial data')
   })
 
-  test('should update initialData when Query exists without data', async () => {
+  it('should update initialData when Query exists without data', async () => {
     const key = queryKey()
     const queryFn = vi.fn(() => sleep(100).then(() => 'data'))
 
@@ -1269,7 +1269,7 @@ describe('query', () => {
     })
   })
 
-  test('should not override fetching state when revert happens after new observer subscribes', async () => {
+  it('should not override fetching state when revert happens after new observer subscribes', async () => {
     const key = queryKey()
     let count = 0
 
@@ -1320,7 +1320,7 @@ describe('query', () => {
     })
   })
 
-  test('should not increment dataUpdateCount when setting initialData on prefetched query', async () => {
+  it('should not increment dataUpdateCount when setting initialData on prefetched query', async () => {
     const key = queryKey()
     const queryFn = vi.fn().mockImplementation(() => 'fetched-data')
 

--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryCache, QueryClient, QueryObserver, hashKey } from '..'
 
@@ -18,7 +18,7 @@ describe('queryCache', () => {
   })
 
   describe('subscribe', () => {
-    test('should pass the correct query', () => {
+    it('should pass the correct query', () => {
       const key = queryKey()
       const subscriber = vi.fn()
       const unsubscribe = queryCache.subscribe(subscriber)
@@ -28,7 +28,7 @@ describe('queryCache', () => {
       unsubscribe()
     })
 
-    test('should notify listeners when new query is added', async () => {
+    it('should notify listeners when new query is added', async () => {
       const key = queryKey()
       const callback = vi.fn()
       queryCache.subscribe(callback)
@@ -40,7 +40,7 @@ describe('queryCache', () => {
       expect(callback).toHaveBeenCalled()
     })
 
-    test('should notify query cache when a query becomes stale', async () => {
+    it('should notify query cache when a query becomes stale', async () => {
       const key = queryKey()
       const events: Array<string> = []
       const queries: Array<unknown> = []
@@ -79,7 +79,7 @@ describe('queryCache', () => {
       unsubScribeObserver()
     })
 
-    test('should include the queryCache and query when notifying listeners', async () => {
+    it('should include the queryCache and query when notifying listeners', async () => {
       const key = queryKey()
       const callback = vi.fn()
       queryCache.subscribe(callback)
@@ -92,7 +92,7 @@ describe('queryCache', () => {
       expect(callback).toHaveBeenCalledWith({ query, type: 'added' })
     })
 
-    test('should notify subscribers when new query with initialData is added', async () => {
+    it('should notify subscribers when new query with initialData is added', async () => {
       const key = queryKey()
       const callback = vi.fn()
       queryCache.subscribe(callback)
@@ -105,7 +105,7 @@ describe('queryCache', () => {
       expect(callback).toHaveBeenCalled()
     })
 
-    test('should be able to limit cache size', async () => {
+    it('should be able to limit cache size', async () => {
       const testCache = new QueryCache()
 
       const unsubscribe = testCache.subscribe((event) => {
@@ -151,7 +151,7 @@ describe('queryCache', () => {
   })
 
   describe('find', () => {
-    test('find should filter correctly', async () => {
+    it('find should filter correctly', async () => {
       const key = queryKey()
       queryClient.prefetchQuery({
         queryKey: key,
@@ -162,7 +162,7 @@ describe('queryCache', () => {
       expect(query).toBeDefined()
     })
 
-    test('find should filter correctly with exact set to false', async () => {
+    it('find should filter correctly with exact set to false', async () => {
       const key = queryKey()
       queryClient.prefetchQuery({
         queryKey: key,
@@ -175,7 +175,7 @@ describe('queryCache', () => {
   })
 
   describe('findAll', () => {
-    test('should filter correctly', async () => {
+    it('should filter correctly', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const keyFetching = queryKey()
@@ -296,7 +296,7 @@ describe('queryCache', () => {
       expect(queryCache.findAll({ fetchStatus: 'fetching' })).toEqual([])
     })
 
-    test('should return all the queries when no filters are defined', async () => {
+    it('should return all the queries when no filters are defined', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       await queryClient.prefetchQuery({
@@ -312,7 +312,7 @@ describe('queryCache', () => {
   })
 
   describe('QueryCacheConfig error callbacks', () => {
-    test('should call onError and onSettled when a query errors', async () => {
+    it('should call onError and onSettled when a query errors', async () => {
       const key = queryKey()
       const onSuccess = vi.fn()
       const onSettled = vi.fn()
@@ -334,7 +334,7 @@ describe('queryCache', () => {
   })
 
   describe('QueryCacheConfig success callbacks', () => {
-    test('should call onSuccess and onSettled when a query is successful', async () => {
+    it('should call onSuccess and onSettled when a query is successful', async () => {
       const key = queryKey()
       const onSuccess = vi.fn()
       const onSettled = vi.fn()
@@ -356,7 +356,7 @@ describe('queryCache', () => {
   })
 
   describe('build', () => {
-    test('should compute queryHash from queryKey when queryHash is not provided', () => {
+    it('should compute queryHash from queryKey when queryHash is not provided', () => {
       const key = queryKey()
 
       const query = queryCache.build(queryClient, {
@@ -366,7 +366,7 @@ describe('queryCache', () => {
       expect(query.queryHash).toBe(hashKey(key))
     })
 
-    test('should use provided queryHash instead of computing it', () => {
+    it('should use provided queryHash instead of computing it', () => {
       const key = queryKey()
       const customHash = 'custom-hash'
 
@@ -381,7 +381,7 @@ describe('queryCache', () => {
   })
 
   describe('QueryCache.add', () => {
-    test('should not try to add a query already added to the cache', async () => {
+    it('should not try to add a query already added to the cache', async () => {
       const key = queryKey()
 
       queryClient.prefetchQuery({

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   CancelledError,
@@ -32,7 +32,7 @@ describe('queryClient', () => {
   })
 
   describe('defaultOptions', () => {
-    test('should merge defaultOptions', () => {
+    it('should merge defaultOptions', () => {
       const key = queryKey()
 
       const queryFn = () => 'data'
@@ -43,7 +43,7 @@ describe('queryClient', () => {
       expect(() => testClient.prefetchQuery({ queryKey: key })).not.toThrow()
     })
 
-    test('should merge defaultOptions when query is added to cache', async () => {
+    it('should merge defaultOptions when query is added to cache', async () => {
       const key = queryKey()
 
       const testClient = new QueryClient({
@@ -58,7 +58,7 @@ describe('queryClient', () => {
       expect(newQuery?.options.gcTime).toBe(Infinity)
     })
 
-    test('should get defaultOptions', () => {
+    it('should get defaultOptions', () => {
       const queryFn = () => 'data'
       const defaultOptions = { queries: { queryFn } }
       const testClient = new QueryClient({
@@ -69,14 +69,14 @@ describe('queryClient', () => {
   })
 
   describe('setQueryDefaults', () => {
-    test('should not trigger a fetch', () => {
+    it('should not trigger a fetch', () => {
       const key = queryKey()
       queryClient.setQueryDefaults(key, { queryFn: () => 'data' })
       const data = queryClient.getQueryData(key)
       expect(data).toBeUndefined()
     })
 
-    test('should be able to override defaults', async () => {
+    it('should be able to override defaults', async () => {
       const key = queryKey()
       queryClient.setQueryDefaults(key, { queryFn: () => 'data' })
       const observer = new QueryObserver(queryClient, { queryKey: key })
@@ -84,7 +84,7 @@ describe('queryClient', () => {
       expect(data).toBe('data')
     })
 
-    test('should match the query key partially', async () => {
+    it('should match the query key partially', async () => {
       const key = queryKey()
       queryClient.setQueryDefaults([key], { queryFn: () => 'data' })
       const observer = new QueryObserver(queryClient, {
@@ -94,7 +94,7 @@ describe('queryClient', () => {
       expect(data).toBe('data')
     })
 
-    test('should not match if the query key is a subset', async () => {
+    it('should not match if the query key is a subset', async () => {
       const key = queryKey()
       queryClient.setQueryDefaults([key, 'a'], {
         queryFn: () => 'data',
@@ -108,7 +108,7 @@ describe('queryClient', () => {
       expect(status).toBe('error')
     })
 
-    test('should also set defaults for observers', () => {
+    it('should also set defaults for observers', () => {
       const key = queryKey()
       queryClient.setQueryDefaults(key, {
         queryFn: () => 'data',
@@ -121,7 +121,7 @@ describe('queryClient', () => {
       expect(observer.getCurrentResult().fetchStatus).toBe('idle')
     })
 
-    test('should update existing query defaults', () => {
+    it('should update existing query defaults', () => {
       const key = queryKey()
       const queryOptions1 = { queryFn: () => 'data' }
       const queryOptions2 = { retry: false }
@@ -130,7 +130,7 @@ describe('queryClient', () => {
       expect(queryClient.getQueryDefaults(key)).toMatchObject(queryOptions2)
     })
 
-    test('should merge defaultOptions', () => {
+    it('should merge defaultOptions', () => {
       const key = queryKey()
 
       queryClient.setQueryDefaults([...key, 'todo'], { suspense: true })
@@ -145,7 +145,7 @@ describe('queryClient', () => {
   })
 
   describe('defaultQueryOptions', () => {
-    test('should default networkMode when persister is present', () => {
+    it('should default networkMode when persister is present', () => {
       expect(
         new QueryClient({
           defaultOptions: {
@@ -157,7 +157,7 @@ describe('queryClient', () => {
       ).toBe('offlineFirst')
     })
 
-    test('should not default networkMode without persister', () => {
+    it('should not default networkMode without persister', () => {
       expect(
         new QueryClient({
           defaultOptions: {
@@ -169,7 +169,7 @@ describe('queryClient', () => {
       ).toBe(undefined)
     })
 
-    test('should not default networkMode when already present', () => {
+    it('should not default networkMode when already present', () => {
       expect(
         new QueryClient({
           defaultOptions: {
@@ -184,7 +184,7 @@ describe('queryClient', () => {
   })
 
   describe('setQueryData', () => {
-    test('should not crash if query could not be found', () => {
+    it('should not crash if query could not be found', () => {
       const key = queryKey()
       const user = { userId: 1 }
       expect(() => {
@@ -195,7 +195,7 @@ describe('queryClient', () => {
       }).not.toThrow()
     })
 
-    test('should not crash when variable is null', () => {
+    it('should not crash when variable is null', () => {
       const key = queryKey()
       queryClient.setQueryData([key, { userId: null }], 'Old Data')
       expect(() => {
@@ -203,7 +203,7 @@ describe('queryClient', () => {
       }).not.toThrow()
     })
 
-    test('should use default options', () => {
+    it('should use default options', () => {
       const key = queryKey()
       const testClient = new QueryClient({
         defaultOptions: { queries: { queryKeyHashFn: () => 'someKey' } },
@@ -214,19 +214,19 @@ describe('queryClient', () => {
       expect(testCache.find({ queryKey: key })).toBe(testCache.get('someKey'))
     })
 
-    test('should create a new query if query was not found 1', () => {
+    it('should create a new query if query was not found 1', () => {
       const key = queryKey()
       queryClient.setQueryData(key, 'bar')
       expect(queryClient.getQueryData(key)).toBe('bar')
     })
 
-    test('should create a new query if query was not found 2', () => {
+    it('should create a new query if query was not found 2', () => {
       const key = queryKey()
       queryClient.setQueryData(key, 'qux')
       expect(queryClient.getQueryData(key)).toBe('qux')
     })
 
-    test('should not create a new query if query was not found and data is undefined', () => {
+    it('should not create a new query if query was not found and data is undefined', () => {
       const key = queryKey()
       expect(queryClient.getQueryCache().find({ queryKey: key })).toBe(
         undefined,
@@ -237,7 +237,7 @@ describe('queryClient', () => {
       )
     })
 
-    test('should not create a new query if query was not found and updater returns undefined', () => {
+    it('should not create a new query if query was not found and updater returns undefined', () => {
       const key = queryKey()
       expect(queryClient.getQueryCache().find({ queryKey: key })).toBe(
         undefined,
@@ -248,21 +248,21 @@ describe('queryClient', () => {
       )
     })
 
-    test('should not update query data if data is undefined', () => {
+    it('should not update query data if data is undefined', () => {
       const key = queryKey()
       queryClient.setQueryData(key, 'qux')
       queryClient.setQueryData(key, undefined)
       expect(queryClient.getQueryData(key)).toBe('qux')
     })
 
-    test('should not update query data if updater returns undefined', () => {
+    it('should not update query data if updater returns undefined', () => {
       const key = queryKey()
       queryClient.setQueryData<string>(key, 'qux')
       queryClient.setQueryData<string>(key, () => undefined)
       expect(queryClient.getQueryData(key)).toBe('qux')
     })
 
-    test('should accept an update function', () => {
+    it('should accept an update function', () => {
       const key = queryKey()
 
       const updater = vi.fn((oldData) => `new data + ${oldData}`)
@@ -276,7 +276,7 @@ describe('queryClient', () => {
       )
     })
 
-    test('should set the new data without comparison if structuralSharing is set to false', () => {
+    it('should set the new data without comparison if structuralSharing is set to false', () => {
       const key = queryKey()
 
       queryClient.setDefaultOptions({
@@ -293,7 +293,7 @@ describe('queryClient', () => {
       expect(queryCache.find({ queryKey: key })!.state.data).toBe(newData)
     })
 
-    test('should apply a custom structuralSharing function when provided', () => {
+    it('should apply a custom structuralSharing function when provided', () => {
       const key = queryKey()
 
       const queryObserverOptions = {
@@ -325,7 +325,7 @@ describe('queryClient', () => {
       expect(queryCache.find({ queryKey: key })!.state.data).toBe(distinctData)
     })
 
-    test('should not set isFetching to false', async () => {
+    it('should not set isFetching to false', async () => {
       const key = queryKey()
       queryClient.prefetchQuery({
         queryKey: key,
@@ -349,7 +349,7 @@ describe('queryClient', () => {
   })
 
   describe('setQueriesData', () => {
-    test('should update all existing, matching queries', () => {
+    it('should update all existing, matching queries', () => {
       queryClient.setQueryData(['key', 1], 1)
       queryClient.setQueryData(['key', 2], 2)
 
@@ -366,7 +366,7 @@ describe('queryClient', () => {
       expect(queryClient.getQueryData(['key', 2])).toBe(7)
     })
 
-    test('should accept queryFilters', () => {
+    it('should accept queryFilters', () => {
       queryClient.setQueryData(['key', 1], 1)
       queryClient.setQueryData(['key', 2], 2)
       const query1 = queryCache.find({ queryKey: ['key', 1] })!
@@ -381,7 +381,7 @@ describe('queryClient', () => {
       expect(queryClient.getQueryData(['key', 2])).toBe(2)
     })
 
-    test('should not update non existing queries', () => {
+    it('should not update non existing queries', () => {
       const result = queryClient.setQueriesData<string>(
         { queryKey: ['key'] },
         'data',
@@ -393,7 +393,7 @@ describe('queryClient', () => {
   })
 
   describe('isFetching', () => {
-    test('should return length of fetching queries', async () => {
+    it('should return length of fetching queries', async () => {
       expect(queryClient.isFetching()).toBe(0)
       queryClient.prefetchQuery({
         queryKey: queryKey(),
@@ -413,7 +413,7 @@ describe('queryClient', () => {
   })
 
   describe('isMutating', () => {
-    test('should return length of mutating', async () => {
+    it('should return length of mutating', async () => {
       expect(queryClient.isMutating()).toBe(0)
       new MutationObserver(queryClient, {
         mutationFn: () => sleep(10).then(() => 'data'),
@@ -431,18 +431,18 @@ describe('queryClient', () => {
   })
 
   describe('getQueryData', () => {
-    test('should return the query data if the query is found', () => {
+    it('should return the query data if the query is found', () => {
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], 'bar')
       expect(queryClient.getQueryData([key, 'id'])).toBe('bar')
     })
 
-    test('should return undefined if the query is not found', () => {
+    it('should return undefined if the query is not found', () => {
       const key = queryKey()
       expect(queryClient.getQueryData(key)).toBeUndefined()
     })
 
-    test('should match exact by default', () => {
+    it('should match exact by default', () => {
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], 'bar')
       expect(queryClient.getQueryData([key])).toBeUndefined()
@@ -450,7 +450,7 @@ describe('queryClient', () => {
   })
 
   describe('ensureQueryData', () => {
-    test('should return the cached query data if the query is found', async () => {
+    it('should return the cached query data if the query is found', async () => {
       const key = queryKey()
       const queryFn = () => Promise.resolve('data')
 
@@ -461,7 +461,7 @@ describe('queryClient', () => {
       ).resolves.toEqual('bar')
     })
 
-    test('should return the cached query data if the query is found and cached query data is falsy', async () => {
+    it('should return the cached query data if the query is found and cached query data is falsy', async () => {
       const key = queryKey()
       const queryFn = () => Promise.resolve(0)
 
@@ -472,7 +472,7 @@ describe('queryClient', () => {
       ).resolves.toEqual(null)
     })
 
-    test('should call fetchQuery and return its results if the query is not found', async () => {
+    it('should call fetchQuery and return its results if the query is not found', async () => {
       const key = queryKey()
       const queryFn = () => Promise.resolve('data')
 
@@ -481,7 +481,7 @@ describe('queryClient', () => {
       ).resolves.toEqual('data')
     })
 
-    test('should return the cached query data if the query is found and preFetchQuery in the background when revalidateIfStale is set', async () => {
+    it('should return the cached query data if the query is found and preFetchQuery in the background when revalidateIfStale is set', async () => {
       const TIMEOUT = 10
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], 'old')
@@ -508,7 +508,7 @@ describe('queryClient', () => {
       ).resolves.toEqual('new')
     })
 
-    test('should not fetch with initialDat', async () => {
+    it('should not fetch with initialDat', async () => {
       const key = queryKey()
       const queryFn = vi.fn().mockImplementation(() => Promise.resolve('data'))
 
@@ -525,7 +525,7 @@ describe('queryClient', () => {
   })
 
   describe('ensureInfiniteQueryData', () => {
-    test('should return the cached query data if the query is found', async () => {
+    it('should return the cached query data if the query is found', async () => {
       const key = queryKey()
       const queryFn = () => Promise.resolve('data')
 
@@ -541,7 +541,7 @@ describe('queryClient', () => {
       ).resolves.toEqual({ pages: ['bar'], pageParams: [0] })
     })
 
-    test('should fetch the query and return its results if the query is not found', async () => {
+    it('should fetch the query and return its results if the query is not found', async () => {
       const key = queryKey()
       const queryFn = () => Promise.resolve('data')
 
@@ -555,7 +555,7 @@ describe('queryClient', () => {
       ).resolves.toEqual({ pages: ['data'], pageParams: [1] })
     })
 
-    test('should return the cached query data if the query is found and preFetchQuery in the background when revalidateIfStale is set', async () => {
+    it('should return the cached query data if the query is found and preFetchQuery in the background when revalidateIfStale is set', async () => {
       const TIMEOUT = 10
       const key = queryKey()
       queryClient.setQueryData([key, 'id'], { pages: ['old'], pageParams: [0] })
@@ -585,7 +585,7 @@ describe('queryClient', () => {
   })
 
   describe('getQueriesData', () => {
-    test('should return the query data for all matched queries', () => {
+    it('should return the query data for all matched queries', () => {
       const key1 = queryKey()
       const key2 = queryKey()
       queryClient.setQueryData([key1, 1], 1)
@@ -597,12 +597,12 @@ describe('queryClient', () => {
       ])
     })
 
-    test('should return empty array if queries are not found', () => {
+    it('should return empty array if queries are not found', () => {
       const key = queryKey()
       expect(queryClient.getQueriesData({ queryKey: key })).toEqual([])
     })
 
-    test('should accept query filters', () => {
+    it('should accept query filters', () => {
       queryClient.setQueryData(['key', 1], 1)
       queryClient.setQueryData(['key', 2], 2)
       const query1 = queryCache.find({ queryKey: ['key', 1] })!
@@ -616,7 +616,7 @@ describe('queryClient', () => {
   })
 
   describe('fetchQuery', () => {
-    test('should not type-error with strict query key', async () => {
+    it('should not type-error with strict query key', async () => {
       type StrictData = 'data'
       type StrictQueryKey = ['strict', ...ReturnType<typeof queryKey>]
       const key: StrictQueryKey = ['strict', ...queryKey()]
@@ -633,7 +633,7 @@ describe('queryClient', () => {
     })
 
     // https://github.com/tannerlinsley/react-query/issues/652
-    test('should not retry by default', async () => {
+    it('should not retry by default', async () => {
       const key = queryKey()
 
       await expect(
@@ -646,7 +646,7 @@ describe('queryClient', () => {
       ).rejects.toEqual(new Error('error'))
     })
 
-    test('should return the cached data on cache hit', async () => {
+    it('should return the cached data on cache hit', async () => {
       const key = queryKey()
 
       const fetchFn = () => Promise.resolve('data')
@@ -662,7 +662,7 @@ describe('queryClient', () => {
       expect(second).toBe(first)
     })
 
-    test('should read from cache with static staleTime even if invalidated', async () => {
+    it('should read from cache with static staleTime even if invalidated', async () => {
       const key = queryKey()
 
       const fetchFn = vi.fn(() => Promise.resolve({ data: 'data' }))
@@ -691,7 +691,7 @@ describe('queryClient', () => {
       expect(second).toBe(first)
     })
 
-    test('should be able to fetch when garbage collection time is set to 0 and then be removed', async () => {
+    it('should be able to fetch when garbage collection time is set to 0 and then be removed', async () => {
       const key1 = queryKey()
       const promise = queryClient.fetchQuery({
         queryKey: key1,
@@ -704,7 +704,7 @@ describe('queryClient', () => {
       expect(queryClient.getQueryData(key1)).toEqual(undefined)
     })
 
-    test('should keep a query in cache if garbage collection time is Infinity', async () => {
+    it('should keep a query in cache if garbage collection time is Infinity', async () => {
       const key1 = queryKey()
       const promise = queryClient.fetchQuery({
         queryKey: key1,
@@ -717,7 +717,7 @@ describe('queryClient', () => {
       expect(result2).toEqual(1)
     })
 
-    test('should not force fetch', async () => {
+    it('should not force fetch', async () => {
       const key = queryKey()
 
       queryClient.setQueryData(key, 'og')
@@ -731,7 +731,7 @@ describe('queryClient', () => {
       expect(first).toBe('og')
     })
 
-    test('should only fetch if the data is older then the given stale time', async () => {
+    it('should only fetch if the data is older then the given stale time', async () => {
       const key = queryKey()
 
       let count = 0
@@ -766,7 +766,7 @@ describe('queryClient', () => {
       await expect(fourthPromise).resolves.toBe(2)
     })
 
-    test('should allow new meta', async () => {
+    it('should allow new meta', async () => {
       const key = queryKey()
 
       const first = await queryClient.fetchQuery({
@@ -790,7 +790,7 @@ describe('queryClient', () => {
   })
 
   describe('fetchInfiniteQuery', () => {
-    test('should not type-error with strict query key', async () => {
+    it('should not type-error with strict query key', async () => {
       type StrictData = string
       type StrictQueryKey = ['strict', ...ReturnType<typeof queryKey>]
       const key: StrictQueryKey = ['strict', ...queryKey()]
@@ -814,7 +814,7 @@ describe('queryClient', () => {
       ).resolves.toEqual(data)
     })
 
-    test('should return infinite query data', async () => {
+    it('should return infinite query data', async () => {
       const key = queryKey()
       const result = await queryClient.fetchInfiniteQuery({
         queryKey: key,
@@ -834,7 +834,7 @@ describe('queryClient', () => {
   })
 
   describe('prefetchInfiniteQuery', () => {
-    test('should not type-error with strict query key', async () => {
+    it('should not type-error with strict query key', async () => {
       type StrictData = 'data'
       type StrictQueryKey = ['strict', ...ReturnType<typeof queryKey>]
       const key: StrictQueryKey = ['strict', ...queryKey()]
@@ -858,7 +858,7 @@ describe('queryClient', () => {
       })
     })
 
-    test('should return infinite query data', async () => {
+    it('should return infinite query data', async () => {
       const key = queryKey()
 
       await queryClient.prefetchInfiniteQuery({
@@ -875,7 +875,7 @@ describe('queryClient', () => {
       })
     })
 
-    test('should prefetch multiple pages', async () => {
+    it('should prefetch multiple pages', async () => {
       const key = queryKey()
 
       await queryClient.prefetchInfiniteQuery({
@@ -895,7 +895,7 @@ describe('queryClient', () => {
       })
     })
 
-    test('should stop prefetching if getNextPageParam returns undefined', async () => {
+    it('should stop prefetching if getNextPageParam returns undefined', async () => {
       const key = queryKey()
       let count = 0
 
@@ -923,7 +923,7 @@ describe('queryClient', () => {
   })
 
   describe('prefetchQuery', () => {
-    test('should not type-error with strict query key', async () => {
+    it('should not type-error with strict query key', async () => {
       type StrictData = 'data'
       type StrictQueryKey = ['strict', ...ReturnType<typeof queryKey>]
       const key: StrictQueryKey = ['strict', ...queryKey()]
@@ -943,7 +943,7 @@ describe('queryClient', () => {
       expect(result).toEqual('data')
     })
 
-    test('should return undefined when an error is thrown', async () => {
+    it('should return undefined when an error is thrown', async () => {
       const key = queryKey()
 
       const result = await queryClient.prefetchQuery({
@@ -957,7 +957,7 @@ describe('queryClient', () => {
       expect(result).toBeUndefined()
     })
 
-    test('should be garbage collected after gcTime if unused', async () => {
+    it('should be garbage collected after gcTime if unused', async () => {
       const key = queryKey()
 
       await queryClient.prefetchQuery({
@@ -972,7 +972,7 @@ describe('queryClient', () => {
   })
 
   describe('removeQueries', () => {
-    test('should not crash when exact is provided', async () => {
+    it('should not crash when exact is provided', async () => {
       const key = queryKey()
 
       const fetchFn = () => Promise.resolve('data')
@@ -992,7 +992,7 @@ describe('queryClient', () => {
   })
 
   describe('cancelQueries', () => {
-    test('should revert queries to their previous state', async () => {
+    it('should revert queries to their previous state', async () => {
       const key1 = queryKey()
       queryClient.setQueryData(key1, 'data')
 
@@ -1015,7 +1015,7 @@ describe('queryClient', () => {
       })
     })
 
-    test('should not revert if revert option is set to false', async () => {
+    it('should not revert if revert option is set to false', async () => {
       const key1 = queryKey()
       await queryClient.fetchQuery({
         queryKey: key1,
@@ -1033,7 +1033,7 @@ describe('queryClient', () => {
       })
     })
 
-    test('should throw CancelledError for imperative methods when initial fetch is cancelled', async () => {
+    it('should throw CancelledError for imperative methods when initial fetch is cancelled', async () => {
       const key = queryKey()
 
       const promise = queryClient.fetchQuery({
@@ -1060,7 +1060,7 @@ describe('queryClient', () => {
   })
 
   describe('refetchQueries', () => {
-    test('should not refetch if all observers are disabled', async () => {
+    it('should not refetch if all observers are disabled', async () => {
       const key = queryKey()
       const queryFn = vi
         .fn<(...args: Array<unknown>) => string>()
@@ -1076,7 +1076,7 @@ describe('queryClient', () => {
       observer1.destroy()
       expect(queryFn).toHaveBeenCalledTimes(1)
     })
-    test('should refetch if at least one observer is enabled', async () => {
+    it('should refetch if at least one observer is enabled', async () => {
       const key = queryKey()
       const queryFn = vi
         .fn<(...args: Array<unknown>) => string>()
@@ -1099,7 +1099,7 @@ describe('queryClient', () => {
       observer2.destroy()
       expect(queryFn).toHaveBeenCalledTimes(2)
     })
-    test('should refetch all queries when no arguments are given', async () => {
+    it('should refetch all queries when no arguments are given', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1131,7 +1131,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(2)
     })
 
-    test('should be able to refetch all fresh queries', async () => {
+    it('should be able to refetch all fresh queries', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1154,7 +1154,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should be able to refetch all stale queries', async () => {
+    it('should be able to refetch all stale queries', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1178,7 +1178,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should be able to refetch all stale and active queries', async () => {
+    it('should be able to refetch all stale and active queries', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1204,7 +1204,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should be able to refetch all active and inactive queries (queryClient.refetchQueries()', async () => {
+    it('should be able to refetch all active and inactive queries (queryClient.refetchQueries()', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1227,7 +1227,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(2)
     })
 
-    test('should be able to refetch all active and inactive queries (queryClient.refetchQueries({ type: "all" }))', async () => {
+    it('should be able to refetch all active and inactive queries (queryClient.refetchQueries({ type: "all" }))', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1250,7 +1250,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(2)
     })
 
-    test('should be able to refetch only active queries', async () => {
+    it('should be able to refetch only active queries', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1273,7 +1273,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should be able to refetch only inactive queries', async () => {
+    it('should be able to refetch only inactive queries', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1296,7 +1296,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(2)
     })
 
-    test('should throw an error if throwOnError option is set to true', async () => {
+    it('should throw an error if throwOnError option is set to true', async () => {
       const key1 = queryKey()
       const queryFnError = () => Promise.reject<unknown>('error')
       try {
@@ -1318,7 +1318,7 @@ describe('queryClient', () => {
       expect(error).toEqual('error')
     })
 
-    test('should resolve Promise immediately if query is paused', async () => {
+    it('should resolve Promise immediately if query is paused', async () => {
       const key1 = queryKey()
       const queryFn1 = vi
         .fn<(...args: Array<unknown>) => string>()
@@ -1333,7 +1333,7 @@ describe('queryClient', () => {
       onlineMock.mockRestore()
     })
 
-    test('should refetch if query we are offline but query networkMode is always', async () => {
+    it('should refetch if query we are offline but query networkMode is always', async () => {
       const key1 = queryKey()
       queryClient.setQueryDefaults(key1, { networkMode: 'always' })
       const queryFn1 = vi
@@ -1349,7 +1349,7 @@ describe('queryClient', () => {
       onlineMock.mockRestore()
     })
 
-    test('should not refetch static queries', async () => {
+    it('should not refetch static queries', async () => {
       const key = queryKey()
       const queryFn = vi.fn(() => 'data1')
       await queryClient.fetchQuery({ queryKey: key, queryFn: queryFn })
@@ -1370,7 +1370,7 @@ describe('queryClient', () => {
   })
 
   describe('invalidateQueries', () => {
-    test('should refetch active queries by default', async () => {
+    it('should refetch active queries by default', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1393,7 +1393,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should not refetch inactive queries by default', async () => {
+    it('should not refetch inactive queries by default', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1416,7 +1416,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should not refetch active queries when "refetch" is "none"', async () => {
+    it('should not refetch active queries when "refetch" is "none"', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1442,7 +1442,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should refetch inactive queries when "refetch" is "inactive"', async () => {
+    it('should refetch inactive queries when "refetch" is "inactive"', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1470,7 +1470,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
 
-    test('should refetch active and inactive queries when "refetch" is "all"', async () => {
+    it('should refetch active and inactive queries when "refetch" is "all"', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const queryFn1 = vi
@@ -1495,7 +1495,7 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(2)
     })
 
-    test('should not refetch disabled inactive queries even if "refetchType" is "all', async () => {
+    it('should not refetch disabled inactive queries even if "refetchType" is "all', async () => {
       const queryFn = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data1')
@@ -1513,7 +1513,7 @@ describe('queryClient', () => {
       expect(queryFn).toHaveBeenCalledTimes(0)
     })
 
-    test('should not refetch inactive queries that have a skipToken queryFn even if "refetchType" is "all', async () => {
+    it('should not refetch inactive queries that have a skipToken queryFn even if "refetchType" is "all', async () => {
       const key = queryKey()
       const observer = new QueryObserver(queryClient, {
         queryKey: key,
@@ -1535,7 +1535,7 @@ describe('queryClient', () => {
       expect(queryClient.getQueryState(key)?.dataUpdateCount).toBe(1)
     })
 
-    test('should cancel ongoing fetches if cancelRefetch option is set (default value)', async () => {
+    it('should cancel ongoing fetches if cancelRefetch option is set (default value)', async () => {
       const key = queryKey()
       const abortFn = vi.fn()
       let fetchCount = 0
@@ -1558,7 +1558,7 @@ describe('queryClient', () => {
       expect(fetchCount).toBe(2)
     })
 
-    test('should not cancel ongoing fetches if cancelRefetch option is set to false', async () => {
+    it('should not cancel ongoing fetches if cancelRefetch option is set to false', async () => {
       const key = queryKey()
       const abortFn = vi.fn()
       let fetchCount = 0
@@ -1582,7 +1582,7 @@ describe('queryClient', () => {
       expect(fetchCount).toBe(1)
     })
 
-    test('should not refetch static queries after invalidation', async () => {
+    it('should not refetch static queries after invalidation', async () => {
       const key = queryKey()
       const queryFn = vi.fn(() => 'data1')
       await queryClient.fetchQuery({ queryKey: key, queryFn: queryFn })
@@ -1603,7 +1603,7 @@ describe('queryClient', () => {
   })
 
   describe('resetQueries', () => {
-    test('should notify listeners when a query is reset', async () => {
+    it('should notify listeners when a query is reset', async () => {
       const key = queryKey()
 
       const callback = vi.fn()
@@ -1617,7 +1617,7 @@ describe('queryClient', () => {
       expect(callback).toHaveBeenCalled()
     })
 
-    test('should reset query', async () => {
+    it('should reset query', async () => {
       const key = queryKey()
 
       await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
@@ -1636,7 +1636,7 @@ describe('queryClient', () => {
       expect(state?.fetchStatus).toEqual('idle')
     })
 
-    test('should reset query data to initial data if set', async () => {
+    it('should reset query data to initial data if set', async () => {
       const key = queryKey()
 
       await queryClient.prefetchQuery({
@@ -1656,7 +1656,7 @@ describe('queryClient', () => {
       expect(state?.data).toEqual('initial')
     })
 
-    test('should refetch all active queries', async () => {
+    it('should refetch all active queries', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const key3 = queryKey()
@@ -1699,7 +1699,7 @@ describe('queryClient', () => {
       onlineManager.setOnline(true)
       focusManager.setFocused(undefined)
     })
-    test('should notify queryCache and mutationCache if focused', async () => {
+    it('should notify queryCache and mutationCache if focused', async () => {
       const testClient = new QueryClient()
       testClient.mount()
 
@@ -1732,7 +1732,7 @@ describe('queryClient', () => {
       queryCacheOnOnlineSpy.mockRestore()
     })
 
-    test('should notify queryCache and mutationCache if online', async () => {
+    it('should notify queryCache and mutationCache if online', async () => {
       const testClient = new QueryClient()
       testClient.mount()
 
@@ -1766,7 +1766,7 @@ describe('queryClient', () => {
       mutationCacheResumePausedMutationsSpy.mockRestore()
     })
 
-    test('should resume paused mutations when coming online', async () => {
+    it('should resume paused mutations when coming online', async () => {
       const consoleMock = vi.spyOn(console, 'error')
       consoleMock.mockImplementation(() => undefined)
       onlineManager.setOnline(false)
@@ -1791,7 +1791,7 @@ describe('queryClient', () => {
       expect(observer2.getCurrentResult().status).toBe('success')
     })
 
-    test('should resume paused mutations in parallel', async () => {
+    it('should resume paused mutations in parallel', async () => {
       onlineManager.setOnline(false)
 
       const orders: Array<string> = []
@@ -1828,7 +1828,7 @@ describe('queryClient', () => {
       expect(orders).toEqual(['1start', '2start', '2end', '1end'])
     })
 
-    test('should resume paused mutations one after the other when in the same scope when invoked manually at the same time', async () => {
+    it('should resume paused mutations one after the other when in the same scope when invoked manually at the same time', async () => {
       const consoleMock = vi.spyOn(console, 'error')
       consoleMock.mockImplementation(() => undefined)
       onlineManager.setOnline(false)
@@ -1874,7 +1874,7 @@ describe('queryClient', () => {
       expect(orders).toEqual(['1start', '1end', '2start', '2end'])
     })
 
-    test('should resumePausedMutations when coming online after having called resumePausedMutations while offline', async () => {
+    it('should resumePausedMutations when coming online after having called resumePausedMutations while offline', async () => {
       const consoleMock = vi.spyOn(console, 'error')
       consoleMock.mockImplementation(() => undefined)
       onlineManager.setOnline(false)
@@ -1898,7 +1898,7 @@ describe('queryClient', () => {
       expect(observer.getCurrentResult().status).toBe('success')
     })
 
-    test('should resumePausedMutations when coming online after having restored cache (and resumed) while offline', async () => {
+    it('should resumePausedMutations when coming online after having restored cache (and resumed) while offline', async () => {
       const consoleMock = vi.spyOn(console, 'error')
       consoleMock.mockImplementation(() => undefined)
       onlineManager.setOnline(false)
@@ -1942,7 +1942,7 @@ describe('queryClient', () => {
       newQueryClient.unmount()
     })
 
-    test('should notify queryCache after resumePausedMutations has finished when coming online', async () => {
+    it('should notify queryCache after resumePausedMutations has finished when coming online', async () => {
       const key = queryKey()
 
       let count = 0
@@ -2027,7 +2027,7 @@ describe('queryClient', () => {
       unsubscribe()
     })
 
-    test('should notify queryCache and mutationCache after multiple mounts and single unmount', async () => {
+    it('should notify queryCache and mutationCache after multiple mounts and single unmount', async () => {
       const testClient = new QueryClient()
       testClient.mount()
       testClient.mount()
@@ -2064,7 +2064,7 @@ describe('queryClient', () => {
       onlineManager.setOnline(true)
     })
 
-    test('should not notify queryCache and mutationCache after multiple mounts/unmounts', () => {
+    it('should not notify queryCache and mutationCache after multiple mounts/unmounts', () => {
       const testClient = new QueryClient()
       testClient.mount()
       testClient.mount()
@@ -2101,7 +2101,7 @@ describe('queryClient', () => {
   })
 
   describe('setMutationDefaults', () => {
-    test('should update existing mutation defaults', () => {
+    it('should update existing mutation defaults', () => {
       const key = queryKey()
       const mutationOptions1 = { mutationFn: () => Promise.resolve('data') }
       const mutationOptions2 = { retry: false }
@@ -2112,7 +2112,7 @@ describe('queryClient', () => {
       )
     })
 
-    test('should return only matching defaults when multiple mutation defaults are set', () => {
+    it('should return only matching defaults when multiple mutation defaults are set', () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const mutationOptions1 = { retry: 1 }

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -5,7 +5,6 @@ import {
   expect,
   expectTypeOf,
   it,
-  test,
   vi,
 } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
@@ -32,7 +31,7 @@ describe('queryObserver', () => {
     vi.useRealTimers()
   })
 
-  test('should trigger a fetch when subscribed', () => {
+  it('should trigger a fetch when subscribed', () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -43,7 +42,7 @@ describe('queryObserver', () => {
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
 
-  test('should be able to read latest data after subscribing', () => {
+  it('should be able to read latest data after subscribing', () => {
     const key = queryKey()
     queryClient.setQueryData(key, 'data')
     const observer = new QueryObserver(queryClient, {
@@ -84,7 +83,7 @@ describe('queryObserver', () => {
       })
     })
 
-    test('should not fetch on mount', () => {
+    it('should not fetch on mount', () => {
       const unsubscribe = observer.subscribe(vi.fn())
 
       // Has not fetched and is not fetching since its disabled
@@ -98,7 +97,7 @@ describe('queryObserver', () => {
       unsubscribe()
     })
 
-    test('should not be re-fetched when invalidated with refetchType: all', async () => {
+    it('should not be re-fetched when invalidated with refetchType: all', async () => {
       const unsubscribe = observer.subscribe(vi.fn())
 
       queryClient.invalidateQueries({ queryKey: key, refetchType: 'all' })
@@ -116,7 +115,7 @@ describe('queryObserver', () => {
       unsubscribe()
     })
 
-    test('should still trigger a fetch when refetch is called', async () => {
+    it('should still trigger a fetch when refetch is called', async () => {
       const unsubscribe = observer.subscribe(vi.fn())
 
       expect(enabled).toBe(false)
@@ -141,7 +140,7 @@ describe('queryObserver', () => {
       unsubscribe()
     })
 
-    test('should fetch if unsubscribed, then enabled returns true, and then re-subscribed', async () => {
+    it('should fetch if unsubscribed, then enabled returns true, and then re-subscribed', async () => {
       let unsubscribe = observer.subscribe(vi.fn())
       expect(observer.getCurrentResult()).toMatchObject({
         status: 'pending',
@@ -166,7 +165,7 @@ describe('queryObserver', () => {
       unsubscribe()
     })
 
-    test('should not be re-fetched if not subscribed to after enabled was toggled to true (fetchStatus: "idle")', () => {
+    it('should not be re-fetched if not subscribed to after enabled was toggled to true (fetchStatus: "idle")', () => {
       const unsubscribe = observer.subscribe(vi.fn())
 
       // Toggle enabled
@@ -184,7 +183,7 @@ describe('queryObserver', () => {
       expect(count).toBe(0)
     })
 
-    test('should not be re-fetched if not subscribed to after enabled was toggled to true (fetchStatus: "fetching")', async () => {
+    it('should not be re-fetched if not subscribed to after enabled was toggled to true (fetchStatus: "fetching")', async () => {
       const unsubscribe = observer.subscribe(vi.fn())
 
       // Toggle enabled
@@ -203,7 +202,7 @@ describe('queryObserver', () => {
       unsubscribe()
     })
 
-    test('should handle that the enabled callback updates the return value', async () => {
+    it('should handle that the enabled callback updates the return value', async () => {
       const unsubscribe = observer.subscribe(vi.fn())
 
       // Toggle enabled
@@ -234,7 +233,7 @@ describe('queryObserver', () => {
     })
   })
 
-  test('should be able to read latest data when re-subscribing (but not re-fetching)', async () => {
+  it('should be able to read latest data when re-subscribing (but not re-fetching)', async () => {
     const key = queryKey()
     let count = 0
     const observer = new QueryObserver(queryClient, {
@@ -272,7 +271,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should notify when switching query', async () => {
+  it('should notify when switching query', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const results: Array<QueryObserverResult> = []
@@ -294,7 +293,7 @@ describe('queryObserver', () => {
     expect(results[3]).toMatchObject({ data: 2, status: 'success' })
   })
 
-  test('should be able to fetch with a selector', async () => {
+  it('should be able to fetch with a selector', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -313,7 +312,7 @@ describe('queryObserver', () => {
     expect(observerResult).toMatchObject({ data: { myCount: 1 } })
   })
 
-  test('should be able to fetch with a selector using the fetch method', async () => {
+  it('should be able to fetch with a selector using the fetch method', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -327,7 +326,7 @@ describe('queryObserver', () => {
     expect(observerResult.data).toMatchObject({ myCount: 1 })
   })
 
-  test('should be able to fetch with a selector and object syntax', async () => {
+  it('should be able to fetch with a selector and object syntax', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -343,7 +342,7 @@ describe('queryObserver', () => {
     expect(observerResult).toMatchObject({ data: { myCount: 1 } })
   })
 
-  test('should run the selector again if the data changed', async () => {
+  it('should run the selector again if the data changed', async () => {
     const key = queryKey()
     let count = 0
     const observer = new QueryObserver(queryClient, {
@@ -361,7 +360,7 @@ describe('queryObserver', () => {
     expect(observerResult2.data).toMatchObject({ myCount: 1 })
   })
 
-  test('should run the selector again if the selector changed', async () => {
+  it('should run the selector again if the selector changed', async () => {
     const key = queryKey()
     let count = 0
     const results: Array<QueryObserverResult> = []
@@ -419,7 +418,7 @@ describe('queryObserver', () => {
     })
   })
 
-  test('should not run the selector again if the data and selector did not change', async () => {
+  it('should not run the selector again if the data and selector did not change', async () => {
     const key = queryKey()
     let count = 0
     const results: Array<QueryObserverResult> = []
@@ -468,7 +467,7 @@ describe('queryObserver', () => {
     })
   })
 
-  test('should not run the selector again if the data did not change', async () => {
+  it('should not run the selector again if the data did not change', async () => {
     const key = queryKey()
     let count = 0
     const observer = new QueryObserver(queryClient, {
@@ -486,7 +485,7 @@ describe('queryObserver', () => {
     expect(observerResult2.data).toMatchObject({ myCount: 1 })
   })
 
-  test('should always run the selector again if selector throws an error and selector is not referentially stable', async () => {
+  it('should always run the selector again if selector throws an error and selector is not referentially stable', async () => {
     const key = queryKey()
     const results: Array<QueryObserverResult> = []
     const queryFn = () => sleep(10).then(() => ({ count: 1 }))
@@ -526,7 +525,7 @@ describe('queryObserver', () => {
     })
   })
 
-  test('should return stale data if selector throws an error', async () => {
+  it('should return stale data if selector throws an error', async () => {
     const key = queryKey()
     const results: Array<QueryObserverResult> = []
     let shouldError = false
@@ -578,7 +577,7 @@ describe('queryObserver', () => {
     })
   })
 
-  test('should structurally share the selector', async () => {
+  it('should structurally share the selector', async () => {
     const key = queryKey()
     let count = 0
     const observer = new QueryObserver(queryClient, {
@@ -592,7 +591,7 @@ describe('queryObserver', () => {
     expect(observerResult1.data).toBe(observerResult2.data)
   })
 
-  test('should not trigger a fetch when subscribed and disabled', async () => {
+  it('should not trigger a fetch when subscribed and disabled', async () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -608,7 +607,7 @@ describe('queryObserver', () => {
     expect(queryFn).toHaveBeenCalledTimes(0)
   })
 
-  test('should not trigger a fetch when subscribed and disabled by callback', async () => {
+  it('should not trigger a fetch when subscribed and disabled by callback', async () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -624,7 +623,7 @@ describe('queryObserver', () => {
     expect(queryFn).toHaveBeenCalledTimes(0)
   })
 
-  test('should not trigger a fetch when not subscribed', async () => {
+  it('should not trigger a fetch when not subscribed', async () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -634,7 +633,7 @@ describe('queryObserver', () => {
     expect(queryFn).toHaveBeenCalledTimes(0)
   })
 
-  test('should be able to watch a query without defining a query function', async () => {
+  it('should be able to watch a query without defining a query function', async () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -652,7 +651,7 @@ describe('queryObserver', () => {
     expect(callback).toHaveBeenCalledTimes(2)
   })
 
-  test('should accept unresolved query config in update function', async () => {
+  it('should accept unresolved query config in update function', async () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -675,7 +674,7 @@ describe('queryObserver', () => {
     expect(results[1]).toMatchObject({ isStale: false, data: 'data' })
   })
 
-  test('should be able to handle multiple subscribers', async () => {
+  it('should be able to handle multiple subscribers', async () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -705,7 +704,7 @@ describe('queryObserver', () => {
     expect(results2[1]).toMatchObject({ data: 'data' })
   })
 
-  test('should stop retry when unsubscribing', async () => {
+  it('should stop retry when unsubscribing', async () => {
     const key = queryKey()
     let count = 0
     const observer = new QueryObserver(queryClient, {
@@ -724,7 +723,7 @@ describe('queryObserver', () => {
     expect(count).toBe(2)
   })
 
-  test('should clear interval when unsubscribing to a refetchInterval query', async () => {
+  it('should clear interval when unsubscribing to a refetchInterval query', async () => {
     const key = queryKey()
     let count = 0
 
@@ -748,7 +747,7 @@ describe('queryObserver', () => {
     expect(count).toBe(2)
   })
 
-  test('uses placeholderData as non-cache data when pending a query with no data', async () => {
+  it('uses placeholderData as non-cache data when pending a query with no data', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -775,7 +774,7 @@ describe('queryObserver', () => {
     expect(results[1]).toMatchObject({ status: 'success', data: 'data' })
   })
 
-  test('should structurally share placeholder data', () => {
+  it('should structurally share placeholder data', () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -793,7 +792,7 @@ describe('queryObserver', () => {
     expect(firstData).toBe(secondData)
   })
 
-  test('should throw an error if enabled option type is not valid', () => {
+  it('should throw an error if enabled option type is not valid', () => {
     const key = queryKey()
 
     expect(
@@ -807,7 +806,7 @@ describe('queryObserver', () => {
     ).toThrow('Expected enabled to be a boolean')
   })
 
-  test('getCurrentQuery should return the current query', () => {
+  it('getCurrentQuery should return the current query', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -818,7 +817,7 @@ describe('queryObserver', () => {
     expect(observer.getCurrentQuery().queryKey).toEqual(key)
   })
 
-  test('should throw an error if throwOnError option is true', async () => {
+  it('should throw an error if throwOnError option is true', async () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -837,7 +836,7 @@ describe('queryObserver', () => {
     expect(error).toEqual('error')
   })
 
-  test('should not refetch in background if refetchIntervalInBackground is false', async () => {
+  it('should not refetch in background if refetchIntervalInBackground is false', async () => {
     const key = queryKey()
     const queryFn = vi
       .fn<(...args: Array<unknown>) => string>()
@@ -861,7 +860,7 @@ describe('queryObserver', () => {
     focusManager.setFocused(true)
   })
 
-  test('should not use replaceEqualDeep for select value when structuralSharing option is true', async () => {
+  it('should not use replaceEqualDeep for select value when structuralSharing option is true', async () => {
     const key = queryKey()
 
     const data = { value: 'data' }
@@ -891,7 +890,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should not use replaceEqualDeep for select value when structuralSharing option is true and placeholderData is defined', () => {
+  it('should not use replaceEqualDeep for select value when structuralSharing option is true and placeholderData is defined', () => {
     const key = queryKey()
 
     const data = { value: 'data' }
@@ -928,7 +927,7 @@ describe('queryObserver', () => {
     expect(observer.getCurrentResult().data).toBe(selectedData2)
   })
 
-  test('should pass the correct previous queryKey (from prevQuery) to placeholderData function params with select', async () => {
+  it('should pass the correct previous queryKey (from prevQuery) to placeholderData function params with select', async () => {
     const results: Array<QueryObserverResult> = []
     const keys: Array<ReadonlyArray<unknown> | null> = []
 
@@ -994,7 +993,7 @@ describe('queryObserver', () => {
     }) // Successful fetch for new key
   })
 
-  test('should pass the correct previous data to placeholderData function params when select function is used in conjunction', async () => {
+  it('should pass the correct previous data to placeholderData function params when select function is used in conjunction', async () => {
     const results: Array<QueryObserverResult> = []
 
     const key1 = queryKey()
@@ -1060,7 +1059,7 @@ describe('queryObserver', () => {
     expect(selectCount).toBe(3)
   })
 
-  test('should use cached selectResult when switching between queries and placeholderData returns previousData', async () => {
+  it('should use cached selectResult when switching between queries and placeholderData returns previousData', async () => {
     const results: Array<QueryObserverResult> = []
 
     const key1 = queryKey()
@@ -1121,7 +1120,7 @@ describe('queryObserver', () => {
     expect(stableSelect.mock.calls[1]![0]).toEqual(data2)
   })
 
-  test('setOptions should notify cache listeners', () => {
+  it('setOptions should notify cache listeners', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -1141,7 +1140,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('disabled observers should not be stale', () => {
+  it('disabled observers should not be stale', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -1153,7 +1152,7 @@ describe('queryObserver', () => {
     expect(result.isStale).toBe(false)
   })
 
-  test('should allow staleTime as a function', async () => {
+  it('should allow staleTime as a function', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -1179,7 +1178,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should not see queries as stale is staleTime is Static', async () => {
+  it('should not see queries as stale is staleTime is Static', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -1205,7 +1204,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should return a promise that resolves when data is present', async () => {
+  it('should return a promise that resolves when data is present', async () => {
     const results: Array<QueryObserverResult> = []
     const key = queryKey()
     let count = 0
@@ -1235,7 +1234,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should return a new promise after recovering from an error', async () => {
+  it('should return a new promise after recovering from an error', async () => {
     const results: Array<QueryObserverResult> = []
     const key = queryKey()
 
@@ -1295,7 +1294,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('shouldFetchOnWindowFocus should respect refetchOnWindowFocus option', () => {
+  it('shouldFetchOnWindowFocus should respect refetchOnWindowFocus option', () => {
     const key = queryKey()
 
     const observer1 = new QueryObserver(queryClient, {
@@ -1313,7 +1312,7 @@ describe('queryObserver', () => {
     expect(observer2.shouldFetchOnWindowFocus()).toBe(false)
   })
 
-  test('fetchOptimistic should fetch and return optimistic result', async () => {
+  it('fetchOptimistic should fetch and return optimistic result', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -1329,7 +1328,7 @@ describe('queryObserver', () => {
     expect(result.data).toBe('data')
   })
 
-  test('should track error prop when throwOnError is true', async () => {
+  it('should track error prop when throwOnError is true', async () => {
     const key = queryKey()
     const results: Array<QueryObserverResult> = []
     const observer = new QueryObserver(queryClient, {
@@ -1368,7 +1367,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should not track error prop when throwOnError is not set', async () => {
+  it('should not track error prop when throwOnError is not set', async () => {
     const key = queryKey()
     const results: Array<QueryObserverResult> = []
     const observer = new QueryObserver(queryClient, {
@@ -1402,7 +1401,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should not refetch on mount when retryOnMount is false and query is in error state', async () => {
+  it('should not refetch on mount when retryOnMount is false and query is in error state', async () => {
     const key = queryKey()
     const queryFn = vi.fn(() => Promise.reject('error'))
 
@@ -1438,7 +1437,7 @@ describe('queryObserver', () => {
     unsubscribeSecond()
   })
 
-  test('should reject promise when experimental_prefetchInRender is disabled and thenable is pending', async () => {
+  it('should reject promise when experimental_prefetchInRender is disabled and thenable is pending', async () => {
     const key = queryKey()
     const queryClient2 = new QueryClient({
       defaultOptions: {
@@ -1463,7 +1462,7 @@ describe('queryObserver', () => {
     queryClient2.clear()
   })
 
-  test('should not refetchOnMount when set to "always" when staleTime is Static', async () => {
+  it('should not refetchOnMount when set to "always" when staleTime is Static', async () => {
     const key = queryKey()
     const queryFn = vi.fn(() => 'data')
     queryClient.setQueryData(key, 'initial')
@@ -1479,7 +1478,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should not refetchOnWindowFocus when staleTime is static and query has background error', async () => {
+  it('should not refetchOnWindowFocus when staleTime is static and query has background error', async () => {
     const key = queryKey()
     let callCount = 0
     const queryFn = vi.fn(async () => {
@@ -1518,7 +1517,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should refetchOnWindowFocus when query has background error and staleTime is not static', async () => {
+  it('should refetchOnWindowFocus when query has background error and staleTime is not static', async () => {
     const key = queryKey()
     let callCount = 0
     const queryFn = vi.fn(async () => {
@@ -1560,7 +1559,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  test('should set fetchStatus to idle when _optimisticResults is isRestoring', () => {
+  it('should set fetchStatus to idle when _optimisticResults is isRestoring', () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -1572,7 +1571,7 @@ describe('queryObserver', () => {
     expect(result.fetchStatus).toBe('idle')
   })
 
-  test('should return isEnabled depending on enabled being resolved', () => {
+  it('should return isEnabled depending on enabled being resolved', () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -1584,7 +1583,7 @@ describe('queryObserver', () => {
     expect(result.isEnabled).toBe(false)
   })
 
-  test('should return isEnabled as true per default', () => {
+  it('should return isEnabled as true per default', () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -1595,7 +1594,7 @@ describe('queryObserver', () => {
     expect(result.isEnabled).toBe(true)
   })
 
-  test('should update currentResult when getOptimisticResult is called with changed data', () => {
+  it('should update currentResult when getOptimisticResult is called with changed data', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {

--- a/packages/query-core/src/__tests__/streamedQuery.test.tsx
+++ b/packages/query-core/src/__tests__/streamedQuery.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { streamedQuery } from '../streamedQuery'
 import { QueryClient, QueryObserver } from '..'
@@ -29,7 +29,7 @@ describe('streamedQuery', () => {
     }
   }
 
-  test('should stream data from an AsyncIterable', async () => {
+  it('should stream data from an AsyncIterable', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -73,7 +73,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should allow Arrays to be returned from the stream', async () => {
+  it('should allow Arrays to be returned from the stream', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -128,7 +128,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should handle empty streams', async () => {
+  it('should handle empty streams', async () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -157,7 +157,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should replace on refetch', async () => {
+  it('should replace on refetch', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -211,7 +211,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should support refetchMode append', async () => {
+  it('should support refetchMode append', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -266,7 +266,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should support refetchMode replace', async () => {
+  it('should support refetchMode replace', async () => {
     const key = queryKey()
     let offset = 0
     const observer = new QueryObserver(queryClient, {
@@ -324,7 +324,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should abort ongoing stream when refetch happens', async () => {
+  it('should abort ongoing stream when refetch happens', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -384,7 +384,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should abort when unsubscribed', async () => {
+  it('should abort when unsubscribed', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -425,7 +425,7 @@ describe('streamedQuery', () => {
     })
   })
 
-  test('should not abort when signal not consumed', async () => {
+  it('should not abort when signal not consumed', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -461,7 +461,7 @@ describe('streamedQuery', () => {
     })
   })
 
-  test('should support custom reducer', async () => {
+  it('should support custom reducer', async () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -498,7 +498,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should support custom reducer with initialValue', async () => {
+  it('should support custom reducer with initialValue', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -539,7 +539,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should keep error state on reset refetch when initialData is defined', async () => {
+  it('should keep error state on reset refetch when initialData is defined', async () => {
     const key = queryKey()
     let shouldError = false
     const error = new Error('stream failed')
@@ -591,7 +591,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should treat a fetch after an initial error as a refetch for reset mode', async () => {
+  it('should treat a fetch after an initial error as a refetch for reset mode', async () => {
     const key = queryKey()
     let shouldError = true
     const error = new Error('stream failed')
@@ -647,7 +647,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should reset to initialData on refetch after an initial error', async () => {
+  it('should reset to initialData on refetch after an initial error', async () => {
     const key = queryKey()
     let shouldError = true
     const error = new Error('stream failed')
@@ -704,7 +704,7 @@ describe('streamedQuery', () => {
     unsubscribe()
   })
 
-  test('should not call reducer twice when refetchMode is replace', async () => {
+  it('should not call reducer twice when refetchMode is replace', async () => {
     const key = queryKey()
     const arr: Array<number> = []
 

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { Query, QueryClient, hashKey } from '@tanstack/query-core'
 import {
   PERSISTER_KEY_PREFIX,
@@ -71,7 +71,7 @@ describe('createPersister', () => {
     vi.useRealTimers()
   })
 
-  test('should fetch if storage is not provided', async () => {
+  it('should fetch if storage is not provided', async () => {
     const { context, persister, query, queryFn } = setupPersister(['foo'], {
       storage: undefined,
     })
@@ -81,7 +81,7 @@ describe('createPersister', () => {
     expect(queryFn).toHaveBeenCalledExactlyOnceWith(context)
   })
 
-  test('should fetch if there is no stored data', async () => {
+  it('should fetch if there is no stored data', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn } = setupPersister(['foo'], {
       storage,
@@ -92,7 +92,7 @@ describe('createPersister', () => {
     expect(queryFn).toHaveBeenCalledExactlyOnceWith(context)
   })
 
-  test('should fetch if query already has data', async () => {
+  it('should fetch if query already has data', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn } = setupPersister(['foo'], {
       storage,
@@ -104,7 +104,7 @@ describe('createPersister', () => {
     expect(queryFn).toHaveBeenCalledExactlyOnceWith(context)
   })
 
-  test('should fetch if deserialization fails', async () => {
+  it('should fetch if deserialization fails', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -122,7 +122,7 @@ describe('createPersister', () => {
     expect(queryFn).toHaveBeenCalledExactlyOnceWith(context)
   })
 
-  test('should remove stored item if `dataUpdatedAt` is empty', async () => {
+  it('should remove stored item if `dataUpdatedAt` is empty', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -146,7 +146,7 @@ describe('createPersister', () => {
     expect(queryFn).toHaveBeenCalledExactlyOnceWith(context)
   })
 
-  test('should remove stored item if its expired', async () => {
+  it('should remove stored item if its expired', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -171,7 +171,7 @@ describe('createPersister', () => {
     expect(queryFn).toHaveBeenCalledExactlyOnceWith(context)
   })
 
-  test('should remove stored item if its busted', async () => {
+  it('should remove stored item if its busted', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -195,7 +195,7 @@ describe('createPersister', () => {
     expect(queryFn).toHaveBeenCalledExactlyOnceWith(context)
   })
 
-  test('should restore item from the storage and set proper `updatedAt` values', async () => {
+  it('should restore item from the storage and set proper `updatedAt` values', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -226,7 +226,7 @@ describe('createPersister', () => {
     expect(query.state.dataUpdatedAt).toEqual(dataUpdatedAt)
   })
 
-  test('should restore item from the storage and refetch when `stale`', async () => {
+  it('should restore item from the storage and refetch when `stale`', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -253,7 +253,7 @@ describe('createPersister', () => {
     expect(query.fetch).toHaveBeenCalledTimes(1)
   })
 
-  test('should restore item from the storage and refetch when `refetchOnRestore` is set to `always`', async () => {
+  it('should restore item from the storage and refetch when `refetchOnRestore` is set to `always`', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -281,7 +281,7 @@ describe('createPersister', () => {
     expect(query.fetch).toHaveBeenCalledTimes(1)
   })
 
-  test('should restore item from the storage and NOT refetch when `refetchOnRestore` is set to false', async () => {
+  it('should restore item from the storage and NOT refetch when `refetchOnRestore` is set to false', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -309,7 +309,7 @@ describe('createPersister', () => {
     expect(query.fetch).toHaveBeenCalledTimes(0)
   })
 
-  test('should store item after successful fetch', async () => {
+  it('should store item after successful fetch', async () => {
     const storage = getFreshStorage()
     const {
       context,
@@ -340,7 +340,7 @@ describe('createPersister', () => {
     })
   })
 
-  test('should skip stored item if not matched by filters', async () => {
+  it('should skip stored item if not matched by filters', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -373,7 +373,7 @@ describe('createPersister', () => {
     expect(query.fetch).toHaveBeenCalledTimes(0)
   })
 
-  test('should restore item from the storage with async deserializer', async () => {
+  it('should restore item from the storage with async deserializer', async () => {
     const storage = getFreshStorage()
     const { context, persister, query, queryFn, storageKey } = setupPersister(
       ['foo'],
@@ -402,7 +402,7 @@ describe('createPersister', () => {
     expect(query.fetch).toHaveBeenCalledTimes(1)
   })
 
-  test('should store item after successful fetch with async serializer', async () => {
+  it('should store item after successful fetch with async serializer', async () => {
     const storage = getFreshStorage()
     const {
       context,
@@ -436,7 +436,7 @@ describe('createPersister', () => {
   })
 
   describe('persistQuery', () => {
-    test('Should properly persiste basic query', async () => {
+    it('Should properly persiste basic query', async () => {
       const storage = getFreshStorage()
       const { persister, query, queryHash, queryKey, storageKey } =
         setupPersister(['foo'], {
@@ -458,7 +458,7 @@ describe('createPersister', () => {
       })
     })
 
-    test('Should skip persistance if storage is not provided', async () => {
+    it('Should skip persistance if storage is not provided', async () => {
       const serializeMock = vi.fn()
       const { persister, query } = setupPersister(['foo'], {
         storage: null,
@@ -473,7 +473,7 @@ describe('createPersister', () => {
   })
 
   describe('persistQueryByKey', () => {
-    test('Should skip persistance if storage is not provided', async () => {
+    it('Should skip persistance if storage is not provided', async () => {
       const serializeMock = vi.fn()
       const { persister, client, queryKey } = setupPersister(['foo'], {
         storage: null,
@@ -486,7 +486,7 @@ describe('createPersister', () => {
       expect(serializeMock).toHaveBeenCalledTimes(0)
     })
 
-    test('should skip persistance if query was not found', async () => {
+    it('should skip persistance if query was not found', async () => {
       const serializeMock = vi.fn()
       const storage = getFreshStorage()
       const { client, persister, queryKey } = setupPersister(['foo'], {
@@ -500,7 +500,7 @@ describe('createPersister', () => {
       expect(serializeMock).toHaveBeenCalledTimes(0)
     })
 
-    test('Should properly persiste basic query', async () => {
+    it('Should properly persiste basic query', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryHash, queryKey, storageKey } =
         setupPersister(['foo'], {
@@ -524,7 +524,7 @@ describe('createPersister', () => {
   })
 
   describe('persisterGc', () => {
-    test('should properly clean storage from busted entries', async () => {
+    it('should properly clean storage from busted entries', async () => {
       const storage = getFreshStorage()
       const { persister, client, query, queryKey } = setupPersister(['foo'], {
         storage,
@@ -545,7 +545,7 @@ describe('createPersister', () => {
   })
 
   describe('restoreQueries', () => {
-    test('should properly clean storage from busted entries', async () => {
+    it('should properly clean storage from busted entries', async () => {
       const storage = getFreshStorage()
       const { persister, client, query, queryKey } = setupPersister(['foo'], {
         storage,
@@ -564,7 +564,7 @@ describe('createPersister', () => {
       expect(await storage.entries()).toHaveLength(0)
     })
 
-    test('should properly restore queries from cache without filters', async () => {
+    it('should properly restore queries from cache without filters', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo'], {
         storage,
@@ -583,7 +583,7 @@ describe('createPersister', () => {
       expect(client.getQueryData(queryKey)).toEqual('foo')
     })
 
-    test('should properly restore queries from cache', async () => {
+    it('should properly restore queries from cache', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -602,7 +602,7 @@ describe('createPersister', () => {
       expect(client.getQueryData(queryKey)).toEqual('foo')
     })
 
-    test('should not restore queries from cache if there is no match', async () => {
+    it('should not restore queries from cache if there is no match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -619,7 +619,7 @@ describe('createPersister', () => {
       expect(client.getQueryCache().getAll()).toHaveLength(0)
     })
 
-    test('should properly restore queries from cache with partial match', async () => {
+    it('should properly restore queries from cache with partial match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -638,7 +638,7 @@ describe('createPersister', () => {
       expect(client.getQueryData(queryKey)).toEqual('foo')
     })
 
-    test('should not restore queries from cache with exact match if there is no match', async () => {
+    it('should not restore queries from cache with exact match if there is no match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -655,7 +655,7 @@ describe('createPersister', () => {
       expect(client.getQueryCache().getAll()).toHaveLength(0)
     })
 
-    test('should restore queries from cache with exact match', async () => {
+    it('should restore queries from cache with exact match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -677,7 +677,7 @@ describe('createPersister', () => {
   })
 
   describe('removeQueries', () => {
-    test('should remove restore queries from storage without filters', async () => {
+    it('should remove restore queries from storage without filters', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo'], {
         storage,
@@ -691,7 +691,7 @@ describe('createPersister', () => {
       expect(await storage.entries()).toHaveLength(0)
     })
 
-    test('should remove queries from storage', async () => {
+    it('should remove queries from storage', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -705,7 +705,7 @@ describe('createPersister', () => {
       expect(await storage.entries()).toHaveLength(0)
     })
 
-    test('should not remove queries from storage if there is no match', async () => {
+    it('should not remove queries from storage if there is no match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -719,7 +719,7 @@ describe('createPersister', () => {
       expect(await storage.entries()).toHaveLength(1)
     })
 
-    test('should properly remove queries from storage with partial match', async () => {
+    it('should properly remove queries from storage with partial match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -733,7 +733,7 @@ describe('createPersister', () => {
       expect(await storage.entries()).toHaveLength(0)
     })
 
-    test('should not remove queries from storage with exact match if there is no match', async () => {
+    it('should not remove queries from storage with exact match if there is no match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,
@@ -747,7 +747,7 @@ describe('createPersister', () => {
       expect(await storage.entries()).toHaveLength(1)
     })
 
-    test('should remove queries from storage with exact match', async () => {
+    it('should remove queries from storage with exact match', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryKey } = setupPersister(['foo', 'bar'], {
         storage,

--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { QueriesObserver, QueryClient } from '@tanstack/query-core'
 import {
   persistQueryClientRestore,
@@ -7,7 +7,7 @@ import {
 import { createMockPersister, createSpyPersister } from './utils'
 
 describe('persistQueryClientSubscribe', () => {
-  test('should persist mutations', async () => {
+  it('should persist mutations', async () => {
     const queryClient = new QueryClient()
 
     const persister = createMockPersister()
@@ -31,7 +31,7 @@ describe('persistQueryClientSubscribe', () => {
 })
 
 describe('persistQueryClientSave', () => {
-  test('should not be triggered on observer type events', () => {
+  it('should not be triggered on observer type events', () => {
     const queryClient = new QueryClient()
 
     const persister = createSpyPersister()
@@ -64,7 +64,7 @@ describe('persistQueryClientSave', () => {
 })
 
 describe('persistQueryClientRestore', () => {
-  test('should rethrow exceptions in `restoreClient`', async () => {
+  it('should rethrow exceptions in `restoreClient`', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
@@ -96,7 +96,7 @@ describe('persistQueryClientRestore', () => {
     consoleWarn.mockRestore()
   })
 
-  test('should rethrow exceptions in `removeClient` before `restoreClient`', async () => {
+  it('should rethrow exceptions in `removeClient` before `restoreClient`', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
@@ -130,7 +130,7 @@ describe('persistQueryClientRestore', () => {
     consoleWarn.mockRestore()
   })
 
-  test('should rethrow error in `removeClient`', async () => {
+  it('should rethrow error in `removeClient`', async () => {
     const queryClient = new QueryClient()
 
     const persister = createSpyPersister()

--- a/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
+++ b/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   MutationCache,
   QueryCache,
@@ -41,7 +41,7 @@ function getMockStorage(limitSize?: number) {
 }
 
 describe('create persister', () => {
-  test('basic store and recover', async () => {
+  it('basic store and recover', async () => {
     const queryCache = new QueryCache()
     const mutationCache = new MutationCache()
     const queryClient = new QueryClient({ queryCache, mutationCache })
@@ -84,7 +84,7 @@ describe('create persister', () => {
     expect(restoredClient).toEqual(persistClient)
   })
 
-  test('should clean the old queries when storage full', async () => {
+  it('should clean the old queries when storage full', async () => {
     const queryCache = new QueryCache()
     const mutationCache = new MutationCache()
     const queryClient = new QueryClient({ queryCache, mutationCache })
@@ -160,7 +160,7 @@ describe('create persister', () => {
       restoredClient2?.clientState.queries.find((q) => q.queryKey[0] === 'B'),
     ).toBeUndefined()
   })
-  test('should clear storage as default error handling', async () => {
+  it('should clear storage as default error handling', async () => {
     const queryCache = new QueryCache()
     const mutationCache = new MutationCache()
     const queryClient = new QueryClient({ queryCache, mutationCache })

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
 import { QueryClient, useQueries, useQuery } from '@tanstack/react-query'
@@ -58,7 +58,7 @@ describe('PersistQueryClientProvider', () => {
     vi.useRealTimers()
   })
 
-  test('restores cache from persister', async () => {
+  it('restores cache from persister', async () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
@@ -134,7 +134,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should subscribe correctly in StrictMode', async () => {
+  it('should subscribe correctly in StrictMode', async () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
@@ -201,7 +201,7 @@ describe('PersistQueryClientProvider', () => {
     expect(state?.clientState.queries[0]?.state.data).toBe('updated')
   })
 
-  test('should also put useQueries into idle state', async () => {
+  it('should also put useQueries into idle state', async () => {
     const key = queryKey()
     const states: Array<UseQueryResult> = []
 
@@ -281,7 +281,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should show initialData while restoring', async () => {
+  it('should show initialData while restoring', async () => {
     const key = queryKey()
     const states: Array<DefinedUseQueryResult<string>> = []
 
@@ -361,7 +361,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should not refetch after restoring when data is fresh', async () => {
+  it('should not refetch after restoring when data is fresh', async () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
@@ -434,7 +434,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should call onSuccess after successful restoring', async () => {
+  it('should call onSuccess after successful restoring', async () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
@@ -486,7 +486,7 @@ describe('PersistQueryClientProvider', () => {
     expect(rendered.getByText('fetched')).toBeInTheDocument()
   })
 
-  test('should await onSuccess after successful restoring', async () => {
+  it('should await onSuccess after successful restoring', async () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
@@ -551,7 +551,7 @@ describe('PersistQueryClientProvider', () => {
     ])
   })
 
-  test('should remove cache after non-successful restoring', async () => {
+  it('should remove cache after non-successful restoring', async () => {
     const key = queryKey()
     const consoleMock = vi.spyOn(console, 'error')
     const consoleWarn = vi
@@ -604,7 +604,7 @@ describe('PersistQueryClientProvider', () => {
     consoleWarn.mockRestore()
   })
 
-  test('should be able to persist into multiple clients', async () => {
+  it('should be able to persist into multiple clients', async () => {
     const key = queryKey()
     const states: Array<UseQueryResult> = []
 
@@ -723,7 +723,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should only restore once in StrictMode', async () => {
+  it('should only restore once in StrictMode', async () => {
     let restoreCount = 0
     const createPersister = (): Persister => {
       let storedState: PersistedClient | undefined

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
 import { render } from '@testing-library/react'
 import * as coreModule from '@tanstack/query-core'
@@ -31,7 +31,7 @@ describe('React hydration', () => {
     vi.useRealTimers()
   })
 
-  test('should hydrate queries to the cache on context', async () => {
+  it('should hydrate queries to the cache on context', async () => {
     const dehydratedState = JSON.parse(stringifiedState)
     const queryClient = new QueryClient()
 
@@ -61,7 +61,7 @@ describe('React hydration', () => {
     queryClient.clear()
   })
 
-  test('should hydrate queries to the cache on custom context', async () => {
+  it('should hydrate queries to the cache on custom context', async () => {
     const queryClientInner = new QueryClient()
     const queryClientOuter = new QueryClient()
 
@@ -98,7 +98,7 @@ describe('React hydration', () => {
   })
 
   describe('ReactQueryCacheProvider with hydration support', () => {
-    test('should hydrate new queries if queries change', async () => {
+    it('should hydrate new queries if queries change', async () => {
       const dehydratedState = JSON.parse(stringifiedState)
       const queryClient = new QueryClient()
 
@@ -169,7 +169,7 @@ describe('React hydration', () => {
     // remounted, I didn't change tabs etc?).
     // Any queries that does not exist in the cache yet can still be hydrated
     // since they don't have any observers on the current page that would update.
-    test('should hydrate new but not existing queries if transition is aborted', async () => {
+    it('should hydrate new but not existing queries if transition is aborted', async () => {
       const initialDehydratedState = JSON.parse(stringifiedState)
       const queryClient = new QueryClient()
 
@@ -262,7 +262,7 @@ describe('React hydration', () => {
       queryClient.clear()
     })
 
-    test('should hydrate queries to new cache if cache changes', async () => {
+    it('should hydrate queries to new cache if cache changes', async () => {
       const dehydratedState = JSON.parse(stringifiedState)
       const queryClient = new QueryClient()
 
@@ -307,7 +307,7 @@ describe('React hydration', () => {
     })
   })
 
-  test('should not hydrate queries if state is null', async () => {
+  it('should not hydrate queries if state is null', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -335,7 +335,7 @@ describe('React hydration', () => {
     queryClient.clear()
   })
 
-  test('should not hydrate queries if state is undefined', async () => {
+  it('should not hydrate queries if state is undefined', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -359,7 +359,7 @@ describe('React hydration', () => {
     queryClient.clear()
   })
 
-  test('should not hydrate queries if state is not an object', async () => {
+  it('should not hydrate queries if state is not an object', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -383,7 +383,7 @@ describe('React hydration', () => {
     queryClient.clear()
   })
 
-  test('should handle state without queries property gracefully', async () => {
+  it('should handle state without queries property gracefully', async () => {
     const queryClient = new QueryClient()
 
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
@@ -408,7 +408,7 @@ describe('React hydration', () => {
   })
 
   // https://github.com/TanStack/query/issues/8677
-  test('should not infinite loop when hydrating promises that resolve to errors', async () => {
+  it('should not infinite loop when hydrating promises that resolve to errors', async () => {
     const originalHydrate = coreModule.hydrate
     const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
     let hydrationCount = 0
@@ -481,7 +481,7 @@ describe('React hydration', () => {
     clientQueryClient.clear()
   })
 
-  test('should not refetch when query has enabled set to false', async () => {
+  it('should not refetch when query has enabled set to false', async () => {
     const queryFn = vi.fn()
     const queryClient = new QueryClient()
 
@@ -511,7 +511,7 @@ describe('React hydration', () => {
     queryClient.clear()
   })
 
-  test('should not refetch when query has staleTime set to Infinity', async () => {
+  it('should not refetch when query has staleTime set to Infinity', async () => {
     const queryFn = vi.fn()
     const queryClient = new QueryClient()
 

--- a/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/react'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
@@ -18,7 +18,7 @@ describe('QueryClientProvider', () => {
     vi.useRealTimers()
   })
 
-  test('sets a specific cache for all queries to use', async () => {
+  it('sets a specific cache for all queries to use', async () => {
     const key = queryKey()
 
     const queryCache = new QueryCache()
@@ -49,7 +49,7 @@ describe('QueryClientProvider', () => {
     expect(queryCache.find({ queryKey: key })).toBeDefined()
   })
 
-  test('allows multiple caches to be partitioned', async () => {
+  it('allows multiple caches to be partitioned', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -105,7 +105,7 @@ describe('QueryClientProvider', () => {
     expect(queryCache2.find({ queryKey: key2 })).toBeDefined()
   })
 
-  test("uses defaultOptions for queries when they don't provide their own config", async () => {
+  it("uses defaultOptions for queries when they don't provide their own config", async () => {
     const key = queryKey()
 
     const queryCache = new QueryCache()
@@ -145,7 +145,7 @@ describe('QueryClientProvider', () => {
   })
 
   describe('useQueryClient', () => {
-    test('should throw an error if no query client has been set', () => {
+    it('should throw an error if no query client has been set', () => {
       const consoleMock = vi
         .spyOn(console, 'error')
         .mockImplementation(() => undefined)

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -1,4 +1,4 @@
-import { assertType, describe, expectTypeOf, it, test } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { QueryClient, dataTagSymbol, skipToken } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
@@ -154,7 +154,7 @@ describe('infiniteQueryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<InfiniteData<string, unknown>>()
   })
 
-  test('should not be allowed to be passed to non-infinite query functions', () => {
+  it('should not be allowed to be passed to non-infinite query functions', () => {
     const queryClient = new QueryClient()
     const options = infiniteQueryOptions({
       queryKey: queryKey(),
@@ -180,7 +180,7 @@ describe('infiniteQueryOptions', () => {
     )
   })
 
-  test('allow optional initialData function', () => {
+  it('allow optional initialData function', () => {
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
       queryKey: queryKey(),
@@ -198,7 +198,7 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
-  test('allow optional initialData object', () => {
+  it('allow optional initialData object', () => {
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
       queryKey: queryKey(),

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render } from '@testing-library/react'
 import * as React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -3889,7 +3889,7 @@ describe('useQuery', () => {
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/360
-  test('should init to status:pending, fetchStatus:idle when enabled is false', async () => {
+  it('should init to status:pending, fetchStatus:idle when enabled is false', async () => {
     const key = queryKey()
 
     function Page() {
@@ -3914,7 +3914,7 @@ describe('useQuery', () => {
     expect(rendered.getByText('status: pending, idle')).toBeInTheDocument()
   })
 
-  test('should not schedule garbage collection, if gcTimeout is set to `Infinity`', async () => {
+  it('should not schedule garbage collection, if gcTimeout is set to `Infinity`', async () => {
     const key = queryKey()
 
     function Page() {
@@ -3937,7 +3937,7 @@ describe('useQuery', () => {
     expect(setTimeoutSpy).not.toHaveBeenCalled()
   })
 
-  test('should schedule garbage collection, if gcTimeout is not set to infinity', async () => {
+  it('should schedule garbage collection, if gcTimeout is not set to infinity', async () => {
     const key = queryKey()
 
     function Page() {

--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@solidjs/testing-library'
 import { QueryClient, useQueries, useQuery } from '@tanstack/solid-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
@@ -54,7 +54,7 @@ describe('PersistQueryClientProvider', () => {
     vi.useRealTimers()
   })
 
-  test('restores cache from persister', async () => {
+  it('restores cache from persister', async () => {
     const key = queryKey()
     const states: Array<{
       status: string
@@ -133,7 +133,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should also put useQueries into idle state', async () => {
+  it('should also put useQueries into idle state', async () => {
     const key = queryKey()
     const states: Array<{
       status: string
@@ -217,7 +217,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should show initialData while restoring', async () => {
+  it('should show initialData while restoring', async () => {
     const key = queryKey()
     const states: Array<{
       status: string
@@ -301,7 +301,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should not refetch after restoring when data is fresh', async () => {
+  it('should not refetch after restoring when data is fresh', async () => {
     const key = queryKey()
     const states: Array<{
       status: string
@@ -384,7 +384,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should call onSuccess after successful restoring', async () => {
+  it('should call onSuccess after successful restoring', async () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
@@ -435,7 +435,7 @@ describe('PersistQueryClientProvider', () => {
     expect(screen.getByText('fetched')).toBeInTheDocument()
   })
 
-  test('should remove cache after non-successful restoring', async () => {
+  it('should remove cache after non-successful restoring', async () => {
     const key = queryKey()
 
     const onErrorMock = vi
@@ -485,7 +485,7 @@ describe('PersistQueryClientProvider', () => {
     onErrorMock.mockRestore()
   })
 
-  test('should be able to persist into multiple clients', async () => {
+  it('should be able to persist into multiple clients', async () => {
     const key = queryKey()
     const states: Array<{
       status: string

--- a/packages/svelte-query-persist-client/tests/PersistQueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query-persist-client/tests/PersistQueryClientProvider.svelte.test.ts
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/svelte'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient } from '@tanstack/svelte-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
 import { sleep } from '@tanstack/query-test-utils'
@@ -60,7 +60,7 @@ const createMockErrorPersister = (
 }
 
 describe('PersistQueryClientProvider', () => {
-  test('restores cache from persister', async () => {
+  it('restores cache from persister', async () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
@@ -112,7 +112,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should also put useQueries into idle state', async () => {
+  it('should also put useQueries into idle state', async () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
@@ -164,7 +164,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should show initialData while restoring', async () => {
+  it('should show initialData while restoring', async () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
@@ -216,7 +216,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should not refetch after restoring when data is fresh', async () => {
+  it('should not refetch after restoring when data is fresh', async () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
@@ -269,7 +269,7 @@ describe('PersistQueryClientProvider', () => {
     })
   })
 
-  test('should call onSuccess after successful restoring', async () => {
+  it('should call onSuccess after successful restoring', async () => {
     const queryClient = new QueryClient()
     queryClient.prefetchQuery({
       queryKey: ['test'],
@@ -302,7 +302,7 @@ describe('PersistQueryClientProvider', () => {
     expect(rendered.getByText('fetched')).toBeInTheDocument()
   })
 
-  test('should await onSuccess after successful restoring', async () => {
+  it('should await onSuccess after successful restoring', async () => {
     const queryClient = new QueryClient()
     queryClient.prefetchQuery({
       queryKey: ['test'],
@@ -345,7 +345,7 @@ describe('PersistQueryClientProvider', () => {
     ])
   })
 
-  test('should remove cache after non-successful restoring', async () => {
+  it('should remove cache after non-successful restoring', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)

--- a/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/svelte'
 import { QueryClient } from '@tanstack/query-core'
 import Base from './Base.svelte'
@@ -16,7 +16,7 @@ describe('QueryClientProvider', () => {
     vi.useRealTimers()
   })
 
-  test('should set a specific cache for all queries to use', async () => {
+  it('should set a specific cache for all queries to use', async () => {
     const queryCache = queryClient.getQueryCache()
 
     const rendered = render(Base, {

--- a/packages/svelte-query/tests/context/context.svelte.test.ts
+++ b/packages/svelte-query/tests/context/context.svelte.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { render } from '@testing-library/svelte'
 import { getIsRestoringContext } from '../../src/index.js'
 import Base from './Base.svelte'
 
 describe('getQueryClientContext', () => {
-  test('should throw when called without a client in context', () => {
+  it('should throw when called without a client in context', () => {
     expect(() => render(Base)).toThrow(
       'No QueryClient was found in Svelte context. Did you forget to wrap your component with QueryClientProvider?',
     )
@@ -12,7 +12,7 @@ describe('getQueryClientContext', () => {
 })
 
 describe('getIsRestoringContext', () => {
-  test('should not throw when called outside of a component', () => {
+  it('should not throw when called outside of a component', () => {
     expect(() => getIsRestoringContext()).not.toThrow()
   })
 })

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushSync } from 'svelte'
 import { fireEvent, render } from '@testing-library/svelte'
 import { QueryClient } from '@tanstack/query-core'
@@ -22,7 +22,7 @@ describe('createMutation', () => {
     vi.useRealTimers()
   })
 
-  test('should be able to reset `error`', async () => {
+  it('should be able to reset `error`', async () => {
     const rendered = render(Reset, {
       props: { queryClient },
     })
@@ -38,7 +38,7 @@ describe('createMutation', () => {
     expect(rendered.getByText('Error: undefined')).toBeInTheDocument()
   })
 
-  test('should be able to call `onSuccess` and `onSettled` after each successful mutate', async () => {
+  it('should be able to call `onSuccess` and `onSettled` after each successful mutate', async () => {
     const onSuccessMock = vi.fn()
     const onSettledMock = vi.fn()
 
@@ -69,7 +69,7 @@ describe('createMutation', () => {
     expect(onSettledMock).toHaveBeenNthCalledWith(3, 3)
   })
 
-  test('should set correct values for `failureReason` and `failureCount` on multiple mutate calls', async () => {
+  it('should set correct values for `failureReason` and `failureCount` on multiple mutate calls', async () => {
     type Value = { count: number }
 
     const mutationFn = vi.fn<(value: Value) => Promise<Value>>()
@@ -108,7 +108,7 @@ describe('createMutation', () => {
     expect(rendered.getByText('Failure Reason: undefined')).toBeInTheDocument()
   })
 
-  test(
+  it(
     'should recreate observer when queryClient changes',
     withEffectRoot(async () => {
       const queryClient1 = new QueryClient()

--- a/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
+++ b/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
@@ -1,11 +1,11 @@
-import { assertType, describe, expectTypeOf, test } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { createInfiniteQuery, infiniteQueryOptions } from '../src/index.js'
 import type { InfiniteData } from '@tanstack/query-core'
 
 describe('infiniteQueryOptions', () => {
-  test('should not allow excess properties', () => {
+  it('should not allow excess properties', () => {
     const key = queryKey()
     assertType(
       infiniteQueryOptions({
@@ -19,7 +19,7 @@ describe('infiniteQueryOptions', () => {
     )
   })
 
-  test('should infer types for callbacks', () => {
+  it('should infer types for callbacks', () => {
     const key = queryKey()
     infiniteQueryOptions({
       queryKey: key,
@@ -33,7 +33,7 @@ describe('infiniteQueryOptions', () => {
     })
   })
 
-  test('should work when passed to createInfiniteQuery', () => {
+  it('should work when passed to createInfiniteQuery', () => {
     const key = queryKey()
     const options = infiniteQueryOptions({
       queryKey: key,
@@ -50,7 +50,7 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
-  test('should work when passed to fetchInfiniteQuery', async () => {
+  it('should work when passed to fetchInfiniteQuery', async () => {
     const key = queryKey()
     const options = infiniteQueryOptions({
       queryKey: key,

--- a/packages/svelte-query/tests/mutationOptions/mutationOptions.test-d.ts
+++ b/packages/svelte-query/tests/mutationOptions/mutationOptions.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, expectTypeOf, test } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { QueryClient } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import {
@@ -19,7 +19,7 @@ import type {
 } from '../../src/types.js'
 
 describe('mutationOptions', () => {
-  test('should not allow excess properties', () => {
+  it('should not allow excess properties', () => {
     const key = queryKey()
 
     // @ts-expect-error this is a good error, because onMutates does not exist!
@@ -33,7 +33,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('should infer types for callbacks', () => {
+  it('should infer types for callbacks', () => {
     const key = queryKey()
 
     mutationOptions({
@@ -45,7 +45,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('should infer types for onError callback', () => {
+  it('should infer types for onError callback', () => {
     const key = queryKey()
 
     mutationOptions({
@@ -59,7 +59,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('should infer types for variables', () => {
+  it('should infer types for variables', () => {
     const key = queryKey()
 
     mutationOptions<number, DefaultError, { id: string }>({
@@ -71,7 +71,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('should infer result type correctly', () => {
+  it('should infer result type correctly', () => {
     const key = queryKey()
 
     mutationOptions<number, DefaultError, void, { name: string }>({
@@ -86,7 +86,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('should infer context type correctly', () => {
+  it('should infer context type correctly', () => {
     const key = queryKey()
 
     mutationOptions<number>({
@@ -110,7 +110,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('should error if mutationFn return type mismatches TData', () => {
+  it('should error if mutationFn return type mismatches TData', () => {
     assertType(
       mutationOptions<number>({
         // @ts-expect-error this is a good error, because return type is string, not number
@@ -119,7 +119,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('should allow mutationKey to be omitted', () => {
+  it('should allow mutationKey to be omitted', () => {
     return mutationOptions({
       mutationFn: () => Promise.resolve(123),
       onSuccess: (data) => {
@@ -128,7 +128,7 @@ describe('mutationOptions', () => {
     })
   })
 
-  test('should infer all types when not explicitly provided', () => {
+  it('should infer all types when not explicitly provided', () => {
     const key = queryKey()
 
     expectTypeOf(
@@ -157,7 +157,7 @@ describe('mutationOptions', () => {
     >()
   })
 
-  test('should work when used with createMutation', () => {
+  it('should work when used with createMutation', () => {
     const key = queryKey()
 
     const mutation = createMutation(() =>
@@ -184,7 +184,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('should work when used with useIsMutating', () => {
+  it('should work when used with useIsMutating', () => {
     const key = queryKey()
 
     const isMutating = useIsMutating(
@@ -203,7 +203,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('should work when used with queryClient.isMutating', () => {
+  it('should work when used with queryClient.isMutating', () => {
     const key = queryKey()
     const queryClient = new QueryClient()
 
@@ -223,7 +223,7 @@ describe('mutationOptions', () => {
     )
   })
 
-  test('should work when used with useMutationState', () => {
+  it('should work when used with useMutationState', () => {
     const key = queryKey()
 
     const mutationState = useMutationState({

--- a/packages/svelte-query/tests/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, expectTypeOf, test } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 import {
   QueriesObserver,
   QueryClient,
@@ -10,7 +10,7 @@ import { createQueries, queryOptions } from '../src/index.js'
 import type { QueryObserverResult } from '@tanstack/query-core'
 
 describe('queryOptions', () => {
-  test('should not allow excess properties', () => {
+  it('should not allow excess properties', () => {
     const key = queryKey()
     assertType(
       queryOptions({
@@ -22,7 +22,7 @@ describe('queryOptions', () => {
     )
   })
 
-  test('should infer types for callbacks', () => {
+  it('should infer types for callbacks', () => {
     const key = queryKey()
     queryOptions({
       queryKey: key,
@@ -34,7 +34,7 @@ describe('queryOptions', () => {
     })
   })
 
-  test('should work when passed to fetchQuery', async () => {
+  it('should work when passed to fetchQuery', async () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -45,7 +45,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number>()
   })
 
-  test('should work when passed to createQueries', () => {
+  it('should work when passed to createQueries', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -59,7 +59,7 @@ describe('queryOptions', () => {
     expectTypeOf(queries[0].data).toEqualTypeOf<number | undefined>()
   })
 
-  test('should tag the queryKey with the result type of the QueryFn', () => {
+  it('should tag the queryKey with the result type of the QueryFn', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -69,7 +69,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<number>()
   })
 
-  test('should tag the queryKey even if no promise is returned', () => {
+  it('should tag the queryKey even if no promise is returned', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -79,7 +79,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<number>()
   })
 
-  test('should tag the queryKey with unknown if there is no queryFn', () => {
+  it('should tag the queryKey with unknown if there is no queryFn', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -88,7 +88,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<unknown>()
   })
 
-  test('should tag the queryKey with the result type of the QueryFn if select is used', () => {
+  it('should tag the queryKey with the result type of the QueryFn if select is used', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -99,7 +99,7 @@ describe('queryOptions', () => {
     expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<number>()
   })
 
-  test('should return the proper type when passed to getQueryData', () => {
+  it('should return the proper type when passed to getQueryData', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -111,7 +111,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('should return the proper type when passed to getQueryState', () => {
+  it('should return the proper type when passed to getQueryState', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -123,7 +123,7 @@ describe('queryOptions', () => {
     expectTypeOf(state?.data).toEqualTypeOf<number | undefined>()
   })
 
-  test('should properly type updaterFn when passed to setQueryData', () => {
+  it('should properly type updaterFn when passed to setQueryData', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -138,7 +138,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('should properly type value when passed to setQueryData', () => {
+  it('should properly type value when passed to setQueryData', () => {
     const key = queryKey()
     const { queryKey: tagged } = queryOptions({
       queryKey: key,
@@ -156,7 +156,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('should infer even if there is a conditional skipToken', () => {
+  it('should infer even if there is a conditional skipToken', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -168,7 +168,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
-  test('should infer to unknown if we disable a query with just a skipToken', () => {
+  it('should infer to unknown if we disable a query with just a skipToken', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -180,7 +180,7 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<unknown>()
   })
 
-  test('should return the proper type when passed to QueriesObserver', () => {
+  it('should return the proper type when passed to QueriesObserver', () => {
     const key = queryKey()
     const options = queryOptions({
       queryKey: key,
@@ -194,7 +194,7 @@ describe('queryOptions', () => {
     >()
   })
 
-  test('should allow undefined response in initialData', () => {
+  it('should allow undefined response in initialData', () => {
     const key = queryKey()
     const options = (id: string | null) =>
       queryOptions({

--- a/packages/svelte-query/tests/useIsFetching/useIsFetching.svelte.test.ts
+++ b/packages/svelte-query/tests/useIsFetching/useIsFetching.svelte.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
 import { QueryClient } from '@tanstack/query-core'
 import Base from './Base.svelte'
@@ -16,7 +16,7 @@ describe('useIsFetching', () => {
     vi.useRealTimers()
   })
 
-  test('should update as queries start and stop fetching', async () => {
+  it('should update as queries start and stop fetching', async () => {
     const rendered = render(Base, {
       props: { queryClient },
     })

--- a/packages/svelte-query/tests/useIsMutating/useIsMutating.svelte.test.ts
+++ b/packages/svelte-query/tests/useIsMutating/useIsMutating.svelte.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
 import { QueryClient } from '@tanstack/query-core'
 import Base from './Base.svelte'
@@ -16,7 +16,7 @@ describe('useIsMutating', () => {
     vi.useRealTimers()
   })
 
-  test('should update as queries start and stop mutating', async () => {
+  it('should update as queries start and stop mutating', async () => {
     const rendered = render(Base, {
       props: { queryClient },
     })

--- a/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
+++ b/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render } from '@testing-library/svelte'
 import { QueryClient } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
@@ -19,7 +19,7 @@ describe('useMutationState', () => {
     vi.useRealTimers()
   })
 
-  test('should run few mutation functions and check from useMutationState', async () => {
+  it('should run few mutation functions and check from useMutationState', async () => {
     const successKey = queryKey()
     const errorKey = queryKey()
     const successMutationFn = vi.fn(() => sleep(10).then(() => 'data'))
@@ -54,7 +54,7 @@ describe('useMutationState', () => {
     expect(rendered.getByText('Data: ["success","error"]')).toBeInTheDocument()
   })
 
-  test('should select specific type of mutation ( i.e: error only )', async () => {
+  it('should select specific type of mutation ( i.e: error only )', async () => {
     const successKey = queryKey()
     const errorKey = queryKey()
     const successMutationFn = vi.fn(() => sleep(10).then(() => 'data'))
@@ -92,7 +92,7 @@ describe('useMutationState', () => {
     expect(rendered.getByText('Data: ["error"]')).toBeInTheDocument()
   })
 
-  test('should return selected value when using select option', async () => {
+  it('should return selected value when using select option', async () => {
     const mutationKey = queryKey()
 
     const rendered = render(Select, {
@@ -119,7 +119,7 @@ describe('useMutationState', () => {
     expect(rendered.getByText('Variables: ["success"]')).toBeInTheDocument()
   })
 
-  test('should select specific mutation using mutation key', async () => {
+  it('should select specific mutation using mutation key', async () => {
     const successKey = queryKey()
     const errorKey = queryKey()
     const successMutationFn = vi.fn(() => sleep(10).then(() => 'data'))

--- a/packages/vue-query/src/__tests__/mutationCache.test.ts
+++ b/packages/vue-query/src/__tests__/mutationCache.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue-demi'
 import { MutationCache as MutationCacheOrigin } from '@tanstack/query-core'
 import { MutationCache } from '../mutationCache'
@@ -10,7 +10,7 @@ describe('MutationCache', () => {
   })
 
   describe('find', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const mutationCache = new MutationCache()
 
       mutationCache.find({
@@ -24,7 +24,7 @@ describe('MutationCache', () => {
   })
 
   describe('findAll', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const mutationCache = new MutationCache()
 
       mutationCache.findAll({

--- a/packages/vue-query/src/__tests__/queryCache.test.ts
+++ b/packages/vue-query/src/__tests__/queryCache.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue-demi'
 import { QueryCache as QueryCacheOrigin } from '@tanstack/query-core'
 import { QueryCache } from '../queryCache'
@@ -10,7 +10,7 @@ describe('QueryCache', () => {
   })
 
   describe('find', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryCache = new QueryCache()
 
       queryCache.find({
@@ -24,7 +24,7 @@ describe('QueryCache', () => {
   })
 
   describe('findAll', () => {
-    test('should properly unwrap two parameters', () => {
+    it('should properly unwrap two parameters', () => {
       const queryCache = new QueryCache()
 
       queryCache.findAll({
@@ -36,7 +36,7 @@ describe('QueryCache', () => {
       })
     })
 
-    test('should default to empty filters', () => {
+    it('should default to empty filters', () => {
       const queryCache = new QueryCache()
 
       queryCache.findAll()

--- a/packages/vue-query/src/__tests__/queryClient.test.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue-demi'
 import { QueryClient as QueryClientOrigin } from '@tanstack/query-core'
 import { QueryClient } from '../queryClient'
@@ -44,7 +44,7 @@ describe('QueryCache', () => {
   })
 
   describe('isFetching', () => {
-    test('should properly unwrap 1 parameter', () => {
+    it('should properly unwrap 1 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.isFetching({
@@ -58,7 +58,7 @@ describe('QueryCache', () => {
   })
 
   describe('isMutating', () => {
-    test('should properly unwrap 1 parameter', () => {
+    it('should properly unwrap 1 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.isMutating({
@@ -72,7 +72,7 @@ describe('QueryCache', () => {
   })
 
   describe('getQueryData', () => {
-    test('should properly unwrap 1 parameter', () => {
+    it('should properly unwrap 1 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.getQueryData(queryKeyRef)
@@ -84,7 +84,7 @@ describe('QueryCache', () => {
   })
 
   describe('ensureQueryData', () => {
-    test('should properly unwrap parameter', () => {
+    it('should properly unwrap parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.ensureQueryData({
@@ -100,7 +100,7 @@ describe('QueryCache', () => {
   })
 
   describe('getQueriesData', () => {
-    test('should properly unwrap queryKey param', () => {
+    it('should properly unwrap queryKey param', () => {
       const queryClient = new QueryClient()
 
       queryClient.getQueriesData({ queryKey: queryKeyRef })
@@ -110,7 +110,7 @@ describe('QueryCache', () => {
       })
     })
 
-    test('should properly unwrap filters param', () => {
+    it('should properly unwrap filters param', () => {
       const queryClient = new QueryClient()
 
       queryClient.getQueriesData({ queryKey: queryKeyRef })
@@ -122,7 +122,7 @@ describe('QueryCache', () => {
   })
 
   describe('setQueryData', () => {
-    test('should properly unwrap 3 parameter', () => {
+    it('should properly unwrap 3 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.setQueryData(queryKeyRef, fn, {
@@ -138,7 +138,7 @@ describe('QueryCache', () => {
   })
 
   describe('setQueriesData', () => {
-    test('should properly unwrap params with queryKey', () => {
+    it('should properly unwrap params with queryKey', () => {
       const queryClient = new QueryClient()
 
       queryClient.setQueriesData({ queryKey: queryKeyRef }, fn, {
@@ -152,7 +152,7 @@ describe('QueryCache', () => {
       )
     })
 
-    test('should properly unwrap params with filters', () => {
+    it('should properly unwrap params with filters', () => {
       const queryClient = new QueryClient()
 
       queryClient.setQueriesData({ queryKey: queryKeyRef }, fn, {
@@ -168,7 +168,7 @@ describe('QueryCache', () => {
   })
 
   describe('getQueryState', () => {
-    test('should properly unwrap 1 parameter', () => {
+    it('should properly unwrap 1 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.getQueryState(queryKeyRef)
@@ -180,7 +180,7 @@ describe('QueryCache', () => {
   })
 
   describe('removeQueries', () => {
-    test('should properly unwrap 1 parameter', () => {
+    it('should properly unwrap 1 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.removeQueries({
@@ -194,7 +194,7 @@ describe('QueryCache', () => {
   })
 
   describe('resetQueries', () => {
-    test('should properly unwrap 2 parameter', () => {
+    it('should properly unwrap 2 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.resetQueries(
@@ -214,7 +214,7 @@ describe('QueryCache', () => {
   })
 
   describe('cancelQueries', () => {
-    test('should properly unwrap 2 parameter', () => {
+    it('should properly unwrap 2 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.cancelQueries(
@@ -234,7 +234,7 @@ describe('QueryCache', () => {
   })
 
   describe('invalidateQueries', () => {
-    test('should properly unwrap 2 parameter', () => {
+    it('should properly unwrap 2 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.invalidateQueries(
@@ -254,7 +254,7 @@ describe('QueryCache', () => {
     })
 
     // #7694
-    test('should call invalidateQueries immediately and refetchQueries after sleep', async () => {
+    it('should call invalidateQueries immediately and refetchQueries after sleep', async () => {
       const invalidateQueries = vi.spyOn(
         QueryClientOrigin.prototype,
         'invalidateQueries',
@@ -278,7 +278,7 @@ describe('QueryCache', () => {
       expect(refetchQueries).toBeCalled()
     })
 
-    test('should call invalidateQueries immediately and not call refetchQueries', async () => {
+    it('should call invalidateQueries immediately and not call refetchQueries', async () => {
       const invalidateQueries = vi.spyOn(
         QueryClientOrigin.prototype,
         'invalidateQueries',
@@ -305,7 +305,7 @@ describe('QueryCache', () => {
   })
 
   describe('refetchQueries', () => {
-    test('should properly unwrap 2 parameter', () => {
+    it('should properly unwrap 2 parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.refetchQueries(
@@ -325,7 +325,7 @@ describe('QueryCache', () => {
   })
 
   describe('fetchQuery', () => {
-    test('should properly unwrap parameter', () => {
+    it('should properly unwrap parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.fetchQuery({
@@ -339,7 +339,7 @@ describe('QueryCache', () => {
   })
 
   describe('prefetchQuery', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
       queryClient.prefetchQuery({ queryKey: queryKeyRef, queryFn: fn })
@@ -352,7 +352,7 @@ describe('QueryCache', () => {
   })
 
   describe('fetchInfiniteQuery', () => {
-    test('should properly unwrap parameter', () => {
+    it('should properly unwrap parameter', () => {
       const queryClient = new QueryClient()
 
       queryClient.fetchInfiniteQuery({
@@ -367,7 +367,7 @@ describe('QueryCache', () => {
         }),
       )
     })
-    test('should properly unwrap parameter using infiniteQueryOptions with unref', () => {
+    it('should properly unwrap parameter using infiniteQueryOptions with unref', () => {
       const queryClient = new QueryClient()
 
       const options = infiniteQueryOptions({
@@ -388,7 +388,7 @@ describe('QueryCache', () => {
   })
 
   describe('prefetchInfiniteQuery', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
       queryClient.prefetchInfiniteQuery({
@@ -406,7 +406,7 @@ describe('QueryCache', () => {
   })
 
   describe('setDefaultOptions', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
       queryClient.setDefaultOptions({
@@ -424,7 +424,7 @@ describe('QueryCache', () => {
   })
 
   describe('setQueryDefaults', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
       queryClient.setQueryDefaults(queryKeyRef, {
@@ -441,7 +441,7 @@ describe('QueryCache', () => {
   })
 
   describe('getQueryDefaults', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
       queryClient.getQueryDefaults(queryKeyRef)
@@ -453,7 +453,7 @@ describe('QueryCache', () => {
   })
 
   describe('setMutationDefaults', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
       queryClient.setMutationDefaults(queryKeyRef, {
@@ -470,7 +470,7 @@ describe('QueryCache', () => {
   })
 
   describe('getMutationDefaults', () => {
-    test('should properly unwrap parameters', () => {
+    it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
       queryClient.getMutationDefaults(queryKeyRef)

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
@@ -14,7 +14,7 @@ describe('useInfiniteQuery', () => {
     vi.useRealTimers()
   })
 
-  test('should properly execute infinite query', async () => {
+  it('should properly execute infinite query', async () => {
     const key = queryKey()
     const { data, fetchNextPage, status } = useInfiniteQuery({
       queryKey: key,
@@ -45,7 +45,7 @@ describe('useInfiniteQuery', () => {
     })
     expect(status.value).toStrictEqual('success')
   })
-  test('should properly execute infinite query using infiniteQueryOptions', async () => {
+  it('should properly execute infinite query using infiniteQueryOptions', async () => {
     const key = queryKey()
     const options = infiniteQueryOptions({
       queryKey: key,

--- a/packages/vue-query/src/__tests__/useIsFetching.test.ts
+++ b/packages/vue-query/src/__tests__/useIsFetching.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { onScopeDispose, reactive, ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useQuery } from '../useQuery'
@@ -16,7 +16,7 @@ describe('useIsFetching', () => {
     vi.useRealTimers()
   })
 
-  test('should properly return isFetching state', async () => {
+  it('should properly return isFetching state', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const { isFetching: isFetchingQuery } = useQuery({
@@ -38,7 +38,7 @@ describe('useIsFetching', () => {
     expect(isFetching.value).toStrictEqual(0)
   })
 
-  test('should stop listening to changes on onScopeDispose', async () => {
+  it('should stop listening to changes on onScopeDispose', async () => {
     const key = queryKey()
     const onScopeDisposeMock = onScopeDispose as MockedFunction<
       typeof onScopeDispose
@@ -67,7 +67,7 @@ describe('useIsFetching', () => {
     onScopeDisposeMock.mockReset()
   })
 
-  test('should properly update filters', async () => {
+  it('should properly update filters', async () => {
     const key = queryKey()
     const filter = reactive({ stale: false, queryKey: key })
     useQuery({
@@ -84,7 +84,7 @@ describe('useIsFetching', () => {
     expect(isFetching.value).toStrictEqual(1)
   })
 
-  test('should work with options getter and be reactive', async () => {
+  it('should work with options getter and be reactive', async () => {
     const key = queryKey()
     const staleRef = ref(false)
     useQuery({
@@ -104,7 +104,7 @@ describe('useIsFetching', () => {
     expect(isFetching.value).toStrictEqual(1)
   })
 
-  test('should warn when used outside of setup function in development mode', () => {
+  it('should warn when used outside of setup function in development mode', () => {
     vi.stubEnv('NODE_ENV', 'development')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/packages/vue-query/src/__tests__/useIsMutating.test.ts
+++ b/packages/vue-query/src/__tests__/useIsMutating.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { onScopeDispose, reactive, ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
@@ -16,7 +16,7 @@ describe('useIsMutating', () => {
     vi.useRealTimers()
   })
 
-  test('should properly return isMutating state', async () => {
+  it('should properly return isMutating state', async () => {
     const mutation = useMutation({
       mutationFn: (params: string) => sleep(10).then(() => params),
     })
@@ -39,7 +39,7 @@ describe('useIsMutating', () => {
     expect(isMutating.value).toStrictEqual(0)
   })
 
-  test('should stop listening to changes on onScopeDispose', async () => {
+  it('should stop listening to changes on onScopeDispose', async () => {
     const onScopeDisposeMock = onScopeDispose as MockedFunction<
       typeof onScopeDispose
     >
@@ -69,7 +69,7 @@ describe('useIsMutating', () => {
     onScopeDisposeMock.mockReset()
   })
 
-  test('should properly update filters', async () => {
+  it('should properly update filters', async () => {
     const key = queryKey()
     const filterKey = queryKey()
     const filter = reactive({ mutationKey: filterKey })
@@ -90,7 +90,7 @@ describe('useIsMutating', () => {
     expect(isMutating.value).toStrictEqual(1)
   })
 
-  test('should work with options getter and be reactive', async () => {
+  it('should work with options getter and be reactive', async () => {
     const key = queryKey()
     const keyRef = ref('isMutatingGetter2')
     const { mutate } = useMutation({

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { reactive, ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
@@ -14,7 +14,7 @@ describe('useMutation', () => {
     vi.useRealTimers()
   })
 
-  test('should be in idle state initially', () => {
+  it('should be in idle state initially', () => {
     const mutation = useMutation({
       mutationFn: (params) => sleep(0).then(() => params),
     })
@@ -27,7 +27,7 @@ describe('useMutation', () => {
     })
   })
 
-  test('should change state after invoking mutate', () => {
+  it('should change state after invoking mutate', () => {
     const result = 'Mock data'
     const mutation = useMutation({
       mutationFn: (params: string) => sleep(0).then(() => params),
@@ -45,7 +45,7 @@ describe('useMutation', () => {
     })
   })
 
-  test('should return error when request fails', async () => {
+  it('should return error when request fails', async () => {
     const mutation = useMutation({
       mutationFn: () =>
         sleep(10).then(() => Promise.reject(new Error('Some error'))),
@@ -62,7 +62,7 @@ describe('useMutation', () => {
     })
   })
 
-  test('should return data when request succeeds', async () => {
+  it('should return data when request succeeds', async () => {
     const result = 'Mock data'
     const mutation = useMutation({
       mutationFn: (params: string) => sleep(10).then(() => params),
@@ -82,7 +82,7 @@ describe('useMutation', () => {
     })
   })
 
-  test('should work with options getter and be reactive', async () => {
+  it('should work with options getter and be reactive', async () => {
     const key = queryKey()
     const result = 'Mock data'
     const keyRef = ref('key01')
@@ -116,7 +116,7 @@ describe('useMutation', () => {
     )
   })
 
-  test('should update reactive options', async () => {
+  it('should update reactive options', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryClient = useQueryClient()
@@ -138,7 +138,7 @@ describe('useMutation', () => {
     expect(mutations?.options.mutationKey).toEqual(key2)
   })
 
-  test('should update reactive options deeply', async () => {
+  it('should update reactive options deeply', async () => {
     type MutationKeyTest = {
       entity: string
       otherObject: {
@@ -179,7 +179,7 @@ describe('useMutation', () => {
     ).toBe(true)
   })
 
-  test('should allow for non-options object (mutationFn or mutationKey) passed as arg1 & arg2 to trigger reactive updates', async () => {
+  it('should allow for non-options object (mutationFn or mutationKey) passed as arg1 & arg2 to trigger reactive updates', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const mutationKeyRef = ref<Array<string>>(key1)
@@ -204,7 +204,7 @@ describe('useMutation', () => {
     expect(proof).toEqual(true)
   })
 
-  test('should reset state after invoking mutation.reset', async () => {
+  it('should reset state after invoking mutation.reset', async () => {
     const mutation = useMutation({
       mutationFn: () =>
         sleep(10).then(() => Promise.reject(new Error('Some error'))),
@@ -231,7 +231,7 @@ describe('useMutation', () => {
       vi.clearAllMocks()
     })
 
-    test('should call onMutate when passed as an option', async () => {
+    it('should call onMutate when passed as an option', async () => {
       const onMutate = vi.fn()
       const mutation = useMutation({
         mutationFn: (params: string) => sleep(10).then(() => params),
@@ -245,7 +245,7 @@ describe('useMutation', () => {
       expect(onMutate).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onError when passed as an option', async () => {
+    it('should call onError when passed as an option', async () => {
       const onError = vi.fn()
       const mutation = useMutation({
         mutationFn: () =>
@@ -260,7 +260,7 @@ describe('useMutation', () => {
       expect(onError).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSuccess when passed as an option', async () => {
+    it('should call onSuccess when passed as an option', async () => {
       const onSuccess = vi.fn()
       const mutation = useMutation({
         mutationFn: (params: string) => sleep(10).then(() => params),
@@ -274,7 +274,7 @@ describe('useMutation', () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSettled when passed as an option', async () => {
+    it('should call onSettled when passed as an option', async () => {
       const onSettled = vi.fn()
       const mutation = useMutation({
         mutationFn: (params: string) => sleep(10).then(() => params),
@@ -288,7 +288,7 @@ describe('useMutation', () => {
       expect(onSettled).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onError when passed as an argument of mutate function', async () => {
+    it('should call onError when passed as an argument of mutate function', async () => {
       const onError = vi.fn()
       const mutation = useMutation({
         mutationFn: () =>
@@ -302,7 +302,7 @@ describe('useMutation', () => {
       expect(onError).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSuccess when passed as an argument of mutate function', async () => {
+    it('should call onSuccess when passed as an argument of mutate function', async () => {
       const onSuccess = vi.fn()
       const mutation = useMutation({
         mutationFn: (params: string) => sleep(10).then(() => params),
@@ -315,7 +315,7 @@ describe('useMutation', () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onSettled when passed as an argument of mutate function', async () => {
+    it('should call onSettled when passed as an argument of mutate function', async () => {
       const onSettled = vi.fn()
       const mutation = useMutation({
         mutationFn: (params: string) => sleep(10).then(() => params),
@@ -328,7 +328,7 @@ describe('useMutation', () => {
       expect(onSettled).toHaveBeenCalledTimes(1)
     })
 
-    test('should fire both onSettled functions', async () => {
+    it('should fire both onSettled functions', async () => {
       const onSettled = vi.fn()
       const onSettledOnFunction = vi.fn()
       const mutation = useMutation({
@@ -350,7 +350,7 @@ describe('useMutation', () => {
       vi.clearAllMocks()
     })
 
-    test('should resolve properly', async () => {
+    it('should resolve properly', async () => {
       const result = 'Mock data'
       const mutation = useMutation({
         mutationFn: (params: string) => sleep(10).then(() => params),
@@ -370,7 +370,7 @@ describe('useMutation', () => {
       })
     })
 
-    test('should throw on error', async () => {
+    it('should throw on error', async () => {
       const mutation = useMutation({
         mutationFn: () =>
           sleep(10).then(() => Promise.reject(new Error('Some error'))),
@@ -391,7 +391,7 @@ describe('useMutation', () => {
     })
   })
 
-  test('should warn when used outside of setup function in development mode', () => {
+  it('should warn when used outside of setup function in development mode', () => {
     vi.stubEnv('NODE_ENV', 'development')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -410,7 +410,7 @@ describe('useMutation', () => {
   })
 
   describe('throwOnError', () => {
-    test('should evaluate throwOnError when mutation is expected to throw', async () => {
+    it('should evaluate throwOnError when mutation is expected to throw', async () => {
       const err = new Error('Expected mock error. All is well!')
       const boundaryFn = vi.fn()
       const { mutate } = useMutation({
@@ -426,7 +426,7 @@ describe('useMutation', () => {
       expect(boundaryFn).toHaveBeenCalledWith(err)
     })
 
-    test('should throw from error watcher when throwOnError returns true', async () => {
+    it('should throw from error watcher when throwOnError returns true', async () => {
       const throwOnErrorFn = vi.fn().mockReturnValue(true)
       const { mutate } = useMutation({
         mutationFn: () =>

--- a/packages/vue-query/src/__tests__/usePrefetchInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/usePrefetchInfiniteQuery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue-demi'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
@@ -13,7 +13,7 @@ describe('usePrefetchInfiniteQuery', () => {
     vi.useRealTimers()
   })
 
-  test('should prefetch infinite query if query state does not exist', () => {
+  it('should prefetch infinite query if query state does not exist', () => {
     const queryClient = new QueryClient()
     const prefetchInfiniteQuerySpy = vi.spyOn(
       queryClient,
@@ -44,7 +44,7 @@ describe('usePrefetchInfiniteQuery', () => {
     })
   })
 
-  test('should not prefetch infinite query if query state exists', () => {
+  it('should not prefetch infinite query if query state exists', () => {
     const queryClient = new QueryClient()
     const prefetchInfiniteQuerySpy = vi.spyOn(
       queryClient,
@@ -73,7 +73,7 @@ describe('usePrefetchInfiniteQuery', () => {
     expect(prefetchInfiniteQuerySpy).not.toHaveBeenCalled()
   })
 
-  test('should unwrap refs in infinite query options', () => {
+  it('should unwrap refs in infinite query options', () => {
     const queryClient = new QueryClient()
     const prefetchInfiniteQuerySpy = vi.spyOn(
       queryClient,
@@ -99,7 +99,7 @@ describe('usePrefetchInfiniteQuery', () => {
     )
   })
 
-  test('should prefetch infinite query again when query key changes reactively', async () => {
+  it('should prefetch infinite query again when query key changes reactively', async () => {
     const queryClient = new QueryClient()
     const prefetchInfiniteQuerySpy = vi.spyOn(
       queryClient,
@@ -136,7 +136,7 @@ describe('usePrefetchInfiniteQuery', () => {
     )
   })
 
-  test('should warn when used outside of setup function in development mode', () => {
+  it('should warn when used outside of setup function in development mode', () => {
     vi.stubEnv('NODE_ENV', 'development')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/packages/vue-query/src/__tests__/usePrefetchQuery.test.ts
+++ b/packages/vue-query/src/__tests__/usePrefetchQuery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue-demi'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
@@ -13,7 +13,7 @@ describe('usePrefetchQuery', () => {
     vi.useRealTimers()
   })
 
-  test('should prefetch query if query state does not exist', () => {
+  it('should prefetch query if query state does not exist', () => {
     const queryClient = new QueryClient()
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
     const queryFn = vi.fn(() => Promise.resolve('prefetched'))
@@ -34,7 +34,7 @@ describe('usePrefetchQuery', () => {
     })
   })
 
-  test('should not prefetch query if query state exists', () => {
+  it('should not prefetch query if query state exists', () => {
     const queryClient = new QueryClient()
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
     const queryFn = vi.fn(() => Promise.resolve('prefetched'))
@@ -52,7 +52,7 @@ describe('usePrefetchQuery', () => {
     expect(prefetchQuerySpy).not.toHaveBeenCalled()
   })
 
-  test('should unwrap refs in query options', () => {
+  it('should unwrap refs in query options', () => {
     const queryClient = new QueryClient()
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
     const nestedRef = ref('value')
@@ -73,7 +73,7 @@ describe('usePrefetchQuery', () => {
     )
   })
 
-  test('should prefetch again when query key changes reactively', async () => {
+  it('should prefetch again when query key changes reactively', async () => {
     const queryClient = new QueryClient()
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
     const keyRef = ref('first')
@@ -103,7 +103,7 @@ describe('usePrefetchQuery', () => {
     })
   })
 
-  test('should warn when used outside of setup function in development mode', () => {
+  it('should warn when used outside of setup function in development mode', () => {
     vi.stubEnv('NODE_ENV', 'development')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { onScopeDispose, ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useQueries } from '../useQueries'
@@ -18,7 +18,7 @@ describe('useQueries', () => {
     vi.useRealTimers()
   })
 
-  test('should return result for each query', () => {
+  it('should return result for each query', () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queries = [
@@ -49,7 +49,7 @@ describe('useQueries', () => {
     ])
   })
 
-  test('should resolve to success and update reactive state', async () => {
+  it('should resolve to success and update reactive state', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queries = [
@@ -82,7 +82,7 @@ describe('useQueries', () => {
     ])
   })
 
-  test('should reject one of the queries and update reactive state', async () => {
+  it('should reject one of the queries and update reactive state', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queries = [
@@ -116,7 +116,7 @@ describe('useQueries', () => {
     ])
   })
 
-  test('should return state for new queries', async () => {
+  it('should return state for new queries', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const key3 = queryKey()
@@ -174,7 +174,7 @@ describe('useQueries', () => {
     ])
   })
 
-  test('should stop listening to changes on onScopeDispose', async () => {
+  it('should stop listening to changes on onScopeDispose', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const onScopeDisposeMock = onScopeDispose as MockedFunction<
@@ -211,7 +211,7 @@ describe('useQueries', () => {
     ])
   })
 
-  test('should use queryClient provided via options', async () => {
+  it('should use queryClient provided via options', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const queryClient = new QueryClient()
@@ -232,7 +232,7 @@ describe('useQueries', () => {
     expect(useQueryClient).toHaveBeenCalledTimes(0)
   })
 
-  test('should combine queries', async () => {
+  it('should combine queries', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const firstResult = 'first result'
@@ -270,7 +270,7 @@ describe('useQueries', () => {
     })
   })
 
-  test('should be `enabled` to accept getter function', async () => {
+  it('should be `enabled` to accept getter function', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const checked = ref(false)
@@ -294,7 +294,7 @@ describe('useQueries', () => {
     expect(fetchFn).toHaveBeenCalled()
   })
 
-  test('should allow getters for query keys', async () => {
+  it('should allow getters for query keys', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
@@ -324,7 +324,7 @@ describe('useQueries', () => {
     expect(fetchFn).toHaveBeenCalledTimes(3)
   })
 
-  test('should allow arbitrarily nested getters for query keys', async () => {
+  it('should allow arbitrarily nested getters for query keys', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
@@ -388,7 +388,7 @@ describe('useQueries', () => {
     expect(fetchFn).toHaveBeenCalledTimes(6)
   })
 
-  test('should refetch only the specific query without affecting others', async () => {
+  it('should refetch only the specific query without affecting others', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     let userCount = 0
@@ -419,7 +419,7 @@ describe('useQueries', () => {
     expect(queriesState.value[1].data).toBe('posts-1')
   })
 
-  test('should warn when used outside of setup function in development mode', () => {
+  it('should warn when used outside of setup function in development mode', () => {
     vi.stubEnv('NODE_ENV', 'development')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -442,7 +442,7 @@ describe('useQueries', () => {
     }
   })
 
-  test('should work with options getter and be reactive', async () => {
+  it('should work with options getter and be reactive', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   computed,
   getCurrentInstance,
@@ -24,7 +24,7 @@ describe('useQuery', () => {
     vi.useRealTimers()
   })
 
-  test('should properly execute query', () => {
+  it('should properly execute query', () => {
     const key = queryKey()
     const queryFn = () => sleep(0).then(() => 'Some data')
 
@@ -45,7 +45,7 @@ describe('useQuery', () => {
     )
   })
 
-  test('should work with options getter', async () => {
+  it('should work with options getter', async () => {
     const key = queryKey()
     const query = useQuery(() => ({
       queryKey: key,
@@ -64,7 +64,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should work with options getter and be reactive', async () => {
+  it('should work with options getter and be reactive', async () => {
     const key = queryKey()
     const keyRef = ref('key011')
     const resultRef = ref('result02')
@@ -98,7 +98,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should return pending status initially', () => {
+  it('should return pending status initially', () => {
     const key = queryKey()
     const query = useQuery({
       queryKey: key,
@@ -113,7 +113,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should resolve to success and update reactive state: useQuery(key, dataFn)', async () => {
+  it('should resolve to success and update reactive state: useQuery(key, dataFn)', async () => {
     const key = queryKey()
     const query = useQuery({
       queryKey: key,
@@ -132,7 +132,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should resolve to success and update reactive state: useQuery(optionsObj)', async () => {
+  it('should resolve to success and update reactive state: useQuery(optionsObj)', async () => {
     const key = queryKey()
     const query = useQuery({
       queryKey: key,
@@ -152,7 +152,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should resolve to success and update reactive state: useQuery(key, optionsObj)', async () => {
+  it('should resolve to success and update reactive state: useQuery(key, optionsObj)', async () => {
     const key = queryKey()
     const query = useQuery({
       queryKey: key,
@@ -172,7 +172,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should reject and update reactive state', async () => {
+  it('should reject and update reactive state', async () => {
     const key = queryKey()
     const query = useQuery({
       queryKey: key,
@@ -195,7 +195,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should update query on reactive (Ref) key change', async () => {
+  it('should update query on reactive (Ref) key change', async () => {
     const key = queryKey()
     const secondKeyRef = ref('key7')
     const query = useQuery({
@@ -224,7 +224,7 @@ describe('useQuery', () => {
     })
   })
 
-  test("should update query when an option is passed as Ref and it's changed", async () => {
+  it("should update query when an option is passed as Ref and it's changed", async () => {
     const key = queryKey()
     const enabled = ref(false)
     const query = useQuery({
@@ -256,7 +256,7 @@ describe('useQuery', () => {
     })
   })
 
-  test('should properly execute dependent queries', async () => {
+  it('should properly execute dependent queries', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
     const { data } = useQuery({
@@ -296,7 +296,7 @@ describe('useQuery', () => {
     )
   })
 
-  test('should stop listening to changes on onScopeDispose', async () => {
+  it('should stop listening to changes on onScopeDispose', async () => {
     const key = queryKey()
     const onScopeDisposeMock = onScopeDispose as MockedFunction<
       typeof onScopeDispose
@@ -319,7 +319,7 @@ describe('useQuery', () => {
     expect(status.value).toStrictEqual('pending')
   })
 
-  test('should use the current value for the queryKey when refetch is called', async () => {
+  it('should use the current value for the queryKey when refetch is called', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const keyRef = ref('key11')
@@ -348,7 +348,7 @@ describe('useQuery', () => {
     )
   })
 
-  test('should be `enabled` to accept getter function', async () => {
+  it('should be `enabled` to accept getter function', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const checked = ref(false)
@@ -368,7 +368,7 @@ describe('useQuery', () => {
     expect(fetchFn).toHaveBeenCalled()
   })
 
-  test('should allow getters for query keys', async () => {
+  it('should allow getters for query keys', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
@@ -394,7 +394,7 @@ describe('useQuery', () => {
     expect(fetchFn).toHaveBeenCalledTimes(3)
   })
 
-  test('should allow arbitrarily nested getters for query keys', async () => {
+  it('should allow arbitrarily nested getters for query keys', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => 'foo')
     const key1 = ref('key1')
@@ -455,7 +455,7 @@ describe('useQuery', () => {
   })
 
   describe('throwOnError', () => {
-    test('should evaluate throwOnError when query is expected to throw', async () => {
+    it('should evaluate throwOnError when query is expected to throw', async () => {
       const key = queryKey()
       const boundaryFn = vi.fn()
       useQuery({
@@ -479,7 +479,7 @@ describe('useQuery', () => {
   })
 
   describe('outside scope warning', () => {
-    test('should warn when used outside of setup function in development mode', () => {
+    it('should warn when used outside of setup function in development mode', () => {
       vi.stubEnv('NODE_ENV', 'development')
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -500,7 +500,7 @@ describe('useQuery', () => {
   })
 
   describe('suspense', () => {
-    test('should return a Promise', () => {
+    it('should return a Promise', () => {
       const key = queryKey()
       const getCurrentInstanceSpy = getCurrentInstance as Mock
       getCurrentInstanceSpy.mockImplementation(() => ({ suspense: {} }))
@@ -514,7 +514,7 @@ describe('useQuery', () => {
       expect(result).toBeInstanceOf(Promise)
     })
 
-    test('should resolve after being enabled', async () => {
+    it('should resolve after being enabled', async () => {
       const key = queryKey()
       const getCurrentInstanceSpy = getCurrentInstance as Mock
       getCurrentInstanceSpy.mockImplementation(() => ({ suspense: {} }))
@@ -539,7 +539,7 @@ describe('useQuery', () => {
       expect(afterTimeout).toBe(true)
     })
 
-    test('should resolve immediately when stale without refetching', () => {
+    it('should resolve immediately when stale without refetching', () => {
       const key = queryKey()
       const getCurrentInstanceSpy = getCurrentInstance as Mock
       getCurrentInstanceSpy.mockImplementation(() => ({ suspense: {} }))
@@ -559,7 +559,7 @@ describe('useQuery', () => {
       })
     })
 
-    test('should not throw from suspense by default', async () => {
+    it('should not throw from suspense by default', async () => {
       const key = queryKey()
       const getCurrentInstanceSpy = getCurrentInstance as Mock
       getCurrentInstanceSpy.mockImplementation(() => ({ suspense: {} }))
@@ -579,7 +579,7 @@ describe('useQuery', () => {
       })
     })
 
-    test('should throw from suspense when throwOnError is true', async () => {
+    it('should throw from suspense when throwOnError is true', async () => {
       const key = queryKey()
       const getCurrentInstanceSpy = getCurrentInstance as Mock
       getCurrentInstanceSpy.mockImplementation(() => ({ suspense: {} }))

--- a/packages/vue-query/src/__tests__/useQueryClient.test.ts
+++ b/packages/vue-query/src/__tests__/useQueryClient.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as VueDemi from 'vue-demi'
 import { useQueryClient } from '../useQueryClient'
 import { VUE_QUERY_CLIENT } from '../utils'
@@ -20,7 +20,7 @@ describe('useQueryClient', () => {
     vi.clearAllMocks()
   })
 
-  test('should return queryClient when it is provided in the context', () => {
+  it('should return queryClient when it is provided in the context', () => {
     const queryClientMock = { name: 'Mocked client' }
     injectSpy.mockReturnValueOnce(queryClientMock)
 
@@ -31,7 +31,7 @@ describe('useQueryClient', () => {
     expect(injectSpy).toHaveBeenCalledWith(VUE_QUERY_CLIENT)
   })
 
-  test('should throw an error when queryClient does not exist in the context', () => {
+  it('should throw an error when queryClient does not exist in the context', () => {
     injectSpy.mockReturnValueOnce(undefined)
 
     expect(useQueryClient).toThrow()
@@ -39,14 +39,14 @@ describe('useQueryClient', () => {
     expect(injectSpy).toHaveBeenCalledWith(VUE_QUERY_CLIENT)
   })
 
-  test('should throw an error when used outside of setup function', () => {
+  it('should throw an error when used outside of setup function', () => {
     hasInjectionContextSpy.mockReturnValueOnce(false)
 
     expect(useQueryClient).toThrow()
     expect(hasInjectionContextSpy).toHaveBeenCalledTimes(1)
   })
 
-  test('should call inject with a custom key as a suffix', () => {
+  it('should call inject with a custom key as a suffix', () => {
     const queryClientKey = 'foo'
     const expectedKeyParameter = `${VUE_QUERY_CLIENT}:${queryClientKey}`
     const queryClientMock = { name: 'Mocked client' }

--- a/packages/vue-query/src/__tests__/utils.test.ts
+++ b/packages/vue-query/src/__tests__/utils.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { reactive, ref } from 'vue-demi'
 import { cloneDeep, cloneDeepUnref, updateState } from '../utils'
 
 describe('utils', () => {
   describe('updateState', () => {
-    test('should update first object with values from the second one', () => {
+    it('should update first object with values from the second one', () => {
       const origin = { option1: 'a', option2: 'b', option3: 'c' }
       const update = { option1: 'x', option2: 'y', option3: 'z' }
       const expected = { option1: 'x', option2: 'y', option3: 'z' }
@@ -13,7 +13,7 @@ describe('utils', () => {
       expect(origin).toEqual(expected)
     })
 
-    test('should update only existing keys', () => {
+    it('should update only existing keys', () => {
       const origin = { option1: 'a', option2: 'b' }
       const update = { option1: 'x', option2: 'y', option3: 'z' }
       const expected = { option1: 'x', option2: 'y' }
@@ -22,7 +22,7 @@ describe('utils', () => {
       expect(origin).toEqual(expected)
     })
 
-    test('should remove non existing keys', () => {
+    it('should remove non existing keys', () => {
       const origin = { option1: 'a', option2: 'b', option3: 'c' }
       const update = { option1: 'x', option2: 'y' }
       const expected = { option1: 'x', option2: 'y' }
@@ -33,13 +33,13 @@ describe('utils', () => {
   })
 
   describe('cloneDeep', () => {
-    test('should copy primitives and functions AS-IS', () => {
+    it('should copy primitives and functions AS-IS', () => {
       expect(cloneDeep(3456)).toBe(3456)
       expect(cloneDeep('theString')).toBe('theString')
       expect(cloneDeep(null)).toBe(null)
     })
 
-    test('should copy Maps and Sets AS-IS', () => {
+    it('should copy Maps and Sets AS-IS', () => {
       const setVal = new Set([3, 4, 5])
       const setValCopy = cloneDeep(setVal)
       expect(setValCopy).toBe(setVal)
@@ -59,7 +59,7 @@ describe('utils', () => {
       )
     })
 
-    test('should deeply copy arrays', () => {
+    it('should deeply copy arrays', () => {
       const val = [
         25,
         'str',
@@ -83,7 +83,7 @@ describe('utils', () => {
       expect((cp[4] as Array<number>)[2]).not.toBe((val[4] as Array<number>)[2]) // { a : 1 }
     })
 
-    test('should deeply copy object', () => {
+    it('should deeply copy object', () => {
       const val = reactive({
         a: 25,
         b: 'str',
@@ -112,18 +112,18 @@ describe('utils', () => {
   })
 
   describe('cloneDeepUnref', () => {
-    test('should unref primitives', () => {
+    it('should unref primitives', () => {
       expect(cloneDeepUnref(ref(34))).toBe(34)
       expect(cloneDeepUnref(ref('myStr'))).toBe('myStr')
     })
 
-    test('should deeply unref arrays', () => {
+    it('should deeply unref arrays', () => {
       const val = ref([2, 3, ref(4), ref('5'), { a: ref(6) }, [ref(7)]])
       const cp = cloneDeepUnref(val)
       expect(cp).toStrictEqual([2, 3, 4, '5', { a: 6 }, [7]])
     })
 
-    test('should deeply unref objects', () => {
+    it('should deeply unref objects', () => {
       const val = ref({
         a: 1,
         b: ref(2),
@@ -142,13 +142,13 @@ describe('utils', () => {
       })
     })
 
-    test('should clone getters returning values in queryKey', () => {
+    it('should clone getters returning values in queryKey', () => {
       const val = ref({ queryKey: [1, 2, () => '3'] })
       const cp = cloneDeepUnref(val)
       expect(cp).toStrictEqual({ queryKey: [1, 2, '3'] })
     })
 
-    test('should unref undefined', () => {
+    it('should unref undefined', () => {
       expect(cloneDeepUnref(ref(undefined))).toBe(undefined)
     })
   })

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isVue2, isVue3, ref } from 'vue-demi'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
@@ -24,7 +24,7 @@ interface TestApp extends App {
   $root: TestApp
 }
 
-const testIf = (condition: boolean) => (condition ? test : test.skip)
+const testIf = (condition: boolean) => (condition ? it : it.skip)
 
 function getAppMock(withUnmountHook = false): TestApp {
   const mock = {
@@ -53,7 +53,7 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('devtools', () => {
-    test('should NOT setup devtools', () => {
+    it('should NOT setup devtools', () => {
       const setupDevtoolsMock = setupDevtools as Mock
       const appMock = getAppMock()
       VueQueryPlugin.install(appMock)
@@ -113,7 +113,7 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when app unmounts', () => {
-    test('should call unmount on each client when onUnmount is missing', () => {
+    it('should call unmount on each client when onUnmount is missing', () => {
       const appMock = getAppMock()
       const customClient = {
         mount: vi.fn(),
@@ -131,7 +131,7 @@ describe('VueQueryPlugin', () => {
       expect(originalUnmount).toHaveBeenCalledTimes(1)
     })
 
-    test('should call onUnmount if present', () => {
+    it('should call onUnmount if present', () => {
       const appMock = getAppMock(true)
       const customClient = {
         mount: vi.fn(),
@@ -260,7 +260,7 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when persister is provided', () => {
-    test('should properly modify isRestoring flag on queryClient', async () => {
+    it('should properly modify isRestoring flag on queryClient', async () => {
       const appMock = getAppMock()
       const customClient = {
         mount: vi.fn(),
@@ -284,7 +284,7 @@ describe('VueQueryPlugin', () => {
       expect(customClient.isRestoring?.value).toBeFalsy()
     })
 
-    test('should delay useQuery subscription and not call fetcher if data is not stale', async () => {
+    it('should delay useQuery subscription and not call fetcher if data is not stale', async () => {
       const key = queryKey()
       const appMock = getAppMock()
       const customClient = new QueryClient({
@@ -332,7 +332,7 @@ describe('VueQueryPlugin', () => {
       expect(fnSpy).toHaveBeenCalledTimes(0)
     })
 
-    test('should delay useQueries subscription and not call fetcher if data is not stale', async () => {
+    it('should delay useQueries subscription and not call fetcher if data is not stale', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const appMock = getAppMock()


### PR DESCRIPTION
## 🎯 Changes

Enforces a single test keyword convention across the repo by adding `vitest/consistent-test-it` rule and migrating all `test()` calls to `it()`.

### Current state

Test files were split between `it()` and `test()` with no lint rule enforcing consistency:

- `it`: ~1,729 calls (66%)
- `test`: ~875 calls (34%)

Per adapter:

- `it` majority: react-query, preact-query, solid-query, vue-query, svelte-query, query-devtools
- `test` majority: angular-query-experimental, query-core, persist-client packages

### What this PR does

1. Adds `'vitest/consistent-test-it': ['error', { fn: 'it', withinDescribe: 'it' }]` to `eslint.config.js` (same config `zustand`/`jotai` use).
2. Runs `eslint --fix` across all test files — 77 files auto-migrated, 884 insertions / 884 deletions.
3. Manually updates the `testIf` helper in `vueQueryPlugin.test.ts` to reference `it` instead of `test`.

### Why `it`?

- `it` is already the majority (66%) in this repo, so migrating to `it` is the lower-cost direction.
- Aligns with the BDD-style `describe`/`it` phrasing that most of our test files already follow.

### Verification

All 7 major adapters pass locally:

- `@tanstack/query-core`: 511 passed
- `@tanstack/react-query`: 535 passed, 1 skipped
- `@tanstack/preact-query`: 500 passed
- `@tanstack/solid-query`: 309 passed
- `@tanstack/vue-query`: 289 passed, 6 skipped
- `@tanstack/svelte-query`: 163 passed
- `@tanstack/angular-query-experimental`: 207 passed

Lint: 0 `consistent-test-it` violations. Prettier: clean.

### Follow-up (not in this PR)

`svelte-query` and `svelte-query-persist-client` have `test:eslint` scoped to `./src` only, so their `tests/` directories aren't lint-covered. Will fix in a separate PR.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Standardized test suite configuration across the project to enforce consistent test function usage.

* **Chores**
  * Updated ESLint rules to maintain consistent coding patterns in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->