### PR TITLE
docs(devtools): align logo, panel, and option union descriptions across docs and JSDoc

### DIFF
--- a/.changeset/good-pots-brush.md
+++ b/.changeset/good-pots-brush.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/angular-query-experimental': patch
+'@tanstack/preact-query-devtools': patch
+'@tanstack/svelte-query-devtools': patch
+'@tanstack/react-query-devtools': patch
+'@tanstack/solid-query-devtools': patch
+'@tanstack/vue-query-devtools': patch
+---
+
+docs(devtools): align logo, panel, and 'buttonPosition' union descriptions across docs and JSDoc

--- a/docs/framework/preact/devtools.md
+++ b/docs/framework/preact/devtools.md
@@ -72,7 +72,7 @@ function App() {
   - Set this `true` if you want the dev tools to default to being open
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`
-  - The position of the Preact Query logo to open and close the devtools panel
+  - The position of the TanStack logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`
   - The position of the Preact Query devtools panel

--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -78,7 +78,7 @@ function App() {
   - Set this `true` if you want the dev tools to default to being open
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`
-  - The position of the React Query logo to open and close the devtools panel
+  - The position of the TanStack logo to open and close the devtools panel
   - If `relative`, the button is placed in the location that you render the devtools.
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`

--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -72,7 +72,7 @@ function App() {
   - Set this `true` if you want the dev tools to default to being open
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`
-  - The position of the Solid Query logo to open and close the devtools panel
+  - The position of the TanStack logo to open and close the devtools panel
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`
   - The position of the Solid Query devtools panel

--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -67,7 +67,7 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
   - Set this `true` if you want the dev tools to default to being open.
 - `buttonPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "relative"`
   - Defaults to `bottom-right`.
-  - The position of the React Query logo to open and close the devtools panel.
+  - The position of the TanStack logo to open and close the devtools panel.
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`.
   - The position of the React Query devtools panel.

--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -70,7 +70,7 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
   - The position of the TanStack logo to open and close the devtools panel.
 - `position?: "top" | "bottom" | "left" | "right"`
   - Defaults to `bottom`.
-  - The position of the React Query devtools panel.
+  - The position of the Vue Query devtools panel.
 - `client?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 - `errorTypes?: { name: string; initializer: (query: Query) => TError}`

--- a/packages/angular-query-experimental/src/devtools/types.ts
+++ b/packages/angular-query-experimental/src/devtools/types.ts
@@ -50,7 +50,7 @@ export interface DevtoolsOptions {
    */
   buttonPosition?: DevtoolsButtonPosition
   /**
-   * The position of the TanStack Query devtools panel.
+   * The position of the Angular Query devtools panel.
    * `top` | `bottom` | `left` | `right`
    * Defaults to `bottom`.
    */

--- a/packages/preact-query-devtools/src/PreactQueryDevtools.tsx
+++ b/packages/preact-query-devtools/src/PreactQueryDevtools.tsx
@@ -23,6 +23,7 @@ export interface DevtoolsOptions {
   buttonPosition?: DevtoolsButtonPosition
   /**
    * The position of the Preact Query devtools panel.
+   * 'top' | 'bottom' | 'left' | 'right'
    * Defaults to 'bottom'.
    */
   position?: DevtoolsPosition

--- a/packages/preact-query-devtools/src/PreactQueryDevtools.tsx
+++ b/packages/preact-query-devtools/src/PreactQueryDevtools.tsx
@@ -17,6 +17,7 @@ export interface DevtoolsOptions {
   initialIsOpen?: boolean
   /**
    * The position of the TanStack logo to open and close the devtools panel.
+   * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'relative'
    * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition

--- a/packages/react-query-devtools/src/ReactQueryDevtools.tsx
+++ b/packages/react-query-devtools/src/ReactQueryDevtools.tsx
@@ -16,7 +16,7 @@ export interface DevtoolsOptions {
    */
   initialIsOpen?: boolean
   /**
-   * The position of the React Query logo to open and close the devtools panel.
+   * The position of the TanStack logo to open and close the devtools panel.
    * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
    * Defaults to 'bottom-right'.
    */

--- a/packages/react-query-devtools/src/ReactQueryDevtools.tsx
+++ b/packages/react-query-devtools/src/ReactQueryDevtools.tsx
@@ -17,7 +17,7 @@ export interface DevtoolsOptions {
   initialIsOpen?: boolean
   /**
    * The position of the TanStack logo to open and close the devtools panel.
-   * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+   * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'relative'
    * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition

--- a/packages/solid-query-devtools/src/devtools.tsx
+++ b/packages/solid-query-devtools/src/devtools.tsx
@@ -15,13 +15,13 @@ interface DevtoolsOptions {
    */
   initialIsOpen?: boolean
   /**
-   * The position of the React Query logo to open and close the devtools panel.
+   * The position of the TanStack logo to open and close the devtools panel.
    * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
    * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition
   /**
-   * The position of the React Query devtools panel.
+   * The position of the Solid Query devtools panel.
    * 'top' | 'bottom' | 'left' | 'right'
    * Defaults to 'bottom'.
    */

--- a/packages/solid-query-devtools/src/devtools.tsx
+++ b/packages/solid-query-devtools/src/devtools.tsx
@@ -16,7 +16,7 @@ interface DevtoolsOptions {
   initialIsOpen?: boolean
   /**
    * The position of the TanStack logo to open and close the devtools panel.
-   * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+   * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'relative'
    * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition

--- a/packages/svelte-query-devtools/src/Devtools.svelte
+++ b/packages/svelte-query-devtools/src/Devtools.svelte
@@ -17,7 +17,7 @@
     initialIsOpen?: boolean
     /**
      * The position of the TanStack logo to open and close the devtools panel.
-     * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+     * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'relative'
      * Defaults to 'bottom-right'.
      */
     buttonPosition?: DevtoolsButtonPosition

--- a/packages/svelte-query-devtools/src/Devtools.svelte
+++ b/packages/svelte-query-devtools/src/Devtools.svelte
@@ -16,13 +16,13 @@
      */
     initialIsOpen?: boolean
     /**
-     * The position of the TanStack Query logo to open and close the devtools panel.
+     * The position of the TanStack logo to open and close the devtools panel.
      * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
      * Defaults to 'bottom-right'.
      */
     buttonPosition?: DevtoolsButtonPosition
     /**
-     * The position of the TanStack Query devtools panel.
+     * The position of the Svelte Query devtools panel.
      * 'top' | 'bottom' | 'left' | 'right'
      * Defaults to 'bottom'.
      */

--- a/packages/vue-query-devtools/src/types.ts
+++ b/packages/vue-query-devtools/src/types.ts
@@ -13,7 +13,7 @@ export interface DevtoolsOptions {
   initialIsOpen?: boolean
   /**
    * The position of the TanStack logo to open and close the devtools panel.
-   * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+   * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'relative'
    * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition

--- a/packages/vue-query-devtools/src/types.ts
+++ b/packages/vue-query-devtools/src/types.ts
@@ -12,13 +12,13 @@ export interface DevtoolsOptions {
    */
   initialIsOpen?: boolean
   /**
-   * The position of the React Query logo to open and close the devtools panel.
+   * The position of the TanStack logo to open and close the devtools panel.
    * 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
    * Defaults to 'bottom-right'.
    */
   buttonPosition?: DevtoolsButtonPosition
   /**
-   * The position of the React Query devtools panel.
+   * The position of the Vue Query devtools panel.
    * 'top' | 'bottom' | 'left' | 'right'
    * Defaults to 'bottom'.
    */


### PR DESCRIPTION
## 🎯 Changes

Align devtools descriptions across both docs and JSDoc to match the actual rendered component, adapter naming, and full type union:

1. **Replace framework-specific logo with `TanStack logo`** in `buttonPosition` descriptions across React, Vue, Solid, Preact docs and React, Vue, Solid, Svelte JSDoc.
   - The `<TanstackLogo />` component (`packages/query-devtools/src/Devtools.tsx:263, 271`) is the only logo rendered in the floating button, regardless of adapter — there's no customization API for it.
   - After this PR, all 6 adapters (docs and JSDoc) use the same `TanStack logo` phrasing.

2. **Use adapter naming for `devtools panel`** in `position` descriptions where it was inconsistent.
   - Vue/Solid JSDoc had `React Query devtools panel` leftover from copy-paste. Vue docs had the same leftover.
   - Svelte/Angular JSDoc used the core component name (`TanStack Query devtools panel`) instead of their adapter name, while their own docs already used the adapter name.
   - After this PR, all adapters consistently use `{Framework} Query devtools panel` (matching what users actually import: `<VueQueryDevtoolsPanel />`, `<SolidQueryDevtoolsPanel />`, etc.).

3. **Add missing union descriptions to JSDoc** for full type coverage:
   - `buttonPosition` — added `'relative'` to React, Vue, Solid, Preact, Svelte JSDoc (5 adapters). The `DevtoolsButtonPosition` type already includes `'relative'`, but JSDoc had the outdated 4-union. Angular JSDoc was the only one already correct.
   - `position` — added the 4-union to Preact JSDoc (the only adapter that was missing it; others already had it).
   - Docs were already updated in #10608 (Vue/Solid) and #10611 (Preact); this PR aligns JSDoc with docs and the actual type.

CodeRabbit's review on the original PR caught the Vue panel leftover; expanding the scope keeps the wording consistent across docs and JSDoc.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).