### PR TITLE
test(query-persist-client-core/createPersister): fix typo 'persiste' to 'persist' and 'persistance' to 'persistence'

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -436,7 +436,7 @@ describe('createPersister', () => {
   })
 
   describe('persistQuery', () => {
-    it('Should properly persiste basic query', async () => {
+    it('Should properly persist basic query', async () => {
       const storage = getFreshStorage()
       const { persister, query, queryHash, queryKey, storageKey } =
         setupPersister(['foo'], {
@@ -458,7 +458,7 @@ describe('createPersister', () => {
       })
     })
 
-    it('Should skip persistance if storage is not provided', async () => {
+    it('Should skip persistence if storage is not provided', async () => {
       const serializeMock = vi.fn()
       const { persister, query } = setupPersister(['foo'], {
         storage: null,
@@ -473,7 +473,7 @@ describe('createPersister', () => {
   })
 
   describe('persistQueryByKey', () => {
-    it('Should skip persistance if storage is not provided', async () => {
+    it('Should skip persistence if storage is not provided', async () => {
       const serializeMock = vi.fn()
       const { persister, client, queryKey } = setupPersister(['foo'], {
         storage: null,
@@ -486,7 +486,7 @@ describe('createPersister', () => {
       expect(serializeMock).toHaveBeenCalledTimes(0)
     })
 
-    it('should skip persistance if query was not found', async () => {
+    it('should skip persistence if query was not found', async () => {
       const serializeMock = vi.fn()
       const storage = getFreshStorage()
       const { client, persister, queryKey } = setupPersister(['foo'], {
@@ -500,7 +500,7 @@ describe('createPersister', () => {
       expect(serializeMock).toHaveBeenCalledTimes(0)
     })
 
-    it('Should properly persiste basic query', async () => {
+    it('Should properly persist basic query', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryHash, queryKey, storageKey } =
         setupPersister(['foo'], {


### PR DESCRIPTION
## 🎯 Changes

Fixes typos in `it` descriptions in `createPersister.test.ts`:

- `'Should properly persiste basic query'` → `'Should properly persist basic query'` (2 occurrences)
- `'Should skip persistance if storage is not provided'` → `'Should skip persistence if storage is not provided'` (2 occurrences)
- `'should skip persistance if query was not found'` → `'should skip persistence if query was not found'`

Resolves the `cspell/spellchecker` warnings that flagged `"persiste"` as an unknown word and `"persistance"` as a misspelling of `"persistence"`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test descriptions for accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->