### PR TITLE
test(query-devtools/Explorer): add tests for 'Map' and iterable rendering branches

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -120,4 +120,44 @@ describe('Explorer', () => {
       expect(rendered.getByText('30')).toBeInTheDocument()
     })
   })
+
+  describe('Map and iterable values', () => {
+    it('should preserve "Map" keys as labels when expanded', () => {
+      const rendered = renderExplorer({
+        label: 'm',
+        value: new Map([
+          ['first', 1],
+          ['second', 2],
+        ]),
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+
+      expect(rendered.getByText('first:')).toBeInTheDocument()
+      expect(rendered.getByText('second:')).toBeInTheDocument()
+    })
+
+    it('should mark an iterable value with an "(Iterable)" prefix on the expander', () => {
+      const rendered = renderExplorer({
+        label: 's',
+        value: new Set(['x', 'y']),
+      })
+
+      expect(
+        rendered.getByRole('button', { expanded: false }).textContent,
+      ).toContain('(Iterable)')
+    })
+
+    it('should render iterable children under their numeric index when expanded', () => {
+      const rendered = renderExplorer({
+        label: 's',
+        value: new Set(['x', 'y']),
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+
+      expect(rendered.getByText('0:')).toBeInTheDocument()
+      expect(rendered.getByText('1:')).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with tests for the `Map` / iterable branches in `subEntries` and `type` memos. These branches were previously uncovered by the `Devtools.test.tsx` integration tests because user query data rarely uses `Map` / `Set` instances.

Added cases under a new `Map and iterable values` describe:
- `should preserve "Map" keys as labels when expanded`
- `should mark an iterable value with an "(Iterable)" prefix on the expander`
- `should render iterable children under their numeric index when expanded`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Map and iterable value rendering behavior in the Explorer component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->