### PR TITLE
docs(react): handle failed fetch responses in simple example

### DIFF
--- a/docs/framework/react/overview.md
+++ b/docs/framework/react/overview.md
@@ -68,10 +68,17 @@ export default function App() {
 function Example() {
   const { isPending, error, data } = useQuery({
     queryKey: ['repoData'],
-    queryFn: () =>
-      fetch('https://api.github.com/repos/TanStack/query').then((res) =>
-        res.json(),
-      ),
+    queryFn: async () => {
+      const response = await fetch(
+        'https://api.github.com/repos/TanStack/query',
+      )
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`)
+      }
+
+      return response.json()
+    },
   })
 
   if (isPending) return 'Loading...'

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -25,6 +25,11 @@ function Example() {
       const response = await fetch(
         'https://api.github.com/repos/TanStack/query',
       )
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`)
+      }
+
       return await response.json()
     },
   })

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -30,7 +30,7 @@ function Example() {
         throw new Error(`Request failed with status ${response.status}`)
       }
 
-      return await response.json()
+      return response.json()
     },
   })
 


### PR DESCRIPTION
## 🎯 Changes

Updates the React simple example and the matching React overview snippet to check `response.ok` before parsing the GitHub API response.

The browser `fetch` API resolves successfully for HTTP error responses like 404 or 500, so the query function now throws `Request failed with status ${response.status}` when the response is not ok. This makes failed HTTP responses surface through TanStack Query's `error` state in the example.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated React docs and example projects to demonstrate improved HTTP fetch error handling. Examples now validate response status and surface descriptive errors for failed requests, promoting more robust request handling in apps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->