### PR TITLE
test(angular-query-persist-client/withPersistQueryClient): move 'effect' into 'constructor' to follow Angular convention

### DIFF
--- a/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
+++ b/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
@@ -97,13 +97,16 @@ describe('withPersistQueryClient', () => {
         queryKey: key,
         queryFn: () => sleep(10).then(() => 'fetched'),
       }))
-      _ = effect(() => {
-        states.push({
-          status: this.state.status(),
-          fetchStatus: this.state.fetchStatus(),
-          data: this.state.data(),
+
+      constructor() {
+        effect(() => {
+          states.push({
+            status: this.state.status(),
+            fetchStatus: this.state.fetchStatus(),
+            data: this.state.data(),
+          })
         })
-      })
+      }
     }
 
     const rendered = await render(Page, {
@@ -189,13 +192,16 @@ describe('withPersistQueryClient', () => {
         // otherwise initialData would be newer and takes precedence
         initialDataUpdatedAt: 1,
       }))
-      _ = effect(() => {
-        states.push({
-          status: this.state.status(),
-          fetchStatus: this.state.fetchStatus(),
-          data: this.state.data(),
+
+      constructor() {
+        effect(() => {
+          states.push({
+            status: this.state.status(),
+            fetchStatus: this.state.fetchStatus(),
+            data: this.state.data(),
+          })
         })
-      })
+      }
     }
 
     const rendered = await render(Page, {
@@ -280,13 +286,16 @@ describe('withPersistQueryClient', () => {
         },
         staleTime: Infinity,
       }))
-      _ = effect(() => {
-        states.push({
-          status: this.state.status(),
-          fetchStatus: this.state.fetchStatus(),
-          data: this.state.data(),
+
+      constructor() {
+        effect(() => {
+          states.push({
+            status: this.state.status(),
+            fetchStatus: this.state.fetchStatus(),
+            data: this.state.data(),
+          })
         })
-      })
+      }
     }
 
     const rendered = await render(Page, {


### PR DESCRIPTION
## 🎯 Changes

Refactors the three `effect()` calls in `with-persist-query-client.test.ts` from the class-field assignment (`_ = effect(...)`) pattern into an explicit `constructor()` body, matching the convention used in our own Angular documentation.

### Before

```ts
class Page {
  state = injectQuery(() => ({ /* ... */ }))

  _ = effect(() => {
    states.push({ /* ... */ })
  })
}
```

### After

```ts
class Page {
  state = injectQuery(() => ({ /* ... */ }))

  constructor() {
    effect(() => {
      states.push({ /* ... */ })
    })
  }
}
```

### Why

The Angular official signals guide explicitly calls out the constructor as the recommended place to register an `effect`:

> "The **easiest way** to satisfy this requirement is to call `effect` within a component, directive, or service **constructor**"
> — [Angular signals guide](https://angular.dev/guide/signals/effect#injection-context)

The same pattern is already used in our own guide at `docs/framework/angular/guides/paginated-queries.md`, so moving the tests to match keeps the codebase internally consistent.

This mirrors the same refactor applied to `inject-queries.test.ts` in #10537.

### Verification

- `@tanstack/angular-query-persist-client` — 5 tests passed, 1 todo, 0 type errors

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test implementation patterns in the query persist client test suite to enhance code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->