### PR TITLE
test(query-devtools/Devtools): add tests for 'errorTypes' prop and error trigger via select

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -727,9 +727,9 @@ describe('Devtools', () => {
       const select = rendered.getByLabelText('Select error type to trigger')
       fireEvent.change(select, { target: { value: 'NetworkError' } })
 
-      expect(
-        queryClient.getQueryState(['error-select-trigger'])?.status,
-      ).toBe('error')
+      expect(queryClient.getQueryState(['error-select-trigger'])?.status).toBe(
+        'error',
+      )
     })
   })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -688,4 +688,48 @@ describe('Devtools', () => {
       expect(rendered.getByText('Invalid Value')).toBeInTheDocument()
     })
   })
+
+  describe('error type select', () => {
+    it('should render the error type select when "errorTypes" is provided', () => {
+      queryClient.setQueryData(['error-select'], [{ id: 1 }])
+      const rendered = renderDevtools({
+        initialIsOpen: true,
+        errorTypes: [
+          {
+            name: 'NetworkError',
+            initializer: () => new Error('Network'),
+          },
+        ],
+      })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["error-select"\]/))
+
+      expect(
+        rendered.getByLabelText('Select error type to trigger'),
+      ).toBeInTheDocument()
+    })
+
+    it('should trigger error when an error type is selected', () => {
+      queryClient.setQueryData(['error-select-trigger'], [{ id: 1 }])
+      const rendered = renderDevtools({
+        initialIsOpen: true,
+        errorTypes: [
+          {
+            name: 'NetworkError',
+            initializer: () => new Error('Network'),
+          },
+        ],
+      })
+
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["error-select-trigger"\]/),
+      )
+      const select = rendered.getByLabelText('Select error type to trigger')
+      fireEvent.change(select, { target: { value: 'NetworkError' } })
+
+      expect(
+        queryClient.getQueryState(['error-select-trigger'])?.status,
+      ).toBe('error')
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add tests for the error type select that appears in the query details panel when `errorTypes` is provided.

**`error type select`** — error simulation via custom error types:
- Renders the error type select when `errorTypes` is provided.
- Sets the query status to `'error'` when an error type is selected from the dropdown.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error-type selection in the query devtools editor, verifying UI rendering and error state triggering when error types are selected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10688)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->