### PR TITLE
test(query-devtools/utils): add tests for 'getPreferredColorScheme'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient, QueryObserver } from '@tanstack/query-core'
+import { createRoot } from 'solid-js'
 import {
   convertRemToPixels,
   deleteNestedDataByPath,
   displayValue,
   getMutationStatusColor,
+  getPreferredColorScheme,
   getQueryStatusColorByLabel,
   getSidedProp,
   mutationSortFns,
@@ -1175,6 +1177,118 @@ describe('Utils tests', () => {
 
         expect(mutationStatusSort(older, newer)).toBe(1)
         expect(mutationStatusSort(newer, older)).toBe(-1)
+      })
+    })
+  })
+
+  describe('getPreferredColorScheme', () => {
+    type MatchMediaListener = (event: MediaQueryListEvent) => void
+
+    function setupMatchMediaMock(initialMatches: boolean) {
+      const listeners = new Set<MatchMediaListener>()
+      const matchMedia: typeof window.matchMedia = vi.fn(
+        (query: string): MediaQueryList => ({
+          matches: initialMatches,
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn(
+            (_event: string, listener: MatchMediaListener) => {
+              listeners.add(listener)
+            },
+          ) as MediaQueryList['addEventListener'],
+          removeEventListener: vi.fn(
+            (_event: string, listener: MatchMediaListener) => {
+              listeners.delete(listener)
+            },
+          ) as MediaQueryList['removeEventListener'],
+          dispatchEvent: vi.fn(() => true),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        }),
+      )
+      vi.stubGlobal('matchMedia', matchMedia)
+      return {
+        matchMedia,
+        emit(matches: boolean) {
+          listeners.forEach((listener) =>
+            listener({ matches } as MediaQueryListEvent),
+          )
+        },
+        listenerCount: () => listeners.size,
+      }
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    })
+
+    it('should return "dark" before "onMount" runs', () => {
+      setupMatchMediaMock(false)
+
+      createRoot((dispose) => {
+        const colorScheme = getPreferredColorScheme()
+        expect(colorScheme()).toBe('dark')
+        dispose()
+      })
+    })
+
+    it('should reflect "matchMedia.matches" after "onMount" runs', async () => {
+      const { matchMedia, listenerCount } = setupMatchMediaMock(true)
+
+      await createRoot(async (dispose) => {
+        const colorScheme = getPreferredColorScheme()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)')
+        expect(listenerCount()).toBe(1)
+        expect(colorScheme()).toBe('dark')
+        dispose()
+      })
+    })
+
+    it('should reflect "light" when "matchMedia.matches" is false after "onMount" runs', async () => {
+      setupMatchMediaMock(false)
+
+      await createRoot(async (dispose) => {
+        const colorScheme = getPreferredColorScheme()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(colorScheme()).toBe('light')
+        dispose()
+      })
+    })
+
+    it('should update the signal when the "change" event fires', async () => {
+      const { emit } = setupMatchMediaMock(false)
+
+      await createRoot(async (dispose) => {
+        const colorScheme = getPreferredColorScheme()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(colorScheme()).toBe('light')
+
+        emit(true)
+        expect(colorScheme()).toBe('dark')
+
+        emit(false)
+        expect(colorScheme()).toBe('light')
+
+        dispose()
+      })
+    })
+
+    it('should remove the "change" listener on cleanup', async () => {
+      const { listenerCount } = setupMatchMediaMock(false)
+
+      await createRoot(async (dispose) => {
+        getPreferredColorScheme()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(listenerCount()).toBe(1)
+
+        dispose()
+        expect(listenerCount()).toBe(0)
       })
     })
   })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `getPreferredColorScheme` helper in `query-devtools/utils.tsx`.

The helper returns a Solid signal that defaults to `'dark'`, then on mount reads `window.matchMedia('(prefers-color-scheme: dark)')` and reflects its value, listening to `change` events for live updates.

Cases:
- returns `'dark'` before `onMount` runs (default signal value)
- after `onMount`, calls `matchMedia` with `'(prefers-color-scheme: dark)'`, registers a listener, and reflects `matches: true` as `'dark'`
- reflects `matches: false` as `'light'`
- updates the signal when the `change` event fires
- removes the `change` listener on cleanup

`window.matchMedia` is stubbed via `vi.stubGlobal` (auto-cleaned by `vi.unstubAllGlobals` in `afterEach`). Solid's `onMount` runs as a microtask, so each test uses fake timers and `await vi.advanceTimersByTimeAsync(0)` to flush — matching the pattern in `solid-query-persist-client`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for color scheme detection and theme switching behavior. Tests validate proper initialization of theme state, accurate system preference tracking, reactive signal updates when user theme preferences change, and complete cleanup of associated event listeners during component lifecycle management and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->