### PR TITLE
docs(devtools): add missing 'theme' option

### DIFF
--- a/docs/framework/preact/devtools.md
+++ b/docs/framework/preact/devtools.md
@@ -85,3 +85,6 @@ function App() {
 - `shadowDOMTarget?: ShadowRoot`
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.

--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -92,6 +92,9 @@ function App() {
 - `shadowDOMTarget?: ShadowRoot`
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.
 
 ## Embedded Mode
 
@@ -135,6 +138,9 @@ function App() {
 - `shadowDOMTarget?: ShadowRoot`
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.
 
 ## Devtools in production
 

--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -85,3 +85,6 @@ function App() {
 - `shadowDOMTarget?: ShadowRoot`
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.

--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -80,6 +80,9 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
 - `shadowDOMTarget?: ShadowRoot`
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.
 
 ## Embedded Mode
 
@@ -121,6 +124,9 @@ function toggleDevtools() {
 - `shadowDOMTarget?: ShadowRoot`
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.
 
 ## Traditional Devtools
 


### PR DESCRIPTION
## 🎯 Changes

Add the missing `theme` option to the React, Vue, Solid, and Preact devtools docs (both Floating Mode and Embedded Mode where applicable).

The `theme` prop is supported across all these adapters — the core `<DevtoolsComponent>` and `<DevtoolsPanelComponent>` use `props.theme` with priority over `localStore.theme_preference`, and the `setTheme` setter is wired up in each adapter for reactive updates. It just wasn't documented.

Svelte and Angular don't have the `theme` prop in their adapter wrappers, so they're not in scope here. (Adding the prop to those adapters would be a separate runtime change.)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented new theme configuration option for devtools across all frameworks. Users can now set the devtools panel theme to "light", "dark", or "system" (defaults to "system").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->