### PR TITLE
test(react-query-devtools): add tests for missing 'QueryClient', context provider, 'client' prop, and production fallback

### DIFF
--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
@@ -63,9 +63,15 @@ describe('ReactQueryDevtools', () => {
   })
 
   it('should return null in non-development environments', async () => {
-    const { ReactQueryDevtools } = await import('..')
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.resetModules()
 
-    expect(process.env.NODE_ENV).not.toBe('development')
-    expect(ReactQueryDevtools({})).toBeNull()
+    try {
+      const { ReactQueryDevtools } = await import('..')
+      expect(ReactQueryDevtools({})).toBeNull()
+    } finally {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
   })
 })

--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { TanstackQueryDevtools } from '@tanstack/query-devtools'
+
+const mountMock = vi.fn()
+const unmountMock = vi.fn()
+const setClientMock = vi.fn()
+const setButtonPositionMock = vi.fn()
+const setPositionMock = vi.fn()
+const setInitialIsOpenMock = vi.fn()
+const setErrorTypesMock = vi.fn()
+const setThemeMock = vi.fn()
+
+vi.mock('@tanstack/query-devtools', () => ({
+  TanstackQueryDevtools: vi.fn(function (this: TanstackQueryDevtools) {
+    this.mount = mountMock
+    this.unmount = unmountMock
+    this.setClient = setClientMock
+    this.setButtonPosition = setButtonPositionMock
+    this.setPosition = setPositionMock
+    this.setInitialIsOpen = setInitialIsOpenMock
+    this.setErrorTypes = setErrorTypesMock
+    this.setTheme = setThemeMock
+  }),
+}))
+
+describe('ReactQueryDevtools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw an error if no query client has been set', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+
+    expect(() => render(<ReactQueryDevtools />)).toThrow(
+      'No QueryClient set, use QueryClientProvider to set one',
+    )
+  })
+
+  it('should not throw an error if query client is provided via context', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(
+        <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtools />
+        </QueryClientProvider>,
+      ),
+    ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
+  })
+
+  it('should not throw an error if query client is provided via props', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(<ReactQueryDevtools client={queryClient} />),
+    ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
+  })
+
+  it('should return null in non-development environments', async () => {
+    const { ReactQueryDevtools } = await import('..')
+
+    expect(process.env.NODE_ENV).not.toBe('development')
+    expect(ReactQueryDevtools({})).toBeNull()
+  })
+})

--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
@@ -64,9 +64,15 @@ describe('ReactQueryDevtoolsPanel', () => {
   })
 
   it('should return null in non-development environments', async () => {
-    const { ReactQueryDevtoolsPanel } = await import('..')
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.resetModules()
 
-    expect(process.env.NODE_ENV).not.toBe('development')
-    expect(ReactQueryDevtoolsPanel({})).toBeNull()
+    try {
+      const { ReactQueryDevtoolsPanel } = await import('..')
+      expect(ReactQueryDevtoolsPanel({})).toBeNull()
+    } finally {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
   })
 })

--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
+
+const mountMock = vi.fn()
+const unmountMock = vi.fn()
+const setClientMock = vi.fn()
+const setOnCloseMock = vi.fn()
+const setErrorTypesMock = vi.fn()
+const setThemeMock = vi.fn()
+
+vi.mock('@tanstack/query-devtools', () => ({
+  TanstackQueryDevtoolsPanel: vi.fn(function (
+    this: TanstackQueryDevtoolsPanel,
+  ) {
+    this.mount = mountMock
+    this.unmount = unmountMock
+    this.setClient = setClientMock
+    this.setOnClose = setOnCloseMock
+    this.setErrorTypes = setErrorTypesMock
+    this.setTheme = setThemeMock
+  }),
+}))
+
+describe('ReactQueryDevtoolsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw an error if no query client has been set', async () => {
+    const { ReactQueryDevtoolsPanel } = await import(
+      '../ReactQueryDevtoolsPanel'
+    )
+
+    expect(() => render(<ReactQueryDevtoolsPanel />)).toThrow(
+      'No QueryClient set, use QueryClientProvider to set one',
+    )
+  })
+
+  it('should not throw an error if query client is provided via context', async () => {
+    const { ReactQueryDevtoolsPanel } = await import(
+      '../ReactQueryDevtoolsPanel'
+    )
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(
+        <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtoolsPanel />
+        </QueryClientProvider>,
+      ),
+    ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
+  })
+
+  it('should not throw an error if query client is provided via props', async () => {
+    const { ReactQueryDevtoolsPanel } = await import(
+      '../ReactQueryDevtoolsPanel'
+    )
+    const queryClient = new QueryClient()
+
+    expect(() =>
+      render(<ReactQueryDevtoolsPanel client={queryClient} />),
+    ).not.toThrow()
+    expect(mountMock).toHaveBeenCalled()
+  })
+
+  it('should return null in non-development environments', async () => {
+    const { ReactQueryDevtoolsPanel } = await import('..')
+
+    expect(process.env.NODE_ENV).not.toBe('development')
+    expect(ReactQueryDevtoolsPanel({})).toBeNull()
+  })
+})

--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
@@ -29,9 +29,8 @@ describe('ReactQueryDevtoolsPanel', () => {
   })
 
   it('should throw an error if no query client has been set', async () => {
-    const { ReactQueryDevtoolsPanel } = await import(
-      '../ReactQueryDevtoolsPanel'
-    )
+    const { ReactQueryDevtoolsPanel } =
+      await import('../ReactQueryDevtoolsPanel')
 
     expect(() => render(<ReactQueryDevtoolsPanel />)).toThrow(
       'No QueryClient set, use QueryClientProvider to set one',
@@ -39,9 +38,8 @@ describe('ReactQueryDevtoolsPanel', () => {
   })
 
   it('should not throw an error if query client is provided via context', async () => {
-    const { ReactQueryDevtoolsPanel } = await import(
-      '../ReactQueryDevtoolsPanel'
-    )
+    const { ReactQueryDevtoolsPanel } =
+      await import('../ReactQueryDevtoolsPanel')
     const queryClient = new QueryClient()
 
     expect(() =>
@@ -55,9 +53,8 @@ describe('ReactQueryDevtoolsPanel', () => {
   })
 
   it('should not throw an error if query client is provided via props', async () => {
-    const { ReactQueryDevtoolsPanel } = await import(
-      '../ReactQueryDevtoolsPanel'
-    )
+    const { ReactQueryDevtoolsPanel } =
+      await import('../ReactQueryDevtoolsPanel')
     const queryClient = new QueryClient()
 
     expect(() =>

--- a/packages/react-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/devtools.test.tsx
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest'
-
-describe('ReactQueryDevtools', () => {
-  it('should be able to open and close devtools', () => {
-    expect(1).toBe(1)
-  })
-})

--- a/packages/react-query-devtools/src/__tests__/not-development.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/not-development.test.tsx
@@ -1,9 +1,0 @@
-import { describe, expect, it } from 'vitest'
-import { ReactQueryDevtools } from '..'
-
-describe('ReactQueryDevtools not in process.env.NODE_ENV=development', () => {
-  it('should return null', () => {
-    expect(process.env.NODE_ENV).not.toBe('development')
-    expect(ReactQueryDevtools({})).toBeNull()
-  })
-})


### PR DESCRIPTION
## 🎯 Changes

Add tests for `react-query-devtools` covering wrapper invariants and the production fallback in `index.ts`, replacing the existing placeholder.

- Replace placeholder `devtools.test.tsx` with `ReactQueryDevtools.test.tsx` containing 4 cases:
  - throws when no `QueryClient` is set.
  - mounts when `QueryClient` is provided via `<QueryClientProvider>` (asserts `mount` was called).
  - mounts when `QueryClient` is provided via the `client` prop (asserts `mount` was called).
  - returns `null` in non-development environments (production fallback in `index.ts`).
- Add `ReactQueryDevtoolsPanel.test.tsx` with the same 4 cases for `ReactQueryDevtoolsPanel`.
- Remove the standalone `not-development.test.tsx`; the production fallback case is now colocated with each component's tests.
- File names match the component names (`ReactQueryDevtools.test.tsx` / `ReactQueryDevtoolsPanel.test.tsx`), aligning with the broader repo convention.

This mirrors the pattern recently introduced in `preact-query-devtools` (#10626) and brings the `react-query-devtools` test suite to parity.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:lib\` (8/8 passed).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized and expanded Vitest coverage for ReactQueryDevtools and ReactQueryDevtoolsPanel: added suites that mock devtools integration, verify error handling when no QueryClient is provided, confirm mounting with QueryClientProvider or direct client prop, and assert production builds evaluate to null. Removed older/obsolete tests that duplicated these checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->