### PR TITLE
test(angular-query-experimental/injectInfiniteQuery): add test for error state when 'queryFn' rejects

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -66,6 +66,44 @@ describe('injectInfiniteQuery', () => {
     ).toBeInTheDocument()
   })
 
+  it('should reject and update signal', async () => {
+    const key = queryKey()
+
+    @Component({
+      template: `
+        <div>status: {{ query.status() }}</div>
+        <div>pages: {{ query.data()?.pages?.join(', ') ?? 'none' }}</div>
+        <div>error: {{ query.error()?.message ?? 'none' }}</div>
+        <div>isError: {{ query.isError() }}</div>
+        <div>failureCount: {{ query.failureCount() }}</div>
+      `,
+    })
+    class Page {
+      readonly query = injectInfiniteQuery(() => ({
+        retry: false,
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+        initialPageParam: 0,
+        getNextPageParam: () => 12,
+      }))
+    }
+
+    const rendered = await render(Page)
+
+    expect(rendered.getByText('status: pending')).toBeInTheDocument()
+    expect(rendered.getByText('pages: none')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('status: error')).toBeInTheDocument()
+    expect(rendered.getByText('pages: none')).toBeInTheDocument()
+    expect(rendered.getByText('error: Some error')).toBeInTheDocument()
+    expect(rendered.getByText('isError: true')).toBeInTheDocument()
+    expect(rendered.getByText('failureCount: 1')).toBeInTheDocument()
+  })
+
   describe('injection context', () => {
     it('should throw NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test for the error path of `injectInfiniteQuery`: when `queryFn` rejects (and `retry: false`), the test asserts the resulting `status`, `error.message`, `data`, `isError`, and `failureCount` signals. The success path was already covered by `should properly execute infinite query`; this brings parity with the `injectQuery` test file (which has both `success` and `reject` cases) and locks the contract for `failureCount` / error signal updates against silent regressions.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling in infinite queries, verifying proper error state management when query execution fails with retry disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->