### PR TITLE
test(query-devtools/utils): add tests for 'getQueryStatusColor'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   displayValue,
   getMutationStatusColor,
   getPreferredColorScheme,
+  getQueryStatusColor,
   getQueryStatusColorByLabel,
   getSidedProp,
   mutationSortFns,
@@ -14,7 +15,12 @@ import {
   sortFns,
   updateNestedDataByPath,
 } from '../utils'
-import type { Mutation, MutationStatus, Query } from '@tanstack/query-core'
+import type {
+  FetchStatus,
+  Mutation,
+  MutationStatus,
+  Query,
+} from '@tanstack/query-core'
 
 describe('Utils tests', () => {
   describe('updatedNestedDataByPath', () => {
@@ -1290,6 +1296,96 @@ describe('Utils tests', () => {
         dispose()
         expect(listenerCount()).toBe(0)
       })
+    })
+  })
+
+  describe('getQueryStatusColor', () => {
+    let queryClient: QueryClient
+
+    function makeState(fetchStatus: FetchStatus): Query['state'] {
+      const query = queryClient.getQueryCache().build(queryClient, {
+        queryKey: [fetchStatus],
+      })
+      query.setState({ fetchStatus })
+      return query.state
+    }
+
+    beforeEach(() => {
+      queryClient = new QueryClient()
+    })
+
+    afterEach(() => {
+      queryClient.clear()
+    })
+
+    it('should return "blue" when fetchStatus is "fetching"', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: makeState('fetching'),
+          observerCount: 1,
+          isStale: false,
+        }),
+      ).toBe('blue')
+    })
+
+    it('should return "blue" even when there are no observers if fetchStatus is "fetching"', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: makeState('fetching'),
+          observerCount: 0,
+          isStale: false,
+        }),
+      ).toBe('blue')
+    })
+
+    it('should return "gray" when there are no observers', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: makeState('idle'),
+          observerCount: 0,
+          isStale: false,
+        }),
+      ).toBe('gray')
+    })
+
+    it('should return "purple" when fetchStatus is "paused"', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: makeState('paused'),
+          observerCount: 1,
+          isStale: false,
+        }),
+      ).toBe('purple')
+    })
+
+    it('should return "purple" even when stale if fetchStatus is "paused"', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: makeState('paused'),
+          observerCount: 1,
+          isStale: true,
+        }),
+      ).toBe('purple')
+    })
+
+    it('should return "yellow" when query is stale', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: makeState('idle'),
+          observerCount: 1,
+          isStale: true,
+        }),
+      ).toBe('yellow')
+    })
+
+    it('should return "green" when query is active and not stale', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: makeState('idle'),
+          observerCount: 1,
+          isStale: false,
+        }),
+      ).toBe('green')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `getQueryStatusColor` helper in `query-devtools/utils.tsx`.

The helper maps a query's `fetchStatus`, `observerCount`, and `isStale` flag to one of five status colors used in the devtools UI.

Cases:
- `'blue'` when `fetchStatus` is `'fetching'`
- `'blue'` even when there are no observers if `fetchStatus` is `'fetching'` (guards the `'fetching'`-over-`!observerCount` precedence)
- `'gray'` when there are no observers
- `'purple'` when `fetchStatus` is `'paused'`
- `'purple'` even when stale if `fetchStatus` is `'paused'` (guards the `'paused'`-over-`isStale` precedence)
- `'yellow'` when the query is stale
- `'green'` when the query is active and not stale

The `queryState` is built from a real `Query` instance via `queryClient.getQueryCache().build`, mirroring the pattern used by the existing `sortFns` and `mutationSortFns` suites. `queryClient.clear()` runs in `afterEach` to keep tests isolated.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for query status color indicators, validating correct color display across multiple query state combinations including fetching, idle states with various observer counts, paused states, stale conditions, and active states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->