### PR TITLE
test(query-devtools/Devtools): add tests for "Bulk Edit Data" mode switch, save, and invalid JSON

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -644,4 +644,48 @@ describe('Devtools', () => {
       )
     })
   })
+
+  describe('data edit', () => {
+    it('should switch to data editor when "Bulk Edit Data" is clicked', () => {
+      queryClient.setQueryData(['edit-data'], { name: 'a' })
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["edit-data"\]/))
+      fireEvent.click(rendered.getByLabelText('Bulk Edit Data'))
+
+      expect(
+        rendered.getByLabelText('Edit query data as JSON'),
+      ).toBeInTheDocument()
+    })
+
+    it('should save the edited data when the form is submitted', () => {
+      queryClient.setQueryData(['edit-save'], { name: 'a' })
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["edit-save"\]/))
+      fireEvent.click(rendered.getByLabelText('Bulk Edit Data'))
+
+      const textarea = rendered.getByLabelText('Edit query data as JSON')
+      fireEvent.input(textarea, {
+        target: { value: JSON.stringify({ name: 'b' }) },
+      })
+      fireEvent.submit(textarea.closest('form')!)
+
+      expect(queryClient.getQueryData(['edit-save'])).toEqual({ name: 'b' })
+    })
+
+    it('should set an error state when the edited data is invalid JSON', () => {
+      queryClient.setQueryData(['edit-invalid'], { name: 'a' })
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["edit-invalid"\]/))
+      fireEvent.click(rendered.getByLabelText('Bulk Edit Data'))
+
+      const textarea = rendered.getByLabelText('Edit query data as JSON')
+      fireEvent.input(textarea, { target: { value: 'not json' } })
+      fireEvent.submit(textarea.closest('form')!)
+
+      expect(rendered.getByText('Invalid Value')).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add tests for the data editor in the query details panel of the `Devtools` body component.

**`data edit`** — `"Bulk Edit Data"` flow:
- Switches to the data editor when `"Bulk Edit Data"` is clicked.
- Saves the edited data to the query cache when the form is submitted with valid JSON.
- Sets an error state and renders `"Invalid Value"` when the form is submitted with invalid JSON.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Devtools bulk data editing functionality, including validation of JSON editor operations and error handling for invalid input.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10687)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->