### PR TITLE
fix(svelte-query): reuse QueriesObserver to fix createQueries empty-init bug

### DIFF
--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -2,6 +2,7 @@ import { QueriesObserver } from '@tanstack/query-core'
 import { useIsRestoring } from './useIsRestoring.js'
 import { createRawRef } from './containers.svelte.js'
 import { useQueryClient } from './useQueryClient.js'
+import { watchChanges } from './utils.svelte.js'
 import type {
   Accessor,
   CreateQueryOptions,
@@ -215,13 +216,25 @@ export function createQueries<
     }),
   )
 
-  // can't do same as createMutation, as QueriesObserver has no `setOptions` method
-  const observer = $derived(
+  /** Creates the observer - reuse when possible, recreate only on client change */
+  // svelte-ignore state_referenced_locally - intentional, initial value
+  let observer = $state(
     new QueriesObserver<TCombinedResult>(
       client,
       resolvedQueryOptions,
       combine as QueriesObserverOptions<TCombinedResult>,
     ),
+  )
+  watchChanges(
+    () => client,
+    'pre',
+    () => {
+      observer = new QueriesObserver<TCombinedResult>(
+        client,
+        resolvedQueryOptions,
+        combine as QueriesObserverOptions<TCombinedResult>,
+      )
+    },
   )
 
   function createResult() {
@@ -233,7 +246,7 @@ export function createQueries<
   }
 
   // @ts-expect-error - the crazy-complex TCombinedResult type doesn't like being called an array
-  // svelte-ignore state_referenced_locally
+  // svelte-ignore state_referenced_locally - intentional, initial value
   const [results, update] = createRawRef<TCombinedResult>(createResult())
 
   $effect(() => {
@@ -243,12 +256,16 @@ export function createQueries<
     return unsubscribe
   })
 
-  $effect.pre(() => {
-    observer.setQueries(resolvedQueryOptions, {
-      combine,
-    } as QueriesObserverOptions<TCombinedResult>)
-    update(createResult())
-  })
+  watchChanges(
+    () => [resolvedQueryOptions, combine],
+    'pre',
+    () => {
+      observer.setQueries(resolvedQueryOptions, {
+        combine,
+      } as QueriesObserverOptions<TCombinedResult>)
+      update(createResult())
+    },
+  )
 
   return results
 }


### PR DESCRIPTION
## What

Fixes `createQueries` becoming permanently inactive when initialized with an empty `queries` array.

Closes #10681.

## Why

The current implementation recreates `QueriesObserver` on every query change via `$derived`. This breaks the observer/subscription lifecycle: when `createQueries` starts with `[]`, the observer is created with no queries, and when the array later becomes non-empty, a new observer is created but the subscription doesn't properly pick up the new queries.

## How

Adopts the same pattern as `createBaseQuery`:

1. **Create observer once** with `$state` instead of `$derived`
2. **Recreate only on client change** via `watchChanges`
3. **Call `setQueries`** when resolved options change via `watchChanges`

This matches the React implementation where the observer is created once in `useState` and updated via `setQueries` in a `useEffect`.

## Testing

The existing svelte-query tests still pass. The fix can be verified by using `createQueries` with an initially empty array that is later populated — previously this stayed pending forever; now it resolves correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal query observation mechanism to ensure more consistent and reliable query state updates. Enhanced observer lifecycle management for better query synchronization across state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->