### PR TITLE
docs: correct refetchOnReconnect default in JSDoc

### DIFF
--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -365,7 +365,7 @@ export interface QueryObserverOptions<
    * If set to `false`, the query will not refetch on reconnect.
    * If set to `'always'`, the query will always refetch on reconnect.
    * If set to a function, the function will be executed with the latest data and query to compute the value.
-   * Defaults to the value of `networkOnline` (`true`)
+   * Defaults to `true` unless `networkMode` is `'always'`.
    */
   refetchOnReconnect?:
     | boolean


### PR DESCRIPTION
## Changes

The JSDoc for `QueryOptions#refetchOnReconnect` referenced `networkOnline`, which does not exist anywhere in the codebase. The actual default is set in `queryClient.ts` based on `networkMode`:

    defaultedOptions.refetchOnReconnect = defaultedOptions.networkMode !== 'always'

Updated the comment to accurately describe the real default.

## Checklist

- [x] I have followed the steps in the Contributing guide.
- [x] I have tested this code locally with `pnpm run test:pr`.

## Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the default behavior documentation for the reconnect refetch option regarding its interaction with network mode settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->