### PR TITLE
test(query-devtools/Devtools): add tests for sort dropdown, hide disabled queries, and sort order toggle

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { QueryClient, onlineManager } from '@tanstack/query-core'
+import {
+  QueryClient,
+  QueryObserver,
+  onlineManager,
+} from '@tanstack/query-core'
 import { fireEvent, render } from '@solidjs/testing-library'
 import { createLocalStorage } from '@solid-primitives/storage'
 import { Devtools } from '../Devtools'
@@ -730,6 +734,78 @@ describe('Devtools', () => {
       expect(queryClient.getQueryState(['error-select-trigger'])?.status).toBe(
         'error',
       )
+    })
+  })
+
+  describe('sort by', () => {
+    it('should change sort key when the sort dropdown is changed in queries view', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.change(rendered.getByLabelText('Sort queries by'), {
+        target: { value: 'last updated' },
+      })
+
+      expect(localStorage.getItem('TanstackQueryDevtools.sort')).toBe(
+        'last updated',
+      )
+    })
+
+    it('should change sort key when the sort dropdown is changed in mutations view', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+      fireEvent.click(rendered.getByText('Mutations'))
+
+      fireEvent.change(rendered.getByLabelText('Sort mutations by'), {
+        target: { value: 'last updated' },
+      })
+
+      expect(localStorage.getItem('TanstackQueryDevtools.mutationSort')).toBe(
+        'last updated',
+      )
+    })
+
+    it('should hide disabled queries when "hideDisabledQueries" is enabled in localStorage', () => {
+      const disabled = new QueryObserver(queryClient, {
+        queryKey: ['hide-test-disabled'],
+        queryFn: () => 'x',
+        enabled: false,
+      })
+      const unsubscribe = disabled.subscribe(() => {})
+      queryClient.setQueryData(['hide-test-disabled'], 'x')
+      queryClient.setQueryData(['hide-test-active'], 'y')
+
+      try {
+        const rendered = renderDevtools(
+          { initialIsOpen: true },
+          { 'TanstackQueryDevtools.hideDisabledQueries': 'true' },
+        )
+
+        expect(
+          rendered.queryByLabelText(/Query key \["hide-test-disabled"\]/),
+        ).not.toBeInTheDocument()
+        expect(
+          rendered.getByLabelText(/Query key \["hide-test-active"\]/),
+        ).toBeInTheDocument()
+      } finally {
+        unsubscribe()
+      }
+    })
+  })
+
+  describe('sort order', () => {
+    it('should toggle the sort order when the sort order button is clicked', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Sort order/))
+      const afterFirstToggle = localStorage.getItem(
+        'TanstackQueryDevtools.sortOrder',
+      )
+      expect(afterFirstToggle).not.toBeNull()
+
+      fireEvent.click(rendered.getByLabelText(/Sort order/))
+      const afterSecondToggle = localStorage.getItem(
+        'TanstackQueryDevtools.sortOrder',
+      )
+      expect(afterSecondToggle).not.toBe(afterFirstToggle)
     })
   })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  QueryClient,
-  QueryObserver,
-  onlineManager,
-} from '@tanstack/query-core'
+import { QueryClient, QueryObserver, onlineManager } from '@tanstack/query-core'
 import { fireEvent, render } from '@solidjs/testing-library'
 import { createLocalStorage } from '@solid-primitives/storage'
 import { Devtools } from '../Devtools'

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -795,13 +795,13 @@ describe('Devtools', () => {
       const afterFirstToggle = localStorage.getItem(
         'TanstackQueryDevtools.sortOrder',
       )
-      expect(afterFirstToggle).not.toBeNull()
+      expect(['1', '-1']).toContain(afterFirstToggle)
 
       fireEvent.click(rendered.getByLabelText(/Sort order/))
       const afterSecondToggle = localStorage.getItem(
         'TanstackQueryDevtools.sortOrder',
       )
-      expect(afterSecondToggle).not.toBe(afterFirstToggle)
+      expect(afterSecondToggle).toBe(afterFirstToggle === '1' ? '-1' : '1')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add tests for the sort dropdown, the `hideDisabledQueries` filter, and the sort order toggle in the `Devtools` body component.

**`sort by`** — sort dropdown and disabled-query filter:
- Persists `'TanstackQueryDevtools.sort'` to `localStorage` when the queries-view sort dropdown is changed.
- Persists `'TanstackQueryDevtools.mutationSort'` to `localStorage` when the mutations-view sort dropdown is changed.
- Hides disabled queries from the row list when `'TanstackQueryDevtools.hideDisabledQueries'` is `'true'`.

**`sort order`** — ascending/descending toggle:
- Persists `'TanstackQueryDevtools.sortOrder'` and toggles its value across consecutive clicks of the sort order button.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Devtools test coverage: verifies sort and sort-order toggles persist, mutation sort preference persists, and the “hide disabled queries” preference filters the displayed list via localStorage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10689)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->