### PR TITLE
test(angular-query-experimental/injectIsRestoring): add test for resolving 'provideIsRestoring' value with 'injector' option

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-is-restoring.test.ts
@@ -71,6 +71,20 @@ describe('injectIsRestoring', () => {
     expect(isRestoring()).toBe(false)
   })
 
+  it('should return the provided signal value when using injector option', () => {
+    const restoringSignal = signal(true)
+
+    TestBed.configureTestingModule({
+      providers: [provideIsRestoring(restoringSignal.asReadonly())],
+    })
+
+    const isRestoring = injectIsRestoring({
+      injector: TestBed.inject(Injector),
+    })
+
+    expect(isRestoring()).toBe(true)
+  })
+
   it('should throw NG0203 with descriptive error outside injection context', () => {
     expect(() => {
       injectIsRestoring()


### PR DESCRIPTION
## 🎯 Changes

Add a test that verifies `injectIsRestoring` resolves the value provided via `provideIsRestoring` when the `injector` option is used (i.e., outside an injection context).

The existing tests covered:
- ✅ Default `false` inside injection context
- ✅ Provided signal value inside injection context
- ✅ Reactivity inside injection context
- ✅ Default `false` with `injector` option (outside injection context)

The missing matrix cell — provided signal value with `injector` option — is now covered. This guarantees the `injector.get(IS_RESTORING)` path correctly resolves through the user-registered DI tree, not just the default factory.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the `injectIsRestoring` utility with additional validation of the injector option path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->