### PR TITLE
fix(solid-query): skip reconcile when data reference is unchanged

### DIFF
--- a/.changeset/solid-query-reconcile-dedup.md
+++ b/.changeset/solid-query-reconcile-dedup.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Skip `reconcile` invocations when the incoming `result.data` reference is identical to the current store data. Previously `reconcile` (and any user-provided callback) could be called multiple times per query update for fetching state transitions where the data reference had not changed. Fixes #8873.

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -4705,6 +4705,62 @@ describe('useQuery', () => {
     expect(states).toHaveLength(1)
   })
 
+  it('should not call user-provided reconcile function when result.data reference is unchanged (#8873)', async () => {
+    const key = queryKey()
+    const reconcileSpy = vi.fn(
+      (oldData: Array<number> | undefined, newData: Array<number>) => {
+        return reconcile(newData)(oldData)
+      },
+    )
+
+    let count = 0
+    function Page() {
+      const state = useQuery(() => ({
+        queryKey: key,
+        queryFn: async () => {
+          await sleep(10)
+          count++
+          return [count]
+        },
+        reconcile: reconcileSpy,
+      }))
+
+      const { refetch } = state
+
+      return (
+        <div>
+          <button onClick={() => refetch()}>refetch</button>
+          <h2>Data: {JSON.stringify(state.data)}</h2>
+        </div>
+      )
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('Data: [1]')).toBeInTheDocument()
+    const callsAfterFirstFetch = reconcileSpy.mock.calls.length
+    expect(callsAfterFirstFetch).toBe(1)
+
+    fireEvent.click(rendered.getByRole('button', { name: /refetch/i }))
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('Data: [2]')).toBeInTheDocument()
+
+    // After a refetch we expect at most one *additional* reconcile call
+    // (one per actual data change). Without dedup, oldData === newData
+    // calls leak through and inflate the count.
+    expect(reconcileSpy.mock.calls.length - callsAfterFirstFetch).toBe(1)
+    // Sanity: reconcile should never be called with oldData === newData
+    for (const call of reconcileSpy.mock.calls) {
+      const [oldData, newData] = call
+      expect(oldData).not.toBe(newData)
+    }
+  })
+
   it('should cancel the query function when there are no more subscriptions', async () => {
     const key = queryKey()
     let cancelFn: Mock = vi.fn()

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -34,6 +34,12 @@ function reconcileFn<TData, TError>(
   queryHash?: string,
 ): QueryObserverResult<TData, TError> {
   if (reconcileOption === false) return result
+  // When the incoming data is the same reference as what is already in the
+  // store there is nothing to reconcile. Skip both user-provided reconcile
+  // callbacks and the structural reconcile to avoid invoking them multiple
+  // times per logical query update (e.g. for fetching=true/false transitions
+  // where the data reference is unchanged). See #8873.
+  if (store.data === result.data) return result
   if (typeof reconcileOption === 'function') {
     const newData = reconcileOption(store.data, result.data as TData)
     return { ...result, data: newData } as typeof result


### PR DESCRIPTION
## Summary

In `useBaseQuery`, the reconcile path could fire multiple times per logical query update — once for fetching state transitions where `result.data` was the same reference as the current store data, and again when the actual data resolved. With a user-provided `reconcile` callback, this surfaced as `oldData === newData` invocations and 2-4 reconcile calls per request.

This change short-circuits `reconcileFn` when `store.data === result.data`. The rest of the result still flows through `setState` so `isFetching` / `status` keep updating reactively.

Closes #8873

## Test plan

- [x] Added failing test that reproduces the bug — `useQuery.test.tsx > should not call user-provided reconcile function when result.data reference is unchanged (#8873)`
- [x] Test passes after fix
- [x] `pnpm exec nx run @tanstack/solid-query:test:lib` — 310 passed
- [x] `pnpm exec nx run @tanstack/solid-query:test:types` — passed
- [x] `pnpm exec nx run @tanstack/solid-query:test:eslint` — passed
- [x] Changeset added

Generated by Ora Studio / Vibe coded by ousamabenyounes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid redundant reconciliation and skip user-provided reconcile callbacks when an update preserves the same data reference, reducing unnecessary work and duplicate callbacks.

* **Tests**
  * Added a test ensuring reconcile callbacks run only when the data reference actually changes during refetches.

* **Chores**
  * Added a release note entry documenting this behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10598)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
_Generated by Ora Studio (with Claude Code)_
_Vibe coded by Ben Younes Ousama_
