### PR TITLE
test(query-devtools/Devtools): add tests for mutation details, sort order, and filter

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -575,4 +575,59 @@ describe('Devtools', () => {
       )
     })
   })
+
+  describe('mutation details', () => {
+    it('should open the mutation details panel when a mutation row is clicked', async () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByText('Mutations'))
+
+      const mutation = queryClient.getMutationCache().build(queryClient, {
+        mutationKey: ['mutation-detail'],
+        mutationFn: () => Promise.resolve('ok'),
+      })
+      mutation.execute({})
+      await vi.advanceTimersByTimeAsync(0)
+
+      fireEvent.click(rendered.getByLabelText(/Mutation submitted at/))
+
+      expect(rendered.getByText('Mutation Details')).toBeInTheDocument()
+    })
+  })
+
+  describe('mutation sort order', () => {
+    it('should toggle the mutation sort order in the mutations view', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+      fireEvent.click(rendered.getByText('Mutations'))
+
+      fireEvent.click(rendered.getByLabelText(/Sort order/))
+
+      expect(
+        localStorage.getItem('TanstackQueryDevtools.mutationSortOrder'),
+      ).not.toBeNull()
+    })
+  })
+
+  describe('mutation filter', () => {
+    it('should filter mutations by their submission timestamp', async () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+      fireEvent.click(rendered.getByText('Mutations'))
+
+      const mutation = queryClient.getMutationCache().build(queryClient, {
+        mutationKey: ['filter-test'],
+        mutationFn: () => Promise.resolve('ok'),
+      })
+      mutation.execute({})
+      await vi.advanceTimersByTimeAsync(0)
+
+      fireEvent.input(
+        rendered.getByLabelText('Filter queries by query key'),
+        { target: { value: 'filter-test' } },
+      )
+
+      expect(
+        rendered.getByLabelText(/Mutation submitted at/),
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -631,17 +631,17 @@ describe('Devtools', () => {
       other.execute({})
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(
-        rendered.getAllByLabelText(/Mutation submitted at/),
-      ).toHaveLength(2)
+      expect(rendered.getAllByLabelText(/Mutation submitted at/)).toHaveLength(
+        2,
+      )
 
       fireEvent.input(rendered.getByLabelText('Filter queries by query key'), {
         target: { value: 'filter-match' },
       })
 
-      expect(
-        rendered.getAllByLabelText(/Mutation submitted at/),
-      ).toHaveLength(1)
+      expect(rendered.getAllByLabelText(/Mutation submitted at/)).toHaveLength(
+        1,
+      )
     })
   })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -601,32 +601,47 @@ describe('Devtools', () => {
       fireEvent.click(rendered.getByText('Mutations'))
 
       fireEvent.click(rendered.getByLabelText(/Sort order/))
+      const afterFirstToggle = localStorage.getItem(
+        'TanstackQueryDevtools.mutationSortOrder',
+      )
+      expect(afterFirstToggle).not.toBeNull()
 
-      expect(
-        localStorage.getItem('TanstackQueryDevtools.mutationSortOrder'),
-      ).not.toBeNull()
+      fireEvent.click(rendered.getByLabelText(/Sort order/))
+      const afterSecondToggle = localStorage.getItem(
+        'TanstackQueryDevtools.mutationSortOrder',
+      )
+      expect(afterSecondToggle).not.toBe(afterFirstToggle)
     })
   })
 
   describe('mutation filter', () => {
-    it('should filter mutations by their submission timestamp', async () => {
+    it('should filter mutations by their "mutationKey"', async () => {
       const rendered = renderDevtools({ initialIsOpen: true })
       fireEvent.click(rendered.getByText('Mutations'))
 
-      const mutation = queryClient.getMutationCache().build(queryClient, {
-        mutationKey: ['filter-test'],
+      const matching = queryClient.getMutationCache().build(queryClient, {
+        mutationKey: ['filter-match'],
         mutationFn: () => Promise.resolve('ok'),
       })
-      mutation.execute({})
+      const other = queryClient.getMutationCache().build(queryClient, {
+        mutationKey: ['filter-other'],
+        mutationFn: () => Promise.resolve('ok'),
+      })
+      matching.execute({})
+      other.execute({})
       await vi.advanceTimersByTimeAsync(0)
 
+      expect(
+        rendered.getAllByLabelText(/Mutation submitted at/),
+      ).toHaveLength(2)
+
       fireEvent.input(rendered.getByLabelText('Filter queries by query key'), {
-        target: { value: 'filter-test' },
+        target: { value: 'filter-match' },
       })
 
       expect(
-        rendered.getByLabelText(/Mutation submitted at/),
-      ).toBeInTheDocument()
+        rendered.getAllByLabelText(/Mutation submitted at/),
+      ).toHaveLength(1)
     })
   })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -620,10 +620,9 @@ describe('Devtools', () => {
       mutation.execute({})
       await vi.advanceTimersByTimeAsync(0)
 
-      fireEvent.input(
-        rendered.getByLabelText('Filter queries by query key'),
-        { target: { value: 'filter-test' } },
-      )
+      fireEvent.input(rendered.getByLabelText('Filter queries by query key'), {
+        target: { value: 'filter-test' },
+      })
 
       expect(
         rendered.getByLabelText(/Mutation submitted at/),


### PR DESCRIPTION
## 🎯 Changes

Add tests for the mutation-side interactions in the `Devtools` body component.

**`mutation details`** — selecting a mutation:
- Opens the mutation details panel when a mutation row is clicked.

**`mutation sort order`** — sort order toggle in the mutations view:
- Persists `'TanstackQueryDevtools.mutationSortOrder'` to `localStorage` and toggles its value across consecutive clicks.

**`mutation filter`** — filter input in the mutations view:
- Filters mutations by their `mutationKey`, asserting that a non-matching mutation is excluded from the rendered list.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for Devtools mutations functionality, including mutation details panel rendering, sort order persistence, and mutation filtering capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10686)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->