### PR TITLE
fix(react-query): hydrate disabled query shells in HydrationBoundary

### DIFF
--- a/.changeset/fix-hydration-boundary-disabled-shell.md
+++ b/.changeset/fix-hydration-boundary-disabled-shell.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Fix `HydrationBoundary` deferring hydration for disabled query shells

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { QueryCache } from '../queryCache'
+import { QueryObserver } from '../queryObserver'
 import { dehydrate, hydrate } from '../hydration'
 import { MutationCache } from '../mutationCache'
 import { executeMutation, mockOnlineManagerIsOnline } from './utils'
@@ -958,6 +959,47 @@ describe('dehydration and rehydration', () => {
       isInvalidated: false,
       status: 'success',
     })
+  })
+
+  test('should hydrate over an existing disabled query shell', async () => {
+    const key = queryKey()
+
+    const prefetchClient = new QueryClient()
+    const prefetchPromise = prefetchClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'prefetched'),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+    await prefetchPromise
+    const dehydrated = dehydrate(prefetchClient)
+
+    const hydrationClient = new QueryClient()
+    const observer = new QueryObserver(hydrationClient, {
+      queryKey: key,
+      queryFn: () => Promise.resolve('client'),
+      enabled: false,
+    })
+    const unsubscribe = observer.subscribe(vi.fn())
+
+    const disabledShellQuery = hydrationClient.getQueryCache().find({ queryKey: key })
+
+    expect(disabledShellQuery?.state).toMatchObject({
+      data: undefined,
+      fetchStatus: 'idle',
+      status: 'pending',
+    })
+    expect(disabledShellQuery?.isDisabled()).toBe(true)
+
+    hydrate(hydrationClient, dehydrated)
+
+    expect(hydrationClient.getQueryCache().find({ queryKey: key })?.state).toMatchObject({
+      data: 'prefetched',
+      status: 'success',
+    })
+
+    unsubscribe()
+    prefetchClient.clear()
+    hydrationClient.clear()
   })
 
   test('should transform promise result', async () => {

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -82,8 +82,17 @@ export const HydrationBoundary = ({
                 dehydratedQuery.dehydratedAt >
                   existingQuery.state.dataUpdatedAt)
 
+            const canHydrateExistingInRender =
+              existingQuery.state.fetchStatus === 'idle' &&
+              (existingQuery.state.data === undefined ||
+                existingQuery.isDisabled())
+
             if (hydrationIsNewer) {
-              existingQueries.push(dehydratedQuery)
+              if (canHydrateExistingInRender) {
+                newQueries.push(dehydratedQuery)
+              } else {
+                existingQueries.push(dehydratedQuery)
+              }
             }
           }
         }

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -9,7 +9,9 @@ import {
   QueryClientProvider,
   dehydrate,
   useQuery,
+  useSuspenseQuery,
 } from '..'
+import { renderWithClient } from './utils'
 import type { hydrate } from '@tanstack/query-core'
 
 describe('React hydration', () => {
@@ -507,6 +509,59 @@ describe('React hydration', () => {
     await vi.advanceTimersByTimeAsync(11)
     expect(queryFn).toHaveBeenCalledTimes(0)
     expect(rendered.getByText('["stringCached"]')).toBeInTheDocument()
+
+    queryClient.clear()
+  })
+
+  test('should hydrate an existing disabled query before a nested suspense query with the same key mounts', async () => {
+    const prefetchedData = ['prefetched']
+    const clientQueryFn = vi.fn(() => sleep(20).then(() => ['client']))
+    const queryClient = new QueryClient()
+
+    const prefetchClient = new QueryClient()
+    const prefetchPromise = prefetchClient.prefetchQuery({
+      queryKey: ['string'],
+      queryFn: () => sleep(10).then(() => prefetchedData),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+    await prefetchPromise
+    const dehydratedState = dehydrate(prefetchClient)
+    prefetchClient.clear()
+
+    function Header() {
+      useQuery({
+        queryKey: ['string'],
+        queryFn: clientQueryFn,
+        enabled: false,
+      })
+      return null
+    }
+
+    function Child() {
+      useSuspenseQuery({
+        queryKey: ['string'],
+        queryFn: clientQueryFn,
+      })
+      return null
+    }
+
+    renderWithClient(
+      queryClient,
+      <>
+        <Header />
+        <React.Suspense fallback="loading">
+          <HydrationBoundary state={dehydratedState}>
+            <Child />
+          </HydrationBoundary>
+        </React.Suspense>
+      </>,
+    )
+
+    expect(queryClient.getQueryCache().find({ queryKey: ['string'] })?.state).toMatchObject({
+      data: prefetchedData,
+      status: 'success',
+    })
+    expect(clientQueryFn).toHaveBeenCalledTimes(0)
 
     queryClient.clear()
   })


### PR DESCRIPTION
## 🎯 Changes

Fixes #10145

When a query with the same key already exists in the cache, `HydrationBoundary` currently defers hydration until the effect phase — which is correct for active queries during transitions.

However, this also applies to queries that are only a disabled idle shell with no data yet. In that case, a nested `useSuspenseQuery` can mount before the prefetched data is applied and unnecessarily suspend or refetch.

This PR makes `HydrationBoundary` hydrate existing queries immediately during render when they are `idle`, disabled, and have no data — treating them as effectively empty shells rather than active queries worth preserving.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `HydrationBoundary` to correctly handle hydration of disabled query shells, ensuring they are properly hydrated during the render phase instead of being deferred to after rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->