### PR TITLE
test(query-devtools/utils): add tests for 'sortFns'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { QueryClient, QueryObserver } from '@tanstack/query-core'
 import {
   convertRemToPixels,
   deleteNestedDataByPath,
@@ -7,9 +8,10 @@ import {
   getQueryStatusColorByLabel,
   getSidedProp,
   setupStyleSheet,
+  sortFns,
   updateNestedDataByPath,
 } from '../utils'
-import type { MutationStatus } from '@tanstack/query-core'
+import type { MutationStatus, Query } from '@tanstack/query-core'
 
 describe('Utils tests', () => {
   describe('updatedNestedDataByPath', () => {
@@ -951,6 +953,118 @@ describe('Utils tests', () => {
       const styleTags = shadow.querySelectorAll('#_goober')
       expect(styleTags).toHaveLength(1)
       expect(styleTags[0]?.getAttribute('nonce')).toBe('first-nonce')
+    })
+  })
+
+  describe('sortFns', () => {
+    let queryClient: QueryClient
+
+    function buildQuery(
+      queryKey: ReadonlyArray<unknown>,
+      state?: Partial<Query['state']>,
+    ): Query {
+      const query = queryClient.getQueryCache().build(queryClient, { queryKey })
+      if (state) {
+        query.setState(state)
+      }
+      return query
+    }
+
+    beforeEach(() => {
+      queryClient = new QueryClient()
+    })
+
+    afterEach(() => {
+      queryClient.clear()
+    })
+
+    describe("'last updated'", () => {
+      const dateSort = sortFns['last updated']!
+
+      it('should place the more recently updated query first', () => {
+        const older = buildQuery(['a'], { dataUpdatedAt: 100 })
+        const newer = buildQuery(['b'], { dataUpdatedAt: 200 })
+
+        expect(dateSort(older, newer)).toBe(1)
+        expect(dateSort(newer, older)).toBe(-1)
+      })
+    })
+
+    describe("'query hash'", () => {
+      const queryHashSort = sortFns['query hash']!
+
+      it('should sort queries by query hash alphabetically', () => {
+        const a = buildQuery(['a'])
+        const b = buildQuery(['b'])
+
+        expect(queryHashSort(a, b)).toBeLessThan(0)
+        expect(queryHashSort(b, a)).toBeGreaterThan(0)
+      })
+
+      it('should return 0 when query hashes are identical', () => {
+        const a = buildQuery(['same'])
+        const b = buildQuery(['same'])
+
+        expect(queryHashSort(a, b)).toBe(0)
+      })
+    })
+
+    describe("'status'", () => {
+      const statusSort = sortFns['status']!
+
+      function addObserver(query: Query) {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: query.queryKey,
+          enabled: false,
+        })
+        return observer.subscribe(() => {})
+      }
+
+      it('should place a fetching query before an idle one', () => {
+        const fetching = buildQuery(['fetching'], {
+          fetchStatus: 'fetching',
+          dataUpdatedAt: 100,
+        })
+        const idle = buildQuery(['idle'], {
+          fetchStatus: 'idle',
+          dataUpdatedAt: 100,
+        })
+        const unsubscribe = addObserver(idle)
+
+        try {
+          expect(statusSort(fetching, idle)).toBe(-1)
+          expect(statusSort(idle, fetching)).toBe(1)
+        } finally {
+          unsubscribe()
+        }
+      })
+
+      it('should place an inactive (no observers) query last', () => {
+        const active = buildQuery(['active'], {
+          fetchStatus: 'idle',
+          dataUpdatedAt: 100,
+        })
+        const inactive = buildQuery(['inactive'], {
+          fetchStatus: 'idle',
+          dataUpdatedAt: 100,
+        })
+        const unsubscribe = addObserver(active)
+
+        try {
+          expect(statusSort(active, inactive)).toBe(-1)
+          expect(statusSort(inactive, active)).toBe(1)
+        } finally {
+          unsubscribe()
+        }
+      })
+
+      it('should fall back to "last updated" sort within the same status rank', () => {
+        const older = buildQuery(['older'], { dataUpdatedAt: 100 })
+        const newer = buildQuery(['newer'], { dataUpdatedAt: 200 })
+
+        expect(statusSort(older, newer)).toBe(1)
+        expect(statusSort(newer, older)).toBe(-1)
+      })
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `sortFns` record of query-sort helpers in `query-devtools/utils.tsx`.

`sortFns` exposes three string keys (`'last updated'`, `'query hash'`, `'status'`) that map to comparators used to order queries in the devtools panel.

Cases:
- `'last updated'` (`dateSort`) — places the more recently updated query first
- `'query hash'` (`queryHashSort`) — sorts queries alphabetically by query hash; returns 0 when hashes are identical
- `'status'` (`statusAndDateSort`) — places fetching queries before idle ones, places inactive (no observers) queries last, and falls back to "last updated" sort within the same status rank

Each test uses a real `QueryClient` and `Query` instance; `'status'` tests rely on a real `QueryObserver` (with `enabled: false` to avoid triggering an automatic fetch). Subscribers are unsubscribed at the end of each test, and `queryClient.clear()` runs in `afterEach` to keep tests isolated.

`dateSort`'s behavior when `dataUpdatedAt` values are equal is intentionally left unasserted while its intent is being clarified separately.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sorting functions are now exposed for customizing how queries and mutations are ordered in the developer tools.

* **Tests**
  * Expanded and more comprehensive test coverage for sorting behavior, covering last-updated, identity, and status-based scenarios to ensure reliable ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->