### PR TITLE
test(angular-query-experimental/injectIsRestoring): add test for reactively reflecting changes to the provided signal

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
@@ -43,6 +43,26 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(true)
   })
 
+  it('should reactively reflect changes to the provided signal', () => {
+    const restoringSignal = signal(true)
+
+    TestBed.configureTestingModule({
+      providers: [provideIsRestoring(restoringSignal.asReadonly())],
+    })
+
+    const isRestoring = TestBed.runInInjectionContext(() => {
+      return injectIsRestoring()
+    })
+
+    expect(isRestoring()).toBe(true)
+
+    restoringSignal.set(false)
+    expect(isRestoring()).toBe(false)
+
+    restoringSignal.set(true)
+    expect(isRestoring()).toBe(true)
+  })
+
   it('should be usable outside injection context when passing an injector', () => {
     const isRestoring = injectIsRestoring({
       injector: TestBed.inject(Injector),


### PR DESCRIPTION
## 🎯 Changes

Add a test that asserts `injectIsRestoring()` reactively reflects subsequent changes to the signal passed via `provideIsRestoring`, not only its initial value. The existing `should return the provided signal value` test only checks the value at the moment of injection.

This locks down the live-proxy contract used by `withPersistQueryClient` (angular-query-persist-client), which creates an `isRestoring = signal(true)`, registers it via `provideIsRestoring`, and later flips it to `false` once `persistQueryClientRestore` settles. Apps that read `injectIsRestoring()` rely on that flip propagating through.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage to verify that signal-based configuration for the restoring injection properly reflects reactive updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->