### PR TITLE
docs(eslint/no-unstable-deps): correct 'react' package name casing in examples

### DIFF
--- a/docs/eslint/no-unstable-deps.md
+++ b/docs/eslint/no-unstable-deps.md
@@ -22,7 +22,7 @@ Examples of **incorrect** code for this rule:
 
 ```tsx
 /* eslint "@tanstack/query/no-unstable-deps": "warn" */
-import { useCallback } from 'React'
+import { useCallback } from 'react'
 import { useMutation } from '@tanstack/react-query'
 
 function Component() {
@@ -38,7 +38,7 @@ Examples of **correct** code for this rule:
 
 ```tsx
 /* eslint "@tanstack/query/no-unstable-deps": "warn" */
-import { useCallback } from 'React'
+import { useCallback } from 'react'
 import { useMutation } from '@tanstack/react-query'
 
 function Component() {


### PR DESCRIPTION
## 🎯 Changes

Fixed import casing in `docs/eslint/no-unstable-deps.md`: `import { useCallback } from 'React'` → `import { useCallback } from 'react'`

The change is applied to both code examples (incorrect and correct sections).

npm package names are case-sensitive. The registered package is `react` (lowercase). Using `'React'` causes `Cannot find module 'React'` on case-sensitive file systems

This is especially impactful because the error appears in the "correct" code example — developers following this ESLint rule's guidance get a build failure.

  ## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
 - [ ] I have tested this code locally with `pnpm run test:pr`.

  ## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset (https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).