### PR TITLE
test(angular-query-experimental/withDevtools): add test for 'No QueryClient found' throw when 'loadDevtools' is 'true' without a 'QueryClient'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/with-devtools.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/with-devtools.test.ts
@@ -153,6 +153,33 @@ describe('withDevtools feature', () => {
     },
   )
 
+  it("should throw 'No QueryClient found' when 'loadDevtools' is 'true' and no 'QueryClient' is provided", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        withDevtools(() => ({
+          loadDevtools: true,
+        })).ɵproviders,
+      ],
+    })
+
+    TestBed.inject(ENVIRONMENT_INITIALIZER)
+    TestBed.tick()
+    await vi.dynamicImportSettled()
+
+    expect(mockTanstackQueryDevtools).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Install @tanstack/query-devtools or reinstall without --omit=optional.',
+      expect.objectContaining({ message: 'No QueryClient found' }),
+    )
+
+    consoleErrorSpy.mockRestore()
+  })
+
   it('should not continue loading devtools after injector is destroyed', async () => {
     TestBed.configureTestingModule({
       providers: [


### PR DESCRIPTION
## 🎯 Changes

Adds a test covering the `throw new Error('No QueryClient found')` branch in `with-devtools.ts` (line 109). When `loadDevtools: true` is set but no `QueryClient` is provided (e.g. `provideTanStackQuery` is missing), the dynamic devtools loader now has explicit coverage that the error is thrown and handled by the `.catch` branch.

### What's tested

- `withDevtools(() => ({ loadDevtools: true })).ɵproviders` is registered without `provideTanStackQuery(queryClient)`.
- Triggering `ENVIRONMENT_INITIALIZER` + one change detection cycle starts the dynamic `import('@tanstack/query-devtools')`.
- Inside the `.then`, `getResolvedQueryClient()` throws because neither `devtoolsOptions().client` nor the optionally injected `QueryClient` is present.
- The `.catch` branch catches the thrown error and logs it via `console.error`.

Line 169 (`console.error` in the `.catch`) is covered as a natural consequence of the thrown error being propagated through the Promise chain.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validation to ensure proper error messaging when devtools is configured without a required client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->