### PR TITLE
test(preact-query/ErrorBoundary): replace British 'behaviour' with American 'behavior'

### DIFF
--- a/packages/preact-query/src/__tests__/ErrorBoundary/ErrorBoundary.ts
+++ b/packages/preact-query/src/__tests__/ErrorBoundary/ErrorBoundary.ts
@@ -49,7 +49,7 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     /**
-     * To emulate the react behaviour of console.error
+     * To emulate the react behavior of console.error
      * we add one here to show that the errors bubble up
      * to the system and can be seen in the console
      */


### PR DESCRIPTION
## 🎯 Changes

Replace British spelling `behaviour` with American `behavior` in the JSDoc comment of the ErrorBoundary test helper to match the rest of the codebase, where `behavior` is used in 39 files.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains only internal maintenance updates with no user-visible changes or new features.

* **Chores**
  * Minor comment correction in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->