### PR TITLE
test(query-devtools/utils): add tests for 'getMutationStatusColor' and 'getQueryStatusColorByLabel'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -743,7 +743,12 @@ describe('Utils tests', () => {
       isPaused: boolean
       expected: string
     }> = [
-      { label: 'paused', status: 'pending', isPaused: true, expected: 'purple' },
+      {
+        label: 'paused',
+        status: 'pending',
+        isPaused: true,
+        expected: 'purple',
+      },
       {
         label: 'paused even when status is "error"',
         status: 'error',
@@ -751,8 +756,18 @@ describe('Utils tests', () => {
         expected: 'purple',
       },
       { label: '"error"', status: 'error', isPaused: false, expected: 'red' },
-      { label: '"pending"', status: 'pending', isPaused: false, expected: 'yellow' },
-      { label: '"success"', status: 'success', isPaused: false, expected: 'green' },
+      {
+        label: '"pending"',
+        status: 'pending',
+        isPaused: false,
+        expected: 'yellow',
+      },
+      {
+        label: '"success"',
+        status: 'success',
+        isPaused: false,
+        expected: 'green',
+      },
       { label: '"idle"', status: 'idle', isPaused: false, expected: 'gray' },
     ]
 

--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { deleteNestedDataByPath, updateNestedDataByPath } from '../utils'
+import {
+  deleteNestedDataByPath,
+  getMutationStatusColor,
+  getQueryStatusColorByLabel,
+  updateNestedDataByPath,
+} from '../utils'
+import type { MutationStatus } from '@tanstack/query-core'
 
 describe('Utils tests', () => {
   describe('updatedNestedDataByPath', () => {
@@ -727,6 +733,56 @@ describe('Utils tests', () => {
         `)
         /* eslint-enable */
       })
+    })
+  })
+
+  describe('getMutationStatusColor', () => {
+    const cases: Array<{
+      label: string
+      status: MutationStatus
+      isPaused: boolean
+      expected: string
+    }> = [
+      { label: 'paused', status: 'pending', isPaused: true, expected: 'purple' },
+      {
+        label: 'paused even when status is "error"',
+        status: 'error',
+        isPaused: true,
+        expected: 'purple',
+      },
+      { label: '"error"', status: 'error', isPaused: false, expected: 'red' },
+      { label: '"pending"', status: 'pending', isPaused: false, expected: 'yellow' },
+      { label: '"success"', status: 'success', isPaused: false, expected: 'green' },
+      { label: '"idle"', status: 'idle', isPaused: false, expected: 'gray' },
+    ]
+
+    it.each(cases)(
+      'should return "$expected" when mutation is $label',
+      ({ status, isPaused, expected }) => {
+        expect(getMutationStatusColor({ status, isPaused })).toBe(expected)
+      },
+    )
+  })
+
+  describe('getQueryStatusColorByLabel', () => {
+    it('should return "green" for "fresh"', () => {
+      expect(getQueryStatusColorByLabel('fresh')).toBe('green')
+    })
+
+    it('should return "yellow" for "stale"', () => {
+      expect(getQueryStatusColorByLabel('stale')).toBe('yellow')
+    })
+
+    it('should return "purple" for "paused"', () => {
+      expect(getQueryStatusColorByLabel('paused')).toBe('purple')
+    })
+
+    it('should return "gray" for "inactive"', () => {
+      expect(getQueryStatusColorByLabel('inactive')).toBe('gray')
+    })
+
+    it('should return "blue" for "fetching"', () => {
+      expect(getQueryStatusColorByLabel('fetching')).toBe('blue')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for two pure status-to-color mapping helpers in `query-devtools/utils.tsx`.

- `getMutationStatusColor` — covers the priority of `isPaused` over status, plus all branches (`error`, `pending`, `success`, `idle`)
- `getQueryStatusColorByLabel` — covers all 5 labels (`fresh`, `stale`, `paused`, `inactive`, `fetching`)

These functions take primitive inputs (no `Query`/`Mutation` instances), so the tests follow textbook unit-test style with no type casts.

Coverage for `utils.tsx`:
- Branch: 25.74% → 41.58%
- Funcs: 18.18% → 27.27%

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for mutation and query status color mapping utilities in query-devtools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->