### PR TITLE
test(query-devtools/utils): add tests for 'getSidedProp'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   displayValue,
   getMutationStatusColor,
   getQueryStatusColorByLabel,
+  getSidedProp,
   updateNestedDataByPath,
 } from '../utils'
 import type { MutationStatus } from '@tanstack/query-core'
@@ -825,6 +826,24 @@ describe('Utils tests', () => {
 
     it('should return an indented multi-line string when "beautify" is true', () => {
       expect(displayValue({ a: 1 }, true)).toBe('{\n  "a": 1\n}')
+    })
+  })
+
+  describe('getSidedProp', () => {
+    it('should append capitalized "top" to the prop', () => {
+      expect(getSidedProp('margin', 'top')).toBe('marginTop')
+    })
+
+    it('should append capitalized "bottom" to the prop', () => {
+      expect(getSidedProp('margin', 'bottom')).toBe('marginBottom')
+    })
+
+    it('should append capitalized "left" to the prop', () => {
+      expect(getSidedProp('padding', 'left')).toBe('paddingLeft')
+    })
+
+    it('should append capitalized "right" to the prop', () => {
+      expect(getSidedProp('padding', 'right')).toBe('paddingRight')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `getSidedProp` helper in `query-devtools/utils.tsx`.

The helper builds a sided property name by appending the capitalized side to a base prop (e.g. `getSidedProp('margin', 'top') === 'marginTop'`).

Cases cover all four `DevtoolsPosition` values: `top`, `bottom`, `left`, `right`.

The `Capitalize<DevtoolsPosition>` template literal type only enforces the return type shape, not the runtime capitalization logic — so dropping `toUpperCase()` would still type-check but break at runtime. These tests guard that behavior.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced test coverage with additional test cases for property name utility functions, ensuring correct camel-case conversion for spacing-related properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->