### PR TITLE
test(query-devtools/Devtools): add tests for online toggle

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1077,4 +1077,24 @@ describe('Devtools', () => {
       ).toBeGreaterThan(initialWidth)
     })
   })
+
+  describe('online toggle', () => {
+    it('should set "onlineManager" offline when the offline button is clicked', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText('Mock offline behavior'))
+
+      expect(onlineManager.isOnline()).toBe(false)
+    })
+
+    it('should swap the toggle label after the offline button is clicked', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText('Mock offline behavior'))
+
+      expect(
+        rendered.getByLabelText('Unset offline mocking behavior'),
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1079,14 +1079,6 @@ describe('Devtools', () => {
   })
 
   describe('online toggle', () => {
-    it('should set "onlineManager" offline when the offline button is clicked', () => {
-      const rendered = renderDevtools({ initialIsOpen: true })
-
-      fireEvent.click(rendered.getByLabelText('Mock offline behavior'))
-
-      expect(onlineManager.isOnline()).toBe(false)
-    })
-
     it('should swap the toggle label after the offline button is clicked', () => {
       const rendered = renderDevtools({ initialIsOpen: true })
 


### PR DESCRIPTION
## 🎯 Changes

Adds a test for the online toggle button in `Devtools.tsx`:

- `should swap the toggle label after the offline button is clicked`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test suite for the Devtools online/offline toggle, verifying the control toggles and its label updates to reflect offline mocking state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10692)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->