### PR TITLE
docs(preact-query/devtools): add missing 'relative' to 'buttonPosition'

### DIFF
--- a/docs/framework/preact/devtools.md
+++ b/docs/framework/preact/devtools.md
@@ -70,7 +70,7 @@ function App() {
 
 - `initialIsOpen: boolean`
   - Set this `true` if you want the dev tools to default to being open
-- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
+- `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`
   - The position of the Preact Query logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`


### PR DESCRIPTION
## 🎯 Changes

Add the missing `"relative"` value to `buttonPosition` in the Preact devtools docs to match the actual `DevtoolsButtonPosition` type exported from `@tanstack/query-devtools` (which is `` `${YPosition}-${XPosition}` | 'relative' ``).

This is a follow-up to #10608, which fixed the same omission in the Vue and Solid docs. The Preact docs were missed in that PR.

The other adapters' docs (React, Svelte, Angular) already include `"relative"`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Preact Query devtools now supports `"relative"` as an additional button positioning option. This documentation update includes the new positioning mode alongside the existing top-left, top-right, bottom-left, and bottom-right options, providing developers with enhanced flexibility for customizing the devtools interface layout and appearance in their applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->