### PR TITLE
test(angular-query-experimental/injectIsMutating): add filter test by 'mutationKey'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-mutating.test.ts
@@ -62,6 +62,39 @@ describe('injectIsMutating', () => {
     expect(rendered.getByText('mutating: 0')).toBeInTheDocument()
   })
 
+  it('should be able to filter by mutationKey', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    @Component({
+      template: `<div>mutating: {{ isMutating() }}</div>`,
+    })
+    class Page {
+      readonly mutation1 = injectMutation(() => ({
+        mutationKey: key1,
+        mutationFn: () => sleep(10).then(() => 'data1'),
+      }))
+      readonly mutation2 = injectMutation(() => ({
+        mutationKey: key2,
+        mutationFn: () => sleep(100).then(() => 'data2'),
+      }))
+      readonly isMutating = injectIsMutating({ mutationKey: key1 })
+    }
+
+    const rendered = await render(Page)
+
+    rendered.fixture.componentInstance.mutation1.mutate()
+    rendered.fixture.componentInstance.mutation2.mutate()
+
+    await vi.advanceTimersByTimeAsync(0)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('mutating: 1')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('mutating: 0')).toBeInTheDocument()
+  })
+
   describe('injection context', () => {
     it('should throw NG0203 with descriptive error outside injection context', () => {
       expect(() => {


### PR DESCRIPTION
## 🎯 Changes

Add a test that asserts `injectIsMutating({ mutationKey })` only counts mutations matching the given key, not all in-flight mutations. The existing test only covered the unfiltered count; this completes the API by also locking down the filter path.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for mutation key filtering in asynchronous operations, ensuring concurrent operations with distinct identifiers are properly tracked and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->