### PR TITLE
test(angular-query-experimental/injectQueries): add test for error state when one of the queries rejects

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -136,6 +136,50 @@ describe('injectQueries', () => {
     expect(results.length).toBeGreaterThanOrEqual(2)
   })
 
+  it('should reflect error state when one of the queries rejects', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    @Component({
+      template: `
+        <div>
+          status1: {{ result()[0].status() }}, error1:
+          {{ result()[0].error()?.message ?? 'none' }}
+        </div>
+        <div>
+          status2: {{ result()[1].status() }}, data2:
+          {{ result()[1].data() ?? 'none' }}
+        </div>
+      `,
+    })
+    class Page {
+      readonly result = injectQueries(() => ({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () =>
+              sleep(10).then(() => Promise.reject(new Error('Some error'))),
+            retry: false,
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(10).then(() => 2),
+          },
+        ],
+      }))
+    }
+
+    const rendered = await render(Page)
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+
+    expect(
+      rendered.getByText('status1: error, error1: Some error'),
+    ).toBeInTheDocument()
+    expect(rendered.getByText('status2: success, data2: 2')).toBeInTheDocument()
+  })
+
   describe('isRestoring', () => {
     it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
       const key1 = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Add a test that asserts `injectQueries` reflects per-query state independently when one of the queries rejects: the rejecting query exposes `status: 'error'` with the thrown error message, while the sibling query still resolves to `status: 'success'` with its data. The existing tests only covered the all-success path and the `combine` option, leaving the error path uncovered.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for error propagation and status reporting in query operations, validating that failed queries correctly display error states while successful queries continue to function as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->