### PR TITLE
feat(angular-query): add devtools theme option

### DIFF
--- a/.changeset/angular-devtools-theme-option.md
+++ b/.changeset/angular-devtools-theme-option.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-query-experimental': patch
+---
+
+Add theme option support to Angular floating devtools.

--- a/packages/angular-query-experimental/src/devtools/types.ts
+++ b/packages/angular-query-experimental/src/devtools/types.ts
@@ -3,6 +3,7 @@ import type {
   DevtoolsButtonPosition,
   DevtoolsErrorType,
   DevtoolsPosition,
+  Theme,
 } from '@tanstack/query-devtools'
 import type { DevtoolsFeature } from '../providers'
 
@@ -75,6 +76,11 @@ export interface DevtoolsOptions {
    * Set this to true to hide disabled queries from the devtools panel.
    */
   hideDisabledQueries?: boolean
+  /**
+   * Set this to 'light', 'dark', or 'system' to change the theme of the devtools panel.
+   * Defaults to 'system'.
+   */
+  theme?: Theme
 
   /**
    * Whether the developer tools should load.

--- a/packages/angular-query-experimental/src/devtools/with-devtools.ts
+++ b/packages/angular-query-experimental/src/devtools/with-devtools.ts
@@ -126,6 +126,7 @@ export const withDevtools: WithDevtools = (
                 errorTypes,
                 buttonPosition,
                 initialIsOpen,
+                theme,
               } = devtoolsOptions()
 
               if (!shouldLoadTools) {
@@ -142,6 +143,7 @@ export const withDevtools: WithDevtools = (
                 buttonPosition && devtools.setButtonPosition(buttonPosition)
                 typeof initialIsOpen === 'boolean' &&
                   devtools.setInitialIsOpen(initialIsOpen)
+                if (theme) devtools.setTheme(theme)
                 return
               }
 

--- a/packages/angular-query-experimental/src/devtools/with-devtools.ts
+++ b/packages/angular-query-experimental/src/devtools/with-devtools.ts
@@ -143,7 +143,7 @@ export const withDevtools: WithDevtools = (
                 buttonPosition && devtools.setButtonPosition(buttonPosition)
                 typeof initialIsOpen === 'boolean' &&
                   devtools.setInitialIsOpen(initialIsOpen)
-                if (theme) devtools.setTheme(theme)
+                theme && devtools.setTheme(theme)
                 return
               }
 


### PR DESCRIPTION
## 🎯 Changes

Add `theme` option support to Angular floating devtools.

React, Vue, and Solid devtools already expose the shared `theme?: Theme` option. This adds the same option to Angular floating devtools and updates an existing devtools instance with `setTheme(theme)` when the option changes.

This keeps Angular devtools aligned with the shared query devtools API and sibling framework bindings.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added theme option support to the Angular floating devtools, enabling light, dark, or system theme selection for the devtools panel. The theme can be applied dynamically to existing devtools instances and is respected on initial load; when unspecified it defaults to the system preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->