### PR TITLE
test(svelte-query-persist-client): remove unused 'svelte-ignore' directives from test components

### DIFF
--- a/packages/svelte-query-persist-client/tests/FreshData/FreshData.svelte
+++ b/packages/svelte-query-persist-client/tests/FreshData/FreshData.svelte
@@ -22,7 +22,6 @@
   }))
 
   $effect(() => {
-    // svelte-ignore state_snapshot_uncloneable
     const snapshot = $state.snapshot(query)
     states.current.push(snapshot)
   })

--- a/packages/svelte-query-persist-client/tests/InitialData/InitialData.svelte
+++ b/packages/svelte-query-persist-client/tests/InitialData/InitialData.svelte
@@ -16,7 +16,6 @@
   }))
 
   $effect(() => {
-    // svelte-ignore state_snapshot_uncloneable
     const snapshot = $state.snapshot(query)
     states.current.push(snapshot)
   })

--- a/packages/svelte-query-persist-client/tests/RestoreCache/RestoreCache.svelte
+++ b/packages/svelte-query-persist-client/tests/RestoreCache/RestoreCache.svelte
@@ -12,7 +12,6 @@
   }))
 
   $effect(() => {
-    // svelte-ignore state_snapshot_uncloneable
     const snapshot = $state.snapshot(query)
     states.current.push(snapshot)
   })

--- a/packages/svelte-query-persist-client/tests/UseQueries/UseQueries.svelte
+++ b/packages/svelte-query-persist-client/tests/UseQueries/UseQueries.svelte
@@ -16,7 +16,6 @@
   }))
 
   $effect(() => {
-    // svelte-ignore state_snapshot_uncloneable
     const snapshot = $state.snapshot(queries[0])
     states.current.push(snapshot)
   })


### PR DESCRIPTION
## 🎯 Changes

Removes `// svelte-ignore state_snapshot_uncloneable` directives from four test components in `svelte-query-persist-client/tests/`. These directives no longer suppress any warning — the referenced `state_snapshot_uncloneable` warning is not triggered by the current code, so `svelte/no-unused-svelte-ignore` flags them as errors when the `tests/` directory is linted.

### Files

- `tests/FreshData/FreshData.svelte`
- `tests/InitialData/InitialData.svelte`
- `tests/RestoreCache/RestoreCache.svelte`
- `tests/UseQueries/UseQueries.svelte`

### Why this PR exists

These files live in `tests/`, which is currently **outside the `test:eslint` script scope** (scoped to `./src` only). That's why these dead suppressions have been sitting there unnoticed.

This PR lands first as a prerequisite for a follow-up PR that widens the lint scope to include `./tests` for both `svelte-query` and `svelte-query-persist-client`.

### Verification

- `pnpm exec eslint ./tests` on the package: 0 errors, 0 warnings
- `pnpm run test:lib`: 7 tests pass, no `state_snapshot_uncloneable` warnings emitted at runtime (confirming the directives were genuinely dead)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up compiler directives from test files to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->