### PR TITLE
fix(query-devtools): align onClose setter type

### DIFF
--- a/.changeset/query-devtools-onclose-setter-type.md
+++ b/.changeset/query-devtools-onclose-setter-type.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-devtools': patch
+---
+
+Update the devtools panel `setOnClose` callback type to return `void`.

--- a/packages/query-devtools/src/TanstackQueryDevtoolsPanel.tsx
+++ b/packages/query-devtools/src/TanstackQueryDevtoolsPanel.tsx
@@ -34,7 +34,7 @@ class TanstackQueryDevtoolsPanel {
   #initialIsOpen: Signal<boolean | undefined>
   #errorTypes: Signal<Array<DevtoolsErrorType> | undefined>
   #hideDisabledQueries: Signal<boolean | undefined>
-  #onClose: Signal<(() => unknown) | undefined>
+  #onClose: Signal<(() => void) | undefined>
   #Component: DevtoolsComponentType | undefined
   #theme: Signal<Theme | undefined>
   #dispose?: () => void
@@ -90,7 +90,7 @@ class TanstackQueryDevtoolsPanel {
     this.#client[1](client)
   }
 
-  setOnClose(onClose: () => unknown) {
+  setOnClose(onClose: () => void) {
     this.#onClose[1](() => onClose)
   }
 


### PR DESCRIPTION
## 🎯 Changes

Align the `onClose` setter type in `TanstackQueryDevtoolsPanel` with the updated callback signature.

The `onClose` callback was previously changed from `() => unknown` to `() => void` across devtools packages, but the internal panel class still exposed:

`setOnClose(onClose: () => unknown)`

This updates:

- #onClose signal type to () => void
- setOnClose parameter type to () => void

This ensures consistency with the public devtools API and avoids leaking the outdated unknown return type.

No runtime behavior changes.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated the devtools panel's closing callback type to correctly specify `void` return type, improving type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->