### PR TITLE
test(svelte-query-devtools): add tests for missing 'QueryClient', context provider, and 'client' prop

### DIFF
--- a/packages/svelte-query-devtools/tests/Devtools.svelte.test.ts
+++ b/packages/svelte-query-devtools/tests/Devtools.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { render } from '@testing-library/svelte'
 import { QueryClient } from '@tanstack/svelte-query'
 import SvelteQueryDevtools from '../src/Devtools.svelte'
+import Wrapper from './Wrapper.svelte'
 
 describe('SvelteQueryDevtools', () => {
   it('should render the parent container without throwing in non-development environments', () => {
@@ -14,5 +15,25 @@ describe('SvelteQueryDevtools', () => {
     expect(
       container.querySelector('.tsqd-parent-container'),
     ).toBeInTheDocument()
+  })
+
+  it('should throw an error if no query client has been set', () => {
+    expect(() => render(SvelteQueryDevtools)).toThrow(
+      'No QueryClient was found in Svelte context. Did you forget to wrap your component with QueryClientProvider?',
+    )
+  })
+
+  it('should not throw an error if query client is provided via context', () => {
+    const queryClient = new QueryClient()
+
+    expect(() => render(Wrapper, { props: { queryClient } })).not.toThrow()
+  })
+
+  it('should not throw an error if query client is provided via props', () => {
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(SvelteQueryDevtools, { props: { client: queryClient } }),
+    ).not.toThrow()
   })
 })

--- a/packages/svelte-query-devtools/tests/Wrapper.svelte
+++ b/packages/svelte-query-devtools/tests/Wrapper.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { QueryClientProvider } from '@tanstack/svelte-query'
+  import SvelteQueryDevtools from '../src/Devtools.svelte'
+  import type { QueryClient } from '@tanstack/svelte-query'
+
+  type Props = {
+    queryClient: QueryClient
+  }
+
+  let { queryClient }: Props = $props()
+</script>
+
+<QueryClientProvider client={queryClient}>
+  <SvelteQueryDevtools />
+</QueryClientProvider>


### PR DESCRIPTION
## 🎯 Changes

Add wrapper invariant tests for `SvelteQueryDevtools`, following up on #10624.

- Add `should throw an error if no query client has been set`.
- Add `should not throw an error if query client is provided via context` (using a new `Wrapper.svelte` helper that renders `SvelteQueryDevtools` inside `<QueryClientProvider>`).
- Add `should not throw an error if query client is provided via props`.

This brings `svelte-query-devtools` in line with `solid-query-devtools`, which already covers the same three cases.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:lib` (4/4 passed).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for devtools to validate proper `QueryClient` configuration. Added test cases ensuring devtools correctly handles scenarios where `QueryClient` is missing, provided via context, or passed as a prop, with appropriate error handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->