### PR TITLE
docs(devtools): add 'relative' to Vue/Solid 'buttonPosition' and fix Vue 'style' type

### DIFF
--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -70,7 +70,7 @@ function App() {
 
 - `initialIsOpen: boolean`
   - Set this `true` if you want the dev tools to default to being open
-- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
+- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`
   - The position of the Solid Query logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`

--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -65,7 +65,7 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
 
 - `initialIsOpen: boolean`
   - Set this `true` if you want the dev tools to default to being open.
-- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
+- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`.
   - The position of the React Query logo to open and close the devtools panel.
 - `position?: "top" | "bottom" | "left" | "right"`
@@ -105,7 +105,7 @@ function toggleDevtools() {
 
 ### Options
 
-- `style?: React.CSSProperties`
+- `style?: Partial<CSSStyleDeclaration>`
   - Custom styles for the devtools panel
   - Default: `{ height: '500px' }`
   - Example: `{ height: '100%' }`


### PR DESCRIPTION
## 🎯 Changes

Align the Vue and Solid devtools docs with the exported devtools option types.

Updates:
- adds `"relative"` to documented `buttonPosition` options
- replaces the React-specific `React.CSSProperties` style type in Vue docs with `Partial<CSSStyleDeclaration>`

Docs-only change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * SolidQueryDevtools and Vue Query Devtools floating-mode button positioning now supports "relative" as an additional position option.
  * Vue Query Devtools embedded-mode style option type was updated to provide better type coverage for CSS styling configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->