### PR TITLE
test(angular-query*): prefix 'it' descriptions with 'should' for consistency

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
@@ -166,7 +166,7 @@ describe('infiniteQueryOptions', () => {
     )
   })
 
-  it('allow optional initialData function', () => {
+  it('should allow optional initialData function', () => {
     const key = queryKey()
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({
@@ -185,7 +185,7 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
-  it('allow optional initialData object', () => {
+  it('should allow optional initialData object', () => {
     const key = queryKey()
     const initialData: { example: boolean } | undefined = { example: true }
     const queryOptions = infiniteQueryOptions({

--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -64,7 +64,7 @@ describe('injectInfiniteQuery', () => {
   })
 
   describe('injection context', () => {
-    it('throws NG0203 with descriptive error outside injection context', () => {
+    it('should throw NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()
       expect(() => {
         injectInfiniteQuery(() => ({
@@ -77,7 +77,7 @@ describe('injectInfiniteQuery', () => {
       }).toThrow(/NG0203(.*?)injectInfiniteQuery/)
     })
 
-    it('can be used outside injection context when passing an injector', () => {
+    it('should be usable outside injection context when passing an injector', () => {
       const key = queryKey()
       const query = injectInfiniteQuery(
         () => ({

--- a/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
@@ -28,7 +28,7 @@ describe('injectIsFetching', () => {
     vi.useRealTimers()
   })
 
-  it('Returns number of fetching queries', async () => {
+  it('should return the number of fetching queries', async () => {
     const key = queryKey()
     const isFetching = TestBed.runInInjectionContext(() => {
       injectQuery(() => ({
@@ -46,13 +46,13 @@ describe('injectIsFetching', () => {
   })
 
   describe('injection context', () => {
-    it('throws NG0203 with descriptive error outside injection context', () => {
+    it('should throw NG0203 with descriptive error outside injection context', () => {
       expect(() => {
         injectIsFetching()
       }).toThrow(/NG0203(.*?)injectIsFetching/)
     })
 
-    it('can be used outside injection context when passing an injector', () => {
+    it('should be usable outside injection context when passing an injector', () => {
       expect(
         injectIsFetching(undefined, {
           injector: TestBed.inject(Injector),

--- a/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
@@ -52,13 +52,13 @@ describe('injectIsMutating', () => {
   })
 
   describe('injection context', () => {
-    it('throws NG0203 with descriptive error outside injection context', () => {
+    it('should throw NG0203 with descriptive error outside injection context', () => {
       expect(() => {
         injectIsMutating()
       }).toThrow(/NG0203(.*?)injectIsMutating/)
     })
 
-    it('can be used outside injection context when passing an injector', () => {
+    it('should be usable outside injection context when passing an injector', () => {
       expect(
         injectIsMutating(undefined, {
           injector: TestBed.inject(Injector),

--- a/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
@@ -21,7 +21,7 @@ describe('injectIsRestoring', () => {
     })
   })
 
-  it('returns false by default when provideIsRestoring is not used', () => {
+  it('should return false by default when provideIsRestoring is not used', () => {
     const isRestoring = TestBed.runInInjectionContext(() => {
       return injectIsRestoring()
     })
@@ -29,7 +29,7 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(false)
   })
 
-  it('returns provided signal value when provideIsRestoring is used', () => {
+  it('should return the provided signal value when provideIsRestoring is used', () => {
     const restoringSignal = signal(true)
 
     TestBed.configureTestingModule({
@@ -43,7 +43,7 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(true)
   })
 
-  it('can be used outside injection context when passing an injector', () => {
+  it('should be usable outside injection context when passing an injector', () => {
     const isRestoring = injectIsRestoring({
       injector: TestBed.inject(Injector),
     })
@@ -51,7 +51,7 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(false)
   })
 
-  it('throws NG0203 with descriptive error outside injection context', () => {
+  it('should throw NG0203 with descriptive error outside injection context', () => {
     expect(() => {
       injectIsRestoring()
     }).toThrow(/NG0203(.*?)injectIsRestoring/)

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation-state.test.ts
@@ -59,7 +59,7 @@ describe('injectMutationState', () => {
       expect(mutationState()).toEqual([variables])
     })
 
-    it('reactive options should update injectMutationState', () => {
+    it('should update injectMutationState when reactive options change', () => {
       const mutationKey1 = queryKey()
       const mutationKey2 = queryKey()
       const variables1 = 'foo123'
@@ -179,13 +179,13 @@ describe('injectMutationState', () => {
     })
 
     describe('injection context', () => {
-      it('throws NG0203 with descriptive error outside injection context', () => {
+      it('should throw NG0203 with descriptive error outside injection context', () => {
         expect(() => {
           injectMutationState()
         }).toThrow(/NG0203(.*?)injectMutationState/)
       })
 
-      it('can be used outside injection context when passing an injector', () => {
+      it('should be usable outside injection context when passing an injector', () => {
         const injector = TestBed.inject(Injector)
         expect(
           injectMutationState(undefined, {

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -114,7 +114,7 @@ describe('injectMutation', () => {
     })
   })
 
-  it('reactive options should update mutation', () => {
+  it('should update mutation when reactive options change', () => {
     const mutationCache = queryClient.getMutationCache()
     // Signal will be updated before the mutation is called
     // this test confirms that the mutation uses the updated value
@@ -473,7 +473,7 @@ describe('injectMutation', () => {
   })
 
   describe('injection context', () => {
-    it('throws NG0203 with descriptive error outside injection context', () => {
+    it('should throw NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()
       expect(() => {
         injectMutation(() => ({
@@ -483,7 +483,7 @@ describe('injectMutation', () => {
       }).toThrow(/NG0203(.*?)injectMutation/)
     })
 
-    it('can be used outside injection context when passing an injector', () => {
+    it('should be usable outside injection context when passing an injector', () => {
       const key = queryKey()
       expect(() => {
         injectMutation(

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -593,7 +593,7 @@ describe('injectQuery', () => {
   })
 
   describe('injection context', () => {
-    it('throws NG0203 with descriptive error outside injection context', () => {
+    it('should throw NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()
       expect(() => {
         injectQuery(() => ({
@@ -603,7 +603,7 @@ describe('injectQuery', () => {
       }).toThrow(/NG0203(.*?)injectQuery/)
     })
 
-    it('can be used outside injection context when passing an injector', () => {
+    it('should be usable outside injection context when passing an injector', () => {
       const key = queryKey()
       const query = injectQuery(
         () => ({

--- a/packages/angular-query-experimental/src/__tests__/signal-proxy.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/signal-proxy.test.ts
@@ -16,12 +16,12 @@ describe('signalProxy', () => {
     expect(isSignal(proxy.fn)).toBe(false)
   })
 
-  it('supports "in" operator', () => {
+  it('should support "in" operator', () => {
     expect('baz' in proxy).toBe(true)
     expect('foo' in proxy).toBe(false)
   })
 
-  it('supports "Object.keys"', () => {
+  it('should support "Object.keys"', () => {
     expect(Object.keys(proxy)).toEqual(['fn', 'baz'])
   })
 })

--- a/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
+++ b/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
@@ -62,7 +62,7 @@ describe('withPersistQueryClient', () => {
     vi.useRealTimers()
   })
 
-  it('restores cache from persister', async () => {
+  it('should restore cache from persister', async () => {
     const key = queryKey()
     const states: Array<{
       status: string


### PR DESCRIPTION
## 🎯 Changes

Prefixes `it` descriptions that didn't start with `should` in both `angular-query-experimental` and `angular-query-persist-client` tests, matching the BDD convention already followed by the vast majority of tests in this repo.

### Examples

- `it('throws NG0203 with descriptive error...')` → `it('should throw NG0203 with descriptive error...')`
- `it('can be used outside injection context...')` → `it('should be usable outside injection context...')`
- `it('Returns number of fetching queries')` → `it('should return the number of fetching queries')`
- `it('reactive options should update mutation')` → `it('should update mutation when reactive options change')`
- `it('supports "in" operator')` → `it('should support "in" operator')`
- `it('allow optional initialData function')` → `it('should allow optional initialData function')`
- `it('restores cache from persister')` → `it('should restore cache from persister')`

### Scope

Test descriptions where the subject is `TData` / `data` / `error` (type-level tests) already carry `should` mid-sentence (e.g. `'TData should always be defined when initialData is provided as an object'`). Those are BDD-valid as-is and intentionally left untouched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Standardized test case descriptions across the test suite to use consistent "should" phrasing for improved readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->