### PR TITLE
docs(reference/QueryCache): clarify fetchFailureCount availability in onError callback

### DIFF
--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -12,7 +12,7 @@ import { QueryCache } from '@tanstack/react-query'
 
 const queryCache = new QueryCache({
   onError: (error, query) => {
-    // query.state.fetchFailureCount reflects total attempts (initial + retries)
+    // query.state.fetchFailureCount is the total number of failed attempts including retries
     if (query.state.fetchFailureCount > 1) {
       console.error(`Failed after retries:`, error)
     } else {

--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -11,8 +11,13 @@ The `QueryCache` is the storage mechanism for TanStack Query. It stores all the 
 import { QueryCache } from '@tanstack/react-query'
 
 const queryCache = new QueryCache({
-  onError: (error) => {
-    console.log(error)
+  onError: (error, query) => {
+    // query.state.fetchFailureCount reflects total attempts (initial + retries)
+    if (query.state.fetchFailureCount > 1) {
+      console.error(`Failed after retries:`, error)
+    } else {
+      console.error(`First attempt failed:`, error)
+    }
   },
   onSuccess: (data) => {
     console.log(data)
@@ -38,6 +43,7 @@ Its available methods are:
 - `onError?: (error: unknown, query: Query) => void`
   - Optional
   - This function will be called if some query encounters an error.
+  - `query.state.fetchFailureCount` indicates how many attempts were made (including retries), which can be used to differentiate a first failure from a failure after retries.
 - `onSuccess?: (data: unknown, query: Query) => void`
   - Optional
   - This function will be called if some query is successful.

--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -43,7 +43,7 @@ Its available methods are:
 - `onError?: (error: unknown, query: Query) => void`
   - Optional
   - This function will be called if some query encounters an error.
-  - `query.state.fetchFailureCount` indicates how many attempts were made (including retries), which can be used to differentiate a first failure from a failure after retries.
+  - `query.state.fetchFailureCount` indicates how many failed fetch attempts were made (including retries), which can be used to differentiate a first failure from a failure after retries.
 - `onSuccess?: (data: unknown, query: Query) => void`
   - Optional
   - This function will be called if some query is successful.


### PR DESCRIPTION

## 🎯 Changes

The `query` parameter passed to `QueryCache`'s `onError` callback already exposes
  `query.state.fetchFailureCount`, which reflects the total number of failed attempts
  (initial + retries). However, this was not documented, leading users to believe retry
  attempt count was inaccessible in error callbacks (see #10713).

  - Updated code example to show `query` parameter usage with a practical retry-count check
  - Added a note to the `onError` option description about `fetchFailureCount`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the onError handler receives both the error and the related query object as parameters.
  * Added guidance showing how to use fetchFailureCount (which includes retries) to distinguish first-time failures from failures after retry attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->