### PR TITLE
test(angular-query-experimental/injectQuery): add test for 'select' option transforming 'queryFn' data

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -356,6 +356,30 @@ describe('injectQuery', () => {
     expect(rendered.getByText('failureReason: Some error')).toBeInTheDocument()
   })
 
+  it('should be able to select a part of the data with select', async () => {
+    const key = queryKey()
+
+    @Component({
+      template: `<div>data: {{ query.data() ?? 'none' }}</div>`,
+    })
+    class Page {
+      readonly query = injectQuery<{ name: string }, Error, string>(() => ({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => ({ name: 'test' })),
+        select: (data) => data.name,
+      }))
+    }
+
+    const rendered = await render(Page)
+
+    expect(rendered.getByText('data: none')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('data: test')).toBeInTheDocument()
+  })
+
   it('should update query on options contained signal change', async () => {
     const key1 = queryKey()
     const key2 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test for the `select` option of `injectQuery` that verifies `queryFn` data is transformed before being exposed via the `data()` signal. Aligns with the existing react-query coverage for `select` and locks the contract that `select` runs after `queryFn` resolves.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the `select` option in `injectQuery` to verify proper data transformation during query execution and change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->