### PR TITLE
feat(query-core): forward caller-provided meta into the invalidate action payload

### DIFF
--- a/.changeset/invalidate-queries-meta.md
+++ b/.changeset/invalidate-queries-meta.md
@@ -1,0 +1,18 @@
+---
+"@tanstack/query-core": minor
+---
+
+Forward caller-provided `meta` from `invalidateQueries` options into the `invalidate` action payload visible in `queryCache.subscribe`.
+
+```ts
+queryClient.invalidateQueries(
+  { queryKey: ['orders'] },
+  { meta: { source: 'websocket', traceId: 'abc123' } },
+)
+
+queryCache.subscribe((event) => {
+  if (event.type === 'updated' && event.action.type === 'invalidate') {
+    console.log(event.action.meta) // { source: 'websocket', traceId: 'abc123' }
+  }
+})
+```

--- a/docs/framework/react/guides/query-invalidation.md
+++ b/docs/framework/react/guides/query-invalidation.md
@@ -131,3 +131,31 @@ const todoListQuery = useQuery({
 ```
 
 [//]: # 'Example5'
+
+## Tracing invalidation sources with `meta`
+
+Pass a `meta` object as the second argument to `invalidateQueries` to attach caller context to the invalidation. The value flows through to the `invalidate` action seen by `queryCache.subscribe` subscribers, making it possible to build structured logs or suppress echo-invalidations without any out-of-band bookkeeping.
+
+[//]: # 'ExampleMeta'
+
+```tsx
+// Attach a source tag when invalidating from a WebSocket message
+queryClient.invalidateQueries(
+  { queryKey: ['orders'] },
+  { meta: { source: 'websocket', traceId: 'abc123' } },
+)
+
+// Read it back in a cache subscriber
+queryCache.subscribe((event) => {
+  if (event.type === 'updated' && event.action.type === 'invalidate') {
+    analytics.track('cache.invalidated', {
+      queryKey: event.query.queryKey,
+      ...event.action.meta,
+    })
+  }
+})
+```
+
+[//]: # 'ExampleMeta'
+
+> **Note:** `meta` in the second argument (`options.meta`) is unrelated to `filters.meta` in the first argument. `filters.meta` selects _which_ queries to invalidate; `options.meta` is arbitrary context that rides along with the invalidation action.

--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -351,6 +351,9 @@ await queryClient.invalidateQueries(
     - Defaults to `true`
       - Per default, a currently running request will be cancelled before a new request is made
     - When set to `false`, no refetch will be made if there is already a request running.
+  - `meta?: QueryMeta`
+    - Optional metadata to attach to the invalidation. The value is forwarded to the `invalidate` action payload visible in `queryCache.subscribe`, allowing cache subscribers to identify the source of the invalidation.
+    - Note: this is distinct from `filters.meta`, which filters queries _by_ their meta.
 
 ## `queryClient.refetchQueries`
 

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1600,6 +1600,27 @@ describe('queryClient', () => {
       expect(queryFn).toHaveBeenCalledTimes(1)
       unsubscribe()
     })
+
+    it('should forward meta to the invalidate action in queryCache.subscribe', async () => {
+      const key = queryKey()
+      await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
+
+      const events: Array<unknown> = []
+      const unsubscribe = queryCache.subscribe((event) => {
+        if (event.type === 'updated' && event.action.type === 'invalidate') {
+          events.push(event.action.meta)
+        }
+      })
+
+      await queryClient.invalidateQueries(
+        { queryKey: key },
+        { meta: { source: 'websocket', traceId: 'abc123' } },
+      )
+
+      unsubscribe()
+      expect(events).toHaveLength(1)
+      expect(events[0]).toEqual({ source: 'websocket', traceId: 'abc123' })
+    })
   })
 
   describe('resetQueries', () => {

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -124,6 +124,7 @@ interface ErrorAction<TError> {
 
 interface InvalidateAction {
   type: 'invalidate'
+  meta?: QueryMeta
 }
 
 interface PauseAction {
@@ -388,9 +389,9 @@ export class Query<
     )
   }
 
-  invalidate(): void {
+  invalidate(meta?: QueryMeta): void {
     if (!this.state.isInvalidated) {
-      this.#dispatch({ type: 'invalidate' })
+      this.#dispatch({ type: 'invalidate', meta })
     }
   }
 

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -302,12 +302,13 @@ export class QueryClient {
       if (filters?.refetchType === 'none') {
         return Promise.resolve()
       }
+      const { meta: _meta, ...refetchOptions } = options
       return this.refetchQueries(
         {
           ...filters,
           type: filters?.refetchType ?? filters?.type ?? 'active',
         },
-        options,
+        refetchOptions,
       )
     })
   }

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -296,7 +296,7 @@ export class QueryClient {
   ): Promise<void> {
     return notifyManager.batch(() => {
       this.#queryCache.findAll(filters).forEach((query) => {
-        query.invalidate()
+        query.invalidate(options.meta)
       })
 
       if (filters?.refetchType === 'none') {

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -591,7 +591,9 @@ export interface RefetchQueryFilters<
   TQueryKey extends QueryKey = QueryKey,
 > extends QueryFilters<TQueryKey> {}
 
-export interface InvalidateOptions extends RefetchOptions {}
+export interface InvalidateOptions extends RefetchOptions {
+  meta?: QueryMeta
+}
 export interface ResetOptions extends RefetchOptions {}
 
 export interface FetchNextPageOptions extends ResultOptions {


### PR DESCRIPTION
## Summary

Implements the proposal from discussion #10539.

- Adds `meta?: QueryMeta` to `InvalidateOptions` (second arg of `invalidateQueries`)
- Threads it through `query.invalidate(meta)` into the dispatched `InvalidateAction`
- Makes `event.action.meta` available in `queryCache.subscribe` for structured observability and echo-suppression

## Usage

```ts
queryClient.invalidateQueries(
  { queryKey: ['orders'] },
  { meta: { source: 'websocket', traceId: 'abc123' } },
)

queryCache.subscribe((event) => {
  if (event.type === 'updated' && event.action.type === 'invalidate') {
    console.log(event.action.meta) // { source: 'websocket', traceId: 'abc123' }
  }
})
```

## Notes

- Fully additive — `meta` is optional and defaults to `undefined`. No existing call site is affected.
- `options.meta` is distinct from `filters.meta` (which filters queries *by* their meta).
- The existing `isInvalidated` guard is preserved: if a query is already invalidated, the dispatch is skipped and the meta from subsequent calls is silently dropped. This is consistent with current behavior and can be revisited separately.
- `query-broadcast-client-experimental` does not broadcast `invalidate` actions today, so no changes are needed there.

## Checklist

- [x] Core implementation (`query.ts`, `queryClient.ts`, `types.ts`)
- [x] Test in `queryClient.test.tsx`
- [x] Reference docs updated (`docs/reference/QueryClient.md`)
- [x] Guide updated (`docs/framework/react/guides/query-invalidation.md`) — other framework guides mirror it via `ref:`
- [x] Changeset (`minor` for `@tanstack/query-core`)

Closes discussion: https://github.com/TanStack/query/discussions/10539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invalidation now accepts a meta option that is forwarded with invalidation events so subscribers can observe the source/context.

* **Documentation**
  * Added guide and reference examples showing how to pass and read meta during invalidation and clarifying it differs from filter metadata.

* **Tests**
  * Added tests verifying that meta is propagated through invalidation events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->