### PR TITLE
test(query-devtools/utils): add tests for 'convertRemToPixels'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  convertRemToPixels,
   deleteNestedDataByPath,
   displayValue,
   getMutationStatusColor,
@@ -844,6 +845,46 @@ describe('Utils tests', () => {
 
     it('should append capitalized "right" to the prop', () => {
       expect(getSidedProp('padding', 'right')).toBe('paddingRight')
+    })
+  })
+
+  describe('convertRemToPixels', () => {
+    beforeEach(() => {
+      document.documentElement.style.fontSize = '16px'
+    })
+
+    afterEach(() => {
+      document.documentElement.style.fontSize = ''
+    })
+
+    it('should convert 1 rem to the document root font size in pixels', () => {
+      expect(convertRemToPixels(1)).toBe(16)
+    })
+
+    it('should return 0 for 0 rem', () => {
+      expect(convertRemToPixels(0)).toBe(0)
+    })
+
+    it('should multiply rem by the document root font size', () => {
+      expect(convertRemToPixels(2)).toBe(32)
+    })
+
+    it('should support decimal rem values', () => {
+      expect(convertRemToPixels(0.5)).toBe(8)
+    })
+
+    it('should reflect the current document root font size', () => {
+      document.documentElement.style.fontSize = '20px'
+      expect(convertRemToPixels(1)).toBe(20)
+    })
+
+    it('should support negative rem values', () => {
+      expect(convertRemToPixels(-1)).toBe(-16)
+    })
+
+    it('should support non-integer font sizes', () => {
+      document.documentElement.style.fontSize = '15.5px'
+      expect(convertRemToPixels(1)).toBe(15.5)
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `convertRemToPixels` helper in `query-devtools/utils.tsx`.

The helper multiplies the given `rem` value by the document root's computed `font-size`.

Cases:
- `1` rem → root font size in pixels
- `0` rem → `0`
- `2` rem → `2 × root font size`
- decimal rem (`0.5`) → fractional pixels
- reflects the current root font size when it changes
- negative rem values preserve the sign (guards against `Math.abs` regressions)
- non-integer font sizes (e.g. `15.5px`) — guards `parseFloat` against `parseInt` regressions

The root font size is set explicitly to '16px' in `beforeEach` (jsdom defaults to an empty `font-size`, which would yield `NaN`) and cleared in `afterEach` to keep tests isolated.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests covering rem-to-pixel conversions, including dynamic font-size scenarios.
  * Added a new case validating the right-side variant of sided-property behavior.
  * Consolidated and improved test setup using lifecycle hooks for clearer, more reliable tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->