### PR TITLE
test(query-devtools/utils): add test for stale vs fresh rank in 'status' sort of 'sortFns'

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1152,9 +1152,7 @@ describe('Utils tests', () => {
           staleTime: 0,
         })
         const staleUnsubscribe = staleObserver.subscribe(() => {})
-        const stale = queryClient
-          .getQueryCache()
-          .find({ queryKey: ['stale'] })!
+        const stale = queryClient.getQueryCache().find({ queryKey: ['stale'] })!
         stale.setState({
           ...stale.state,
           fetchStatus: 'idle',

--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1146,6 +1146,39 @@ describe('Utils tests', () => {
         }
       })
 
+      it('should place a stale query after a fresh one when both are idle and have observers', () => {
+        const staleObserver = new QueryObserver(queryClient, {
+          queryKey: ['stale'],
+          staleTime: 0,
+        })
+        const staleUnsubscribe = staleObserver.subscribe(() => {})
+        const stale = queryClient
+          .getQueryCache()
+          .find({ queryKey: ['stale'] })!
+        stale.setState({
+          ...stale.state,
+          fetchStatus: 'idle',
+          data: 'data',
+          dataUpdatedAt: 200,
+        })
+
+        const fresh = buildQuery(['fresh'], {
+          fetchStatus: 'idle',
+          data: 'fresh-data',
+          dataUpdatedAt: 100,
+        })
+        const freshUnsubscribe = addObserver(fresh)
+
+        try {
+          expect(stale.isStale()).toBe(true)
+          expect(statusSort(fresh, stale)).toBe(-1)
+          expect(statusSort(stale, fresh)).toBe(1)
+        } finally {
+          staleUnsubscribe()
+          freshUnsubscribe()
+        }
+      })
+
       it('should fall back to "last updated" sort within the same status rank', () => {
         const older = buildQuery(['older'], { dataUpdatedAt: 100 })
         const newer = buildQuery(['newer'], { dataUpdatedAt: 200 })


### PR DESCRIPTION
## 🎯 Changes

Add a test for the stale-vs-fresh rank distinction inside the `'status'` sort of `sortFns` in `query-devtools/utils.tsx`. The existing `'status'` cases compare across different `getStatusRank` levels (fetching/inactive/fall back), but never exercise the rank 1 (fresh) vs rank 2 (stale) split, leaving that branch unprotected.

The new test:
- Builds a stale query (`fetchStatus: 'idle'` with a `staleTime: 0` observer and `dataUpdatedAt: 200`).
- Builds a fresh query (`fetchStatus: 'idle'` with an `enabled: false` observer and `dataUpdatedAt: 100`).
- The stale one is intentionally given the more recent `dataUpdatedAt`, so a regression that collapses the stale/fresh ranks would fall back to `dateSort` and place the stale query first. Asserting that the fresh query is placed first proves the rank distinction is being respected.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query sorting functionality, verifying correct ordering of stale and fresh queries in idle states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->