### PR TITLE
chore(lit-query): realign to the main TanStack Query version line

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,7 @@
       "@tanstack/angular-query-experimental",
       "@tanstack/angular-query-persist-client",
       "@tanstack/eslint-plugin-query",
+      "@tanstack/lit-query",
       "@tanstack/preact-query",
       "@tanstack/preact-query-devtools",
       "@tanstack/preact-query-persist-client",

--- a/.changeset/lit-query-version-align.md
+++ b/.changeset/lit-query-version-align.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/lit-query': patch
+---
+
+Realign `@tanstack/lit-query` to the main TanStack Query version line.
+
+The package is now part of the main fixed version group alongside `@tanstack/react-query`, `@tanstack/vue-query`, `@tanstack/solid-query`, etc., so its version tracks the rest of the core lineup.

--- a/examples/lit/basic/package.json
+++ b/examples/lit/basic/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@tanstack/query-example-lit-basic",
   "private": true,
-  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,8 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tanstack/lit-query": "^0.2.0",
-    "@tanstack/query-core": "^5.99.0",
+    "@tanstack/lit-query": "^5.100.9",
+    "@tanstack/query-core": "^5.100.9",
     "lit": "^3.3.1"
   },
   "devDependencies": {

--- a/examples/lit/pagination/package.json
+++ b/examples/lit/pagination/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@tanstack/query-example-lit-pagination",
   "private": true,
-  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "node ./scripts/dev.mjs",
@@ -9,8 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tanstack/lit-query": "^0.2.0",
-    "@tanstack/query-core": "^5.99.0",
+    "@tanstack/lit-query": "^5.100.9",
+    "@tanstack/query-core": "^5.100.9",
     "lit": "^3.3.1"
   },
   "devDependencies": {

--- a/examples/lit/ssr/package.json
+++ b/examples/lit/ssr/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@tanstack/query-example-lit-ssr",
   "private": true,
-  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "node ./scripts/dev.mjs",
@@ -9,8 +8,8 @@
   },
   "dependencies": {
     "@lit-labs/ssr": "^3.3.0",
-    "@tanstack/lit-query": "^0.2.0",
-    "@tanstack/query-core": "^5.99.0",
+    "@tanstack/lit-query": "^5.100.9",
+    "@tanstack/query-core": "^5.100.9",
     "lit": "^3.3.1"
   },
   "devDependencies": {

--- a/packages/lit-query/package.json
+++ b/packages/lit-query/package.json
@@ -1,8 +1,19 @@
 {
   "name": "@tanstack/lit-query",
-  "version": "0.2.0",
-  "description": "Lit adapter for TanStack Query Core",
+  "version": "5.100.9",
+  "description": "Controllers for managing, caching and syncing asynchronous and remote data in Lit",
+  "author": "tannerlinsley",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/query.git",
+    "directory": "packages/lit-query"
+  },
+  "homepage": "https://tanstack.com/query",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
   "type": "module",
   "main": "dist-cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## 🎯 Changes

Realign `@tanstack/lit-query` to the main TanStack Query version line so it tracks the rest of the core lineup (React Query, Vue Query, Solid Query, etc.) instead of standing alone on a `0.x` track.

- Add `@tanstack/lit-query` to the main fixed version group in `.changeset/config.json`
- Bump `packages/lit-query/package.json` from `0.2.0` → `5.100.9` and adjust the `description` to match the format used by the other adapters
- Drop the spurious `version` field from the lit examples and update their `@tanstack/lit-query` and `@tanstack/query-core` dependencies to `^5.100.9`
- Add a `patch` changeset so the realigned version flows through the next release

This builds on the metadata cleanup in 2f6e16b1e and 3894b052b. Build infrastructure (tsc vs `tsup`, `dist/` vs `build/` outputs, multi-version TypeScript scripts) and the issue template adapter dropdown are intentionally left out — those are separate cleanups.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TanStack Lit Query to a newer version across the package and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->