### PR TITLE
test(query-devtools/utils): add tests for 'setupStyleSheet'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
   getMutationStatusColor,
   getQueryStatusColorByLabel,
   getSidedProp,
+  setupStyleSheet,
   updateNestedDataByPath,
 } from '../utils'
 import type { MutationStatus } from '@tanstack/query-core'
@@ -885,6 +886,71 @@ describe('Utils tests', () => {
     it('should support non-integer font sizes', () => {
       document.documentElement.style.fontSize = '15.5px'
       expect(convertRemToPixels(1)).toBe(15.5)
+    })
+  })
+
+  describe('setupStyleSheet', () => {
+    afterEach(() => {
+      document.head.querySelector('#_goober')?.remove()
+    })
+
+    it('should not insert any style tag when "nonce" is missing', () => {
+      setupStyleSheet()
+
+      expect(document.head.querySelector('#_goober')).toBeNull()
+    })
+
+    it('should not insert any style tag when "nonce" is an empty string', () => {
+      setupStyleSheet('')
+
+      expect(document.head.querySelector('#_goober')).toBeNull()
+    })
+
+    it('should append a style tag with id "_goober" to "document.head"', () => {
+      setupStyleSheet('test-nonce')
+
+      const styleTag = document.head.querySelector('#_goober')
+      expect(styleTag).not.toBeNull()
+      expect(styleTag?.tagName).toBe('STYLE')
+    })
+
+    it('should set the "nonce" attribute on the inserted style tag', () => {
+      setupStyleSheet('test-nonce')
+
+      expect(
+        document.head.querySelector('#_goober')?.getAttribute('nonce'),
+      ).toBe('test-nonce')
+    })
+
+    it('should not insert a duplicate style tag when "document.head" already has one', () => {
+      setupStyleSheet('first-nonce')
+      setupStyleSheet('second-nonce')
+
+      const styleTags = document.head.querySelectorAll('#_goober')
+      expect(styleTags).toHaveLength(1)
+      expect(styleTags[0]?.getAttribute('nonce')).toBe('first-nonce')
+    })
+
+    it('should append the style tag to the provided "ShadowRoot" target', () => {
+      const host = document.createElement('div')
+      const shadow = host.attachShadow({ mode: 'open' })
+
+      setupStyleSheet('test-nonce', shadow)
+
+      expect(shadow.querySelector('#_goober')).not.toBeNull()
+      expect(document.head.querySelector('#_goober')).toBeNull()
+    })
+
+    it('should not insert a duplicate style tag when the target already has one', () => {
+      const host = document.createElement('div')
+      const shadow = host.attachShadow({ mode: 'open' })
+
+      setupStyleSheet('first-nonce', shadow)
+      setupStyleSheet('second-nonce', shadow)
+
+      const styleTags = shadow.querySelectorAll('#_goober')
+      expect(styleTags).toHaveLength(1)
+      expect(styleTags[0]?.getAttribute('nonce')).toBe('first-nonce')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `setupStyleSheet` helper in `query-devtools/utils.tsx`.

The helper inserts a `<style id="_goober">` tag with the given `nonce` attribute, either into `document.head` or into a provided `ShadowRoot` target. It is a no-op when no `nonce` is provided, and it does not insert a duplicate tag if one already exists in the destination.

Cases:
- no-op when `nonce` is missing
- no-op when `nonce` is an empty string (guards against strict `=== undefined` regressions)
- appends `<style id="_goober">` to `document.head`
- sets the `nonce` attribute on the inserted style tag
- does not insert a duplicate tag when `document.head` already has one
- appends to a provided `ShadowRoot` target instead of `document.head`
- does not insert a duplicate tag when the target already has one

The shared `<style>` tag in `document.head` is removed in `afterEach` to keep tests isolated.

The cross-target dedup behavior (whether a `document.head` tag should block insertion into a provided ShadowRoot target) is intentionally left unasserted while its intent is being clarified separately.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).