### PR TITLE
test(query-devtools/utils): cover empty path, array nested path, and primitive cases of 'updateNestedDataByPath'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -135,6 +135,51 @@ describe('Utils tests', () => {
       /* eslint-enable */
     })
 
+    describe('empty path', () => {
+      it('should return the new value as-is when "updatePath" is empty', () => {
+        const oldData = { title: 'Hello world' }
+
+        expect(updateNestedDataByPath(oldData, [], 'replaced')).toBe('replaced')
+      })
+    })
+
+    describe('array nested path', () => {
+      it('should update nested data inside an array correctly', () => {
+        const oldData = [
+          { id: 1, title: 'first' },
+          { id: 2, title: 'second' },
+        ]
+
+        const newData = updateNestedDataByPath(
+          oldData,
+          ['1', 'title'],
+          'updated',
+        )
+
+        expect(newData).not.toBe(oldData)
+        expect(newData).toMatchInlineSnapshot(`
+          [
+            {
+              "id": 1,
+              "title": "first",
+            },
+            {
+              "id": 2,
+              "title": "updated",
+            },
+          ]
+        `)
+      })
+    })
+
+    describe('primitive', () => {
+      it('should return primitive data as-is when it is not an Object/Array/Map/Set', () => {
+        expect(updateNestedDataByPath(42, ['x'], 'new')).toBe(42)
+        expect(updateNestedDataByPath('hello', ['x'], 'new')).toBe('hello')
+        expect(updateNestedDataByPath(null, ['x'], 'new')).toBe(null)
+      })
+    })
+
     describe('nested data', () => {
       it('should update data correctly', () => {
         /* eslint-disable cspell/spellchecker */


### PR DESCRIPTION
## 🎯 Changes

Cover the three remaining branches of the `updateNestedDataByPath` helper in `query-devtools/utils.tsx`. The existing suite already exercises the single-step `array`, `object`, `set`, `map`, and deeply-nested cases; this PR fills in the branches that weren't hit yet.

Cases:
- empty path — returns the new value as-is when `updatePath` is empty
- array nested path — recurses into an element of an array when `updatePath.length > 1`
- primitive — returns primitive data unchanged when it is not an `Object` / `Array` / `Map` / `Set`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for utility functions, including edge cases for empty paths, nested array updates, and primitive value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->