### PR TITLE
fix(eslint-plugin-query): fix no-unstable-deps false positive for useSuspenseQueries

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -63,6 +63,24 @@ const baseTestCases = {
             }
           `,
         },
+        {
+          name: `should pass when useSuspenseQueries with combine is passed to ${reactHookAlias} as dependency`,
+          code: `
+            ${reactHookImport}
+            import { useSuspenseQueries } from "@tanstack/react-query";
+
+            function Component() {
+              const queries = useSuspenseQueries({
+                queries: [
+                  { queryKey: ['test'], queryFn: () => 'test' }
+                ],
+                combine: (results) => ({ data: results[0]?.data })
+              });
+              const callback = ${reactHookInvocation}(() => { queries.data }, [queries]);
+              return;
+            }
+          `,
+        },
       ])
       .concat([
         {

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -112,12 +112,13 @@ export const rule = createRule({
           allHookNames.includes(node.init.callee.name) &&
           helpers.isTanstackQueryImport(node.init.callee)
         ) {
-          // Special case for useQueries with combine property - it's stable
+          // Special case for useQueries/useSuspenseQueries with combine property - it's stable
           if (
-            node.init.callee.name === 'useQueries' &&
+            (node.init.callee.name === 'useQueries' ||
+              node.init.callee.name === 'useSuspenseQueries') &&
             hasCombineProperty(node.init)
           ) {
-            // Don't track useQueries with combine as unstable
+            // Don't track useQueries/useSuspenseQueries with combine as unstable
             return
           }
           collectVariableNames(node.id, node.init.callee.name)


### PR DESCRIPTION
## Summary

The `no-unstable-deps` ESLint rule was fixed for `useQueries` with `combine` in PR #9720, but the same false positive persists for `useSuspenseQueries` with `combine`. Using the combined value in a `useMemo` or `useEffect` dependency array incorrectly triggers the rule.

This PR extends the existing fix from #9720 to also cover `useSuspenseQueries` with a `combine` property. The rule now recognizes that `useSuspenseQueries` with `combine` returns a stable value, just like `useQueries` with `combine`.

Closes #10641

## Changes

- Updated `no-unstable-deps` rule to check for both `useQueries` and `useSuspenseQueries` when determining if the `combine` property makes the return value stable
- Added test case for `useSuspenseQueries` with `combine` in the valid test cases

## Test plan

- [x] All 1624 existing tests pass
- [x] New test case for `useSuspenseQueries` with `combine` passes
- [x] Existing invalid test for `useSuspenseQueries` without `combine` still correctly reports errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the rule to correctly recognize `useSuspenseQueries` with a `combine` function as a referentially stable dependency, preventing false linting warnings when used in React hook dependency arrays.

* **Tests**
  * Added test coverage validating the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->