### PR TITLE
feat(svelte-query-devtools): add theme option

### DIFF
--- a/.changeset/svelte-devtools-theme-option.md
+++ b/.changeset/svelte-devtools-theme-option.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/svelte-query-devtools': patch
+---
+
+Add theme option support to the floating devtools.

--- a/docs/framework/svelte/devtools.md
+++ b/docs/framework/svelte/devtools.md
@@ -79,3 +79,6 @@ Place the following code as high in your Svelte app as you can. The closer it is
 - `shadowDOMTarget?: ShadowRoot`
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: Theme`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.

--- a/packages/svelte-query-devtools/src/Devtools.svelte
+++ b/packages/svelte-query-devtools/src/Devtools.svelte
@@ -8,6 +8,7 @@
     DevtoolsErrorType,
     DevtoolsPosition,
     TanstackQueryDevtools,
+    Theme,
   } from '@tanstack/query-devtools'
 
   interface DevtoolsOptions {
@@ -47,6 +48,11 @@
      * Set this to true to hide disabled queries from the devtools panel.
      */
     hideDisabledQueries?: boolean
+    /**
+     * Set this to 'light', 'dark', or 'system' to change the theme of the devtools panel.
+     * Defaults to 'system'.
+     */
+    theme?: Theme
   }
 
   let {
@@ -58,6 +64,7 @@
     styleNonce = undefined,
     shadowDOMTarget = undefined,
     hideDisabledQueries = false,
+    theme = 'system',
   }: DevtoolsOptions = $props()
 
   let ref: HTMLDivElement
@@ -80,6 +87,7 @@
           styleNonce,
           shadowDOMTarget,
           hideDisabledQueries,
+          theme,
         })
 
         devtools.mount(ref)
@@ -101,6 +109,10 @@
 
     $effect(() => {
       devtools?.setErrorTypes(errorTypes)
+    })
+
+    $effect(() => {
+      devtools?.setTheme(theme)
     })
   }
 </script>


### PR DESCRIPTION
## 🎯 Changes

Add `theme` option support to Svelte floating devtools.

Other framework bindings (React, Vue, Solid, Angular) already expose the shared `theme?: Theme` option. This adds the same support to Svelte devtools and keeps behavior consistent across frameworks.

The theme is applied on initialization and updated reactively via `setTheme`.

## ✅ Checklist

- [x] I have followed the steps in the Contributing guide.
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme configuration option to the Svelte Query Devtools floating panel, defaulting to the system theme. Theme changes are automatically synchronized while the panel is open.

* **Documentation**
  * Updated the devtools documentation to describe the new theme option, its default behavior, and supported configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->