### PR TITLE
test(query-devtools/TanstackQueryDevtools{,Panel}): add tests for setters

### DIFF
--- a/packages/query-devtools/src/__tests__/TanstackQueryDevtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/TanstackQueryDevtools.test.tsx
@@ -56,4 +56,61 @@ describe('TanstackQueryDevtools', () => {
       expect(() => devtools.unmount()).toThrow('Devtools is not mounted')
     })
   })
+
+  describe('setters', () => {
+    describe('before mount', () => {
+      it('should not throw when "setButtonPosition" is called', () => {
+        expect(() => devtools.setButtonPosition('top-left')).not.toThrow()
+      })
+
+      it('should not throw when "setPosition" is called', () => {
+        expect(() => devtools.setPosition('left')).not.toThrow()
+      })
+
+      it('should not throw when "setInitialIsOpen" is called', () => {
+        expect(() => devtools.setInitialIsOpen(true)).not.toThrow()
+      })
+
+      it('should not throw when "setErrorTypes" is called', () => {
+        expect(() =>
+          devtools.setErrorTypes([
+            { name: 'NetworkError', initializer: () => new Error('Network') },
+          ]),
+        ).not.toThrow()
+      })
+
+      it('should not throw when "setClient" is called', () => {
+        expect(() => devtools.setClient(new QueryClient())).not.toThrow()
+      })
+
+      it('should not throw when "setTheme" is called', () => {
+        expect(() => devtools.setTheme('dark')).not.toThrow()
+        expect(() => devtools.setTheme('light')).not.toThrow()
+        expect(() => devtools.setTheme('system')).not.toThrow()
+        expect(() => devtools.setTheme(undefined)).not.toThrow()
+      })
+    })
+
+    describe('after mount', () => {
+      it('should not throw when setters are called on a mounted instance', () => {
+        const el = document.createElement('div')
+        devtools.mount(el)
+
+        try {
+          expect(() => devtools.setButtonPosition('top-left')).not.toThrow()
+          expect(() => devtools.setPosition('left')).not.toThrow()
+          expect(() => devtools.setInitialIsOpen(true)).not.toThrow()
+          expect(() =>
+            devtools.setErrorTypes([
+              { name: 'NetworkError', initializer: () => new Error('Network') },
+            ]),
+          ).not.toThrow()
+          expect(() => devtools.setClient(new QueryClient())).not.toThrow()
+          expect(() => devtools.setTheme('dark')).not.toThrow()
+        } finally {
+          devtools.unmount()
+        }
+      })
+    })
+  })
 })

--- a/packages/query-devtools/src/__tests__/TanstackQueryDevtoolsPanel.test.tsx
+++ b/packages/query-devtools/src/__tests__/TanstackQueryDevtoolsPanel.test.tsx
@@ -56,4 +56,66 @@ describe('TanstackQueryDevtoolsPanel', () => {
       expect(() => devtools.unmount()).toThrow('Devtools is not mounted')
     })
   })
+
+  describe('setters', () => {
+    describe('before mount', () => {
+      it('should not throw when "setButtonPosition" is called', () => {
+        expect(() => devtools.setButtonPosition('top-left')).not.toThrow()
+      })
+
+      it('should not throw when "setPosition" is called', () => {
+        expect(() => devtools.setPosition('left')).not.toThrow()
+      })
+
+      it('should not throw when "setInitialIsOpen" is called', () => {
+        expect(() => devtools.setInitialIsOpen(true)).not.toThrow()
+      })
+
+      it('should not throw when "setErrorTypes" is called', () => {
+        expect(() =>
+          devtools.setErrorTypes([
+            { name: 'NetworkError', initializer: () => new Error('Network') },
+          ]),
+        ).not.toThrow()
+      })
+
+      it('should not throw when "setClient" is called', () => {
+        expect(() => devtools.setClient(new QueryClient())).not.toThrow()
+      })
+
+      it('should not throw when "setOnClose" is called', () => {
+        expect(() => devtools.setOnClose(() => {})).not.toThrow()
+      })
+
+      it('should not throw when "setTheme" is called', () => {
+        expect(() => devtools.setTheme('dark')).not.toThrow()
+        expect(() => devtools.setTheme('light')).not.toThrow()
+        expect(() => devtools.setTheme('system')).not.toThrow()
+        expect(() => devtools.setTheme(undefined)).not.toThrow()
+      })
+    })
+
+    describe('after mount', () => {
+      it('should not throw when setters are called on a mounted instance', () => {
+        const el = document.createElement('div')
+        devtools.mount(el)
+
+        try {
+          expect(() => devtools.setButtonPosition('top-left')).not.toThrow()
+          expect(() => devtools.setPosition('left')).not.toThrow()
+          expect(() => devtools.setInitialIsOpen(true)).not.toThrow()
+          expect(() =>
+            devtools.setErrorTypes([
+              { name: 'NetworkError', initializer: () => new Error('Network') },
+            ]),
+          ).not.toThrow()
+          expect(() => devtools.setClient(new QueryClient())).not.toThrow()
+          expect(() => devtools.setOnClose(() => {})).not.toThrow()
+          expect(() => devtools.setTheme('dark')).not.toThrow()
+        } finally {
+          devtools.unmount()
+        }
+      })
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add tests for setter methods in `TanstackQueryDevtools` and `TanstackQueryDevtoolsPanel`.

- `TanstackQueryDevtools`: 7 cases for 6 setters (`setButtonPosition`, `setPosition`, `setInitialIsOpen`, `setErrorTypes`, `setClient`, `setTheme`) — 6 cases before mount + 1 integration case after mount
- `TanstackQueryDevtoolsPanel`: 8 cases for 7 setters (above + `setOnClose`) — 7 cases before mount + 1 integration case after mount

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for devtools setter methods to ensure reliable configuration updates before and after component mounting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10676)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->