### PR TITLE
fix(query-core): prevent optimistic fetching when unsubscribedFix/subscribed isfetching

### DIFF
--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -67,7 +67,7 @@ export class QueryObserver<
   #refetchIntervalId?: ManagedTimerId
   #currentRefetchInterval?: number | false
   #trackedProps = new Set<keyof QueryObserverResult>()
-
+  #everSubscribed = false 
   constructor(
     client: QueryClient,
     public options: QueryObserverOptions<
@@ -95,7 +95,7 @@ export class QueryObserver<
   protected onSubscribe(): void {
     if (this.listeners.size === 1) {
       this.#currentQuery.addObserver(this)
-
+      this.#everSubscribed = true
       if (shouldFetchOnMount(this.#currentQuery, this.options)) {
         this.#executeFetch()
       } else {
@@ -176,7 +176,7 @@ export class QueryObserver<
     }
 
     const mounted = this.hasListeners()
-
+   
     // Fetch if there are subscribers
     if (
       mounted &&
@@ -191,7 +191,7 @@ export class QueryObserver<
     }
 
     // Update result
-    this.updateResult()
+    this.updateResult(mounted ? undefined : false)
 
     // Update stale interval if needed
     if (
@@ -228,11 +228,17 @@ export class QueryObserver<
       TQueryKey
     >,
   ): QueryObserverResult<TData, TError> {
-    const query = this.#client.getQueryCache().build(this.#client, options)
+  const query = this.#client.getQueryCache().build(this.#client, options)
 
-    const result = this.createResult(query, options)
+  const result = this.createResult(
+  query,
+  options,
+  !this.#everSubscribed || this.hasListeners(),
+)
 
-    if (shouldAssignObserverCurrentProperties(this, result)) {
+
+   if (shouldAssignObserverCurrentProperties(this, result)) { 
+
       // this assigns the optimistic result to the current Observer
       // because if the query function changes, useQuery will be performing
       // an effect where it would fetch again.
@@ -250,8 +256,8 @@ export class QueryObserver<
       // When keeping the previous data, the result doesn't change until new
       // data arrives.
       this.#currentResult = result
-      this.#currentResultOptions = this.options
-      this.#currentResultState = this.#currentQuery.state
+    this.#currentResultOptions = this.options
+    this.#currentResultState = this.#currentQuery.state
     }
     return result
   }
@@ -439,6 +445,7 @@ export class QueryObserver<
       TQueryData,
       TQueryKey
     >,
+    optimistic = true,
   ): QueryObserverResult<TData, TError> {
     const prevQuery = this.#currentQuery
     const prevOptions = this.options
@@ -461,7 +468,7 @@ export class QueryObserver<
     if (options._optimisticResults) {
       const mounted = this.hasListeners()
 
-      const fetchOnMount = !mounted && shouldFetchOnMount(query, options)
+      const fetchOnMount = optimistic && !mounted && shouldFetchOnMount(query, options)
 
       const fetchOptionally =
         mounted && shouldFetchOptionally(query, prevQuery, options, prevOptions)
@@ -642,12 +649,12 @@ export class QueryObserver<
     return nextResult
   }
 
-  updateResult(): void {
+   updateResult(optimistic?: boolean): void{
     const prevResult = this.#currentResult as
       | QueryObserverResult<TData, TError>
       | undefined
 
-    const nextResult = this.createResult(this.#currentQuery, this.options)
+    const nextResult = this.createResult(this.#currentQuery, this.options, optimistic)
 
     this.#currentResultState = this.#currentQuery.state
     this.#currentResultOptions = this.options
@@ -737,10 +744,12 @@ export class QueryObserver<
       }
 
       // Then the cache listeners
+      if (this.hasListeners()) {
       this.#client.getQueryCache().notify({
         query: this.#currentQuery,
         type: 'observerResultsUpdated',
       })
+    }
     })
   }
 }

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -5980,6 +5980,48 @@ describe('useQuery', () => {
 
       expect(renders).toBe(1)
     })
+    it('should not report isFetching when subscribed is false and no fetch is running', async () => {
+      const key = queryKey()
+
+      const states: Array<UseQueryResult<string>> = []
+
+      function Page() {
+        const [subscribed, setSubscribed] = React.useState(true)
+
+        const result = useQuery({
+          queryKey: key,
+          queryFn: () => Promise.resolve('data'),
+          subscribed,
+        })
+
+        states.push(result)
+
+        return (
+          <div>
+            <span>
+              {result.fetchStatus} {String(result.isFetching)}
+            </span>
+
+            <button onClick={() => setSubscribed(false)}>unsubscribe</button>
+          </div>
+        )
+      }
+
+      const rendered = renderWithClient(queryClient, <Page />)
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      rendered.getByText('idle false')
+
+      fireEvent.click(rendered.getByRole('button', { name: 'unsubscribe' }))
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      const latest = states[states.length - 1]!
+
+      expect(latest.fetchStatus).toBe('idle')
+      expect(latest.isFetching).toBe(false)
+    })
   })
 
   it('should have status=error on mount when a query has failed', async () => {


### PR DESCRIPTION

## Problem

When using the `subscribed` option (common React Native pattern for unfocused screens), `isFetching` could become `true` even though:

* no fetch was running
* `queryFn` was not called
* no observer was attached
* no query state changed

This resulted in an inconsistent state where:

```ts
fetchStatus === 'fetching'
isFetching === true
```

while the query was actually idle.

Fixes #10718.

---

## Root Cause

`QueryObserver.createResult` optimistically injected `fetchState(...)` whenever:

```ts
!mounted && shouldFetchOnMount(...)
```

However, `!mounted` was true both for:

* initial optimistic renders before subscription
* observers that were previously subscribed and later unsubscribed (`subscribed: false`)

This caused optimistic fetching state to appear even after unsubscribing.

---

## Fix

Adds tracking for whether the observer has ever been subscribed via `#everSubscribed`.

Optimistic fetch state is now only applied for genuine pre-subscription optimistic renders.

Additionally:

* `updateResult` now accepts an optimistic flag
* `getOptimisticResult` passes the correct optimistic state
* `#notify` skips cache notifications when no listeners exist

---

## Tests

Added regression coverage for:

* `isFetching`
* `fetchStatus`
* `subscribed: false`
* toggling subscription state

All existing tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fetch status reporting for unsubscribed queries, now correctly reporting `fetchStatus: 'idle'` and `isFetching: false` when appropriate.

* **Refactor**
  * Enhanced internal query observer logic to optimize subscription tracking and result creation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->