### PR TITLE
test(angular-query-experimental/injectMutation): add test for 'mutateAsync' resolving with 'mutationFn' return value

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -518,6 +518,21 @@ describe('injectMutation', () => {
     await expect(() => mutateAsync()).rejects.toThrow(err)
   })
 
+  it('should resolve mutateAsync with the value returned from mutationFn', async () => {
+    const key = queryKey()
+    const { mutateAsync } = TestBed.runInInjectionContext(() => {
+      return injectMutation(() => ({
+        mutationKey: key,
+        mutationFn: (params: string) => sleep(10).then(() => params),
+      }))
+    })
+
+    const promise = mutateAsync('Mock data')
+    await vi.advanceTimersByTimeAsync(11)
+
+    await expect(promise).resolves.toBe('Mock data')
+  })
+
   describe('injection context', () => {
     it('should throw NG0203 with descriptive error outside injection context', () => {
       const key = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test that asserts `mutateAsync` resolves with the value returned by `mutationFn`. The existing `mutateAsync` coverage in this file only verified the rejection paths (`throwOnError: true` and `throwOnError: () => true`); this completes the API by also locking down the resolve path.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for mutation promise resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->