### PR TITLE
test(query-persist-client-core/createPersister): lowercase 'Should' to 'should' in 'it' descriptions for consistency

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -436,7 +436,7 @@ describe('createPersister', () => {
   })
 
   describe('persistQuery', () => {
-    it('Should properly persist basic query', async () => {
+    it('should properly persist basic query', async () => {
       const storage = getFreshStorage()
       const { persister, query, queryHash, queryKey, storageKey } =
         setupPersister(['foo'], {
@@ -458,7 +458,7 @@ describe('createPersister', () => {
       })
     })
 
-    it('Should skip persistence if storage is not provided', async () => {
+    it('should skip persistence if storage is not provided', async () => {
       const serializeMock = vi.fn()
       const { persister, query } = setupPersister(['foo'], {
         storage: null,
@@ -473,7 +473,7 @@ describe('createPersister', () => {
   })
 
   describe('persistQueryByKey', () => {
-    it('Should skip persistence if storage is not provided', async () => {
+    it('should skip persistence if storage is not provided', async () => {
       const serializeMock = vi.fn()
       const { persister, client, queryKey } = setupPersister(['foo'], {
         storage: null,
@@ -500,7 +500,7 @@ describe('createPersister', () => {
       expect(serializeMock).toHaveBeenCalledTimes(0)
     })
 
-    it('Should properly persist basic query', async () => {
+    it('should properly persist basic query', async () => {
       const storage = getFreshStorage()
       const { persister, client, queryHash, queryKey, storageKey } =
         setupPersister(['foo'], {


### PR DESCRIPTION
## 🎯 Changes

Lowercase `Should` to `should` in `it` descriptions in `createPersister.test.ts` for consistency with the rest of the test suite.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test naming conventions for improved consistency across persistence-related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->