### PR TITLE
test(angular-query-experimental/injectQuery): add test for 'placeholderData' lifecycle

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -380,6 +380,38 @@ describe('injectQuery', () => {
     expect(rendered.getByText('data: test')).toBeInTheDocument()
   })
 
+  it('should show placeholderData until queryFn resolves and then expose real data', async () => {
+    const key = queryKey()
+
+    @Component({
+      template: `
+        <div>data: {{ query.data() }}</div>
+        <div>isPlaceholderData: {{ query.isPlaceholderData() }}</div>
+        <div>isSuccess: {{ query.isSuccess() }}</div>
+      `,
+    })
+    class Page {
+      readonly query = injectQuery(() => ({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'real-data'),
+        placeholderData: 'placeholder',
+      }))
+    }
+
+    const rendered = await render(Page)
+
+    expect(rendered.getByText('data: placeholder')).toBeInTheDocument()
+    expect(rendered.getByText('isPlaceholderData: true')).toBeInTheDocument()
+    expect(rendered.getByText('isSuccess: true')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('data: real-data')).toBeInTheDocument()
+    expect(rendered.getByText('isPlaceholderData: false')).toBeInTheDocument()
+    expect(rendered.getByText('isSuccess: true')).toBeInTheDocument()
+  })
+
   it('should update query on options contained signal change', async () => {
     const key1 = queryKey()
     const key2 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test for `injectQuery`'s `placeholderData` option that verifies:

- Before `queryFn` resolves: `data()` returns the placeholder, `isSuccess: true`, `isPlaceholderData: true`.
- After `queryFn` resolves: `data()` is replaced by the real data, `isSuccess: true`, `isPlaceholderData: false`.

This locks the `placeholderData` lifecycle and the `isPlaceholderData` signal contract against silent regressions.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for placeholder data behavior in query operations to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->