### PR TITLE
chore(query-devtools): set up '@solidjs/testing-library' for component tests

### DIFF
--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -67,6 +67,7 @@
     "@solid-primitives/keyed": "^1.2.2",
     "@solid-primitives/resize-observer": "^2.0.26",
     "@solid-primitives/storage": "^1.3.11",
+    "@solidjs/testing-library": "^0.8.10",
     "@tanstack/match-sorter-utils": "^8.19.4",
     "@tanstack/query-core": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/query-devtools/test-setup.ts
+++ b/packages/query-devtools/test-setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@solidjs/testing-library'
+import { afterEach } from 'vitest'
+
+afterEach(() => cleanup())

--- a/packages/query-devtools/tsconfig.json
+++ b/packages/query-devtools/tsconfig.json
@@ -6,6 +6,12 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src", "*.config.ts", "*.config.js", "package.json"],
+  "include": [
+    "src",
+    "test-setup.ts",
+    "*.config.ts",
+    "*.config.js",
+    "package.json"
+  ],
   "references": [{ "path": "../query-core" }]
 }

--- a/packages/query-devtools/vite.config.ts
+++ b/packages/query-devtools/vite.config.ts
@@ -29,5 +29,6 @@ export default defineConfig({
     },
     typecheck: { enabled: true },
     restoreMocks: true,
+    setupFiles: ['test-setup.ts'],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2730,6 +2730,9 @@ importers:
       '@solid-primitives/storage':
         specifier: ^1.3.11
         version: 1.3.11(solid-js@1.9.12)
+      '@solidjs/testing-library':
+        specifier: ^0.8.10
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
         version: 8.19.4


### PR DESCRIPTION
## 🎯 Changes

Set up the test environment for upcoming component tests in `query-devtools`.

- Add `@solidjs/testing-library` to `devDependencies` (already used across `solid-query`, `solid-query-persist-client`, `solid-query-devtools`).
- Add `test-setup.ts` to import `@testing-library/jest-dom/vitest` and call `cleanup()` from `@solidjs/testing-library` in `afterEach`.
- Wire the setup file via `setupFiles` in `vite.config.ts`.
- Include `test-setup.ts` in `tsconfig.json` so the matcher type augmentation is picked up.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added testing library dependencies and configured test cleanup registration for the devtools package.
  * Updated build configuration to support improved testing infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10678)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->