### PR TITLE
chore(svelte-query*/package.json): include 'tests' directory in 'test:eslint' scope

### DIFF
--- a/packages/svelte-query-persist-client/package.json
+++ b/packages/svelte-query-persist-client/package.json
@@ -23,7 +23,7 @@
     "clean": "premove ./dist ./coverage ./.svelte-kit ./dist-ts",
     "compile": "tsc --build",
     "test:types": "svelte-check --tsconfig ./tsconfig.json",
-    "test:eslint": "eslint --concurrency=auto ./src",
+    "test:eslint": "eslint --concurrency=auto ./src ./tests",
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -23,7 +23,7 @@
     "clean": "premove ./dist ./coverage ./.svelte-kit ./dist-ts",
     "compile": "tsc --build",
     "test:types": "svelte-check --tsconfig ./tsconfig.json",
-    "test:eslint": "eslint --concurrency=auto ./src",
+    "test:eslint": "eslint --concurrency=auto ./src ./tests",
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",


### PR DESCRIPTION
## 🎯 Changes

Widens the `test:eslint` script scope in `svelte-query` and `svelte-query-persist-client` to include the `./tests` directory in addition to `./src`.

```diff
- "test:eslint": "eslint --concurrency=auto ./src",
+ "test:eslint": "eslint --concurrency=auto ./src ./tests",
```

### Why

Both packages keep their test files under `tests/` (not `src/__tests__/`), so the existing `./src`-only scope left those files uncovered by lint. This meant repo-wide ESLint rules weren't enforced on a large portion of test code — dead `svelte-ignore` directives and other issues could accumulate unnoticed (the prerequisite PR #10531 cleaned up the existing instances).

### Files

- `packages/svelte-query/package.json`
- `packages/svelte-query-persist-client/package.json`

`svelte-query-devtools` is intentionally excluded — it has no `tests/` directory.

### Verification

After the scope change, both packages lint cleanly (0 errors):

- `@tanstack/svelte-query`: 0 errors (1 unrelated cspell warning on `"refetched"`)
- `@tanstack/svelte-query-persist-client`: 0 errors, 0 warnings

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded ESLint coverage to include test files alongside source files across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->