### PR TITLE
chore(svelte-query-devtools): set up vitest environment with '@testing-library/svelte' and a smoke test

### DIFF
--- a/packages/svelte-query-devtools/package.json
+++ b/packages/svelte-query-devtools/package.json
@@ -24,6 +24,8 @@
     "compile": "tsc --build",
     "test:types": "svelte-check --tsconfig ./tsconfig.json",
     "test:eslint": "eslint --concurrency=auto ./src",
+    "test:lib": "vitest",
+    "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",
     "build": "svelte-package --input ./src --output ./dist"
   },
@@ -53,6 +55,7 @@
     "@sveltejs/package": "^2.4.0",
     "@sveltejs/vite-plugin-svelte": "^5.1.1",
     "@tanstack/svelte-query": "workspace:*",
+    "@testing-library/svelte": "^5.2.8",
     "@typescript-eslint/parser": "^8.48.0",
     "eslint-plugin-svelte": "^3.11.0",
     "svelte": "^5.39.3",

--- a/packages/svelte-query-devtools/tests/Devtools.svelte.test.ts
+++ b/packages/svelte-query-devtools/tests/Devtools.svelte.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/svelte'
+import { QueryClient } from '@tanstack/svelte-query'
+import SvelteQueryDevtools from '../src/Devtools.svelte'
+
+describe('SvelteQueryDevtools', () => {
+  it('should render the parent container without throwing in non-development environments', () => {
+    const queryClient = new QueryClient()
+
+    const { container } = render(SvelteQueryDevtools, {
+      props: { client: queryClient },
+    })
+
+    expect(
+      container.querySelector('.tsqd-parent-container'),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/svelte-query-devtools/tests/test-setup.ts
+++ b/packages/svelte-query-devtools/tests/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/packages/svelte-query-devtools/tsconfig.json
+++ b/packages/svelte-query-devtools/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "./dist-ts",
     "rootDir": "."
   },
-  "include": ["src", "*.config.*", "package.json"],
+  "include": ["src", "tests", "*.config.*", "package.json"],
   "references": [{ "path": "../query-devtools" }, { "path": "../svelte-query" }]
 }

--- a/packages/svelte-query-devtools/vite.config.ts
+++ b/packages/svelte-query-devtools/vite.config.ts
@@ -1,8 +1,11 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
+import { svelteTesting } from '@testing-library/svelte/vite'
+
+import packageJson from './package.json'
 
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), svelteTesting()],
   // fix from https://github.com/vitest-dev/vitest/issues/6992#issuecomment-2509408660
   resolve: {
     conditions: ['@tanstack/custom-condition'],
@@ -13,5 +16,18 @@ export default defineConfig({
         conditions: ['@tanstack/custom-condition'],
       },
     },
+  },
+  test: {
+    name: packageJson.name,
+    dir: './tests',
+    watch: false,
+    environment: 'jsdom',
+    setupFiles: ['./tests/test-setup.ts'],
+    coverage: {
+      enabled: true,
+      provider: 'istanbul',
+      include: ['src/**/*'],
+    },
+    typecheck: { enabled: true },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2936,6 +2936,9 @@ importers:
       '@tanstack/svelte-query':
         specifier: workspace:*
         version: link:../svelte-query
+      '@testing-library/svelte':
+        specifier: ^5.2.8
+        version: 5.3.1(svelte@5.55.1)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.2(@types/node@22.19.15)(jsdom@27.4.0)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(yaml@2.8.3)))
       '@typescript-eslint/parser':
         specifier: 8.58.1
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)


### PR DESCRIPTION
## 🎯 Changes

Set up the vitest environment for `svelte-query-devtools`, following the same pattern used by `svelte-query` and `svelte-query-persist-client`.

- Add `test:lib` / `test:lib:dev` scripts and `@testing-library/svelte` devDependency.
- Add a `test` block to `vite.config.ts` with `svelteTesting()` plugin, `jsdom` environment, and a `tests/test-setup.ts` setup file.
- Include `tests` directory in `tsconfig.json`.
- Add a smoke test for `SvelteQueryDevtools` to verify the environment works end-to-end.

This unblocks future tests for the Svelte devtools wrapper without scope-creeping into wrapper-invariant cases (those will land in a follow-up PR).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally (per-package: \`pnpm test:lib\` passes for \`svelte-query-devtools\`, and unaffected packages such as \`svelte-query\` continue to pass).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test suite for the devtools component to verify it renders correctly in a simulated browser environment.
  * Enabled DOM matcher support for richer assertions.

* **Chores**
  * Added test scripts for running library tests (standard and watch modes).
  * Configured the test runner, coverage collection, and TypeScript inclusion of test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->