### PR TITLE
test(query-devtools/Explorer): add tests for action menu buttons

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -5,7 +5,6 @@ import Explorer from '../Explorer'
 import { QueryDevtoolsContext, ThemeContext } from '../contexts'
 import type { Query } from '@tanstack/query-core'
 
-
 // `goober` compiles every `css\`...\`` template literal at mount time;
 // replace it with a no-op factory so label/role-based assertions stay fast.
 vi.mock('goober', () => {
@@ -193,9 +192,7 @@ describe('Explorer', () => {
           .find({ queryKey: ['data'] }) as Query,
       })
 
-      fireEvent.click(
-        rendered.getByLabelText('Copy object to clipboard'),
-      )
+      fireEvent.click(rendered.getByLabelText('Copy object to clipboard'))
 
       expect(writeText).toHaveBeenCalledTimes(1)
       const [arg] = writeText.mock.calls[0]!
@@ -270,9 +267,7 @@ describe('Explorer', () => {
           .find({ queryKey: ['data'] }) as Query,
       })
 
-      expect(
-        rendered.queryByLabelText('Copy object to clipboard'),
-      ).toBeNull()
+      expect(rendered.queryByLabelText('Copy object to clipboard')).toBeNull()
       expect(rendered.queryByLabelText('Remove all items')).toBeNull()
     })
 

--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render } from '@solidjs/testing-library'
 import { QueryClient, onlineManager } from '@tanstack/query-core'
 import Explorer from '../Explorer'
 import { QueryDevtoolsContext, ThemeContext } from '../contexts'
+import type { Query } from '@tanstack/query-core'
+
 
 // `goober` compiles every `css\`...\`` template literal at mount time;
 // replace it with a no-op factory so label/role-based assertions stay fast.
@@ -173,6 +175,123 @@ describe('Explorer', () => {
         rendered.getByRole('button', { expanded: true }),
       ).toBeInTheDocument()
       expect(rendered.getByText('0:')).toBeInTheDocument()
+    })
+  })
+
+  describe('action menu', () => {
+    it('should copy the serialized value to the clipboard when the copy button is clicked', () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      vi.stubGlobal('navigator', { clipboard: { writeText } })
+      queryClient.setQueryData(['data'], { name: 'Anna' })
+
+      const rendered = renderExplorer({
+        label: 'data',
+        value: { name: 'Anna' },
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+      })
+
+      fireEvent.click(
+        rendered.getByLabelText('Copy object to clipboard'),
+      )
+
+      expect(writeText).toHaveBeenCalledTimes(1)
+      const [arg] = writeText.mock.calls[0]!
+      expect(JSON.parse(arg as string)).toMatchObject({
+        json: { name: 'Anna' },
+      })
+    })
+
+    it('should clear array items via "setQueryData" when the clear-array button is clicked', () => {
+      queryClient.setQueryData(['data'], ['a', 'b', 'c'])
+
+      const rendered = renderExplorer({
+        label: 'list',
+        value: ['a', 'b', 'c'],
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+      })
+
+      fireEvent.click(rendered.getByLabelText('Remove all items'))
+
+      expect(queryClient.getQueryData(['data'])).toEqual([])
+    })
+
+    it('should delete the entry at the current "dataPath" when the delete button is clicked', () => {
+      queryClient.setQueryData(['data'], ['a', 'b', 'c'])
+
+      const rendered = renderExplorer({
+        label: 'list',
+        value: ['a', 'b', 'c'],
+        editable: true,
+        itemsDeletable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+        dataPath: ['1'],
+      })
+
+      fireEvent.click(rendered.getByLabelText('Delete item'))
+
+      expect(queryClient.getQueryData(['data'])).toEqual(['a', 'c'])
+    })
+
+    it('should toggle a boolean value via "setQueryData" when the toggle button is clicked', () => {
+      queryClient.setQueryData(['data'], { flag: true })
+
+      const rendered = renderExplorer({
+        label: 'flag',
+        value: true,
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+        dataPath: ['flag'],
+      })
+
+      fireEvent.click(rendered.getByLabelText('Toggle value'))
+
+      expect(queryClient.getQueryData(['data'])).toEqual({ flag: false })
+    })
+
+    it('should not render action buttons when "editable" is false', () => {
+      queryClient.setQueryData(['data'], ['a'])
+
+      const rendered = renderExplorer({
+        label: 'list',
+        value: ['a'],
+        editable: false,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+      })
+
+      expect(
+        rendered.queryByLabelText('Copy object to clipboard'),
+      ).toBeNull()
+      expect(rendered.queryByLabelText('Remove all items')).toBeNull()
+    })
+
+    it('should not render "ClearArrayButton" when value is not an array', () => {
+      queryClient.setQueryData(['data'], { name: 'Anna' })
+
+      const rendered = renderExplorer({
+        label: 'user',
+        value: { name: 'Anna' },
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+      })
+
+      expect(rendered.queryByLabelText('Remove all items')).toBeNull()
+      expect(
+        rendered.getByLabelText('Copy object to clipboard'),
+      ).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with tests for action menu buttons that appear when `editable` is enabled — `CopyButton`, `ClearArrayButton`, `DeleteItemButton`, and `ToggleValueButton` — along with their conditional rendering.

Added cases (`action menu`, 6):

- `should copy the serialized value to the clipboard when the copy button is clicked` — stubs `navigator.clipboard.writeText` and verifies the superjson payload.
- `should clear array items via "setQueryData" when the clear-array button is clicked` — asserts the active query is updated to `[]`.
- `should delete the entry at the current "dataPath" when the delete button is clicked` — covers `itemsDeletable` + `dataPath` together.
- `should toggle a boolean value via "setQueryData" when the toggle button is clicked` — locks the `boolean` type path that renders `ToggleValueButton`.
- `should not render action buttons when "editable" is false` — guards the `<Show when={props.editable}>` boundary.
- `should not render "ClearArrayButton" when value is not an array` — locks the `type() === 'array'` condition.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Added test coverage for action menu functionality in Explorer, including clipboard operations, array item management, value toggling, and conditional button visibility based on configuration states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->