### PR TITLE
test(*): resolve 'require-await' warnings in test files

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1481,12 +1481,12 @@ describe('queryObserver', () => {
   it('should not refetchOnWindowFocus when staleTime is static and query has background error', async () => {
     const key = queryKey()
     let callCount = 0
-    const queryFn = vi.fn(async () => {
+    const queryFn = vi.fn(() => {
       callCount++
       if (callCount === 1) {
-        return 'data'
+        return Promise.resolve('data')
       }
-      throw new Error('background error')
+      return Promise.reject(new Error('background error'))
     })
 
     const observer = new QueryObserver(queryClient, {
@@ -1520,15 +1520,15 @@ describe('queryObserver', () => {
   it('should refetchOnWindowFocus when query has background error and staleTime is not static', async () => {
     const key = queryKey()
     let callCount = 0
-    const queryFn = vi.fn(async () => {
+    const queryFn = vi.fn(() => {
       callCount++
       if (callCount === 1) {
-        return 'data'
+        return Promise.resolve('data')
       }
       if (callCount === 2) {
-        throw new Error('background error')
+        return Promise.reject(new Error('background error'))
       }
-      return 'new data'
+      return Promise.resolve('new data')
     })
 
     const observer = new QueryObserver(queryClient, {

--- a/packages/query-core/src/__tests__/streamedQuery.test.tsx
+++ b/packages/query-core/src/__tests__/streamedQuery.test.tsx
@@ -550,6 +550,7 @@ describe('streamedQuery', () => {
       retry: false,
       queryFn: streamedQuery({
         refetchMode: 'reset',
+        // eslint-disable-next-line @typescript-eslint/require-await
         streamFn: async function* () {
           if (shouldError) {
             throw error
@@ -711,6 +712,7 @@ describe('streamedQuery', () => {
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
       queryFn: streamedQuery({
+        // eslint-disable-next-line @typescript-eslint/require-await
         streamFn: async function* () {
           const v = [1, 2, 3]
           yield* v

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -5675,9 +5675,9 @@ describe('useQuery', () => {
       function Component() {
         const state = useQuery({
           queryKey: key,
-          queryFn: async () => {
+          queryFn: () => {
             count++
-            return `data${count}`
+            return Promise.resolve(`data${count}`)
           },
         })
 

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -3950,7 +3950,7 @@ describe('useQuery', () => {
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/360
-  it('should init to status:pending, fetchStatus:idle when enabled is false', async () => {
+  it('should init to status:pending, fetchStatus:idle when enabled is false', () => {
     const key = queryKey()
 
     function Page() {
@@ -5017,7 +5017,7 @@ describe('useQuery', () => {
     })
   })
 
-  it('should only call the query hash function once', async () => {
+  it('should only call the query hash function once', () => {
     const key = queryKey()
 
     let hashes = 0
@@ -5943,9 +5943,9 @@ describe('useQuery', () => {
       function Component() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
+          queryFn: () => {
             count++
-            return `data${count}`
+            return Promise.resolve(`data${count}`)
           },
         }))
 


### PR DESCRIPTION
## 🎯 Changes

Resolves the 8 `@typescript-eslint/require-await` warnings that existed in real test files across `query-core`, `react-query`, and `solid-query`. Three distinct strategies are applied depending on what each case actually needs.

### Strategy 1 — `async` → non-async with `Promise.resolve` / `Promise.reject`

Used in `queryFn` callbacks whose `async` keyword was leftover after `await` was removed. The resulting function still returns a `Promise<T>`, so TanStack Query keeps routing the call through the async path. Semantically identical to `async` + `throw`, following the existing repo pattern (e.g. `query-core/__tests__/query.test.tsx:913-916`, `hydration.test.tsx:198, 1285`).

- `query-core/__tests__/queryObserver.test.tsx:1484, 1523` — call-count-based `queryFn`
- `react-query/__tests__/useQuery.test.tsx:5678` — `async () => { count++; return \`data${count}\` }`
- `solid-query/__tests__/useQuery.test.tsx:5946` — same pattern as above

### Strategy 2 — drop `async` from `it` callbacks that never await

Used when `it(..., async () => { ... })` had no `await` in the body.

- `solid-query/__tests__/useQuery.test.tsx:3953` — simple render + DOM assertion
- `solid-query/__tests__/useQuery.test.tsx:5020` — simple render + hash count assertion

### Strategy 3 — `eslint-disable-next-line` for unavoidable `async function*`

The `streamFn` passed to `streamedQuery` must return an `AsyncIterable`, and dropping `async` would break the type. These two call sites happen not to have any `await`/`for await` in their body (which is why eslint flags them), but every other `streamFn` in the same file does and is already warn-free. Matches the existing disable-comment style in this repo (`// eslint-disable-next-line <rule>` with no reason trailer).

- `query-core/__tests__/streamedQuery.test.tsx:553, 715`

### Out of scope

28 additional `require-await` warnings remain in `packages/query-codemods/src/*/__testfixtures__/` — those files are codemod input/output fixtures that intentionally mirror user code shapes and must not be modified.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test mocking patterns across multiple packages to use explicit Promise-returning functions instead of async/throw patterns for consistency.
  * Added ESLint suppressions for async generator functions without await expressions.
  * Refactored async test function signatures to remove unnecessary async/await where not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->