### PR TITLE
test(angular-query-experimental/injectQuery): remove duplicate error test already covered by 'should reject and update signal'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -604,24 +604,6 @@ describe('injectQuery', () => {
     })
   })
 
-  it('should set state to error when queryFn returns reject promise', async () => {
-    const key = queryKey()
-    const query = TestBed.runInInjectionContext(() => {
-      return injectQuery(() => ({
-        retry: false,
-        queryKey: key,
-        queryFn: () =>
-          sleep(10).then(() => Promise.reject(new Error('Some error'))),
-      }))
-    })
-
-    expect(query.status()).toBe('pending')
-
-    await vi.advanceTimersByTimeAsync(11)
-
-    expect(query.status()).toBe('error')
-  })
-
   it('should render with required signal inputs', async () => {
     @Component({
       selector: 'app-fake',


### PR DESCRIPTION
## 🎯 Changes

Remove `should set state to error when queryFn returns reject promise` from `injectQuery` tests. Its scenario (`retry: false` + a `queryFn` that rejects → `status: 'error'`) is already fully covered by `should reject and update signal`, which uses the same setup and additionally asserts `data`, `error`, `isPending`, `isFetching`, `isError`, `failureCount`, and `failureReason`. The only piece the deleted test still exercised was the initial `status: 'pending'` check, and that is already covered by `should return pending status initially`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a test case for query rejection behavior validation.

*Note: This change is a test infrastructure update with no impact on user-facing functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->