### PR TITLE
test(query-devtools/Devtools): add tests for resize handle

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1009,7 +1009,7 @@ describe('Devtools', () => {
       // that drag math starts from `initialHeight` instead of 0.
       // Only `height` is read by the production code; other fields are unused.
       const panel = handle.parentElement
-      expect(panel).not.toBeNull()
+      expect(panel).toBeInstanceOf(HTMLElement)
       vi.spyOn(panel!, 'getBoundingClientRect').mockReturnValue({
         height: initialHeight,
         width: 0,
@@ -1048,7 +1048,7 @@ describe('Devtools', () => {
       // detect when the panel hits its minimum. Returning the same value both
       // times keeps the "minimum reached" branch from firing.
       const panel = handle.parentElement
-      expect(panel).not.toBeNull()
+      expect(panel).toBeInstanceOf(HTMLElement)
       vi.spyOn(panel!, 'getBoundingClientRect').mockReturnValue({
         height: 0,
         width: initialWidth,

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -939,4 +939,140 @@ describe('Devtools', () => {
       ).toBe('true')
     })
   })
+
+  describe('resize handle', () => {
+    it('should increase height when "ArrowUp" is pressed on the resize handle in "bottom" position', () => {
+      const rendered = renderDevtools(
+        { position: 'bottom', initialIsOpen: true },
+        { 'TanstackQueryDevtools.height': '500' },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      fireEvent.keyDown(handle, { key: 'ArrowUp' })
+
+      expect(
+        Number(localStorage.getItem('TanstackQueryDevtools.height')),
+      ).toBeGreaterThan(500)
+    })
+
+    it('should decrease height when "ArrowDown" is pressed on the resize handle in "bottom" position', () => {
+      const rendered = renderDevtools(
+        { position: 'bottom', initialIsOpen: true },
+        { 'TanstackQueryDevtools.height': '500' },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      fireEvent.keyDown(handle, { key: 'ArrowDown' })
+
+      expect(
+        Number(localStorage.getItem('TanstackQueryDevtools.height')),
+      ).toBeLessThan(500)
+    })
+
+    it('should increase width when "ArrowLeft" is pressed on the resize handle in "right" position', () => {
+      const rendered = renderDevtools(
+        { position: 'right', initialIsOpen: true },
+        { 'TanstackQueryDevtools.width': '500' },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      fireEvent.keyDown(handle, { key: 'ArrowLeft' })
+
+      expect(
+        Number(localStorage.getItem('TanstackQueryDevtools.width')),
+      ).toBeGreaterThan(500)
+    })
+
+    it('should decrease width when "ArrowRight" is pressed on the resize handle in "right" position', () => {
+      const rendered = renderDevtools(
+        { position: 'right', initialIsOpen: true },
+        { 'TanstackQueryDevtools.width': '500' },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      fireEvent.keyDown(handle, { key: 'ArrowRight' })
+
+      expect(
+        Number(localStorage.getItem('TanstackQueryDevtools.width')),
+      ).toBeLessThan(500)
+    })
+
+    it('should increase height while dragging up in "bottom" position', () => {
+      const initialHeight = 500
+      const rendered = renderDevtools(
+        { position: 'bottom', initialIsOpen: true },
+        { 'TanstackQueryDevtools.height': String(initialHeight) },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      // jsdom returns zeros for `getBoundingClientRect`; stub the panel size so
+      // that drag math starts from `initialHeight` instead of 0.
+      // Only `height` is read by the production code; other fields are unused.
+      const panel = handle.parentElement
+      expect(panel).not.toBeNull()
+      vi.spyOn(panel!, 'getBoundingClientRect').mockReturnValue({
+        height: initialHeight,
+        width: 0,
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      })
+
+      // Move the cursor up by 50px (`clientY` 100 → 50), which adds 50px to the
+      // drag base of `initialHeight`.
+      fireEvent.mouseDown(handle, { clientX: 0, clientY: 100 })
+      fireEvent(
+        document,
+        new MouseEvent('mousemove', { clientX: 0, clientY: 50 }),
+      )
+      fireEvent(document, new MouseEvent('mouseup'))
+
+      expect(
+        Number(localStorage.getItem('TanstackQueryDevtools.height')),
+      ).toBeGreaterThan(initialHeight)
+    })
+
+    it('should increase width while dragging left in "right" position', () => {
+      const initialWidth = 500
+      const rendered = renderDevtools(
+        { position: 'right', initialIsOpen: true },
+        { 'TanstackQueryDevtools.width': String(initialWidth) },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      // `width` is read twice during drag: once as the base size, and again to
+      // detect when the panel hits its minimum. Returning the same value both
+      // times keeps the "minimum reached" branch from firing.
+      const panel = handle.parentElement
+      expect(panel).not.toBeNull()
+      vi.spyOn(panel!, 'getBoundingClientRect').mockReturnValue({
+        height: 0,
+        width: initialWidth,
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      })
+
+      // Move the cursor left by 50px (`clientX` 100 → 50); in `right` position,
+      // moving left grows the panel by 50px from the drag base of `initialWidth`.
+      fireEvent.mouseDown(handle, { clientX: 100, clientY: 0 })
+      fireEvent(
+        document,
+        new MouseEvent('mousemove', { clientX: 50, clientY: 0 }),
+      )
+      fireEvent(document, new MouseEvent('mouseup'))
+
+      expect(
+        Number(localStorage.getItem('TanstackQueryDevtools.width')),
+      ).toBeGreaterThan(initialWidth)
+    })
+  })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -964,9 +964,11 @@ describe('Devtools', () => {
       const handle = rendered.getByLabelText('Resize devtools panel')
       fireEvent.keyDown(handle, { key: 'ArrowDown' })
 
-      expect(
-        Number(localStorage.getItem('TanstackQueryDevtools.height')),
-      ).toBeLessThan(500)
+      // Assert the value exists before parsing — `Number(null)` is `0`,
+      // which would falsely satisfy `toBeLessThan(500)` if the write was missing.
+      const nextHeight = localStorage.getItem('TanstackQueryDevtools.height')
+      expect(nextHeight).not.toBeNull()
+      expect(Number(nextHeight)).toBeLessThan(500)
     })
 
     it('should increase width when "ArrowLeft" is pressed on the resize handle in "right" position', () => {
@@ -992,9 +994,9 @@ describe('Devtools', () => {
       const handle = rendered.getByLabelText('Resize devtools panel')
       fireEvent.keyDown(handle, { key: 'ArrowRight' })
 
-      expect(
-        Number(localStorage.getItem('TanstackQueryDevtools.width')),
-      ).toBeLessThan(500)
+      const nextWidth = localStorage.getItem('TanstackQueryDevtools.width')
+      expect(nextWidth).not.toBeNull()
+      expect(Number(nextWidth)).toBeLessThan(500)
     })
 
     it('should increase height while dragging up in "bottom" position', () => {


### PR DESCRIPTION
## 🎯 Changes

Adds tests for the resize handle in `Devtools.tsx`, covering 6 cases:

- `should increase height when "ArrowUp" is pressed on the resize handle in "bottom" position`
- `should decrease height when "ArrowDown" is pressed on the resize handle in "bottom" position`
- `should increase width when "ArrowLeft" is pressed on the resize handle in "right" position`
- `should decrease width when "ArrowRight" is pressed on the resize handle in "right" position`
- `should increase height while dragging up in "bottom" position`
- `should increase width while dragging left in "right" position`

The drag-flow tests stub `getBoundingClientRect` on the panel since jsdom does not perform layout, so the production resize math can use a non-zero base size and meaningful assertions like `toBeGreaterThan(initialHeight)`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the devtools resize handle: verifies keyboard arrow behavior and mouse-drag interactions, ensures panel height/width persist correctly in bottom/right placements, and accounts for test-environment sizing quirks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10691)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->