### PR TITLE
test(preact-query-devtools): make production fallback test deterministic with 'vi.stubEnv' and 'vi.resetModules'

### DIFF
--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -63,9 +63,15 @@ describe('PreactQueryDevtools', () => {
   })
 
   it('should return null in non-development environments', async () => {
-    const { PreactQueryDevtools } = await import('..')
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.resetModules()
 
-    expect(process.env.NODE_ENV).not.toBe('development')
-    expect(PreactQueryDevtools({})).toBeNull()
+    try {
+      const { PreactQueryDevtools } = await import('..')
+      expect(PreactQueryDevtools({})).toBeNull()
+    } finally {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
   })
 })

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -64,9 +64,15 @@ describe('PreactQueryDevtoolsPanel', () => {
   })
 
   it('should return null in non-development environments', async () => {
-    const { PreactQueryDevtoolsPanel } = await import('..')
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.resetModules()
 
-    expect(process.env.NODE_ENV).not.toBe('development')
-    expect(PreactQueryDevtoolsPanel({})).toBeNull()
+    try {
+      const { PreactQueryDevtoolsPanel } = await import('..')
+      expect(PreactQueryDevtoolsPanel({})).toBeNull()
+    } finally {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Make the `production fallback` tests in `preact-query-devtools` deterministic by explicitly setting `NODE_ENV` to `'production'` and resetting the module cache, instead of relying on the runner's ambient `NODE_ENV`.

- Replace `expect(process.env.NODE_ENV).not.toBe('development')` ambient check with explicit `vi.stubEnv('NODE_ENV', 'production')` + `vi.resetModules()`.
- Wrap the assertion in `try/finally` to guarantee cleanup (`vi.unstubAllEnvs()` + `vi.resetModules()`) even on assertion failure.
- Apply to both `PreactQueryDevtools.test.tsx` and `PreactQueryDevtoolsPanel.test.tsx`.

This mirrors the same fix landing in `react-query-devtools` (see #10627) and aligns with the existing pattern used in `vue-query` (`vi.stubEnv` + `try/finally` + `vi.unstubAllEnvs`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:lib\` (8/8 passed).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved environment variable handling and module reset procedures in devtools tests for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->