### PR TITLE
test(query-devtools/utils): add tests for 'array nested path' and 'primitive' cases of 'deleteNestedDataByPath'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -539,6 +539,38 @@ describe('Utils tests', () => {
     `)
     })
 
+    describe('array nested path', () => {
+      it('should delete nested data inside an array correctly', () => {
+        const oldData = [
+          { id: 1, title: 'first' },
+          { id: 2, title: 'second' },
+        ]
+
+        const newData = deleteNestedDataByPath(oldData, ['1', 'title'])
+
+        expect(newData).not.toBe(oldData)
+        expect(newData).toMatchInlineSnapshot(`
+          [
+            {
+              "id": 1,
+              "title": "first",
+            },
+            {
+              "id": 2,
+            },
+          ]
+        `)
+      })
+    })
+
+    describe('primitive', () => {
+      it('should return primitive data as-is when it is not an Object/Array/Map/Set', () => {
+        expect(deleteNestedDataByPath(42, ['x'])).toBe(42)
+        expect(deleteNestedDataByPath('hello', ['x'])).toBe('hello')
+        expect(deleteNestedDataByPath(null, ['x'])).toBe(null)
+      })
+    })
+
     describe('nested data', () => {
       it('should delete nested items correctly', () => {
         /* eslint-disable cspell/spellchecker */


### PR DESCRIPTION
## 🎯 Changes

Add tests covering the two remaining branches of the `deleteNestedDataByPath` helper in `query-devtools/utils.tsx`. The existing suite already exercises the single-step `array`, `object`, `set`, `map`, and deeply-nested cases; this PR fills in the branches that weren't hit yet.

Cases:
- array nested path — recurses into an element of an array when `deletePath.length > 1`
- primitive — returns primitive data unchanged when it is not an `Object` / `Array` / `Map` / `Set`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for nested data operations and primitive value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->