### PR TITLE
test(angular-query-experimental/injectQueries): remove duplicate 'render' providers already configured in 'beforeEach'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -66,12 +66,7 @@ describe('injectQueries', () => {
       }
     }
 
-    const rendered = await render(Page, {
-      providers: [
-        provideZonelessChangeDetection(),
-        provideTanStackQuery(queryClient),
-      ],
-    })
+    const rendered = await render(Page)
 
     await vi.advanceTimersByTimeAsync(101)
     rendered.fixture.detectChanges()
@@ -120,12 +115,7 @@ describe('injectQueries', () => {
       }
     }
 
-    const rendered = await render(Page, {
-      providers: [
-        provideZonelessChangeDetection(),
-        provideTanStackQuery(queryClient),
-      ],
-    })
+    const rendered = await render(Page)
 
     expect(rendered.getByText('data: ,')).toBeInTheDocument()
     expect(rendered.getByText('isPending: true')).toBeInTheDocument()


### PR DESCRIPTION
## 🎯 Changes

Removes the duplicate `providers` argument from `render(Page, { providers: [...] })` in `inject-queries.test.ts`. The `beforeEach` hook already configures the same providers via `TestBed.configureTestingModule`, so `@testing-library/angular`'s `render()` inherits them and the explicit second registration is redundant.

### Before

```ts
beforeEach(() => {
  vi.useFakeTimers()
  queryClient = new QueryClient()
  TestBed.configureTestingModule({
    providers: [
      provideZonelessChangeDetection(),
      provideTanStackQuery(queryClient),
    ],
  })
})

// ...

const rendered = await render(Page, {
  providers: [
    provideZonelessChangeDetection(),
    provideTanStackQuery(queryClient),
  ],
})
```

### After

```ts
const rendered = await render(Page)
```

### Scope

Only the two call sites in `injectQueries`'s top-level tests — the `isRestoring` block still calls `TestBed.resetTestingModule()` and must re-register providers (including `provideIsRestoring`), so it's intentionally left untouched.

### Verification

- `@tanstack/angular-query-experimental` — 208 tests passed, 0 type errors
- `src/inject-queries.ts` coverage unchanged (100% across Stmts/Branch/Funcs/Lines)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup by consolidating Angular provider configuration, reducing redundancy in individual test cases while maintaining existing test coverage and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->