### PR TITLE
test(react-query/useQuery): rename 'throwOnError' callback parameter to 'err' to avoid 'no-shadow' with outer 'error'

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -6846,7 +6846,7 @@ describe('useQuery', () => {
       const { status, error } = useQuery({
         queryKey: key,
         queryFn,
-        throwOnError: (error) => error.message.includes('404'),
+        throwOnError: (err) => err.message.includes('404'),
         retryOnMount: true,
         staleTime: Infinity,
         retry: false,


### PR DESCRIPTION
## 🎯 Changes

Renames the `throwOnError` callback parameter on line 6849 from `error` to `err` so it no longer shadows the outer `error` returned by `useQuery` on line 6846. This resolves the `no-shadow` warning and matches the convention already used elsewhere in this file:

- `throwOnError: (err) => err.message !== 'Local Error'` (line 2832, 2868)
- `retry: (_failureCount, err) => err.message !== 'NoRetry'` (line 3290)

After this change, every error-callback parameter in `useQuery.test.tsx` is named `err`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test callback parameter naming for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->