### PR TITLE
ci(labeler-config): add missing 'preact-query-devtools' and 'preact-query-persist-client' package labels

### DIFF
--- a/labeler-config.yml
+++ b/labeler-config.yml
@@ -13,6 +13,12 @@
 'package: preact-query':
   - changed-files:
       - any-glob-to-any-file: 'packages/preact-query/**/*'
+'package: preact-query-devtools':
+  - changed-files:
+      - any-glob-to-any-file: 'packages/preact-query-devtools/**/*'
+'package: preact-query-persist-client':
+  - changed-files:
+      - any-glob-to-any-file: 'packages/preact-query-persist-client/**/*'
 'package: query-async-storage-persister':
   - changed-files:
       - any-glob-to-any-file: 'packages/query-async-storage-persister/**/*'


### PR DESCRIPTION
## 🎯 Changes

Add missing package labels for `preact-query-devtools` and `preact-query-persist-client`. These two packages exist under `packages/` but were missing from the labeler config, so PRs touching them never received their package label automatically.

This follows up on `ci(labeler-config): add missing 'preact-query' package label`, which added the missing core preact label. With this PR, all Preact packages have label coverage matching the other adapters (React, Vue, Solid, Svelte, Angular).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal repository configuration to support additional package organization and automated workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->