### PR TITLE
test(query-devtools/Devtools): add test for hiding the panel when the 'TANSTACK' logo is clicked

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1089,4 +1089,16 @@ describe('Devtools', () => {
       ).toBeInTheDocument()
     })
   })
+
+  describe('logo close', () => {
+    it('should hide the panel when the TanStack logo is clicked', () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText('Close Tanstack query devtools'))
+
+      expect(
+        rendered.queryByLabelText('Tanstack query devtools'),
+      ).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds a test for `Devtools.tsx` covering:

- `should hide the panel when the TanStack logo is clicked`

The TanStack logo doubles as a close button and triggers `setLocalStore('open', 'false')` when no PiP window or panel-only mode is active.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for devtools panel close functionality when triggering the logo control action.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10693)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->