### PR TITLE
fix(devtools): add transform: translateZ(0) for Safari overflow rendering

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -2765,6 +2765,8 @@ const stylesFactory = (
         right: -8px;
         bottom: -8px;
         border-radius: 9999px;
+        -webkit-transform: translateZ(0);
+        transform: translateZ(0);
 
         & svg {
           position: absolute;


### PR DESCRIPTION
## Summary

Safari has a known issue where `overflow: hidden` with `border-radius` doesn't work correctly without hardware acceleration. This causes the devtools icon to render incorrectly in Safari.

## Changes

Added `transform: translateZ(0)` and `-webkit-transform: translateZ(0)` to the background div element to force GPU compositing, which fixes the overflow rendering issue in Safari.

Fixes #10633

## Test plan

- [ ] Open TanStack Query DevTools in Safari
- [ ] Verify the icon renders as a properly cropped pill shape
- [ ] Verify the icon still renders correctly in Chrome/Firefox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved devtools button rendering performance with GPU acceleration enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->