### PR TITLE
test(query-devtools/Explorer): add tests for inline edit on primitive rows

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -327,4 +327,81 @@ describe('Explorer', () => {
       expect(rendered.getByText('"item-0"')).toBeInTheDocument()
     })
   })
+
+  describe('inline edit', () => {
+    it('should write the new string value via "setQueryData" when a text input is changed', () => {
+      queryClient.setQueryData(['data'], { name: 'Anna' })
+
+      const rendered = renderExplorer({
+        label: 'name',
+        value: 'Anna',
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+        dataPath: ['name'],
+      })
+
+      const input = rendered.getByLabelText('name:')
+      expect(input).toHaveAttribute('type', 'text')
+
+      fireEvent.change(input, { target: { value: 'Bob' } })
+
+      expect(queryClient.getQueryData(['data'])).toEqual({ name: 'Bob' })
+    })
+
+    it('should write the new number value via "setQueryData" when a number input is changed', () => {
+      queryClient.setQueryData(['data'], { count: 1 })
+
+      const rendered = renderExplorer({
+        label: 'count',
+        value: 1,
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+        dataPath: ['count'],
+      })
+
+      const input = rendered.getByLabelText('count:')
+      expect(input).toHaveAttribute('type', 'number')
+
+      fireEvent.change(input, { target: { value: '42' } })
+
+      expect(queryClient.getQueryData(['data'])).toEqual({ count: 42 })
+    })
+
+    it('should render "ToggleValueButton" inline for a boolean primitive row', () => {
+      queryClient.setQueryData(['data'], { flag: false })
+
+      const rendered = renderExplorer({
+        label: 'flag',
+        value: false,
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+        dataPath: ['flag'],
+      })
+
+      expect(rendered.getByLabelText('Toggle value')).toBeInTheDocument()
+    })
+
+    it('should render "DeleteItemButton" inline when a primitive row has "itemsDeletable"', () => {
+      queryClient.setQueryData(['data'], { name: 'Anna' })
+
+      const rendered = renderExplorer({
+        label: 'name',
+        value: 'Anna',
+        editable: true,
+        itemsDeletable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+        dataPath: ['name'],
+      })
+
+      expect(rendered.getByLabelText('Delete item')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -366,7 +366,9 @@ describe('Explorer', () => {
       const input = rendered.getByLabelText('count:')
       expect(input).toHaveAttribute('type', 'number')
 
-      fireEvent.change(input, { target: { value: '42' } })
+      fireEvent.change(input, {
+        target: { value: '42', valueAsNumber: 42 },
+      })
 
       expect(queryClient.getQueryData(['data'])).toEqual({ count: 42 })
     })


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with tests for the inline edit UI rendered on primitive rows when `editable` is enabled — the `input` element for `string`/`number` values, the inline `ToggleValueButton` for `boolean`, and the inline `DeleteItemButton` gated by `itemsDeletable`.

Added cases (`inline edit`, 4):

- `should write the new string value via "setQueryData" when a text input is changed` — covers the `input onChange` path that writes the raw `target.value` for `string`.
- `should write the new number value via "setQueryData" when a number input is changed` — covers the `valueAsNumber` branch for the `number` type.
- `should render "ToggleValueButton" inline for a boolean primitive row` — locks the `type() === 'boolean'` branch in the primitive row.
- `should render "DeleteItemButton" inline when a primitive row has "itemsDeletable"` — locks the `editable && itemsDeletable && activeQuery !== undefined` guard.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for inline-edit behavior in the Explorer UI when editable: true. Includes verifying text edits update cached data, numeric edits parse and update values, boolean toggles render and operate, and inline controls for deleting items are present.
  * No changes to exported/public interfaces; test-only additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->