### PR TITLE
test(angular-query*): simplify 'TestBed' setup by removing redundant 'resetTestingModule' and leveraging provider merging

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { Injector, provideZonelessChangeDetection, signal } from '@angular/core'
 import {
   QueryClient,
@@ -11,16 +11,17 @@ import {
 describe('injectIsRestoring', () => {
   let queryClient: QueryClient
 
-  it('returns false by default when provideIsRestoring is not used', () => {
+  beforeEach(() => {
     queryClient = new QueryClient()
-
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
         provideTanStackQuery(queryClient),
       ],
     })
+  })
 
+  it('returns false by default when provideIsRestoring is not used', () => {
     const isRestoring = TestBed.runInInjectionContext(() => {
       return injectIsRestoring()
     })
@@ -29,15 +30,10 @@ describe('injectIsRestoring', () => {
   })
 
   it('returns provided signal value when provideIsRestoring is used', () => {
-    queryClient = new QueryClient()
     const restoringSignal = signal(true)
 
     TestBed.configureTestingModule({
-      providers: [
-        provideZonelessChangeDetection(),
-        provideTanStackQuery(queryClient),
-        provideIsRestoring(restoringSignal.asReadonly()),
-      ],
+      providers: [provideIsRestoring(restoringSignal.asReadonly())],
     })
 
     const isRestoring = TestBed.runInInjectionContext(() => {
@@ -48,15 +44,6 @@ describe('injectIsRestoring', () => {
   })
 
   it('can be used outside injection context when passing an injector', () => {
-    queryClient = new QueryClient()
-
-    TestBed.configureTestingModule({
-      providers: [
-        provideZonelessChangeDetection(),
-        provideTanStackQuery(queryClient),
-      ],
-    })
-
     const isRestoring = injectIsRestoring({
       injector: TestBed.inject(Injector),
     })

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -536,14 +536,6 @@ describe('injectMutation', () => {
     })
 
     it('should handle synchronous mutation with retry', async () => {
-      TestBed.resetTestingModule()
-      TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-        ],
-      })
-
       const app = TestBed.inject(ApplicationRef)
       let attemptCount = 0
 
@@ -586,14 +578,6 @@ describe('injectMutation', () => {
     })
 
     it('should handle multiple synchronous mutations on same key', async () => {
-      TestBed.resetTestingModule()
-      TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-        ],
-      })
-
       const app = TestBed.inject(ApplicationRef)
       let callCount = 0
 
@@ -640,14 +624,6 @@ describe('injectMutation', () => {
     })
 
     it('should handle synchronous mutation with optimistic updates', async () => {
-      TestBed.resetTestingModule()
-      TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-        ],
-      })
-
       const app = TestBed.inject(ApplicationRef)
       const testQueryKey = queryKey()
       let onMutateCalled = false
@@ -692,14 +668,6 @@ describe('injectMutation', () => {
     })
 
     it('should handle synchronous mutation cancellation', async () => {
-      TestBed.resetTestingModule()
-      TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-        ],
-      })
-
       const app = TestBed.inject(ApplicationRef)
 
       const key = queryKey()

--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -11,24 +11,24 @@ import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient, provideIsRestoring, provideTanStackQuery } from '..'
 import { injectQueries } from '../inject-queries'
 
-let queryClient: QueryClient
-
-beforeEach(() => {
-  vi.useFakeTimers()
-  queryClient = new QueryClient()
-  TestBed.configureTestingModule({
-    providers: [
-      provideZonelessChangeDetection(),
-      provideTanStackQuery(queryClient),
-    ],
-  })
-})
-
-afterEach(() => {
-  vi.useRealTimers()
-})
-
 describe('injectQueries', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    queryClient = new QueryClient()
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideTanStackQuery(queryClient),
+      ],
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('should return the correct states', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
@@ -143,13 +143,8 @@ describe('injectQueries', () => {
       const queryFn1 = vi.fn().mockImplementation(() => sleep(10).then(() => 1))
       const queryFn2 = vi.fn().mockImplementation(() => sleep(10).then(() => 2))
 
-      TestBed.resetTestingModule()
       TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-          provideIsRestoring(signal(true).asReadonly()),
-        ],
+        providers: [provideIsRestoring(signal(true).asReadonly())],
       })
 
       const queries = TestBed.runInInjectionContext(() =>

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -38,6 +38,7 @@ import type { CreateQueryOptions, OmitKeyof, QueryFunction } from '..'
 describe('injectQuery', () => {
   let queryCache: QueryCache
   let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
     queryCache = new QueryCache()
@@ -566,13 +567,8 @@ describe('injectQuery', () => {
         .fn()
         .mockImplementation(() => sleep(10).then(() => 'data'))
 
-      TestBed.resetTestingModule()
       TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-          provideIsRestoring(signal(true).asReadonly()),
-        ],
+        providers: [provideIsRestoring(signal(true).asReadonly())],
       })
 
       const query = TestBed.runInInjectionContext(() =>
@@ -645,14 +641,8 @@ describe('injectQuery', () => {
     })
 
     it('should complete HttpClient-based queries before whenStable() resolves', async () => {
-      TestBed.resetTestingModule()
       TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-          provideHttpClient(),
-          provideHttpClientTesting(),
-        ],
+        providers: [provideHttpClient(), provideHttpClientTesting()],
       })
 
       const app = TestBed.inject(ApplicationRef)
@@ -691,14 +681,6 @@ describe('injectQuery', () => {
     })
 
     it('should handle synchronous queryFn with staleTime', async () => {
-      TestBed.resetTestingModule()
-      TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-        ],
-      })
-
       const app = TestBed.inject(ApplicationRef)
       let callCount = 0
 
@@ -735,14 +717,6 @@ describe('injectQuery', () => {
     })
 
     it('should handle enabled/disabled transitions with synchronous queryFn', async () => {
-      TestBed.resetTestingModule()
-      TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-        ],
-      })
-
       const app = TestBed.inject(ApplicationRef)
       const enabledSignal = signal(false)
       let callCount = 0
@@ -777,14 +751,6 @@ describe('injectQuery', () => {
     })
 
     it('should handle query invalidation with synchronous data', async () => {
-      TestBed.resetTestingModule()
-      TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-        ],
-      })
-
       const app = TestBed.inject(ApplicationRef)
       const testKey = queryKey()
       let callCount = 0

--- a/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
@@ -458,14 +458,8 @@ describe('PendingTasks Integration', () => {
 
   describe('HttpClient Integration', () => {
     beforeEach(() => {
-      TestBed.resetTestingModule()
       TestBed.configureTestingModule({
-        providers: [
-          provideZonelessChangeDetection(),
-          provideTanStackQuery(queryClient),
-          provideHttpClient(),
-          provideHttpClientTesting(),
-        ],
+        providers: [provideHttpClient(), provideHttpClientTesting()],
       })
     })
 

--- a/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
+++ b/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
@@ -18,14 +18,6 @@ import type {
   Persister,
 } from '@tanstack/query-persist-client-core'
 
-beforeEach(() => {
-  vi.useFakeTimers()
-})
-
-afterEach(() => {
-  vi.useRealTimers()
-})
-
 const createMockPersister = (): Persister => {
   let storedState: PersistedClient | undefined
 
@@ -62,6 +54,14 @@ const createMockErrorPersister = (
 }
 
 describe('withPersistQueryClient', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('restores cache from persister', async () => {
     const key = queryKey()
     const states: Array<{


### PR DESCRIPTION
## 🎯 Changes

Simplifies `TestBed` setup across Angular tests by removing redundant `resetTestingModule()` calls and leveraging Angular's provider merging behavior — `configureTestingModule()` merges providers on repeated calls, so tests that only need to add extra providers on top of the `beforeEach` baseline no longer have to re-declare the whole provider array.

### Per-file changes

- **`angular-query-experimental/src/__tests__/inject-is-restoring.test.ts`**: extract common setup into a `beforeEach` hook and let the `provideIsRestoring` test merge its extra provider.
- **`angular-query-experimental/src/__tests__/inject-mutation.test.ts`**: drop 4 `resetTestingModule` + `configureTestingModule` blocks that just re-declared the exact providers already set up in `beforeEach`.
- **`angular-query-experimental/src/__tests__/inject-queries.test.ts`**: move the top-level `beforeEach`/`afterEach` hooks into the `describe` block they belong to, and simplify the `isRestoring` test to only declare the extra provider it needs.
- **`angular-query-experimental/src/__tests__/inject-query.test.ts`**: remove 3 redundant `resetTestingModule` + full re-declaration blocks, and simplify the `isRestoring` / `HttpClient` tests to only declare their extra providers.
- **`angular-query-experimental/src/__tests__/pending-tasks.test.ts`**: the nested `HttpClient Integration` describe now merges `provideHttpClient` / `provideHttpClientTesting` on top of the parent `beforeEach` instead of resetting and rebuilding from scratch.
- **`angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts`**: move the top-level `beforeEach`/`afterEach` hooks into the `describe` block they belong to, matching the convention used in the rest of the suite.

### Out of scope

Three `TestBed.resetTestingModule()` calls in `with-devtools.test.ts` are intentionally preserved — they're either cleanup in `afterEach` or part of the test's own subject ("injector destroy" behavior), not redundant setup.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restructured test initialization across multiple test files to consolidate shared setup configurations, improving test maintainability and reducing redundant setup code without affecting test functionality or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->