### PR TITLE
test(angular-query-experimental/injectIsFetching): add filter test by 'queryKey'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-fetching.test.ts
@@ -60,6 +60,36 @@ describe('injectIsFetching', () => {
     expect(rendered.getByText('fetching: 0')).toBeInTheDocument()
   })
 
+  it('should be able to filter by queryKey', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    @Component({
+      template: `<div>fetching: {{ isFetching() }}</div>`,
+    })
+    class Page {
+      readonly query1 = injectQuery(() => ({
+        queryKey: key1,
+        queryFn: () => sleep(10).then(() => 'test1'),
+      }))
+      readonly query2 = injectQuery(() => ({
+        queryKey: key2,
+        queryFn: () => sleep(100).then(() => 'test2'),
+      }))
+      readonly isFetching = injectIsFetching({ queryKey: key1 })
+    }
+
+    const rendered = await render(Page)
+
+    await vi.advanceTimersByTimeAsync(0)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('fetching: 1')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('fetching: 0')).toBeInTheDocument()
+  })
+
   describe('injection context', () => {
     it('should throw NG0203 with descriptive error outside injection context', () => {
       expect(() => {


### PR DESCRIPTION
## 🎯 Changes

Add a test that asserts `injectIsFetching({ queryKey })` only counts queries matching the given key, not all in-flight queries. The existing test only covered the unfiltered count; this completes the API by also locking down the filter path.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying `injectIsFetching` filtering functionality by `queryKey`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->