### PR TITLE
test(angular-query-experimental/injectIsMutating): switch main test to '@Component' + 'render' pattern

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TestBed } from '@angular/core/testing'
-import { Injector, provideZonelessChangeDetection } from '@angular/core'
+import {
+  Component,
+  Injector,
+  provideZonelessChangeDetection,
+} from '@angular/core'
+import { render } from '@testing-library/angular'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   QueryClient,
@@ -30,25 +35,31 @@ describe('injectIsMutating', () => {
 
   it('should properly return isMutating state', async () => {
     const key = queryKey()
-    const [mutation, isMutating] = TestBed.runInInjectionContext(() => [
-      injectMutation(() => ({
+
+    @Component({
+      template: `<div>mutating: {{ isMutating() }}</div>`,
+    })
+    class Page {
+      readonly mutation = injectMutation(() => ({
         mutationKey: key,
         mutationFn: (params: { par1: string }) => sleep(10).then(() => params),
-      })),
-      injectIsMutating(),
-    ])
+      }))
+      readonly isMutating = injectIsMutating()
+    }
 
-    expect(isMutating()).toBe(0)
+    const rendered = await render(Page)
 
-    mutation.mutate({
-      par1: 'par1',
-    })
+    expect(rendered.getByText('mutating: 0')).toBeInTheDocument()
 
-    expect(isMutating()).toBe(0)
+    rendered.fixture.componentInstance.mutation.mutate({ par1: 'par1' })
+
     await vi.advanceTimersByTimeAsync(0)
-    expect(isMutating()).toBe(1)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('mutating: 1')).toBeInTheDocument()
+
     await vi.advanceTimersByTimeAsync(11)
-    expect(isMutating()).toBe(0)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('mutating: 0')).toBeInTheDocument()
   })
 
   describe('injection context', () => {


### PR DESCRIPTION
## 🎯 Changes

Rewrites the main test in `inject-is-mutating.test.ts` to use a `@Component` + `@testing-library/angular`'s `render` instead of calling `TestBed.runInInjectionContext` and asserting on the signal value directly. The assertion now checks the rendered DOM text, which mirrors how a user actually observes `injectIsMutating` in an Angular component.

Mirrors the approach taken for `injectIsFetching` in #10556.

### Before

```ts
it('should properly return isMutating state', async () => {
  const key = queryKey()
  const [mutation, isMutating] = TestBed.runInInjectionContext(() => [
    injectMutation(() => ({
      mutationKey: key,
      mutationFn: (params: { par1: string }) => sleep(10).then(() => params),
    })),
    injectIsMutating(),
  ])

  expect(isMutating()).toBe(0)

  mutation.mutate({ par1: 'par1' })

  expect(isMutating()).toBe(0)
  await vi.advanceTimersByTimeAsync(0)
  expect(isMutating()).toBe(1)
  await vi.advanceTimersByTimeAsync(11)
  expect(isMutating()).toBe(0)
})
```

### After

```ts
it('should properly return isMutating state', async () => {
  const key = queryKey()

  @Component({
    template: `<div>mutating: {{ isMutating() }}</div>`,
  })
  class Page {
    readonly mutation = injectMutation(() => ({
      mutationKey: key,
      mutationFn: (params: { par1: string }) => sleep(10).then(() => params),
    }))
    readonly isMutating = injectIsMutating()
  }

  const rendered = await render(Page)

  expect(rendered.getByText('mutating: 0')).toBeInTheDocument()

  rendered.fixture.componentInstance.mutation.mutate({ par1: 'par1' })

  await vi.advanceTimersByTimeAsync(0)
  rendered.fixture.detectChanges()
  expect(rendered.getByText('mutating: 1')).toBeInTheDocument()

  await vi.advanceTimersByTimeAsync(11)
  rendered.fixture.detectChanges()
  expect(rendered.getByText('mutating: 0')).toBeInTheDocument()
})
```

### Why

- Matches the component-based usage shown across `examples/angular/*` (`readonly mutation = injectMutation(...)` in `auto-refetching`, `optimistic-updates`, etc.).
- `readonly` fields on the test component follow the convention used in our Angular examples.
- The `injection context` describe block (NG0203 throw / passing an injector) is kept as-is — those checks don't need a rendered component.

### Verification

- `@tanstack/angular-query-experimental` — 209 tests passed, 0 type errors

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored mutation state tests to use component-level integration testing, verifying UI updates correctly reflect state changes during the mutation lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->