### PR TITLE
ref(core): remove leftover setStateOptions

### DIFF
--- a/.changeset/wet-lands-wait.md
+++ b/.changeset/wet-lands-wait.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+ref(core): remove leftover setStateOptions

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -137,7 +137,6 @@ interface ContinueAction {
 interface SetStateAction<TData, TError> {
   type: 'setState'
   state: Partial<QueryState<TData, TError>>
-  setStateOptions?: SetStateOptions
 }
 
 export type Action<TData, TError> =
@@ -149,10 +148,6 @@ export type Action<TData, TError> =
   | PauseAction
   | SetStateAction<TData, TError>
   | SuccessAction<TData>
-
-export interface SetStateOptions {
-  meta?: any
-}
 
 // CLASS
 
@@ -241,11 +236,8 @@ export class Query<
     return data
   }
 
-  setState(
-    state: Partial<QueryState<TData, TError>>,
-    setStateOptions?: SetStateOptions,
-  ): void {
-    this.#dispatch({ type: 'setState', state, setStateOptions })
+  setState(state: Partial<QueryState<TData, TError>>): void {
+    this.#dispatch({ type: 'setState', state })
   }
 
   cancel(options?: CancelOptions): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the state setter method by removing an unused optional parameter, streamlining the API for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->