### PR TITLE
test(query-devtools/Explorer): add tests for primitive values and basic collection rendering

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render } from '@solidjs/testing-library'
+import { QueryClient, onlineManager } from '@tanstack/query-core'
+import Explorer from '../Explorer'
+import { QueryDevtoolsContext, ThemeContext } from '../contexts'
+
+// `goober` compiles every `css\`...\`` template literal at mount time;
+// replace it with a no-op factory so label/role-based assertions stay fast.
+vi.mock('goober', () => {
+  let counter = 0
+  const css = Object.assign(() => `tsqd-${++counter}`, {
+    bind: () => css,
+  })
+  return { css, glob: () => {}, setup: () => {} }
+})
+
+describe('Explorer', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  function renderExplorer(props: Parameters<typeof Explorer>[0]) {
+    return render(() => (
+      <QueryDevtoolsContext.Provider
+        value={{
+          client: queryClient,
+          queryFlavor: 'TanStack Query',
+          version: '5',
+          onlineManager,
+        }}
+      >
+        <ThemeContext.Provider value={() => 'dark'}>
+          <Explorer {...props} />
+        </ThemeContext.Provider>
+      </QueryDevtoolsContext.Provider>
+    ))
+  }
+
+  describe('primitive values', () => {
+    it('should render a "label: value" row for a string value', () => {
+      const rendered = renderExplorer({ label: 'name', value: 'Anna' })
+
+      expect(rendered.getByText('name:')).toBeInTheDocument()
+      expect(rendered.getByText('"Anna"')).toBeInTheDocument()
+    })
+
+    it('should render a "label: value" row for a number value', () => {
+      const rendered = renderExplorer({ label: 'count', value: 42 })
+
+      expect(rendered.getByText('count:')).toBeInTheDocument()
+      expect(rendered.getByText('42')).toBeInTheDocument()
+    })
+
+    it('should render a "label: value" row for a boolean value', () => {
+      const rendered = renderExplorer({ label: 'active', value: true })
+
+      expect(rendered.getByText('active:')).toBeInTheDocument()
+      expect(rendered.getByText('true')).toBeInTheDocument()
+    })
+
+    it('should render a "label: value" row for a "null" value', () => {
+      const rendered = renderExplorer({ label: 'missing', value: null })
+
+      expect(rendered.getByText('missing:')).toBeInTheDocument()
+      expect(rendered.getByText('null')).toBeInTheDocument()
+    })
+  })
+
+  describe('arrays and objects', () => {
+    it('should render an empty object as a primitive row (no expander)', () => {
+      const rendered = renderExplorer({ label: 'data', value: {} })
+
+      expect(rendered.getByText('data:')).toBeInTheDocument()
+      expect(rendered.queryByRole('button', { expanded: false })).toBeNull()
+    })
+
+    it('should render an array with an expander showing the item count', () => {
+      const rendered = renderExplorer({
+        label: 'list',
+        value: ['a', 'b', 'c'],
+      })
+
+      const expander = rendered.getByRole('button', { expanded: false })
+      expect(expander).toBeInTheDocument()
+      expect(expander.textContent).toContain('list')
+      expect(expander.textContent).toContain('3 items')
+    })
+
+    it('should render children under their index labels when the array expander is clicked', () => {
+      const rendered = renderExplorer({
+        label: 'list',
+        value: ['a', 'b'],
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+
+      expect(rendered.getByText('0:')).toBeInTheDocument()
+      expect(rendered.getByText('1:')).toBeInTheDocument()
+      expect(rendered.getByText('"a"')).toBeInTheDocument()
+      expect(rendered.getByText('"b"')).toBeInTheDocument()
+    })
+
+    it('should render object entries under their keys when expanded', () => {
+      const rendered = renderExplorer({
+        label: 'user',
+        value: { name: 'Anna', age: 30 },
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+
+      expect(rendered.getByText('name:')).toBeInTheDocument()
+      expect(rendered.getByText('"Anna"')).toBeInTheDocument()
+      expect(rendered.getByText('age:')).toBeInTheDocument()
+      expect(rendered.getByText('30')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add the first batch of unit tests for `Explorer.tsx`. This PR introduces the test infrastructure (mock for \`goober\`, \`QueryDevtoolsContext\` + \`ThemeContext\` providers) along with read-only rendering cases.

Covered cases:
- **\`primitive values\`** (4): rows for \`string\`, \`number\`, \`boolean\`, \`null\`
- **\`arrays and objects\`** (4): empty object (no expander), array expander with item count, array children under index labels, object entries under their keys

Excluded from this PR (planned for follow-ups):
- \`Map\` / iterable (\`Set\`) branches
- \`defaultExpanded\` and pagination (100+ entries) behavior
- \`editable\` mode (input change, toggle, delete, copy, bulk edit)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for the Explorer component, verifying rendering of various data types and expand/collapse functionality for structured values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->