### PR TITLE
test(angular-query-experimental/injectIsFetching): switch main test to '@Component' + 'render' pattern

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
@@ -1,6 +1,11 @@
 import { TestBed } from '@angular/core/testing'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Injector, provideZonelessChangeDetection } from '@angular/core'
+import {
+  Component,
+  Injector,
+  provideZonelessChangeDetection,
+} from '@angular/core'
+import { render } from '@testing-library/angular'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   QueryClient,
@@ -30,19 +35,29 @@ describe('injectIsFetching', () => {
 
   it('should return the number of fetching queries', async () => {
     const key = queryKey()
-    const isFetching = TestBed.runInInjectionContext(() => {
-      injectQuery(() => ({
+
+    @Component({
+      template: `<div>fetching: {{ isFetching() }}</div>`,
+    })
+    class Page {
+      readonly query = injectQuery(() => ({
         queryKey: key,
         queryFn: () => sleep(100).then(() => 'Some data'),
       }))
-      return injectIsFetching()
-    })
+      readonly isFetching = injectIsFetching()
+    }
 
-    expect(isFetching()).toStrictEqual(0)
-    await vi.advanceTimersByTimeAsync(1)
-    expect(isFetching()).toStrictEqual(1)
-    await vi.advanceTimersByTimeAsync(100)
-    expect(isFetching()).toStrictEqual(0)
+    const rendered = await render(Page)
+
+    expect(rendered.getByText('fetching: 0')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(0)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('fetching: 1')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(101)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('fetching: 0')).toBeInTheDocument()
   })
 
   describe('injection context', () => {


### PR DESCRIPTION
## 🎯 Changes

Rewrites the main test in `inject-is-fetching.test.ts` to use a `@Component` + `@testing-library/angular`'s `render` instead of calling `TestBed.runInInjectionContext` and asserting on the signal value directly. The assertion now checks the rendered DOM text, which mirrors how a user actually observes `injectIsFetching` in an Angular component.

### Before

```ts
it('should return the number of fetching queries', async () => {
  const key = queryKey()
  const isFetching = TestBed.runInInjectionContext(() => {
    injectQuery(() => ({
      queryKey: key,
      queryFn: () => sleep(100).then(() => 'Some data'),
    }))
    return injectIsFetching()
  })

  expect(isFetching()).toStrictEqual(0)
  await vi.advanceTimersByTimeAsync(1)
  expect(isFetching()).toStrictEqual(1)
  await vi.advanceTimersByTimeAsync(100)
  expect(isFetching()).toStrictEqual(0)
})
```

### After

```ts
it('should return the number of fetching queries', async () => {
  const key = queryKey()

  @Component({
    template: `<div>fetching: {{ isFetching() }}</div>`,
  })
  class Page {
    readonly query = injectQuery(() => ({
      queryKey: key,
      queryFn: () => sleep(100).then(() => 'Some data'),
    }))
    readonly isFetching = injectIsFetching()
  }

  const rendered = await render(Page)

  expect(rendered.getByText('fetching: 0')).toBeInTheDocument()

  await vi.advanceTimersByTimeAsync(0)
  rendered.fixture.detectChanges()
  expect(rendered.getByText('fetching: 1')).toBeInTheDocument()

  await vi.advanceTimersByTimeAsync(101)
  rendered.fixture.detectChanges()
  expect(rendered.getByText('fetching: 0')).toBeInTheDocument()
})
```

### Why

- Matches the component-based usage shown in the official Angular guide (\`docs/framework/angular/guides/background-fetching-indicators.md\`) and across \`examples/angular/*\`.
- \`readonly\` fields on the test component follow the convention used in our Angular examples (\`readonly query = injectQuery(...)\`, \`readonly isFetching = injectIsFetching()\`).
- The \`injection context\` describe block (NG0203 throw / passing an injector) is kept as-is — those checks don't need a rendered component.

### Verification

- \`@tanstack/angular-query-experimental\` — 209 tests passed, 0 type errors

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).