### PR TITLE
fix(query-core): restore NoInfer on persister's TQueryKey

### DIFF
--- a/.changeset/fix-persister-query-key-infer.md
+++ b/.changeset/fix-persister-query-key-infer.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+fix(query-core): wrap `persister`'s `TQueryKey` in `NoInfer` so that the `persister` slot no longer contributes to `TQueryKey` inference. Follow-up to #10510, which removed `NoInfer` on all three `persister` generics. Preserving `NoInfer<TQueryKey>` keeps that fix's benefit for `TQueryFnData` while preventing `TQueryKey` from widening to the augmented constraint when `Register.queryKey` is narrowed — which made `DataTag`-branded wrapper returns un-assignable in contravariant slots.

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -246,7 +246,7 @@ export interface QueryOptions<
    */
   gcTime?: number
   queryFn?: QueryFunction<TQueryFnData, TQueryKey, TPageParam> | SkipToken
-  persister?: QueryPersister<TQueryFnData, TQueryKey, TPageParam>
+  persister?: QueryPersister<TQueryFnData, NoInfer<TQueryKey>, TPageParam>
   queryHash?: string
   queryKey?: TQueryKey
   queryKeyHashFn?: QueryKeyHashFunction<TQueryKey>


### PR DESCRIPTION
## Summary

Follow-up to #10510. That PR removed `NoInfer` from all three `persister` generics to fix `TQueryFnData` inference when the companion `queryFn` declares a parameter (#7842). This restores `NoInfer<TQueryKey>` only — keeping #10510's benefit while preventing the `persister` slot from widening `TQueryKey` inference.

Fixes #10600.

## The interaction

Without `NoInfer` on `TQueryKey`, the `persister` slot contributes to `TQueryKey` inference. When `Register.queryKey` is augmented to a narrowed constraint (as [documented](https://tanstack.com/query/latest/docs/framework/react/typescript#registering-the-query-and-mutation-key-types) and introduced in #8521), `TQueryKey` widens to that constraint instead of the literal passed to `queryKey`. Wrappers whose return type brands the key with `DataTag<TQueryKey, ...>` (which is required to support type-safety when using options with e.g. `getQueryData`) then produce a brand on the wider type, and a plain literal tuple can no longer satisfy both the augmented constraint *and* the phantom brand.

See #10600 for the minimal repro (a ~15-line wrapper + augmented `Register.queryKey` + a typed variable assignment reproduces `TS2322` on 5.100.5 and compiles cleanly on 5.100.1).

## Why this fix is safe

- `TQueryFnData` still participates in inference, so the positive-inference test from #10510 (`'should infer TQueryFnData from persister paired with a queryFn declaring a parameter'`) passes unchanged.
- The genuine-conflict negative test from #10510 also passes unchanged — `@ts-expect-error` still triggers.
- All `test:types` variants pass (TS 5.4 through 6.0) and all unit tests pass.

## A note on regression testing

I tried to add a `.test-d.tsx` that augments `Register.queryKey` and asserts a `DataTag`-branded wrapper return accepts literal `queryKey`s. It caught the bug, but `declare module '@tanstack/query-core'` is global — the augmentation leaked into every sibling `.test-d.tsx` and produced ~30 spurious `TS2322`s across `useQuery`, `useSuspenseQuery`, etc. (all of which use literal `string[]` keys that don't satisfy the narrowed constraint).

More broadly, I didn't find any existing tests for the `Register` augmentations (`defaultError`, `queryMeta`, `mutationMeta`, `queryKey`, `mutationKey`) — by construction each would need its own isolated compilation unit. Flagging it in case the maintainers want to set that up separately; I've left it out of this PR to keep the scope minimal.

## Test plan

- [x] `packages/query-core` — `pnpm run test:types` (TS 5.4 – 6.0): pass
- [x] `packages/react-query` — `pnpm run test:types` (TS 5.4 – 6.0): pass
- [x] `packages/query-core` — vitest: 526 pass / 0 fail
- [x] `packages/react-query` — vitest: 540 pass / 0 fail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a type checking issue with the query persister option that prevented proper configuration in certain advanced scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->