### PR TITLE
test(query-devtools/Devtools): add test for clamping the width when resizing below min width

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1110,6 +1110,60 @@ describe('Devtools', () => {
       ).toBeGreaterThan(initialWidth)
     })
 
+    it('should clamp the width to the minimum when dragging shrinks the panel below the minimum width', () => {
+      const initialWidth = 200
+      const rendered = renderDevtools(
+        { position: 'left', initialIsOpen: true },
+        { 'TanstackQueryDevtools.width': String(initialWidth) },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      const panel = handle.parentElement
+      expect(panel).toBeInstanceOf(HTMLElement)
+      // `width` is read twice during drag: once as the base size, and again
+      // after the clamp to detect when the panel has hit its minimum. The
+      // first call returns `initialWidth`; the second returns `0` so the
+      // `localStore.width < newWidth` restore branch stays inactive and only
+      // the `newSize < minWidth` clamp is observed.
+      const getBoundingClientRect = vi
+        .spyOn(panel!, 'getBoundingClientRect')
+        .mockReturnValueOnce({
+          height: 0,
+          width: initialWidth,
+          x: 0,
+          y: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          toJSON: () => ({}),
+        })
+      getBoundingClientRect.mockReturnValue({
+        height: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      })
+
+      // In `left` position, dragging the cursor left (`clientX` 100 → 0)
+      // shrinks the panel by 100px, which lands well under the 192px minimum.
+      fireEvent.mouseDown(handle, { clientX: 100, clientY: 0 })
+      fireEvent(
+        document,
+        new MouseEvent('mousemove', { clientX: 0, clientY: 0 }),
+      )
+      fireEvent(document, new MouseEvent('mouseup'))
+
+      expect(
+        Number(localStorage.getItem('TanstackQueryDevtools.width')),
+      ).toBe(192)
+    })
+
     it('should close the query details panel when dragging shrinks the panel below the minimum height', () => {
       queryClient.setQueryData(['shrink-below-min-height'], [{ id: 1 }])
       const rendered = renderDevtools({

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1159,9 +1159,9 @@ describe('Devtools', () => {
       )
       fireEvent(document, new MouseEvent('mouseup'))
 
-      expect(
-        Number(localStorage.getItem('TanstackQueryDevtools.width')),
-      ).toBe(192)
+      expect(Number(localStorage.getItem('TanstackQueryDevtools.width'))).toBe(
+        192,
+      )
     })
 
     it('should close the query details panel when dragging shrinks the panel below the minimum height', () => {


### PR DESCRIPTION
## 🎯 Changes

Adds a test for `Devtools.tsx` covering the resize handle `minWidth` clamp branch:

- `should clamp the width to the minimum when dragging shrinks the panel below the minimum width`

In `left`/`right` positions, when the user drags the resize handle past the 192px (`12rem`) minimum, the panel width is clamped to that minimum. This is the horizontal counterpart of the vertical `minHeight` clamp covered in #10698. No existing case covered this branch.

`getBoundingClientRect` is read twice during drag: once as the base size, and again after the clamp to detect when the panel has hit its minimum. The first call is stubbed to `initialWidth` and the second to `0`, so only the `newSize < minWidth` clamp branch is observed (the `localStore.width < newWidth` restore branch stays inactive).

Coverage delta on `Devtools.tsx`: Stmts 95.30 → 95.40, Branch 78.19 → 78.88, Lines 96.07 → 96.18.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).