### PR TITLE
test(query-devtools/Devtools): add tests for settings menu

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -864,7 +864,7 @@ describe('Devtools', () => {
         document.querySelectorAll<HTMLElement>(
           '.tsqd-settings-menu-sub-trigger',
         ),
-      ).find((el) => el.textContent.includes('Theme'))
+      ).find((el) => String(el.textContent).includes('Theme'))
       expect(themeTrigger).not.toBeUndefined()
       fireEvent.keyDown(themeTrigger!, { key: 'ArrowRight' })
 
@@ -884,7 +884,7 @@ describe('Devtools', () => {
         document.querySelectorAll<HTMLElement>(
           '.tsqd-settings-menu-sub-trigger',
         ),
-      ).find((el) => el.textContent.includes('Theme'))
+      ).find((el) => String(el.textContent).includes('Theme'))
       expect(themeTrigger).not.toBeUndefined()
       fireEvent.keyDown(themeTrigger!, { key: 'ArrowRight' })
 
@@ -894,7 +894,7 @@ describe('Devtools', () => {
       const lightItem = Array.from(
         themeMenu?.querySelectorAll<HTMLElement>('[role="menuitemradio"]') ??
           [],
-      ).find((el) => el.textContent.includes('Light'))
+      ).find((el) => String(el.textContent).includes('Light'))
       expect(lightItem).not.toBeUndefined()
       fireEvent.keyDown(lightItem!, { key: 'Enter' })
 

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -823,9 +823,8 @@ describe('Devtools', () => {
       const subTrigger = document.querySelector<HTMLElement>(
         '.tsqd-settings-menu-sub-trigger-position',
       )
-      if (subTrigger) {
-        fireEvent.keyDown(subTrigger, { key: 'ArrowRight' })
-      }
+      expect(subTrigger).not.toBeNull()
+      fireEvent.keyDown(subTrigger!, { key: 'ArrowRight' })
 
       expect(
         document.querySelector('[aria-label="Position settings"]'),
@@ -842,16 +841,14 @@ describe('Devtools', () => {
       const subTrigger = document.querySelector<HTMLElement>(
         '.tsqd-settings-menu-sub-trigger-position',
       )
-      if (subTrigger) {
-        fireEvent.keyDown(subTrigger, { key: 'ArrowRight' })
-      }
+      expect(subTrigger).not.toBeNull()
+      fireEvent.keyDown(subTrigger!, { key: 'ArrowRight' })
 
       const topItem = document.querySelector<HTMLElement>(
         '.tsqd-settings-menu-position-btn-top',
       )
-      if (topItem) {
-        fireEvent.keyDown(topItem, { key: 'Enter' })
-      }
+      expect(topItem).not.toBeNull()
+      fireEvent.keyDown(topItem!, { key: 'Enter' })
 
       expect(localStorage.getItem('TanstackQueryDevtools.position')).toBe('top')
     })
@@ -868,9 +865,8 @@ describe('Devtools', () => {
           '.tsqd-settings-menu-sub-trigger',
         ),
       ).find((el) => el.textContent.includes('Theme'))
-      if (themeTrigger) {
-        fireEvent.keyDown(themeTrigger, { key: 'ArrowRight' })
-      }
+      expect(themeTrigger).not.toBeUndefined()
+      fireEvent.keyDown(themeTrigger!, { key: 'ArrowRight' })
 
       expect(
         document.querySelector('[aria-label="Theme preference"]'),
@@ -889,9 +885,8 @@ describe('Devtools', () => {
           '.tsqd-settings-menu-sub-trigger',
         ),
       ).find((el) => el.textContent.includes('Theme'))
-      if (themeTrigger) {
-        fireEvent.keyDown(themeTrigger, { key: 'ArrowRight' })
-      }
+      expect(themeTrigger).not.toBeUndefined()
+      fireEvent.keyDown(themeTrigger!, { key: 'ArrowRight' })
 
       const themeMenu = document.querySelector(
         '[aria-label="Theme preference"]',
@@ -900,9 +895,8 @@ describe('Devtools', () => {
         themeMenu?.querySelectorAll<HTMLElement>('[role="menuitemradio"]') ??
           [],
       ).find((el) => el.textContent.includes('Light'))
-      if (lightItem) {
-        fireEvent.keyDown(lightItem, { key: 'Enter' })
-      }
+      expect(lightItem).not.toBeUndefined()
+      fireEvent.keyDown(lightItem!, { key: 'Enter' })
 
       expect(
         localStorage.getItem('TanstackQueryDevtools.theme_preference'),
@@ -919,9 +913,8 @@ describe('Devtools', () => {
       const hideTrigger = document.querySelector<HTMLElement>(
         '.tsqd-settings-menu-sub-trigger-disabled-queries',
       )
-      if (hideTrigger) {
-        fireEvent.keyDown(hideTrigger, { key: 'ArrowRight' })
-      }
+      expect(hideTrigger).not.toBeNull()
+      fireEvent.keyDown(hideTrigger!, { key: 'ArrowRight' })
 
       expect(
         document.querySelector('[aria-label="Hide disabled queries setting"]'),
@@ -938,16 +931,14 @@ describe('Devtools', () => {
       const hideTrigger = document.querySelector<HTMLElement>(
         '.tsqd-settings-menu-sub-trigger-disabled-queries',
       )
-      if (hideTrigger) {
-        fireEvent.keyDown(hideTrigger, { key: 'ArrowRight' })
-      }
+      expect(hideTrigger).not.toBeNull()
+      fireEvent.keyDown(hideTrigger!, { key: 'ArrowRight' })
 
       const hideItem = document.querySelector<HTMLElement>(
         '.tsqd-settings-menu-position-btn-hide',
       )
-      if (hideItem) {
-        fireEvent.keyDown(hideItem, { key: 'Enter' })
-      }
+      expect(hideItem).not.toBeNull()
+      fireEvent.keyDown(hideItem!, { key: 'Enter' })
 
       expect(
         localStorage.getItem('TanstackQueryDevtools.hideDisabledQueries'),

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -796,9 +796,7 @@ describe('Devtools', () => {
     it('should render the settings button', () => {
       const rendered = renderDevtools({ initialIsOpen: true })
 
-      expect(
-        rendered.getByLabelText('Open settings menu'),
-      ).toBeInTheDocument()
+      expect(rendered.getByLabelText('Open settings menu')).toBeInTheDocument()
     })
 
     it('should show "Position" sub-trigger when the settings menu is opened', () => {
@@ -855,9 +853,7 @@ describe('Devtools', () => {
         fireEvent.keyDown(topItem, { key: 'Enter' })
       }
 
-      expect(localStorage.getItem('TanstackQueryDevtools.position')).toBe(
-        'top',
-      )
+      expect(localStorage.getItem('TanstackQueryDevtools.position')).toBe('top')
     })
 
     it('should open "Theme" sub-menu when the sub-trigger is activated', () => {

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -34,19 +34,6 @@ describe('Devtools', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     previousRootFontSize = document.documentElement.style.fontSize
-    // jsdom doesn't implement `PointerEvent`; the DropdownMenu trigger checks
-    // `e.pointerType !== 'touch'` on pointerdown to decide whether to open,
-    // so we polyfill it as a thin wrapper around `MouseEvent`.
-    if (typeof window.PointerEvent === 'undefined') {
-      class FakePointerEvent extends MouseEvent {
-        pointerType: string
-        constructor(type: string, init: PointerEventInit = {}) {
-          super(type, init)
-          this.pointerType = init.pointerType ?? 'mouse'
-        }
-      }
-      vi.stubGlobal('PointerEvent', FakePointerEvent)
-    }
     vi.stubGlobal('localStorage', {
       getItem: (key: string) =>
         Object.prototype.hasOwnProperty.call(storage, key)
@@ -802,6 +789,173 @@ describe('Devtools', () => {
         'TanstackQueryDevtools.sortOrder',
       )
       expect(afterSecondToggle).toBe(afterFirstToggle === '1' ? '-1' : '1')
+    })
+  })
+
+  describe('settings menu', () => {
+    it('should render the settings button', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      expect(
+        rendered.getByLabelText('Open settings menu'),
+      ).toBeInTheDocument()
+    })
+
+    it('should show "Position" sub-trigger when the settings menu is opened', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.keyDown(rendered.getByLabelText('Open settings menu'), {
+        key: 'Enter',
+      })
+
+      // The menu is rendered through a Portal mounted on `document.body`,
+      // outside `rendered.container`, so look it up via `document` directly.
+      expect(
+        document.querySelector('.tsqd-settings-menu-sub-trigger-position'),
+      ).not.toBeNull()
+    })
+
+    it('should open "Position" sub-menu when the sub-trigger is activated', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.keyDown(rendered.getByLabelText('Open settings menu'), {
+        key: 'Enter',
+      })
+
+      const subTrigger = document.querySelector<HTMLElement>(
+        '.tsqd-settings-menu-sub-trigger-position',
+      )
+      if (subTrigger) {
+        fireEvent.keyDown(subTrigger, { key: 'ArrowRight' })
+      }
+
+      expect(
+        document.querySelector('[aria-label="Position settings"]'),
+      ).not.toBeNull()
+    })
+
+    it('should persist "position" when a position radio item is selected', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.keyDown(rendered.getByLabelText('Open settings menu'), {
+        key: 'Enter',
+      })
+
+      const subTrigger = document.querySelector<HTMLElement>(
+        '.tsqd-settings-menu-sub-trigger-position',
+      )
+      if (subTrigger) {
+        fireEvent.keyDown(subTrigger, { key: 'ArrowRight' })
+      }
+
+      const topItem = document.querySelector<HTMLElement>(
+        '.tsqd-settings-menu-position-btn-top',
+      )
+      if (topItem) {
+        fireEvent.keyDown(topItem, { key: 'Enter' })
+      }
+
+      expect(localStorage.getItem('TanstackQueryDevtools.position')).toBe(
+        'top',
+      )
+    })
+
+    it('should open "Theme" sub-menu when the sub-trigger is activated', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.keyDown(rendered.getByLabelText('Open settings menu'), {
+        key: 'Enter',
+      })
+
+      const themeTrigger = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '.tsqd-settings-menu-sub-trigger',
+        ),
+      ).find((el) => el.textContent.includes('Theme'))
+      if (themeTrigger) {
+        fireEvent.keyDown(themeTrigger, { key: 'ArrowRight' })
+      }
+
+      expect(
+        document.querySelector('[aria-label="Theme preference"]'),
+      ).not.toBeNull()
+    })
+
+    it('should persist "theme_preference" when a theme radio item is selected', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.keyDown(rendered.getByLabelText('Open settings menu'), {
+        key: 'Enter',
+      })
+
+      const themeTrigger = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '.tsqd-settings-menu-sub-trigger',
+        ),
+      ).find((el) => el.textContent.includes('Theme'))
+      if (themeTrigger) {
+        fireEvent.keyDown(themeTrigger, { key: 'ArrowRight' })
+      }
+
+      const themeMenu = document.querySelector(
+        '[aria-label="Theme preference"]',
+      )
+      const lightItem = Array.from(
+        themeMenu?.querySelectorAll<HTMLElement>('[role="menuitemradio"]') ??
+          [],
+      ).find((el) => el.textContent.includes('Light'))
+      if (lightItem) {
+        fireEvent.keyDown(lightItem, { key: 'Enter' })
+      }
+
+      expect(
+        localStorage.getItem('TanstackQueryDevtools.theme_preference'),
+      ).toBe('light')
+    })
+
+    it('should open "Hide disabled queries" sub-menu when the sub-trigger is activated', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.keyDown(rendered.getByLabelText('Open settings menu'), {
+        key: 'Enter',
+      })
+
+      const hideTrigger = document.querySelector<HTMLElement>(
+        '.tsqd-settings-menu-sub-trigger-disabled-queries',
+      )
+      if (hideTrigger) {
+        fireEvent.keyDown(hideTrigger, { key: 'ArrowRight' })
+      }
+
+      expect(
+        document.querySelector('[aria-label="Hide disabled queries setting"]'),
+      ).not.toBeNull()
+    })
+
+    it('should persist "hideDisabledQueries" when a hide-disabled radio item is selected', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.keyDown(rendered.getByLabelText('Open settings menu'), {
+        key: 'Enter',
+      })
+
+      const hideTrigger = document.querySelector<HTMLElement>(
+        '.tsqd-settings-menu-sub-trigger-disabled-queries',
+      )
+      if (hideTrigger) {
+        fireEvent.keyDown(hideTrigger, { key: 'ArrowRight' })
+      }
+
+      const hideItem = document.querySelector<HTMLElement>(
+        '.tsqd-settings-menu-position-btn-hide',
+      )
+      if (hideItem) {
+        fireEvent.keyDown(hideItem, { key: 'Enter' })
+      }
+
+      expect(
+        localStorage.getItem('TanstackQueryDevtools.hideDisabledQueries'),
+      ).toBe('true')
     })
   })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -793,12 +793,6 @@ describe('Devtools', () => {
   })
 
   describe('settings menu', () => {
-    it('should render the settings button', () => {
-      const rendered = renderDevtools({ initialIsOpen: true })
-
-      expect(rendered.getByLabelText('Open settings menu')).toBeInTheDocument()
-    })
-
     it('should show "Position" sub-trigger when the settings menu is opened', () => {
       const rendered = renderDevtools({ initialIsOpen: true })
 


### PR DESCRIPTION
## 🎯 Changes

Adds tests for the settings menu in `Devtools.tsx`, covering 7 cases:

- `should show "Position" sub-trigger when the settings menu is opened`
- `should open "Position" sub-menu when the sub-trigger is activated`
- `should persist "position" when a position radio item is selected`
- `should open "Theme" sub-menu when the sub-trigger is activated`
- `should persist "theme_preference" when a theme radio item is selected`
- `should open "Hide disabled queries" sub-menu when the sub-trigger is activated`
- `should persist "hideDisabledQueries" when a hide-disabled radio item is selected`

Kobalte's `DropdownMenu` is exercised through its keyboard activation path (`Enter` on the trigger and radio items, `ArrowRight` on sub-triggers), avoiding the need for a `PointerEvent` polyfill in jsdom.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for the DevTools settings menu: verifies keyboard navigation opens the Settings menu and its sub-menus (Position, Theme preference, Hide disabled queries), asserts sub-menu controls render correctly (including portal-based content), and confirms persistence of position, theme preference, and hide-disabled-queries in localStorage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10690)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->