### PR TITLE
docs(reference/QueryClient): clarify query client query methods

### DIFF
--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -352,6 +352,11 @@ await queryClient.invalidateQueries(
       - Per default, a currently running request will be cancelled before a new request is made
     - When set to `false`, no refetch will be made if there is already a request running.
 
+**Notes**
+
+- Unlike [`refetchQueries`](#queryclientrefetchqueries), `invalidateQueries` marks matching queries as invalid and then refetches them according to the `refetchType` option.
+- Unlike [`removeQueries`](#queryclientremovequeries), `invalidateQueries` keeps matching queries in the cache.
+
 ## `queryClient.refetchQueries`
 
 The `refetchQueries` method can be used to refetch queries based on certain conditions.
@@ -395,6 +400,7 @@ This function returns a promise that will resolve when all of the queries are do
 
 - Queries that are "disabled" because they only have disabled Observers will never be refetched.
 - Queries that are "static" because they only have Observers with a Static StaleTime will never be refetched.
+- Unlike [`invalidateQueries`](#queryclientinvalidatequeries), `refetchQueries` refetches matching queries without marking them as invalid first.
 
 ## `queryClient.cancelQueries`
 
@@ -433,6 +439,10 @@ queryClient.removeQueries({ queryKey, exact: true })
 **Returns**
 
 This method does not return anything
+
+**Notes**
+
+- Unlike [`invalidateQueries`](#queryclientinvalidatequeries) or [`refetchQueries`](#queryclientrefetchqueries), `removeQueries` removes matching queries from the cache instead of refetching them.
 
 ## `queryClient.resetQueries`
 

--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -354,7 +354,7 @@ await queryClient.invalidateQueries(
 
 **Notes**
 
-- Unlike [`refetchQueries`](#queryclientrefetchqueries), `invalidateQueries` marks matching queries as invalid and then refetches them according to the `refetchType` option.
+- Unlike [`refetchQueries`](#queryclientrefetchqueries), `invalidateQueries` marks matching queries as invalidated and then refetches `active` queries (unless otherwise specified with the `refetchType` option).
 - Unlike [`removeQueries`](#queryclientremovequeries), `invalidateQueries` keeps matching queries in the cache.
 
 ## `queryClient.refetchQueries`
@@ -400,7 +400,7 @@ This function returns a promise that will resolve when all of the queries are do
 
 - Queries that are "disabled" because they only have disabled Observers will never be refetched.
 - Queries that are "static" because they only have Observers with a Static StaleTime will never be refetched.
-- Unlike [`invalidateQueries`](#queryclientinvalidatequeries), `refetchQueries` refetches matching queries without marking them as invalid first.
+- Unlike [`invalidateQueries`](#queryclientinvalidatequeries), `refetchQueries` refetches all matching queries.
 
 ## `queryClient.cancelQueries`
 


### PR DESCRIPTION
## 🎯 Changes

Clarifies the differences between `queryClient.invalidateQueries`, `queryClient.refetchQueries`, and `queryClient.removeQueries` in the `QueryClient` reference docs.

These methods can look similar because they all match queries by filters, so this adds short Notes explaining whether each method invalidates, refetches, keeps, or removes matching queries.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified QueryClient reference with a new Notes section for three query-management methods:
    * invalidateQueries — now explains it marks matching queries as invalidated and then refetches active queries (unless overridden).
    * refetchQueries — clarifies it refetches all matching queries without prior invalidation.
    * removeQueries — clarifies it removes matching queries from the cache instead of refetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->