### PR TITLE
test(query-core/query): add test for refetch after a previous fetch errored

### DIFF
--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -849,7 +849,7 @@ describe('query', () => {
     unsubscribe()
   })
 
-  it('fetch should start a new fetch when the previous retryer has rejected', async () => {
+  it('fetch should refetch successfully after the previous fetch errored', async () => {
     const key = queryKey()
 
     let shouldFail = true
@@ -860,7 +860,6 @@ describe('query', () => {
       return sleep(10).then(() => 'success')
     })
 
-    // Trigger a failing fetch so the query's retryer ends up rejected.
     queryClient.prefetchQuery({ queryKey: key, queryFn, retry: false })
     await vi.advanceTimersByTimeAsync(10)
 
@@ -868,11 +867,6 @@ describe('query', () => {
     expect(queryFn).toHaveBeenCalledTimes(1)
     expect(query.state.status).toBe('error')
 
-    // Flip the queryFn to succeed and invoke fetch directly on the Query.
-    // The guard `this.#retryer?.status() !== 'rejected'` in Query.fetch must
-    // let execution fall through to create a fresh retryer — otherwise the
-    // call would early-return the previous (rejected) retryer's promise and
-    // queryFn would never run again.
     shouldFail = false
     const refetchPromise = query.fetch({ queryKey: key, queryFn, retry: false })
     await vi.advanceTimersByTimeAsync(10)

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -849,6 +849,39 @@ describe('query', () => {
     unsubscribe()
   })
 
+  it('fetch should start a new fetch when the previous retryer has rejected', async () => {
+    const key = queryKey()
+
+    let shouldFail = true
+    const queryFn = vi.fn(() => {
+      if (shouldFail) {
+        return sleep(10).then(() => Promise.reject(new Error('fail')))
+      }
+      return sleep(10).then(() => 'success')
+    })
+
+    // Trigger a failing fetch so the query's retryer ends up rejected.
+    queryClient.prefetchQuery({ queryKey: key, queryFn, retry: false })
+    await vi.advanceTimersByTimeAsync(10)
+
+    const query = queryCache.find<string>({ queryKey: key })!
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(query.state.status).toBe('error')
+
+    // Flip the queryFn to succeed and invoke fetch directly on the Query.
+    // The guard `this.#retryer?.status() !== 'rejected'` in Query.fetch must
+    // let execution fall through to create a fresh retryer — otherwise the
+    // call would early-return the previous (rejected) retryer's promise and
+    // queryFn would never run again.
+    shouldFail = false
+    const refetchPromise = query.fetch({ queryKey: key, queryFn, retry: false })
+    await vi.advanceTimersByTimeAsync(10)
+
+    await expect(refetchPromise).resolves.toBe('success')
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    expect(query.state.status).toBe('success')
+  })
+
   it('fetch should throw an error if the queryFn is not defined', async () => {
     const key = queryKey()
 


### PR DESCRIPTION
## 🎯 Changes

Adds a behavioral test for `Query.fetch` that covers the case where the previous retryer has ended in a `rejected` state. After an initial fetch fails with `retry: false`, calling `query.fetch(...)` directly must fall through the early-return guard in `query.ts:401-417` (specifically the `this.#retryer?.status() !== 'rejected'` condition) and create a fresh retryer. The test also asserts the resulting status transition and that the new `queryFn` runs.

This complements the existing "fetch should not dispatch 'fetch' query is already fetching" test (query.test.tsx:819), which only validates the in-flight concurrent-fetch path, not the post-rejection recovery path.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `npx nx run @tanstack/query-core:test:lib` and `npx nx run @tanstack/query-core:test:types`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage validating a query that initially fails then later succeeds: confirms error state is recorded, advancing timers and a subsequent fetch resolves successfully, call counts and retry behavior update, and the query state transitions from error to success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->