### PR TITLE
fix(angular-query): refresh injectQueries results after query list changes

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -180,6 +180,46 @@ describe('injectQueries', () => {
     expect(rendered.getByText('status2: success, data2: 2')).toBeInTheDocument()
   })
 
+  it('should reflect query list changes after subscriber results exist', async () => {
+    const key = queryKey()
+
+    @Component({
+      template: `
+        <div>
+          count: {{ result().length }}, data:
+          {{ dataText() }}
+        </div>
+      `,
+    })
+    class Page {
+      readonly ids = signal([1])
+      readonly result = injectQueries(() => ({
+        queries: this.ids().map((id) => ({
+          queryKey: [...key, id],
+          queryFn: () => sleep(10).then(() => id),
+        })),
+      }))
+
+      dataText() {
+        return this.result()
+          .map((query) => query.data() ?? 'none')
+          .join(',')
+      }
+    }
+
+    const rendered = await render(Page)
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('count: 1, data: 1')).toBeInTheDocument()
+
+    rendered.fixture.componentInstance.ids.set([])
+    rendered.fixture.detectChanges()
+
+    expect(rendered.getByText('count: 0, data:')).toBeInTheDocument()
+  })
+
   describe('isRestoring', () => {
     it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
       const key1 = queryKey()

--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -274,13 +274,17 @@ export function injectQueries<
       ),
     )
 
+    const resultFromSubscriberSignal = signal<TCombinedResult | null>(null)
+
     // Do not notify on updates because of changes in the options because
     // these changes should already be reflected in the optimistic result.
     effect(() => {
-      observerSignal().setQueries(
-        defaultedQueries(),
-        optionsSignal() as QueriesObserverOptions<TCombinedResult>,
-      )
+      const observer = observerSignal()
+      const defaulted = defaultedQueries()
+      const options = optionsSignal() as QueriesObserverOptions<TCombinedResult>
+
+      resultFromSubscriberSignal.set(null)
+      observer.setQueries(defaulted, options)
     })
 
     const optimisticCombinedResultSignal = computed(() => {
@@ -288,8 +292,6 @@ export function injectQueries<
         optimisticResultSignal()
       return getCombinedResult(trackResult())
     })
-
-    const resultFromSubscriberSignal = signal<TCombinedResult | null>(null)
 
     effect(() => {
       const observer = observerSignal()


### PR DESCRIPTION
## Summary
Fixes #8704.

When the `injectQueries` query list changes after subscriber results exist, the subscriber result can mask the new optimistic result. This clears the subscriber snapshot whenever the observer query set is updated, allowing the latest query list to be reflected immediately.

## Validation
- `corepack pnpm exec vitest run src/__tests__/inject-queries.test.ts` from `packages/angular-query-experimental` (5 tests pass)
- `git diff --check origin/main...HEAD`

Windows checkout limitations:
- `corepack pnpm test:eslint` fails before checking this change because tracked config symlinks are materialized as plain text in this checkout (`core.symlinks=false`), and Windows denied creating real symlinks.
- `corepack pnpm test:types:tscurrent` fails on those same materialized symlink config files.
- `corepack pnpm --filter @tanstack/query-core build` fails for the same `root.tsup.config.js` symlink materialization, so the Angular package build cannot be completed locally here.