### PR TITLE
test(preact-query-devtools): add tests for missing 'QueryClient', context provider, 'client' prop, and production fallback

### DIFF
--- a/packages/preact-query-devtools/package.json
+++ b/packages/preact-query-devtools/package.json
@@ -27,6 +27,8 @@
     "test:types:ts59": "node ../../node_modules/typescript59/lib/tsc.js --build tsconfig.legacy.json",
     "test:types:tscurrent": "tsc --build",
     "test:types:ts60": "node ../../node_modules/typescript60/lib/tsc.js --build tsconfig.legacy.json",
+    "test:lib": "vitest",
+    "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict && attw --pack",
     "build": "tsup --tsconfig tsconfig.prod.json",
     "build:dev": "tsup --watch"

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/preact'
 import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
 import type { TanstackQueryDevtools } from '@tanstack/query-devtools'
@@ -26,6 +26,10 @@ vi.mock('@tanstack/query-devtools', () => ({
 }))
 
 describe('PreactQueryDevtools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should throw an error if no query client has been set', async () => {
     const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
 
@@ -45,6 +49,7 @@ describe('PreactQueryDevtools', () => {
         </QueryClientProvider>,
       ),
     ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
   })
 
   it('should not throw an error if query client is provided via props', async () => {
@@ -54,6 +59,7 @@ describe('PreactQueryDevtools', () => {
     expect(() =>
       render(<PreactQueryDevtools client={queryClient} />),
     ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
   })
 
   it('should return null in non-development environments', async () => {

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/preact'
+import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
+import type { TanstackQueryDevtools } from '@tanstack/query-devtools'
+
+const mountMock = vi.fn()
+const unmountMock = vi.fn()
+const setClientMock = vi.fn()
+const setButtonPositionMock = vi.fn()
+const setPositionMock = vi.fn()
+const setInitialIsOpenMock = vi.fn()
+const setErrorTypesMock = vi.fn()
+const setThemeMock = vi.fn()
+
+vi.mock('@tanstack/query-devtools', () => ({
+  TanstackQueryDevtools: vi.fn(function (this: TanstackQueryDevtools) {
+    this.mount = mountMock
+    this.unmount = unmountMock
+    this.setClient = setClientMock
+    this.setButtonPosition = setButtonPositionMock
+    this.setPosition = setPositionMock
+    this.setInitialIsOpen = setInitialIsOpenMock
+    this.setErrorTypes = setErrorTypesMock
+    this.setTheme = setThemeMock
+  }),
+}))
+
+describe('PreactQueryDevtools', () => {
+  it('should throw an error if no query client has been set', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+
+    expect(() => render(<PreactQueryDevtools />)).toThrow(
+      'No QueryClient set, use QueryClientProvider to set one',
+    )
+  })
+
+  it('should not throw an error if query client is provided via context', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PreactQueryDevtools />
+        </QueryClientProvider>,
+      ),
+    ).not.toThrow()
+  })
+
+  it('should not throw an error if query client is provided via props', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(<PreactQueryDevtools client={queryClient} />),
+    ).not.toThrow()
+  })
+
+  it('should return null in non-development environments', async () => {
+    const { PreactQueryDevtools } = await import('..')
+
+    expect(process.env.NODE_ENV).not.toBe('development')
+    expect(PreactQueryDevtools({})).toBeNull()
+  })
+})

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -11,7 +11,9 @@ const setErrorTypesMock = vi.fn()
 const setThemeMock = vi.fn()
 
 vi.mock('@tanstack/query-devtools', () => ({
-  TanstackQueryDevtoolsPanel: vi.fn(function (this: TanstackQueryDevtoolsPanel) {
+  TanstackQueryDevtoolsPanel: vi.fn(function (
+    this: TanstackQueryDevtoolsPanel,
+  ) {
     this.mount = mountMock
     this.unmount = unmountMock
     this.setClient = setClientMock
@@ -23,9 +25,8 @@ vi.mock('@tanstack/query-devtools', () => ({
 
 describe('PreactQueryDevtoolsPanel', () => {
   it('should throw an error if no query client has been set', async () => {
-    const { PreactQueryDevtoolsPanel } = await import(
-      '../PreactQueryDevtoolsPanel'
-    )
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
 
     expect(() => render(<PreactQueryDevtoolsPanel />)).toThrow(
       'No QueryClient set, use QueryClientProvider to set one',
@@ -33,9 +34,8 @@ describe('PreactQueryDevtoolsPanel', () => {
   })
 
   it('should not throw an error if query client is provided via context', async () => {
-    const { PreactQueryDevtoolsPanel } = await import(
-      '../PreactQueryDevtoolsPanel'
-    )
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
     const queryClient = new QueryClient()
 
     expect(() =>
@@ -48,9 +48,8 @@ describe('PreactQueryDevtoolsPanel', () => {
   })
 
   it('should not throw an error if query client is provided via props', async () => {
-    const { PreactQueryDevtoolsPanel } = await import(
-      '../PreactQueryDevtoolsPanel'
-    )
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
     const queryClient = new QueryClient()
 
     expect(() =>

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/preact'
 import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
 import type { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
@@ -24,6 +24,10 @@ vi.mock('@tanstack/query-devtools', () => ({
 }))
 
 describe('PreactQueryDevtoolsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should throw an error if no query client has been set', async () => {
     const { PreactQueryDevtoolsPanel } =
       await import('../PreactQueryDevtoolsPanel')
@@ -45,6 +49,7 @@ describe('PreactQueryDevtoolsPanel', () => {
         </QueryClientProvider>,
       ),
     ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
   })
 
   it('should not throw an error if query client is provided via props', async () => {
@@ -55,6 +60,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     expect(() =>
       render(<PreactQueryDevtoolsPanel client={queryClient} />),
     ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
   })
 
   it('should return null in non-development environments', async () => {

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/preact'
+import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
+import type { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
+
+const mountMock = vi.fn()
+const unmountMock = vi.fn()
+const setClientMock = vi.fn()
+const setOnCloseMock = vi.fn()
+const setErrorTypesMock = vi.fn()
+const setThemeMock = vi.fn()
+
+vi.mock('@tanstack/query-devtools', () => ({
+  TanstackQueryDevtoolsPanel: vi.fn(function (this: TanstackQueryDevtoolsPanel) {
+    this.mount = mountMock
+    this.unmount = unmountMock
+    this.setClient = setClientMock
+    this.setOnClose = setOnCloseMock
+    this.setErrorTypes = setErrorTypesMock
+    this.setTheme = setThemeMock
+  }),
+}))
+
+describe('PreactQueryDevtoolsPanel', () => {
+  it('should throw an error if no query client has been set', async () => {
+    const { PreactQueryDevtoolsPanel } = await import(
+      '../PreactQueryDevtoolsPanel'
+    )
+
+    expect(() => render(<PreactQueryDevtoolsPanel />)).toThrow(
+      'No QueryClient set, use QueryClientProvider to set one',
+    )
+  })
+
+  it('should not throw an error if query client is provided via context', async () => {
+    const { PreactQueryDevtoolsPanel } = await import(
+      '../PreactQueryDevtoolsPanel'
+    )
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PreactQueryDevtoolsPanel />
+        </QueryClientProvider>,
+      ),
+    ).not.toThrow()
+  })
+
+  it('should not throw an error if query client is provided via props', async () => {
+    const { PreactQueryDevtoolsPanel } = await import(
+      '../PreactQueryDevtoolsPanel'
+    )
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(<PreactQueryDevtoolsPanel client={queryClient} />),
+    ).not.toThrow()
+  })
+
+  it('should return null in non-development environments', async () => {
+    const { PreactQueryDevtoolsPanel } = await import('..')
+
+    expect(process.env.NODE_ENV).not.toBe('development')
+    expect(PreactQueryDevtoolsPanel({})).toBeNull()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add tests for `preact-query-devtools` covering wrapper invariants and the production fallback in `index.ts`.

- Enable `test:lib` / `test:lib:dev` scripts (package's vitest environment was already in place from prior work).
- Add `PreactQueryDevtools.test.tsx` with 4 cases:
  - throws when no `QueryClient` is set.
  - mounts when `QueryClient` is provided via `<QueryClientProvider>`.
  - mounts when `QueryClient` is provided via the `client` prop.
  - returns `null` in non-development environments (production fallback in `index.ts`).
- Add `PreactQueryDevtoolsPanel.test.tsx` with the same 4 cases for `PreactQueryDevtoolsPanel`.

The tests mock `@tanstack/query-devtools` to keep the wrapper isolated from the Solid-based core, since `@preact/preset-vite` cannot transform the core's `.tsx` files.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:lib\` (8/8 passed).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Vitest + Testing Library tests for devtools components covering rendering behavior with and without a query client, lifecycle interactions, and environment-specific (development vs non-development) behavior to improve reliability.

* **Chores**
  * Added npm scripts for testing: `test:lib` and `test:lib:dev` (watch mode) to simplify running the library test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->