### PR TITLE
test(query-devtools/Devtools): add test for restoring previous query options after 'Trigger Loading' is clicked

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -561,6 +561,39 @@ describe('Devtools', () => {
         'pending',
       )
     })
+
+    it('should restore the previous query options when "Restore Loading" is clicked after "Trigger Loading"', async () => {
+      const queryFn = vi.fn(() => Promise.resolve('original'))
+      queryClient.prefetchQuery({
+        queryKey: ['action-restore-loading'],
+        queryFn,
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText(/Query key \["action-restore-loading"\]/),
+      )
+
+      // First click puts the query into a pending state with `data: undefined`
+      // and stashes the original options in `fetchMeta.__previousQueryOptions`.
+      fireEvent.click(rendered.getByText('Trigger Loading'))
+      expect(queryClient.getQueryState(['action-restore-loading'])?.status).toBe(
+        'pending',
+      )
+
+      // Second click runs `restoreQueryAfterLoadingOrError`, which cancels the
+      // never-resolving fetch and refetches with the stashed options.
+      fireEvent.click(rendered.getByText('Restore Loading'))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(queryFn).toHaveBeenCalledTimes(2)
+      expect(queryClient.getQueryData(['action-restore-loading'])).toBe(
+        'original',
+      )
+    })
   })
 
   describe('mutation details', () => {

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -580,9 +580,9 @@ describe('Devtools', () => {
       // First click puts the query into a pending state with `data: undefined`
       // and stashes the original options in `fetchMeta.__previousQueryOptions`.
       fireEvent.click(rendered.getByText('Trigger Loading'))
-      expect(queryClient.getQueryState(['action-restore-loading'])?.status).toBe(
-        'pending',
-      )
+      expect(
+        queryClient.getQueryState(['action-restore-loading'])?.status,
+      ).toBe('pending')
 
       // Second click runs `restoreQueryAfterLoadingOrError`, which cancels the
       // never-resolving fetch and refetches with the stashed options.


### PR DESCRIPTION
## 🎯 Changes

Adds a test for `Devtools.tsx` covering the `restoreQueryAfterLoadingOrError` flow that runs when the user clicks `Restore Loading` after `Trigger Loading`:

- `should restore the previous query options when "Restore Loading" is clicked after "Trigger Loading"`

The first click on `Trigger Loading` switches the query into a pending state with `data: undefined` and stashes the original options in `fetchMeta.__previousQueryOptions`. The second click cancels the never-resolving fetch and refetches with those stashed options, restoring the original data. Neither the `restoreQueryAfterLoadingOrError` function nor the `Trigger Loading` else-branch was covered before.

Coverage delta on `Devtools.tsx`: Stmts 93.56 → 95.30, Branch 76.79 → 78.19, Funcs 94.90 → 95.78, Lines 93.93 → 96.07.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).