### PR TITLE
test(query-devtools/Explorer): add test for independently toggling two pages

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -357,6 +357,25 @@ describe('Explorer', () => {
       expect(rendered.getByText('0:')).toBeInTheDocument()
       expect(rendered.getByText('"item-0"')).toBeInTheDocument()
     })
+
+    it('should independently toggle two pages when their headers are clicked', () => {
+      const rendered = renderExplorer({
+        label: 'big',
+        value: Array.from({ length: 200 }, (_, i) => `item-${i}`),
+      })
+
+      fireEvent.click(rendered.getByRole('button', { expanded: false }))
+      fireEvent.click(rendered.getByText('[0...99]'))
+      fireEvent.click(rendered.getByText('[100...199]'))
+
+      expect(rendered.getByText('"item-0"')).toBeInTheDocument()
+      expect(rendered.getByText('"item-100"')).toBeInTheDocument()
+
+      fireEvent.click(rendered.getByText('[0...99]'))
+
+      expect(rendered.queryByText('"item-0"')).toBeNull()
+      expect(rendered.getByText('"item-100"')).toBeInTheDocument()
+    })
   })
 
   describe('inline edit', () => {


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with a test that locks the independent toggle behavior of pagination — each page header maintains its own expand/collapse state without affecting other pages.

Added cases (`pagination`, 1):

- `should independently toggle two pages when their headers are clicked` — opens `[0...99]` and `[100...199]` simultaneously, asserts both pages render their items, then closes `[0...99]` and asserts only that page is hidden while `[100...199]` stays open.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for pagination functionality to verify page headers can be toggled independently without affecting other pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->