### PR TITLE
test(angular-query-experimental/injectQueries): move 'effect' into 'constructor' to follow Angular convention

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -58,10 +58,12 @@ describe('injectQueries', () => {
         ],
       }))
 
-      _ = effect(() => {
-        const snapshot = this.result().map((q) => ({ data: q.data() }))
-        results.push(snapshot)
-      })
+      constructor() {
+        effect(() => {
+          const snapshot = this.result().map((q) => ({ data: q.data() }))
+          results.push(snapshot)
+        })
+      }
     }
 
     const rendered = await render(Page, {
@@ -111,9 +113,11 @@ describe('injectQueries', () => {
         }),
       }))
 
-      _ = effect(() => {
-        results.push({ ...this.combined() })
-      })
+      constructor() {
+        effect(() => {
+          results.push({ ...this.combined() })
+        })
+      }
     }
 
     const rendered = await render(Page, {


### PR DESCRIPTION
## 🎯 Changes

Refactors the two `effect()` calls in `inject-queries.test.ts` from the class-field assignment (`_ = effect(...)`) pattern into an explicit `constructor()` body, matching the convention used in our own Angular documentation.

### Before

```ts
class Page {
  result = injectQueries(() => ({ /* ... */ }))

  _ = effect(() => {
    const snapshot = this.result().map((q) => ({ data: q.data() }))
    results.push(snapshot)
  })
}
```

### After

```ts
class Page {
  result = injectQueries(() => ({ /* ... */ }))

  constructor() {
    effect(() => {
      const snapshot = this.result().map((q) => ({ data: q.data() }))
      results.push(snapshot)
    })
  }
}
```

### Why

The Angular official signals guide explicitly calls out the constructor as the recommended place to register an `effect`:

> "The **easiest way** to satisfy this requirement is to call `effect` within a component, directive, or service **constructor**"
> — [Angular signals guide](https://angular.dev/guide/signals/effect#injection-context)

The same pattern is already used in our own guide at `docs/framework/angular/guides/paginated-queries.md`, so moving the tests to match keeps the codebase internally consistent.

`_ = effect(...)` works (class-field initialization is still inside an injection context), but it leaves behind a meaningless `_` identifier and diverges from the conventions shown in both the Angular docs and our own Angular guide.

### Scope

Only `inject-queries.test.ts` is touched. `inject-query.test.ts` also calls `effect()` but wraps it in `TestBed.runInInjectionContext(() => effect(...))` — that's a different pattern for injector-less tests and is out of scope here.

### Verification

- `@tanstack/angular-query-experimental` — 208 tests passed, 0 type errors
- `src/inject-queries.ts` coverage unchanged (100% across Stmts/Branch/Funcs/Lines)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test cases to improve effect initialization timing within component construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->