### PR TITLE
fix(svelte-query): wrap TData in NoInfer on query return types (#7673)

### DIFF
--- a/.changeset/svelte-query-no-infer-tdata.md
+++ b/.changeset/svelte-query-no-infer-tdata.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/svelte-query': patch
+---
+
+fix(svelte-query): wrap `TData` in `NoInfer` on `createQuery` and `createInfiniteQuery` return types so `TData` is inferred from the input options only (matching `react-query`, `preact-query`, and `vue-query`). Prevents the result-type annotation from silently widening `TData` and improves `select` inference (#7673).

--- a/packages/svelte-query/src/createInfiniteQuery.ts
+++ b/packages/svelte-query/src/createInfiniteQuery.ts
@@ -3,6 +3,7 @@ import { createBaseQuery } from './createBaseQuery.svelte.js'
 import type {
   DefaultError,
   InfiniteData,
+  NoInfer,
   QueryClient,
   QueryKey,
   QueryObserver,
@@ -30,7 +31,7 @@ export function createInfiniteQuery<
     >
   >,
   queryClient?: Accessor<QueryClient>,
-): CreateInfiniteQueryResult<TData, TError> {
+): CreateInfiniteQueryResult<NoInfer<TData>, TError> {
   return createBaseQuery(
     options,
     InfiniteQueryObserver as typeof QueryObserver,

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -1,6 +1,11 @@
 import { QueryObserver } from '@tanstack/query-core'
 import { createBaseQuery } from './createBaseQuery.svelte.js'
-import type { DefaultError, QueryClient, QueryKey } from '@tanstack/query-core'
+import type {
+  DefaultError,
+  NoInfer,
+  QueryClient,
+  QueryKey,
+} from '@tanstack/query-core'
 import type {
   Accessor,
   CreateQueryOptions,
@@ -22,7 +27,7 @@ export function createQuery<
     UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
   >,
   queryClient?: Accessor<QueryClient>,
-): CreateQueryResult<TData, TError>
+): CreateQueryResult<NoInfer<TData>, TError>
 
 export function createQuery<
   TQueryFnData = unknown,
@@ -34,7 +39,7 @@ export function createQuery<
     DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
   >,
   queryClient?: Accessor<QueryClient>,
-): DefinedCreateQueryResult<TData, TError>
+): DefinedCreateQueryResult<NoInfer<TData>, TError>
 
 export function createQuery<
   TQueryFnData,
@@ -44,7 +49,7 @@ export function createQuery<
 >(
   options: Accessor<CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>>,
   queryClient?: Accessor<QueryClient>,
-): CreateQueryResult<TData, TError>
+): CreateQueryResult<NoInfer<TData>, TError>
 
 export function createQuery(
   options: Accessor<CreateQueryOptions>,

--- a/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
@@ -1,8 +1,47 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import { createQuery, queryOptions } from '../../src/index.js'
+import type { CreateQueryResult } from '../../src/index.js'
 
 describe('createQuery', () => {
+  describe('select', () => {
+    it('should infer select data type from queryFn return (issue #7673)', () => {
+      const key = queryKey()
+      const { data } = createQuery(() => ({
+        queryKey: key,
+        queryFn: () => Promise.resolve({ a: { b: { c: 'hello' } } }),
+        select: (input) => input.a.b.c,
+      }))
+
+      expectTypeOf(data).toEqualTypeOf<string | undefined>()
+    })
+
+    it('should infer select data type when options come from queryOptions', () => {
+      const key = queryKey()
+      const options = queryOptions({
+        queryKey: key,
+        queryFn: () => Promise.resolve(1),
+      })
+      const { data } = createQuery(() => ({
+        ...options,
+        select: (input) => input > 1,
+      }))
+
+      expectTypeOf(data).toEqualTypeOf<boolean | undefined>()
+    })
+
+    // eslint-disable-next-line vitest/expect-expect
+    it('TData should depend on arguments only, not on the result type annotation', () => {
+      // @ts-expect-error TData inferred from queryFn ({ wow: boolean }), not from result
+      const result: CreateQueryResult<{ wow: string }> = createQuery(() => ({
+        queryKey: queryKey(),
+        queryFn: () => ({ wow: true }),
+      }))
+
+      void result
+    })
+  })
+
   describe('initialData', () => {
     describe('Config object overload', () => {
       it('TData should always be defined when initialData is provided as an object', () => {


### PR DESCRIPTION
## Summary

Fixes #7673.

The original report showed `select`'s `data` parameter typed as `any` when wrapping options in a Svelte 4 `derived` store. The Svelte 5 rewrite removed that store-based API and the basic inline case now infers `select` correctly, but `createQuery` / `createInfiniteQuery` were still missing the `NoInfer<TData>` wrapper that `react-query`, `preact-query`, and `vue-query` all use on their return types.

This PR aligns svelte-query with the rest of the ecosystem so:

- `TData` is inferred from the input options only, never widened by a result-type annotation at the call site.
- `select` inference is locked in instead of being silently overridden by contextual typing.

## Files changed

| File | Change |
|------|--------|
| `packages/svelte-query/src/createQuery.ts` | Wrap `TData` in `NoInfer` on all 3 overload return types |
| `packages/svelte-query/src/createInfiniteQuery.ts` | Same wrapper on the single return type |
| `packages/svelte-query/tests/createQuery/createQuery.test-d.ts` | 3 new type tests under a `select` describe block |
| `.changeset/svelte-query-no-infer-tdata.md` | Patch changeset for `@tanstack/svelte-query` |

## Verification

- [x] `pnpm exec nx run @tanstack/svelte-query:test:types` — 0 errors across all TS versions
- [x] `pnpm exec nx run @tanstack/svelte-query:test:lib` — all unit tests pass, coverage unchanged
- [x] `pnpm exec nx run @tanstack/svelte-query:test:eslint` — clean
- [x] `pnpm exec nx run @tanstack/query-core:test:types` — no downstream regression
- [x] New negative test: removing `NoInfer` causes the `@ts-expect-error` directive to become unused (test fails) — confirmed manually
- [x] Pre-existing svelte-query type tests untouched

Generated by Ora Studio
Vibe coded by ousamabenyounes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for queries using select functions so returned data types are inferred more accurately and consistently.

* **Tests**
  * Added TypeScript compile-time tests to validate correct data-type inference for various select/use scenarios.

* **Chores**
  * Added a release entry documenting the patch-level type-inference improvement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
