### PR TITLE
test(angular-query-experimental/injectQuery): switch 'success' and 'reject' tests to '@Component' + 'render' pattern

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -353,9 +353,7 @@ describe('injectQuery', () => {
     expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
     expect(rendered.getByText('isError: true')).toBeInTheDocument()
     expect(rendered.getByText('failureCount: 1')).toBeInTheDocument()
-    expect(
-      rendered.getByText('failureReason: Some error'),
-    ).toBeInTheDocument()
+    expect(rendered.getByText('failureReason: Some error')).toBeInTheDocument()
   })
 
   it('should update query on options contained signal change', async () => {

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -23,6 +23,7 @@ import {
   it,
   vi,
 } from 'vitest'
+import { render } from '@testing-library/angular'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { lastValueFrom } from 'rxjs'
 import {
@@ -285,42 +286,76 @@ describe('injectQuery', () => {
 
   it('should resolve to success and update signal: injectQuery()', async () => {
     const key = queryKey()
-    const query = TestBed.runInInjectionContext(() => {
-      return injectQuery(() => ({
+
+    @Component({
+      template: `
+        <div>status: {{ query.status() }}</div>
+        <div>data: {{ query.data() ?? 'none' }}</div>
+        <div>isPending: {{ query.isPending() }}</div>
+        <div>isFetching: {{ query.isFetching() }}</div>
+        <div>isFetched: {{ query.isFetched() }}</div>
+        <div>isSuccess: {{ query.isSuccess() }}</div>
+      `,
+    })
+    class Page {
+      readonly query = injectQuery(() => ({
         queryKey: key,
         queryFn: () => sleep(10).then(() => 'result2'),
       }))
-    })
+    }
+
+    const rendered = await render(Page)
 
     await vi.advanceTimersByTimeAsync(11)
-    expect(query.status()).toBe('success')
-    expect(query.data()).toBe('result2')
-    expect(query.isPending()).toBe(false)
-    expect(query.isFetching()).toBe(false)
-    expect(query.isFetched()).toBe(true)
-    expect(query.isSuccess()).toBe(true)
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('status: success')).toBeInTheDocument()
+    expect(rendered.getByText('data: result2')).toBeInTheDocument()
+    expect(rendered.getByText('isPending: false')).toBeInTheDocument()
+    expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
+    expect(rendered.getByText('isFetched: true')).toBeInTheDocument()
+    expect(rendered.getByText('isSuccess: true')).toBeInTheDocument()
   })
 
   it('should reject and update signal', async () => {
     const key = queryKey()
-    const query = TestBed.runInInjectionContext(() => {
-      return injectQuery(() => ({
+
+    @Component({
+      template: `
+        <div>status: {{ query.status() }}</div>
+        <div>data: {{ query.data() ?? 'none' }}</div>
+        <div>error: {{ query.error()?.message ?? 'none' }}</div>
+        <div>isPending: {{ query.isPending() }}</div>
+        <div>isFetching: {{ query.isFetching() }}</div>
+        <div>isError: {{ query.isError() }}</div>
+        <div>failureCount: {{ query.failureCount() }}</div>
+        <div>failureReason: {{ query.failureReason()?.message ?? 'none' }}</div>
+      `,
+    })
+    class Page {
+      readonly query = injectQuery(() => ({
         retry: false,
         queryKey: key,
         queryFn: () =>
           sleep(10).then(() => Promise.reject(new Error('Some error'))),
       }))
-    })
+    }
+
+    const rendered = await render(Page)
 
     await vi.advanceTimersByTimeAsync(11)
-    expect(query.status()).toBe('error')
-    expect(query.data()).toBe(undefined)
-    expect(query.error()).toMatchObject({ message: 'Some error' })
-    expect(query.isPending()).toBe(false)
-    expect(query.isFetching()).toBe(false)
-    expect(query.isError()).toBe(true)
-    expect(query.failureCount()).toBe(1)
-    expect(query.failureReason()).toMatchObject({ message: 'Some error' })
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('status: error')).toBeInTheDocument()
+    expect(rendered.getByText('data: none')).toBeInTheDocument()
+    expect(rendered.getByText('error: Some error')).toBeInTheDocument()
+    expect(rendered.getByText('isPending: false')).toBeInTheDocument()
+    expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
+    expect(rendered.getByText('isError: true')).toBeInTheDocument()
+    expect(rendered.getByText('failureCount: 1')).toBeInTheDocument()
+    expect(
+      rendered.getByText('failureReason: Some error'),
+    ).toBeInTheDocument()
   })
 
   it('should update query on options contained signal change', async () => {


### PR DESCRIPTION
## 🎯 Changes

Switch `should resolve to success and update signal: injectQuery()` and `should reject and update signal` in `injectQuery` to the `@Component` + `@testing-library/angular` `render()` pattern, matching recent conversions in other `inject-*` tests. All signal flags previously checked directly (status/data/error/isPending/isFetching/isFetched/isSuccess/isError/failureCount/failureReason) are preserved by rendering them into the template and asserting via `getByText`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the query functionality with improved signal state validation using component-based testing approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->