### PR TITLE
docs: fix invalid README markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 <div align="center">
 <a href="https://www.npmjs.com/package/@tanstack/query-core" target="_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/query-core.svg" alt="npm downloads" />
+  <img src="https://img.shields.io/npm/dm/@tanstack/query-core.svg" alt="npm downloads" />
 </a>
  <a href="https://github.com/TanStack/query/stargazers" target="_parent">
-  <img alt="" src="https://img.shields.io/github/stars/TanStack/query.svg?style=social&label=Star" alt="GitHub stars" />
+  <img src="https://img.shields.io/github/stars/TanStack/query.svg?style=social&label=Star" alt="GitHub stars" />
 </a>
 <a href="https://bundlejs.com/?q=%40tanstack%2Freact-query&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%2C%22react-dom%22%5D%7D%7D&badge=" target="_parent">
-  <img alt="" src="https://deno.bundlejs.com/?q=@tanstack/react-query&config={%22esbuild%22:{%22external%22:[%22react%22,%22react-dom%22]}}&badge=detailed" alt="Bundle size" />
+  <img src="https://deno.bundlejs.com/?q=@tanstack/react-query&config={%22esbuild%22:{%22external%22:[%22react%22,%22react-dom%22]}}&badge=detailed" alt="Bundle size" />
 </a>
 </div>
 
@@ -41,7 +41,7 @@ An async state management library built to simplify fetching, caching, synchroni
 - Mutations, dependent queries & background updates
 - Prefetching, cancellation & React Suspense support
 
-### <a href="https://tanstack.com/query">Read the docs →</b></a>
+### [Read the docs →](https://tanstack.com/query)
 
 ## Get Involved
 
@@ -81,8 +81,6 @@ An async state management library built to simplify fetching, caching, synchroni
 We're looking for TanStack Query Partners to join our mission! Partner with us to push the boundaries of TanStack Query and build amazing things together.
 </p>
 <a href="mailto:partners@tanstack.com?subject=TanStack Query Partnership"><b>LET'S CHAT</b></a>
-</div>
-
 </div>
 
 ## Explore the TanStack Ecosystem


### PR DESCRIPTION

**Repo:** TanStack/query (⭐ 44000)
**Type:** docs
**Files changed:** 1
**Lines:** +4/-6

## What
This change fixes invalid markup in the root `README.md`. It removes duplicate `alt` attributes from the badge images, replaces a malformed HTML anchor in the "Read the docs" heading with valid Markdown link syntax, and deletes an unmatched closing `</div>` near the partners section.

## Why
The README is the main entry point for contributors and users, so invalid HTML there is worth fixing even when the visual impact is subtle. These markup issues can cause inconsistent rendering, reduce accessibility for the badge images, and make future README edits harder because the structure is not well-formed.

## Testing
Verified the resulting diff locally with `git diff` and `git diff --stat`. No automated tests were run because this is a README-only documentation change.

## Risk
Low / Single-file docs-only change that corrects malformed markup without touching package code or build configuration.
