### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+.github/ @TanStack/tanstack-core
+.changeset/config.json @TanStack/tanstack-core
+scripts/ @TanStack/tanstack-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 .github/ @TanStack/tanstack-core
+.nx/ @TanStack/tanstack-core
+nx.json @TanStack/tanstack-core
 .changeset/config.json @TanStack/tanstack-core
 scripts/ @TanStack/tanstack-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 nx.json @TanStack/tanstack-core
 .changeset/config.json @TanStack/tanstack-core
 scripts/ @TanStack/tanstack-core
+.npmrc @TanStack/tanstack-core


### PR DESCRIPTION
As part of our ongoing security hardening, we're mandating specific sensitive release files to be approved by the core maintainers team.