### PR TITLE
test(vue-query/vueQueryPlugin): rename 'testIf' helper to 'itIf' for consistency with 'it' convention

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,7 @@ export default [
       'vitest/no-standalone-expect': [
         'error',
         {
-          additionalTestBlockFunctions: ['testIf'],
+          additionalTestBlockFunctions: ['itIf'],
         },
       ],
     },

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -24,7 +24,7 @@ interface TestApp extends App {
   $root: TestApp
 }
 
-const testIf = (condition: boolean) => (condition ? it : it.skip)
+const itIf = (condition: boolean) => (condition ? it : it.skip)
 
 function getAppMock(withUnmountHook = false): TestApp {
   const mock = {
@@ -61,7 +61,7 @@ describe('VueQueryPlugin', () => {
       expect(setupDevtoolsMock).toHaveBeenCalledTimes(0)
     })
 
-    testIf(isVue2)('should NOT setup devtools by default', () => {
+    itIf(isVue2)('should NOT setup devtools by default', () => {
       const envCopy = process.env.NODE_ENV
       process.env.NODE_ENV = 'development'
       const setupDevtoolsMock = setupDevtools as Mock
@@ -75,7 +75,7 @@ describe('VueQueryPlugin', () => {
       expect(setupDevtoolsMock).toHaveBeenCalledTimes(0)
     })
 
-    testIf(isVue2)('should setup devtools', () => {
+    itIf(isVue2)('should setup devtools', () => {
       const envCopy = process.env.NODE_ENV
       process.env.NODE_ENV = 'development'
       const setupDevtoolsMock = setupDevtools as Mock
@@ -89,7 +89,7 @@ describe('VueQueryPlugin', () => {
       expect(setupDevtoolsMock).toHaveBeenCalledTimes(1)
     })
 
-    testIf(isVue3)('should NOT setup devtools by default', () => {
+    itIf(isVue3)('should NOT setup devtools by default', () => {
       const envCopy = process.env.NODE_ENV
       process.env.NODE_ENV = 'development'
       const setupDevtoolsMock = setupDevtools as Mock
@@ -100,7 +100,7 @@ describe('VueQueryPlugin', () => {
       expect(setupDevtoolsMock).toHaveBeenCalledTimes(0)
     })
 
-    testIf(isVue3)('should setup devtools', () => {
+    itIf(isVue3)('should setup devtools', () => {
       const envCopy = process.env.NODE_ENV
       process.env.NODE_ENV = 'development'
       const setupDevtoolsMock = setupDevtools as Mock
@@ -148,7 +148,7 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when called without additional options', () => {
-    testIf(isVue2)('should provide a client with default clientKey', () => {
+    itIf(isVue2)('should provide a client with default clientKey', () => {
       const appMock = getAppMock()
       VueQueryPlugin.install(appMock)
 
@@ -159,7 +159,7 @@ describe('VueQueryPlugin', () => {
       })
     })
 
-    testIf(isVue3)('should provide a client with default clientKey', () => {
+    itIf(isVue3)('should provide a client with default clientKey', () => {
       const appMock = getAppMock()
       VueQueryPlugin.install(appMock)
 
@@ -171,7 +171,7 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when called with custom clientKey', () => {
-    testIf(isVue2)('should provide a client with customized clientKey', () => {
+    itIf(isVue2)('should provide a client with customized clientKey', () => {
       const appMock = getAppMock()
       VueQueryPlugin.install(appMock, { queryClientKey: 'CUSTOM' })
 
@@ -182,7 +182,7 @@ describe('VueQueryPlugin', () => {
       })
     })
 
-    testIf(isVue3)('should provide a client with customized clientKey', () => {
+    itIf(isVue3)('should provide a client with customized clientKey', () => {
       const appMock = getAppMock()
       VueQueryPlugin.install(appMock, { queryClientKey: 'CUSTOM' })
 
@@ -194,7 +194,7 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when called with custom client', () => {
-    testIf(isVue2)('should provide that custom client', () => {
+    itIf(isVue2)('should provide that custom client', () => {
       const appMock = getAppMock()
       const customClient = { mount: vi.fn() } as unknown as QueryClient
       VueQueryPlugin.install(appMock, { queryClient: customClient })
@@ -207,7 +207,7 @@ describe('VueQueryPlugin', () => {
       })
     })
 
-    testIf(isVue3)('should provide that custom client', () => {
+    itIf(isVue3)('should provide that custom client', () => {
       const appMock = getAppMock()
       const customClient = { mount: vi.fn() } as unknown as QueryClient
       VueQueryPlugin.install(appMock, { queryClient: customClient })
@@ -221,7 +221,7 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when called with custom client config', () => {
-    testIf(isVue2)(
+    itIf(isVue2)(
       'should instantiate a client with the provided config',
       () => {
         const appMock = getAppMock()
@@ -240,7 +240,7 @@ describe('VueQueryPlugin', () => {
       },
     )
 
-    testIf(isVue3)(
+    itIf(isVue3)(
       'should instantiate a client with the provided config',
       () => {
         const appMock = getAppMock()

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -221,42 +221,36 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when called with custom client config', () => {
-    itIf(isVue2)(
-      'should instantiate a client with the provided config',
-      () => {
-        const appMock = getAppMock()
-        const config = {
-          defaultOptions: { queries: { enabled: true } },
-        }
-        VueQueryPlugin.install(appMock, {
-          queryClientConfig: config,
-        })
+    itIf(isVue2)('should instantiate a client with the provided config', () => {
+      const appMock = getAppMock()
+      const config = {
+        defaultOptions: { queries: { enabled: true } },
+      }
+      VueQueryPlugin.install(appMock, {
+        queryClientConfig: config,
+      })
 
-        appMock._mixin.beforeCreate?.call(appMock)
-        const client = appMock._provided.VUE_QUERY_CLIENT as QueryClient
-        const defaultOptions = client.getDefaultOptions()
+      appMock._mixin.beforeCreate?.call(appMock)
+      const client = appMock._provided.VUE_QUERY_CLIENT as QueryClient
+      const defaultOptions = client.getDefaultOptions()
 
-        expect(defaultOptions).toEqual(config.defaultOptions)
-      },
-    )
+      expect(defaultOptions).toEqual(config.defaultOptions)
+    })
 
-    itIf(isVue3)(
-      'should instantiate a client with the provided config',
-      () => {
-        const appMock = getAppMock()
-        const config = {
-          defaultOptions: { queries: { enabled: true } },
-        }
-        VueQueryPlugin.install(appMock, {
-          queryClientConfig: config,
-        })
+    itIf(isVue3)('should instantiate a client with the provided config', () => {
+      const appMock = getAppMock()
+      const config = {
+        defaultOptions: { queries: { enabled: true } },
+      }
+      VueQueryPlugin.install(appMock, {
+        queryClientConfig: config,
+      })
 
-        const client = (appMock.provide as Mock).mock.calls[0]?.[1]
-        const defaultOptions = client.getDefaultOptions()
+      const client = (appMock.provide as Mock).mock.calls[0]?.[1]
+      const defaultOptions = client.getDefaultOptions()
 
-        expect(defaultOptions).toEqual(config.defaultOptions)
-      },
-    )
+      expect(defaultOptions).toEqual(config.defaultOptions)
+    })
   })
 
   describe('when persister is provided', () => {


### PR DESCRIPTION
## 🎯 Changes

Renames the `testIf` helper in `vueQueryPlugin.test.ts` to `itIf` to align with the `it` convention enforced project-wide by `vitest/consistent-test-it`.

### Files

- `packages/vue-query/src/__tests__/vueQueryPlugin.test.ts` — helper definition + 13 usages
- `eslint.config.js` — `additionalTestBlockFunctions: ['testIf']` → `['itIf']`

### Why

After #10528 enforced `{ fn: 'it', withinDescribe: 'it' }` across the repo, a helper named `testIf` that internally returns `it` / `it.skip` reads inconsistently. The rename keeps the naming aligned with:

- the helper's actual return value (`it` / `it.skip`)
- vitest's own `it.runIf` / `it.skipIf` API
- the project-wide `it` convention

The helper itself is kept (not replaced with `it.runIf`) because it also serves a second purpose: avoiding `vitest/no-identical-title` false positives when the same title is intentionally used twice for `isVue2` and `isVue3` branches in the same `describe` block.

### Verification

- `test:eslint` in `@tanstack/vue-query`: 0 errors
- `test:lib` in `@tanstack/vue-query`: 289 passed, 6 skipped (unchanged from main)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test helper function naming and refactored test invocations for improved code consistency.

* **Chores**
  * Updated ESLint configuration for test validation rules.

**Note:** This release contains internal maintenance updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->