### PR TITLE
test(angular-query-experimental/injectInfiniteQuery): switch main test to '@Component' + 'render' pattern

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -1,9 +1,13 @@
 import { TestBed } from '@angular/core/testing'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Injector, provideZonelessChangeDetection } from '@angular/core'
+import {
+  Component,
+  Injector,
+  provideZonelessChangeDetection,
+} from '@angular/core'
+import { render } from '@testing-library/angular'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient, injectInfiniteQuery, provideTanStackQuery } from '..'
-import { expectSignals } from './test-utils'
 
 describe('injectInfiniteQuery', () => {
   let queryClient: QueryClient
@@ -25,42 +29,41 @@ describe('injectInfiniteQuery', () => {
 
   it('should properly execute infinite query', async () => {
     const key = queryKey()
-    const query = TestBed.runInInjectionContext(() => {
-      return injectInfiniteQuery(() => ({
+
+    @Component({
+      template: `
+        <div>status: {{ query.status() }}</div>
+        <div>pages: {{ query.data()?.pages?.join(', ') ?? 'none' }}</div>
+      `,
+    })
+    class Page {
+      readonly query = injectInfiniteQuery(() => ({
         queryKey: key,
         queryFn: ({ pageParam }) =>
           sleep(10).then(() => 'data on page ' + pageParam),
         initialPageParam: 0,
         getNextPageParam: () => 12,
       }))
-    })
+    }
 
-    expectSignals(query, {
-      data: undefined,
-      status: 'pending',
-    })
+    const rendered = await render(Page)
 
-    await vi.advanceTimersByTimeAsync(11)
-
-    expectSignals(query, {
-      data: {
-        pageParams: [0],
-        pages: ['data on page 0'],
-      },
-      status: 'success',
-    })
-
-    void query.fetchNextPage()
+    expect(rendered.getByText('status: pending')).toBeInTheDocument()
+    expect(rendered.getByText('pages: none')).toBeInTheDocument()
 
     await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('status: success')).toBeInTheDocument()
+    expect(rendered.getByText('pages: data on page 0')).toBeInTheDocument()
 
-    expectSignals(query, {
-      data: {
-        pageParams: [0, 12],
-        pages: ['data on page 0', 'data on page 12'],
-      },
-      status: 'success',
-    })
+    rendered.fixture.componentInstance.query.fetchNextPage()
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('status: success')).toBeInTheDocument()
+    expect(
+      rendered.getByText('pages: data on page 0, data on page 12'),
+    ).toBeInTheDocument()
   })
 
   describe('injection context', () => {


### PR DESCRIPTION
## 🎯 Changes

Rewrites the main test in `inject-infinite-query.test.ts` to use a `@Component` + `@testing-library/angular`'s `render` instead of calling `TestBed.runInInjectionContext` and asserting on the signal value via `expectSignals`. The assertion now checks the rendered DOM text, which mirrors how a user actually observes `injectInfiniteQuery` in an Angular component.

Mirrors the approach taken for `injectIsFetching` in #10556 and `injectIsMutating` in #10557.

### Before

```ts
it('should properly execute infinite query', async () => {
  const key = queryKey()
  const query = TestBed.runInInjectionContext(() => {
    return injectInfiniteQuery(() => ({
      queryKey: key,
      queryFn: ({ pageParam }) =>
        sleep(10).then(() => 'data on page ' + pageParam),
      initialPageParam: 0,
      getNextPageParam: () => 12,
    }))
  })

  expectSignals(query, {
    data: undefined,
    status: 'pending',
  })

  await vi.advanceTimersByTimeAsync(11)

  expectSignals(query, {
    data: { pageParams: [0], pages: ['data on page 0'] },
    status: 'success',
  })

  void query.fetchNextPage()

  await vi.advanceTimersByTimeAsync(11)

  expectSignals(query, {
    data: {
      pageParams: [0, 12],
      pages: ['data on page 0', 'data on page 12'],
    },
    status: 'success',
  })
})
```

### After

```ts
it('should properly execute infinite query', async () => {
  const key = queryKey()

  @Component({
    template: `
      <div>status: {{ query.status() }}</div>
      <div>pages: {{ query.data()?.pages?.join(', ') ?? 'none' }}</div>
    `,
  })
  class Page {
    readonly query = injectInfiniteQuery(() => ({
      queryKey: key,
      queryFn: ({ pageParam }) =>
        sleep(10).then(() => 'data on page ' + pageParam),
      initialPageParam: 0,
      getNextPageParam: () => 12,
    }))
  }

  const rendered = await render(Page)

  expect(rendered.getByText('status: pending')).toBeInTheDocument()
  expect(rendered.getByText('pages: none')).toBeInTheDocument()

  await vi.advanceTimersByTimeAsync(11)
  rendered.fixture.detectChanges()
  expect(rendered.getByText('status: success')).toBeInTheDocument()
  expect(rendered.getByText('pages: data on page 0')).toBeInTheDocument()

  rendered.fixture.componentInstance.query.fetchNextPage()

  await vi.advanceTimersByTimeAsync(11)
  rendered.fixture.detectChanges()
  expect(rendered.getByText('status: success')).toBeInTheDocument()
  expect(
    rendered.getByText('pages: data on page 0, data on page 12'),
  ).toBeInTheDocument()
})
```

### Why

- Matches the component-based usage shown across `examples/angular/*` (`readonly query = injectInfiniteQuery(...)`).
- `readonly` fields on the test component follow the convention used in our Angular examples.
- The `injection context` describe block (NG0203 throw / passing an injector) is kept as-is — those checks don't need a rendered component.

### Verification

- `@tanstack/angular-query-experimental` — 209 tests passed, 0 type errors

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for infinite query functionality with improved component rendering validation and comprehensive DOM output assertions to ensure robust verification of query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->