### PR TITLE
test(query-devtools/Explorer): add tests for 'defaultExpanded' and pagination behavior

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -160,4 +160,57 @@ describe('Explorer', () => {
       expect(rendered.getByText('1:')).toBeInTheDocument()
     })
   })
+
+  describe('"defaultExpanded"', () => {
+    it('should render children eagerly when the label is in "defaultExpanded"', () => {
+      const rendered = renderExplorer({
+        label: 'list',
+        value: ['a'],
+        defaultExpanded: ['list'],
+      })
+
+      expect(
+        rendered.getByRole('button', { expanded: true }),
+      ).toBeInTheDocument()
+      expect(rendered.getByText('0:')).toBeInTheDocument()
+    })
+  })
+
+  describe('pagination', () => {
+    it('should group entries into 100-item pages when the array has more than 100 entries', () => {
+      const rendered = renderExplorer({
+        label: 'big',
+        value: Array.from({ length: 101 }, (_, i) => i),
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+
+      expect(rendered.getByText('[0...99]')).toBeInTheDocument()
+      expect(rendered.getByText('[100...199]')).toBeInTheDocument()
+    })
+
+    it('should keep the items of a page hidden until the page header is clicked', () => {
+      const rendered = renderExplorer({
+        label: 'big',
+        value: Array.from({ length: 101 }, (_, i) => `item-${i}`),
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+
+      expect(rendered.queryByText('0:')).toBeNull()
+    })
+
+    it('should reveal the items of a page when the page header is clicked', () => {
+      const rendered = renderExplorer({
+        label: 'big',
+        value: Array.from({ length: 101 }, (_, i) => `item-${i}`),
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+      fireEvent.click(rendered.getByText('[0...99]'))
+
+      expect(rendered.getByText('0:')).toBeInTheDocument()
+      expect(rendered.getByText('"item-0"')).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with tests for props-driven behavior — `defaultExpanded` and pagination of large arrays (`subEntryPages.length > 1` branch).

Added cases:
- **`"defaultExpanded"`** (1)
  - `should render children eagerly when the label is in "defaultExpanded"` — the call site `Devtools.tsx` always passes `defaultExpanded={['Data']}`, so this locks the contract that the Data panel renders pre-expanded.
- **`pagination`** (3)
  - `should group entries into 100-item pages when the array has more than 100 entries`
  - `should keep the items of a page hidden until the page header is clicked`
  - `should reveal the items of a page when the page header is clicked`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the Explorer component's `defaultExpanded` behavior and array pagination functionality, including validation of expanded state rendering and pagination interactions for large arrays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->