### PR TITLE
fix(eslint-plugin-query): allow useSuspenseQueries combine deps

### DIFF
--- a/.changeset/suspense-combine-stable-deps.md
+++ b/.changeset/suspense-combine-stable-deps.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/eslint-plugin-query': patch
+---
+
+fix(eslint-plugin-query): treat `useSuspenseQueries` results with `combine` as stable for `no-unstable-deps`

--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -63,6 +63,24 @@ const baseTestCases = {
             }
           `,
         },
+        {
+          name: `should pass when useSuspenseQueries with combine is passed to ${reactHookAlias} as dependency`,
+          code: `
+            ${reactHookImport}
+            import { useSuspenseQueries } from "@tanstack/react-query";
+
+            function Component() {
+              const queries = useSuspenseQueries({
+                queries: [
+                  { queryKey: ['test'], queryFn: () => 'test' }
+                ],
+                combine: (results) => ({ data: results[0]?.data })
+              });
+              const callback = ${reactHookInvocation}(() => { queries.data }, [queries]);
+              return;
+            }
+          `,
+        },
       ])
       .concat([
         {
@@ -160,6 +178,32 @@ const baseTestCases = {
             {
               messageId: 'noUnstableDeps',
               data: { reactHook: reactHookAlias, queryHook: 'useQueries' },
+            },
+          ],
+        },
+        {
+          name: `result of useSuspenseQueries without combine is passed to ${reactHookInvocation} as dependency`,
+          code: `
+            ${reactHookImport}
+            import { useSuspenseQueries } from "@tanstack/react-query";
+
+            function Component() {
+              const queries = useSuspenseQueries({
+                queries: [
+                  { queryKey: ['test'], queryFn: () => 'test' }
+                ]
+              });
+              const callback = ${reactHookInvocation}(() => { queries[0]?.data }, [queries]);
+              return;
+            }
+          `,
+          errors: [
+            {
+              messageId: 'noUnstableDeps',
+              data: {
+                reactHook: reactHookAlias,
+                queryHook: 'useSuspenseQueries',
+              },
             },
           ],
         },

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -112,12 +112,13 @@ export const rule = createRule({
           allHookNames.includes(node.init.callee.name) &&
           helpers.isTanstackQueryImport(node.init.callee)
         ) {
-          // Special case for useQueries with combine property - it's stable
+          // Special case for queries hooks with combine property - it's stable
           if (
-            node.init.callee.name === 'useQueries' &&
+            (node.init.callee.name === 'useQueries' ||
+              node.init.callee.name === 'useSuspenseQueries') &&
             hasCombineProperty(node.init)
           ) {
-            // Don't track useQueries with combine as unstable
+            // Don't track query hook results with combine as unstable
             return
           }
           collectVariableNames(node.id, node.init.callee.name)


### PR DESCRIPTION
﻿## Summary
- Treat `useSuspenseQueries({ combine })` like `useQueries({ combine })` in `@tanstack/query/no-unstable-deps`
- Keep `useSuspenseQueries` without `combine` reported as unstable
- Add a patch changeset for `@tanstack/eslint-plugin-query`

Closes #10641.

## Validation
- `corepack pnpm --dir packages/eslint-plugin-query exec vitest run src/__tests__/no-unstable-deps.test.ts`
- `corepack pnpm --dir packages/eslint-plugin-query run test:eslint` (with local Windows symlink-file workaround for `root.eslint.config.js`)
- `corepack pnpm --dir packages/eslint-plugin-query run test:types` (with local Windows symlink-file workaround for `root.eslint.config.js`)
- `corepack pnpm --dir packages/eslint-plugin-query run build`
- `corepack pnpm --dir packages/eslint-plugin-query run test:build` (with local pnpm shim because `publint` shells out to `pnpm`)
- `corepack pnpm prettier --check packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts .changeset/suspense-combine-stable-deps.md`
- `corepack pnpm changeset status --since origin/main`
- `git diff --cached --check`

Note: the full `test:lib` package run hit a local timeout in unrelated `no-void-query-fn.test.ts`; rerunning that file with `--testTimeout 30000` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `no-unstable-deps` ESLint rule now correctly treats `useSuspenseQueries` with `combine` as stable dependencies, eliminating false positives when these values are used in React hook dependency arrays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->