### PR TITLE
test(angular-query-experimental/injectQueries): add test for 'combine' option

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -82,6 +82,66 @@ describe('injectQueries', () => {
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
   })
 
+  it('should return the combined result when combine is provided', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+    const results: Array<Record<string, any>> = []
+
+    @Component({
+      template: `
+        <div>data: {{ combined().data.join(',') }}</div>
+        <div>isPending: {{ combined().isPending }}</div>
+      `,
+    })
+    class Page {
+      combined = injectQueries(() => ({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(10).then(() => 1),
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(10).then(() => 2),
+          },
+        ],
+        combine: (queries) => ({
+          data: queries.map((q) => q.data),
+          isPending: queries.some((q) => q.isPending),
+        }),
+      }))
+
+      _ = effect(() => {
+        results.push({ ...this.combined() })
+      })
+    }
+
+    const rendered = await render(Page, {
+      providers: [
+        provideZonelessChangeDetection(),
+        provideTanStackQuery(queryClient),
+      ],
+    })
+
+    expect(rendered.getByText('data: ,')).toBeInTheDocument()
+    expect(rendered.getByText('isPending: true')).toBeInTheDocument()
+    expect(results[0]).toMatchObject({
+      data: [undefined, undefined],
+      isPending: true,
+    })
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('data: 1,2')).toBeInTheDocument()
+    expect(rendered.getByText('isPending: false')).toBeInTheDocument()
+    expect(results[results.length - 1]).toMatchObject({
+      data: [1, 2],
+      isPending: false,
+    })
+    expect(results.length).toBeGreaterThanOrEqual(2)
+  })
+
   describe('isRestoring', () => {
     it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
       const key1 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Adds a test covering the `combine` branch in `inject-queries.ts` (line 323), raising the branch coverage from 91.66% to 100%.

### What's tested

- `injectQueries` with a `combine` function that merges multiple query results into a single aggregated shape
- Initial render: combined value reflects the pending state (`data: [undefined, undefined]`, `isPending: true`)
- After both queries resolve: combined value reflects the resolved state (`data: [1, 2]`, `isPending: false`)
- Reactivity: `effect` records at least two snapshots as the combined signal updates

### Verification

- `@tanstack/angular-query-experimental` — 208 tests passed (previously 207)
- `src/inject-queries.ts` coverage — Stmts/Branch/Funcs/Lines all 100% (previously branch was 91.66%)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the `injectQueries` combine callback functionality, verifying correct behavior during initial render and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->