### PR TITLE
test(query-devtools/utils): add tests for 'displayValue'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   deleteNestedDataByPath,
+  displayValue,
   getMutationStatusColor,
   getQueryStatusColorByLabel,
   updateNestedDataByPath,
@@ -798,6 +799,32 @@ describe('Utils tests', () => {
 
     it('should return "blue" for "fetching"', () => {
       expect(getQueryStatusColorByLabel('fetching')).toBe('blue')
+    })
+  })
+
+  describe('displayValue', () => {
+    it('should stringify a primitive value', () => {
+      expect(displayValue('hello')).toBe('"hello"')
+    })
+
+    it('should stringify a number', () => {
+      expect(displayValue(42)).toBe('42')
+    })
+
+    it('should serialize an object using superjson and discard meta', () => {
+      expect(displayValue({ a: 1, b: 'two' })).toBe('{"a":1,"b":"two"}')
+    })
+
+    it('should return "null" for "undefined" since only the json part is used', () => {
+      expect(displayValue(undefined)).toBe('null')
+    })
+
+    it('should return a single-line string by default', () => {
+      expect(displayValue({ a: 1 })).toBe('{"a":1}')
+    })
+
+    it('should return an indented multi-line string when "beautify" is true', () => {
+      expect(displayValue({ a: 1 }, true)).toBe('{\n  "a": 1\n}')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `displayValue` helper in `query-devtools/utils.tsx`.

The helper takes `superjson.serialize(value).json` (discarding `.meta`) and runs it through `JSON.stringify`, with an optional `beautify` flag for indented multi-line output.

Cases:
- Primitive sanity (`string`, `number`)
- Composite sanity (`object`)
- `undefined` → `'null'` — exercises the "discard `.meta`" behavior
- Default `beautify` (single-line)
- `beautify: true` (indented multi-line)

External library behavior (`superjson`'s handling of `Date`, `Map`, `Set`, `NaN`, etc.) is intentionally out of scope — those belong to `superjson`'s own test suite.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for value serialization and formatting capabilities, including validation of primitive handling, number formatting, object serialization, and display mode variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->