### PR TITLE
test(query-devtools/Devtools): add tests for open and close interactions and 'localStorage' persistence

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient, onlineManager } from '@tanstack/query-core'
-import { render } from '@solidjs/testing-library'
+import { fireEvent, render } from '@solidjs/testing-library'
 import { createLocalStorage } from '@solid-primitives/storage'
 import { Devtools } from '../Devtools'
 import { PiPProvider, QueryDevtoolsContext, ThemeContext } from '../contexts'
@@ -184,6 +184,64 @@ describe('Devtools', () => {
       expect(
         rendered.queryByLabelText('Tanstack query devtools'),
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('open and close', () => {
+    it('should render the panel when the open button is clicked', () => {
+      const rendered = renderDevtools()
+
+      fireEvent.click(rendered.getByLabelText('Open Tanstack query devtools'))
+
+      expect(
+        rendered.getByLabelText('Tanstack query devtools'),
+      ).toBeInTheDocument()
+    })
+
+    it('should hide the open button when the panel is open', () => {
+      const rendered = renderDevtools()
+
+      fireEvent.click(rendered.getByLabelText('Open Tanstack query devtools'))
+
+      expect(
+        rendered.queryByLabelText('Open Tanstack query devtools'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should hide the panel when the close button is clicked', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText('Close tanstack query devtools'))
+
+      expect(
+        rendered.queryByLabelText('Tanstack query devtools'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should render the open button after the panel is closed', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText('Close tanstack query devtools'))
+
+      expect(
+        rendered.getByLabelText('Open Tanstack query devtools'),
+      ).toBeInTheDocument()
+    })
+
+    it('should persist "open" as "true" to "localStorage" when the open button is clicked', () => {
+      const rendered = renderDevtools()
+
+      fireEvent.click(rendered.getByLabelText('Open Tanstack query devtools'))
+
+      expect(localStorage.getItem('TanstackQueryDevtools.open')).toBe('true')
+    })
+
+    it('should persist "open" as "false" to "localStorage" when the close button is clicked', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText('Close tanstack query devtools'))
+
+      expect(localStorage.getItem('TanstackQueryDevtools.open')).toBe('false')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add tests for the open/close button interactions and the resulting `localStorage` persistence on the `Devtools` body component.

- Verifies the panel renders when the open button is clicked.
- Verifies the open button is hidden once the panel is open.
- Verifies the panel hides when the close button is clicked.
- Verifies the open button reappears after the panel is closed.
- Verifies `'TanstackQueryDevtools.open'` is set to `'true'` after the open button is clicked.
- Verifies `'TanstackQueryDevtools.open'` is set to `'false'` after the close button is clicked.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the devtools panel open/close functionality and state persistence, ensuring reliable behavior when toggling the panel and maintaining user preferences.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->