### PR TITLE
test(angular-query-experimental/injectQueries): add 'readonly' modifier to component fields for consistency with other render-pattern tests

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -45,7 +45,7 @@ describe('injectQueries', () => {
       `,
     })
     class Page {
-      result = injectQueries(() => ({
+      readonly result = injectQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -91,7 +91,7 @@ describe('injectQueries', () => {
       `,
     })
     class Page {
-      combined = injectQueries(() => ({
+      readonly combined = injectQueries(() => ({
         queries: [
           {
             queryKey: key1,
@@ -160,7 +160,7 @@ describe('injectQueries', () => {
         `,
       })
       class Page {
-        queries = injectQueries(() => ({
+        readonly queries = injectQueries(() => ({
           queries: [
             { queryKey: key1, queryFn: queryFn1 },
             { queryKey: key2, queryFn: queryFn2 },


### PR DESCRIPTION
## 🎯 Changes

Add `readonly` modifier to `injectQueries(...)` component fields so the file matches the convention used in the other render-pattern tests (e.g. `injectIsFetching`, `injectIsMutating`, `injectInfiniteQuery`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Internal test improvements to enforce immutability on test components.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->