### PR TITLE
test(query-devtools/TanstackQueryDevtoolsPanel): add 'mount' and 'unmount' lifecycle tests

### DIFF
--- a/packages/query-devtools/src/__tests__/TanstackQueryDevtoolsPanel.test.tsx
+++ b/packages/query-devtools/src/__tests__/TanstackQueryDevtoolsPanel.test.tsx
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { QueryClient, onlineManager } from '@tanstack/query-core'
+import { TanstackQueryDevtoolsPanel } from '..'
+
+describe('TanstackQueryDevtoolsPanel', () => {
+  let devtools: TanstackQueryDevtoolsPanel
+
+  beforeEach(() => {
+    devtools = new TanstackQueryDevtoolsPanel({
+      client: new QueryClient(),
+      queryFlavor: 'TanStack Query',
+      version: '5',
+      onlineManager,
+    })
+  })
+
+  describe('mount', () => {
+    it('should mount devtools to the provided element', () => {
+      const el = document.createElement('div')
+
+      expect(() => devtools.mount(el)).not.toThrow()
+
+      devtools.unmount()
+    })
+
+    it('should throw if mount is called twice without unmount', () => {
+      const el = document.createElement('div')
+      devtools.mount(el)
+
+      expect(() => devtools.mount(el)).toThrow('Devtools is already mounted')
+
+      devtools.unmount()
+    })
+  })
+
+  describe('unmount', () => {
+    it('should unmount devtools and allow remounting', () => {
+      const el = document.createElement('div')
+      devtools.mount(el)
+
+      expect(() => devtools.unmount()).not.toThrow()
+      expect(() => devtools.mount(el)).not.toThrow()
+
+      devtools.unmount()
+    })
+
+    it('should throw if unmount is called before mount', () => {
+      expect(() => devtools.unmount()).toThrow('Devtools is not mounted')
+    })
+
+    it('should throw if unmount is called twice', () => {
+      const el = document.createElement('div')
+      devtools.mount(el)
+      devtools.unmount()
+
+      expect(() => devtools.unmount()).toThrow('Devtools is not mounted')
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add the first lifecycle tests for the `TanstackQueryDevtoolsPanel` core class, following the pattern established in #10639.

- Add `src/__tests__/TanstackQueryDevtoolsPanel.test.tsx` with 5 cases covering `mount`/`unmount` lifecycle and guard behavior:
  - `mount`: succeeds on a provided element / throws on double mount
  - `unmount`: allows remounting / throws when called before mount / throws on double unmount

Setter contract and reactive UI behavior are intentionally out of scope for this PR — they will be covered in follow-up PRs.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Query Devtools panel initialization and lifecycle management, including mount/unmount behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->