### PR TITLE
refactor(preact-query-devtools): replace deprecated 'JSX.CSSProperties' with 'CSSProperties' from Preact namespace

### DIFF
--- a/.changeset/cyan-words-hunt.md
+++ b/.changeset/cyan-words-hunt.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query-devtools': patch
+---
+
+refactor(preact-query-devtools): replace deprecated 'JSX.CSSProperties' with 'CSSProperties' from Preact namespace

--- a/packages/preact-query-devtools/src/PreactQueryDevtoolsPanel.tsx
+++ b/packages/preact-query-devtools/src/PreactQueryDevtoolsPanel.tsx
@@ -3,7 +3,7 @@ import { onlineManager, useQueryClient } from '@tanstack/preact-query'
 import { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
 import type { DevtoolsErrorType, Theme } from '@tanstack/query-devtools'
 import type { QueryClient } from '@tanstack/preact-query'
-import type { JSX, VNode } from 'preact'
+import type { CSSProperties, VNode } from 'preact'
 
 export interface DevtoolsPanelOptions {
   /**
@@ -28,7 +28,7 @@ export interface DevtoolsPanelOptions {
   /**
    * Custom styles for the devtools panel container.
    */
-  style?: JSX.CSSProperties
+  style?: CSSProperties
   /**
    * Callback function when the devtools panel is closed.
    */


### PR DESCRIPTION
## 🎯 Changes

Replace deprecated `JSX.CSSProperties` with `CSSProperties` from the Preact namespace, as recommended by Preact's deprecation message:

> `@deprecated — Please import from the Preact namespace instead`

The `CSSProperties` type is the same in both locations; this is a type-only refactor with no runtime or user-facing type behavior change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type definitions in the preact-query-devtools package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->