### PR TITLE
fix: Safari DevTools icon rendering with isolation: isolate

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -2757,6 +2757,7 @@ const stylesFactory = (
       border-radius: 9999px;
       box-shadow: ${shadow.md()};
       overflow: hidden;
+      isolation: isolate;
 
       & div {
         position: absolute;


### PR DESCRIPTION
## Summary

Fixes #10633

This PR fixes a Safari-specific rendering bug where the TanStack Query DevTools icon is not rendering properly. The pill-shaped background was not being cropped correctly, causing visual artifacts.

## Problem

In Safari, the DevTools icon background extends beyond the intended pill shape, creating a visual rendering issue. The icon should appear as a clean pill with the background properly cropped to the rounded border.

### Root Cause

Safari has issues with nested `overflow: hidden` + absolute positioning + negative margins. The background blur div extends beyond the container bounds (`top/left/right/bottom: -8px`) and Safari doesn't properly clip it despite `overflow: hidden` on the parent container.

## Solution

Add `isolation: isolate` to the `devtoolsBtn` container. This creates a new stacking context that forces Safari to properly respect the `overflow: hidden` boundary. The `isolation` property is specifically designed to fix rendering issues with filters and blending modes in nested contexts.

### Why `isolation: isolate` works

- Creates a new stacking context
- Forces Safari to properly apply `overflow: hidden` clipping
- Well-supported across all modern browsers (Chrome, Firefox, Safari, Edge)
- No performance impact
- No functional changes, only visual fix

## Changes

- `packages/query-devtools/src/Devtools.tsx`
  - Add `isolation: isolate` to `devtoolsBtn` CSS (line 2760)

## Testing

- Tested in Safari (latest version on macOS)
- Verified no regression in Chrome, Firefox, Edge
- The icon now renders correctly as a pill shape with proper background clipping

## Before/After

**Before (Safari):**
- Background extends beyond the pill shape
- Visual artifacts around the icon edges

**After (Safari):**
- Clean pill shape
- Background properly clipped to rounded borders
- Matches the rendering in other browsers

## Browser Compatibility

`isolation: isolate` is supported in:
- Chrome 41+
- Firefox 36+
- Safari 8+
- Edge 79+

## References

- MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/isolation
- Related Safari rendering issues with filters and overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved CSS stacking behavior of the devtools button component for better layering with other interface elements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10675)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->