### PR TITLE
test(query-devtools/DevtoolsPanelComponent): add tests for rendering without throwing, panel-only mode, and 'onClose' prop

### DIFF
--- a/packages/query-devtools/src/__tests__/DevtoolsPanelComponent.test.tsx
+++ b/packages/query-devtools/src/__tests__/DevtoolsPanelComponent.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, onlineManager } from '@tanstack/query-core'
+import { render } from '@solidjs/testing-library'
+import DevtoolsPanelComponent from '../DevtoolsPanelComponent'
+
+// `solid-transition-group` internally imports from
+// `@solid-primitives/transition-group`, whose `exports` field points at
+// `src/index.ts` (not published) under a `@solid-primitives/source` condition
+// that Vite can't fall through, so we stub it with a transparent pass-through.
+vi.mock('solid-transition-group', () => ({
+  TransitionGroup: (props: { children: unknown }) => props.children,
+}))
+
+// `goober` compiles every `css\`...\`` template literal at mount time
+// (template parsing + class hashing + style serialization), which
+// dominates mount cost and produces no value for label/role-based
+// assertions, so we replace it with a no-op factory.
+vi.mock('goober', () => {
+  let counter = 0
+  const css = Object.assign(() => `tsqd-${++counter}`, {
+    bind: () => css,
+  })
+  return { css, glob: () => {}, setup: () => {} }
+})
+
+describe('DevtoolsPanelComponent', () => {
+  const storage: { [key: string]: string } = {}
+  let queryClient: QueryClient
+  let previousRootFontSize = ''
+
+  beforeEach(() => {
+    previousRootFontSize = document.documentElement.style.fontSize
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) =>
+        Object.prototype.hasOwnProperty.call(storage, key)
+          ? storage[key]
+          : null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value
+      },
+      removeItem: (key: string) => {
+        delete storage[key]
+      },
+      clear: () => {
+        Object.keys(storage).forEach((key) => delete storage[key])
+      },
+    })
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    )
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+      },
+    )
+    queryClient = new QueryClient()
+    document.documentElement.style.fontSize = '16px'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.keys(storage).forEach((key) => delete storage[key])
+    queryClient.clear()
+    document.documentElement.style.fontSize = previousRootFontSize
+  })
+
+  it('should render the panel without throwing', () => {
+    expect(() =>
+      render(() => (
+        <DevtoolsPanelComponent
+          client={queryClient}
+          queryFlavor="TanStack Query"
+          version="5"
+          onlineManager={onlineManager}
+        />
+      )),
+    ).not.toThrow()
+  })
+
+  it('should not render the open devtools button in panel-only mode', () => {
+    const rendered = render(() => (
+      <DevtoolsPanelComponent
+        client={queryClient}
+        queryFlavor="TanStack Query"
+        version="5"
+        onlineManager={onlineManager}
+      />
+    ))
+
+    expect(
+      rendered.queryByLabelText('Open Tanstack query devtools'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should call "onClose" when the close button is clicked', () => {
+    const onClose = vi.fn()
+    const rendered = render(() => (
+      <DevtoolsPanelComponent
+        client={queryClient}
+        queryFlavor="TanStack Query"
+        version="5"
+        onlineManager={onlineManager}
+        onClose={onClose}
+      />
+    ))
+
+    rendered.getByLabelText('Close Tanstack query devtools').click()
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add tests for `DevtoolsPanelComponent`, the lightweight wrapper used by `TanstackQueryDevtoolsPanel` to render the devtools as a panel-only mode.

- Verifies the component mounts without throwing.
- Verifies the open devtools button is **not** rendered in panel-only mode.
- Verifies the `onClose` prop is invoked when the close button is clicked.

Reuses the same mocks and stubs as `DevtoolsComponent.test.tsx`:
- `solid-transition-group` mock to bypass a transitive `@solid-primitives/transition-group` `exports` field that Vite cannot resolve.
- `goober` mock to avoid heavy css template compilation on each mount.
- `localStorage`, `matchMedia`, `ResizeObserver` stubs.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Devtools panel test suite to verify rendering, panel-only mode hides the open control, the close control calls its callback, and test isolation/cleanup is ensured between runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10680)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->