### PR TITLE
test(query-devtools/Explorer): add test for 'CopyButton' error state on clipboard failure

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -19,10 +19,12 @@ describe('Explorer', () => {
   let queryClient: QueryClient
 
   beforeEach(() => {
+    vi.useFakeTimers()
     queryClient = new QueryClient()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     queryClient.clear()
   })
 
@@ -199,6 +201,35 @@ describe('Explorer', () => {
       expect(JSON.parse(arg as string)).toMatchObject({
         json: { name: 'Anna' },
       })
+    })
+
+    it('should switch the copy button to an error state when clipboard write fails', async () => {
+      const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+      vi.stubGlobal('navigator', { clipboard: { writeText } })
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+      queryClient.setQueryData(['data'], { name: 'Anna' })
+
+      const rendered = renderExplorer({
+        label: 'data',
+        value: { name: 'Anna' },
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+      })
+
+      fireEvent.click(rendered.getByLabelText('Copy object to clipboard'))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(
+        rendered.getByLabelText('Error copying object to clipboard'),
+      ).toBeInTheDocument()
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to copy: ',
+        expect.any(Error),
+      )
     })
 
     it('should clear array items via "setQueryData" when the clear-array button is clicked', () => {


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with a test for the error path of `CopyButton` — when `navigator.clipboard.writeText` rejects, the button's `aria-label` should switch to the error state and the failure should be logged via `console.error`.

Also enable fake timers globally in `beforeEach`/`afterEach` so promise rejection microtasks can be flushed deterministically with `vi.advanceTimersByTimeAsync(0)` (without affecting any existing case).

Added cases (`action menu`, 1):

- `should switch the copy button to an error state when clipboard write fails` — stubs `navigator.clipboard.writeText` with `mockRejectedValue`, silences `console.error` via `vi.spyOn`, and asserts both the post-rejection `aria-label` and the `console.error` call shape.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with improved timer handling for deterministic UI updates.
  * Added comprehensive test coverage for clipboard copy failure scenarios, ensuring proper error state transitions and logging when clipboard operations fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->