### PR TITLE
test(query-devtools/Devtools): add tests for query details panel and query actions

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -484,9 +484,12 @@ describe('Devtools', () => {
       queryClient.setQueryData(['details-toggle'], [{ id: 1 }])
       const rendered = renderDevtools({ initialIsOpen: true })
 
-      const row = rendered.getByLabelText(/Query key \["details-toggle"\]/)
-      fireEvent.click(row)
-      fireEvent.click(row)
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["details-toggle"\]/),
+      )
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["details-toggle"\]/),
+      )
 
       expect(rendered.queryByText('Query Details')).not.toBeInTheDocument()
     })
@@ -573,7 +576,7 @@ describe('Devtools', () => {
 
       expect(
         queryClient.getQueryState(['action-restore-error'])?.status,
-      ).not.toBe('error')
+      ).toBe('pending')
     })
   })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -469,4 +469,119 @@ describe('Devtools', () => {
       expect(rendered.queryByRole('tooltip')).not.toBeInTheDocument()
     })
   })
+
+  describe('query details', () => {
+    it('should open the query details panel when a query row is clicked', () => {
+      queryClient.setQueryData(['posts'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["posts"\]/))
+
+      expect(rendered.getByText('Query Details')).toBeInTheDocument()
+    })
+
+    it('should close the query details panel when the same row is clicked again', () => {
+      queryClient.setQueryData(['details-toggle'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      const row = rendered.getByLabelText(/Query key \["details-toggle"\]/)
+      fireEvent.click(row)
+      fireEvent.click(row)
+
+      expect(rendered.queryByText('Query Details')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('query actions', () => {
+    it('should remove the query when the "Remove" button is clicked', () => {
+      queryClient.setQueryData(['action-remove'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["action-remove"\]/),
+      )
+      fireEvent.click(rendered.getByText('Remove'))
+
+      expect(
+        rendered.queryByLabelText(/Query key \["action-remove"\]/),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should reset the query when the "Reset" button is clicked', () => {
+      queryClient.setQueryData(['action-reset'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["action-reset"\]/),
+      )
+      fireEvent.click(rendered.getByText('Reset'))
+
+      expect(queryClient.getQueryData(['action-reset'])).toBeUndefined()
+    })
+
+    it('should invalidate the query when the "Invalidate" button is clicked', () => {
+      queryClient.setQueryData(['action-invalidate'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["action-invalidate"\]/),
+      )
+      fireEvent.click(rendered.getByText('Invalidate'))
+
+      expect(
+        queryClient.getQueryState(['action-invalidate'])?.isInvalidated,
+      ).toBe(true)
+    })
+
+    it('should dispatch a "REFETCH" event when "Refetch" is clicked', () => {
+      queryClient.setQueryData(['action-refetch'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      const listener = vi.fn()
+      window.addEventListener('@tanstack/query-devtools-event', listener)
+
+      try {
+        fireEvent.click(
+          rendered.getByLabelText(/Query key \["action-refetch"\]/),
+        )
+        fireEvent.click(rendered.getByText('Refetch'))
+
+        const dispatched = listener.mock.calls.some(
+          ([e]) => (e as CustomEvent).detail.type === 'REFETCH',
+        )
+        expect(dispatched).toBe(true)
+      } finally {
+        window.removeEventListener(
+          '@tanstack/query-devtools-event',
+          listener,
+        )
+      }
+    })
+
+    it('should set the query status to "error" when "Trigger Error" is clicked', () => {
+      queryClient.setQueryData(['action-error'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["action-error"\]/))
+      fireEvent.click(rendered.getByText('Trigger Error'))
+
+      expect(queryClient.getQueryState(['action-error'])?.status).toBe('error')
+    })
+
+    it('should restore the query status when "Restore Error" is clicked after "Trigger Error"', () => {
+      queryClient.setQueryData(['action-restore-error'], [{ id: 1 }])
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["action-restore-error"\]/),
+      )
+      fireEvent.click(rendered.getByText('Trigger Error'))
+      fireEvent.click(rendered.getByText('Restore Error'))
+
+      expect(
+        queryClient.getQueryState(['action-restore-error'])?.status,
+      ).not.toBe('error')
+    })
+
+  })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -497,9 +497,7 @@ describe('Devtools', () => {
       queryClient.setQueryData(['action-remove'], [{ id: 1 }])
       const rendered = renderDevtools({ initialIsOpen: true })
 
-      fireEvent.click(
-        rendered.getByLabelText(/Query key \["action-remove"\]/),
-      )
+      fireEvent.click(rendered.getByLabelText(/Query key \["action-remove"\]/))
       fireEvent.click(rendered.getByText('Remove'))
 
       expect(
@@ -511,9 +509,7 @@ describe('Devtools', () => {
       queryClient.setQueryData(['action-reset'], [{ id: 1 }])
       const rendered = renderDevtools({ initialIsOpen: true })
 
-      fireEvent.click(
-        rendered.getByLabelText(/Query key \["action-reset"\]/),
-      )
+      fireEvent.click(rendered.getByLabelText(/Query key \["action-reset"\]/))
       fireEvent.click(rendered.getByText('Reset'))
 
       expect(queryClient.getQueryData(['action-reset'])).toBeUndefined()
@@ -551,10 +547,7 @@ describe('Devtools', () => {
         )
         expect(dispatched).toBe(true)
       } finally {
-        window.removeEventListener(
-          '@tanstack/query-devtools-event',
-          listener,
-        )
+        window.removeEventListener('@tanstack/query-devtools-event', listener)
       }
     })
 
@@ -582,6 +575,5 @@ describe('Devtools', () => {
         queryClient.getQueryState(['action-restore-error'])?.status,
       ).not.toBe('error')
     })
-
   })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -484,12 +484,8 @@ describe('Devtools', () => {
       queryClient.setQueryData(['details-toggle'], [{ id: 1 }])
       const rendered = renderDevtools({ initialIsOpen: true })
 
-      fireEvent.click(
-        rendered.getByLabelText(/Query key \["details-toggle"\]/),
-      )
-      fireEvent.click(
-        rendered.getByLabelText(/Query key \["details-toggle"\]/),
-      )
+      fireEvent.click(rendered.getByLabelText(/Query key \["details-toggle"\]/))
+      fireEvent.click(rendered.getByLabelText(/Query key \["details-toggle"\]/))
 
       expect(rendered.queryByText('Query Details')).not.toBeInTheDocument()
     })
@@ -574,9 +570,9 @@ describe('Devtools', () => {
       fireEvent.click(rendered.getByText('Trigger Error'))
       fireEvent.click(rendered.getByText('Restore Error'))
 
-      expect(
-        queryClient.getQueryState(['action-restore-error'])?.status,
-      ).toBe('pending')
+      expect(queryClient.getQueryState(['action-restore-error'])?.status).toBe(
+        'pending',
+      )
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add tests for the query details panel and the action buttons that operate on the selected query.

**`query details`** — opening and closing the details panel:
- Opens the query details panel when a query row is clicked.
- Closes the details panel when the same row is clicked again (toggle).

**`query actions`** — buttons inside the details panel:
- `Remove` removes the query from the cache.
- `Reset` resets the query data to `undefined`.
- `Invalidate` marks the query as invalidated.
- `Refetch` dispatches a `'REFETCH'` event.
- `Trigger Error` sets the query status to `'error'`.
- `Restore Error` restores the query status from `'error'`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the Query Details panel toggling and for Query Actions (Remove, Reset, Invalidate, Refetch, Trigger/Restore Error), verifying cache/state changes, status transitions, and that Refetch dispatches the expected devtools event.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10685)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->