### PR TITLE
test(angular-query-experimental/injectQueries): switch 'isRestoring' test to '@Component' + 'render' pattern

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -147,32 +147,48 @@ describe('injectQueries', () => {
         providers: [provideIsRestoring(signal(true).asReadonly())],
       })
 
-      const queries = TestBed.runInInjectionContext(() =>
-        injectQueries(() => ({
+      @Component({
+        template: `
+          <div>
+            status1: {{ queries()[0].status() }}, fetchStatus1:
+            {{ queries()[0].fetchStatus() }}
+          </div>
+          <div>
+            status2: {{ queries()[1].status() }}, fetchStatus2:
+            {{ queries()[1].fetchStatus() }}
+          </div>
+        `,
+      })
+      class Page {
+        queries = injectQueries(() => ({
           queries: [
             { queryKey: key1, queryFn: queryFn1 },
             { queryKey: key2, queryFn: queryFn2 },
           ],
-        })),
-      )
+        }))
+      }
+
+      const rendered = await render(Page)
 
       await vi.advanceTimersByTimeAsync(0)
-      expect(queries()[0].status()).toBe('pending')
-      expect(queries()[0].fetchStatus()).toBe('idle')
-      expect(queries()[0].data()).toBeUndefined()
-      expect(queries()[1].status()).toBe('pending')
-      expect(queries()[1].fetchStatus()).toBe('idle')
-      expect(queries()[1].data()).toBeUndefined()
+      rendered.fixture.detectChanges()
+      expect(
+        rendered.getByText('status1: pending, fetchStatus1: idle'),
+      ).toBeInTheDocument()
+      expect(
+        rendered.getByText('status2: pending, fetchStatus2: idle'),
+      ).toBeInTheDocument()
       expect(queryFn1).toHaveBeenCalledTimes(0)
       expect(queryFn2).toHaveBeenCalledTimes(0)
 
       await vi.advanceTimersByTimeAsync(11)
-      expect(queries()[0].status()).toBe('pending')
-      expect(queries()[0].fetchStatus()).toBe('idle')
-      expect(queries()[0].data()).toBeUndefined()
-      expect(queries()[1].status()).toBe('pending')
-      expect(queries()[1].fetchStatus()).toBe('idle')
-      expect(queries()[1].data()).toBeUndefined()
+      rendered.fixture.detectChanges()
+      expect(
+        rendered.getByText('status1: pending, fetchStatus1: idle'),
+      ).toBeInTheDocument()
+      expect(
+        rendered.getByText('status2: pending, fetchStatus2: idle'),
+      ).toBeInTheDocument()
       expect(queryFn1).toHaveBeenCalledTimes(0)
       expect(queryFn2).toHaveBeenCalledTimes(0)
     })


### PR DESCRIPTION
## 🎯 Changes

Align the `isRestoring` test in `injectQueries` with the rest of the suite by using a `@Component` + `@testing-library/angular` `render()` setup instead of `TestBed.runInInjectionContext`. This verifies behavior through a real component/template rather than a synthetic injection context.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for query restoration state validation by refactoring how test assertions are performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->