### PR TITLE
test(query-devtools/DevtoolsComponent): add smoke test for rendering without throwing

### DIFF
--- a/packages/query-devtools/src/__tests__/DevtoolsComponent.test.tsx
+++ b/packages/query-devtools/src/__tests__/DevtoolsComponent.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, onlineManager } from '@tanstack/query-core'
+import { render } from '@solidjs/testing-library'
+import DevtoolsComponent from '../DevtoolsComponent'
+
+// `solid-transition-group` internally imports from
+// `@solid-primitives/transition-group`, whose `exports` field points at
+// `src/index.ts` (not published) under a `@solid-primitives/source` condition
+// that Vite can't fall through, so we stub it with a transparent pass-through.
+vi.mock('solid-transition-group', () => ({
+  TransitionGroup: (props: { children: unknown }) => props.children,
+}))
+
+describe('DevtoolsComponent', () => {
+  const storage: { [key: string]: string } = {}
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) =>
+        Object.prototype.hasOwnProperty.call(storage, key)
+          ? storage[key]
+          : null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value
+      },
+      removeItem: (key: string) => {
+        delete storage[key]
+      },
+      clear: () => {
+        Object.keys(storage).forEach((key) => delete storage[key])
+      },
+    })
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    )
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+      },
+    )
+    queryClient = new QueryClient()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.keys(storage).forEach((key) => delete storage[key])
+    queryClient.clear()
+  })
+
+  it('should render without throwing', () => {
+    expect(() =>
+      render(() => (
+        <DevtoolsComponent
+          client={queryClient}
+          queryFlavor="TanStack Query"
+          version="5"
+          onlineManager={onlineManager}
+        />
+      )),
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add a smoke test for `DevtoolsComponent`, the lightweight wrapper that wires `QueryDevtoolsContext`, `PiPProvider`, and `ThemeContext` around the Solid `Devtools` body.

- Verifies the component mounts without throwing.
- Stubs `matchMedia` and `ResizeObserver` to satisfy jsdom.
- Mocks `solid-transition-group` to bypass a transitive `@solid-primitives/transition-group` `exports` field that Vite cannot resolve.
- Mocks an in-memory `localStorage` so `createLocalStorage` from `@solid-primitives/storage` does not leak across tests.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Vitest + Solid test suite for the Devtools component. Includes environment stubs for localStorage, matchMedia, and ResizeObserver, a simplified transition pass-through, lifecycle setup/teardown that creates and clears a test client, and a smoke test verifying the component renders without errors with initialized client and connectivity props.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10679)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->