### PR TITLE
fix(devtools): fix crash with custom queryKeyHashFn and async persistence

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -1384,54 +1384,35 @@ const QueryRow: Component<{ query: Query }> = (props) => {
   const t = (light: string, dark: string) => (theme() === 'dark' ? dark : light)
 
   const queryState = createSubscribeToQueryCacheBatcher(
-    (queryCache) =>
-      queryCache().find({
-        queryKey: props.query.queryKey,
-      })?.state,
+    (queryCache) => queryCache().get(props.query.queryHash)?.state,
     true,
     (e) => e.query.queryHash === props.query.queryHash,
   )
 
   const isDisabled = createSubscribeToQueryCacheBatcher(
     (queryCache) =>
-      queryCache()
-        .find({
-          queryKey: props.query.queryKey,
-        })
-        ?.isDisabled() ?? false,
+      queryCache().get(props.query.queryHash)?.isDisabled() ?? false,
     true,
     (e) => e.query.queryHash === props.query.queryHash,
   )
 
   const isStatic = createSubscribeToQueryCacheBatcher(
     (queryCache) =>
-      queryCache()
-        .find({
-          queryKey: props.query.queryKey,
-        })
-        ?.isStatic() ?? false,
+      queryCache().get(props.query.queryHash)?.isStatic() ?? false,
     true,
     (e) => e.query.queryHash === props.query.queryHash,
   )
 
   const isStale = createSubscribeToQueryCacheBatcher(
     (queryCache) =>
-      queryCache()
-        .find({
-          queryKey: props.query.queryKey,
-        })
-        ?.isStale() ?? false,
+      queryCache().get(props.query.queryHash)?.isStale() ?? false,
     true,
     (e) => e.query.queryHash === props.query.queryHash,
   )
 
   const observers = createSubscribeToQueryCacheBatcher(
     (queryCache) =>
-      queryCache()
-        .find({
-          queryKey: props.query.queryKey,
-        })
-        ?.getObserversCount() ?? 0,
+      queryCache().get(props.query.queryHash)?.getObserversCount() ?? 0,
     true,
     (e) => e.query.queryHash === props.query.queryHash,
   )


### PR DESCRIPTION
## Summary

When using async persistence (e.g. IndexedDB) combined with a custom `queryKeyHashFn`, the DevTools crash on initial load with:
```
TypeError: Cannot read properties of undefined (reading 'fetchStatus')
```

The root cause is that `queryCache.find({ queryKey })` internally uses the default `hashQueryKey` to compute the hash and match queries. When a custom `queryKeyHashFn` is configured, this computed hash won't match the query's actual hash in the cache, so `find()` returns `undefined`.

## Fix

Replaced `queryCache.find({ queryKey: props.query.queryKey })` calls with `queryCache.get(props.query.queryHash)` in the DevTools query detail component. The `get()` method looks up queries directly by their already-computed hash string, which correctly finds the query regardless of which hash function was used.

The `props.query.queryHash` is already available in this component since each query entry in the DevTools list carries its `queryHash`.

Closes #6958

## Test plan

- [x] Verified the fix targets the correct `queryCache().find()` calls that use `queryKey` matching
- [ ] Manual testing with a custom `queryKeyHashFn` and async persistence (IndexedDB) recommended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized query resolution in the DevTools to improve performance and responsiveness when retrieving and displaying query state information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->