### PR TITLE
test(query-devtools/TanstackQueryDevtools): replace placeholder with 'mount' and 'unmount' lifecycle tests

### DIFF
--- a/packages/query-devtools/src/__tests__/TanstackQueryDevtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/TanstackQueryDevtools.test.tsx
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { QueryClient, onlineManager } from '@tanstack/query-core'
+import { TanstackQueryDevtools } from '..'
+
+describe('TanstackQueryDevtools', () => {
+  let devtools: TanstackQueryDevtools
+
+  beforeEach(() => {
+    devtools = new TanstackQueryDevtools({
+      client: new QueryClient(),
+      queryFlavor: 'TanStack Query',
+      version: '5',
+      onlineManager,
+    })
+  })
+
+  describe('mount', () => {
+    it('should mount devtools to the provided element', () => {
+      const el = document.createElement('div')
+
+      expect(() => devtools.mount(el)).not.toThrow()
+
+      devtools.unmount()
+    })
+
+    it('should throw if mount is called twice without unmount', () => {
+      const el = document.createElement('div')
+      devtools.mount(el)
+
+      expect(() => devtools.mount(el)).toThrow('Devtools is already mounted')
+
+      devtools.unmount()
+    })
+  })
+
+  describe('unmount', () => {
+    it('should unmount devtools and allow remounting', () => {
+      const el = document.createElement('div')
+      devtools.mount(el)
+
+      expect(() => devtools.unmount()).not.toThrow()
+      expect(() => devtools.mount(el)).not.toThrow()
+
+      devtools.unmount()
+    })
+
+    it('should throw if unmount is called before mount', () => {
+      expect(() => devtools.unmount()).toThrow('Devtools is not mounted')
+    })
+
+    it('should throw if unmount is called twice', () => {
+      const el = document.createElement('div')
+      devtools.mount(el)
+      devtools.unmount()
+
+      expect(() => devtools.unmount()).toThrow('Devtools is not mounted')
+    })
+  })
+})

--- a/packages/query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/devtools.test.tsx
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest'
-
-describe('ReactQueryDevtools', () => {
-  it('should be able to open and close devtools', () => {
-    expect(1).toBe(1)
-  })
-})


### PR DESCRIPTION
## 🎯 Changes

Replace the placeholder test (`expect(1).toBe(1)`) with the first real lifecycle tests for the `TanstackQueryDevtools` core class.

- Remove `src/__tests__/devtools.test.tsx` (placeholder)
- Add `src/__tests__/TanstackQueryDevtools.test.tsx` with 5 cases covering `mount`/`unmount` lifecycle and guard behavior:
  - `mount`: succeeds on a provided element / throws on double mount
  - `unmount`: allows remounting / throws when called before mount / throws on double unmount

Setter contract and reactive UI behavior are intentionally out of scope for this PR — they will be covered in follow-up PRs.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Vitest tests covering devtools initialization, mount/unmount flows and error-handling for repeated or invalid mount/unmount sequences.
  * Removed a placeholder test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->