### PR TITLE
test(vue-query/queryClient): rename local 'queryKey' to 'key' to avoid 'no-shadow' with the 'queryKey' import

### DIFF
--- a/packages/vue-query/src/__tests__/queryClient.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test-d.ts
@@ -5,25 +5,25 @@ import type { DataTag, InfiniteData } from '@tanstack/query-core'
 
 describe('getQueryData', () => {
   it('should be typed if key is tagged', () => {
-    const queryKey = ['key'] as DataTag<Array<string>, number>
+    const key = ['key'] as DataTag<Array<string>, number>
     const queryClient = new QueryClient()
-    const data = queryClient.getQueryData(queryKey)
+    const data = queryClient.getQueryData(key)
 
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
   it('should infer unknown if key is not tagged', () => {
-    const queryKey = ['key'] as const
+    const key = ['key'] as const
     const queryClient = new QueryClient()
-    const data = queryClient.getQueryData(queryKey)
+    const data = queryClient.getQueryData(key)
 
     expectTypeOf(data).toEqualTypeOf<unknown>()
   })
 
   it('should infer passed generic if passed', () => {
-    const queryKey = ['key'] as const
+    const key = ['key'] as const
     const queryClient = new QueryClient()
-    const data = queryClient.getQueryData<number>(queryKey)
+    const data = queryClient.getQueryData<number>(key)
 
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
@@ -38,9 +38,9 @@ describe('getQueryData', () => {
 
 describe('setQueryData', () => {
   it('updater should be typed if key is tagged', () => {
-    const queryKey = ['key'] as DataTag<Array<string>, number>
+    const key = ['key'] as DataTag<Array<string>, number>
     const queryClient = new QueryClient()
-    const data = queryClient.setQueryData(queryKey, (prev) => {
+    const data = queryClient.setQueryData(key, (prev) => {
       expectTypeOf(prev).toEqualTypeOf<number | undefined>()
       return prev
     })
@@ -48,24 +48,24 @@ describe('setQueryData', () => {
   })
 
   it('value should be typed if key is tagged', () => {
-    const queryKey = ['key'] as DataTag<Array<string>, number>
+    const key = ['key'] as DataTag<Array<string>, number>
     const queryClient = new QueryClient()
 
     // @ts-expect-error value should be a number
-    queryClient.setQueryData(queryKey, '1')
+    queryClient.setQueryData(key, '1')
 
     // @ts-expect-error value should be a number
-    queryClient.setQueryData(queryKey, () => '1')
+    queryClient.setQueryData(key, () => '1')
 
-    const data = queryClient.setQueryData(queryKey, 1)
+    const data = queryClient.setQueryData(key, 1)
 
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
   it('should infer unknown for updater if key is not tagged', () => {
-    const queryKey = ['key'] as const
+    const key = ['key'] as const
     const queryClient = new QueryClient()
-    const data = queryClient.setQueryData(queryKey, (prev) => {
+    const data = queryClient.setQueryData(key, (prev) => {
       expectTypeOf(prev).toEqualTypeOf<unknown>()
       return prev
     })
@@ -73,17 +73,17 @@ describe('setQueryData', () => {
   })
 
   it('should infer unknown for value if key is not tagged', () => {
-    const queryKey = ['key'] as const
+    const key = ['key'] as const
     const queryClient = new QueryClient()
-    const data = queryClient.setQueryData(queryKey, 'foo')
+    const data = queryClient.setQueryData(key, 'foo')
 
     expectTypeOf(data).toEqualTypeOf<unknown>()
   })
 
   it('should infer passed generic if passed', () => {
-    const queryKey = ['key'] as const
+    const key = ['key'] as const
     const queryClient = new QueryClient()
-    const data = queryClient.setQueryData<string>(queryKey, (prev) => {
+    const data = queryClient.setQueryData<string>(key, (prev) => {
       expectTypeOf(prev).toEqualTypeOf<string | undefined>()
       return prev
     })
@@ -91,21 +91,21 @@ describe('setQueryData', () => {
   })
 
   it('should infer passed generic for value', () => {
-    const queryKey = ['key'] as const
+    const key = ['key'] as const
     const queryClient = new QueryClient()
-    const data = queryClient.setQueryData<string>(queryKey, 'foo')
+    const data = queryClient.setQueryData<string>(key, 'foo')
 
     expectTypeOf(data).toEqualTypeOf<string | undefined>()
   })
 
   it('should preserve updater parameter type inference when used in functions with explicit return types', () => {
-    const queryKey = ['key'] as DataTag<Array<string>, number>
+    const key = ['key'] as DataTag<Array<string>, number>
     const queryClient = new QueryClient()
 
     // Simulate usage inside a function with explicit return type
     // The outer function returns 'unknown' but this shouldn't affect the updater's type inference
     ;(() =>
-      queryClient.setQueryData(queryKey, (data) => {
+      queryClient.setQueryData(key, (data) => {
         expectTypeOf(data).toEqualTypeOf<number | undefined>()
         return data
       })) satisfies () => unknown


### PR DESCRIPTION
## 🎯 Changes

Renames local `queryKey` variables inside the type-level tests to `key`, matching the convention used elsewhere in this file (`const key = queryKey()`) and across the rest of the test suite. This resolves the 10 `no-shadow` warnings previously triggered because the `queryKey` imported from `@tanstack/query-test-utils` was shadowed by these local declarations.

### Scope

Only `describe('getQueryData', ...)` and `describe('setQueryData', ...)` are affected — 10 local `const queryKey = [...]` declarations become `const key = [...]`. The existing `const key = queryKey()` usages in `describe('fetchInfiniteQuery', ...)` are already correct and are left untouched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases to improve code consistency and maintainability in type-checking tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->