### PR TITLE
fix(react-query): do not report isFetching when subscribed is false

### DIFF
--- a/.changeset/fix-subscribed-isfetching.md
+++ b/.changeset/fix-subscribed-isfetching.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Fix `isFetching` reporting `true` when `subscribed: false` and no fetch is actually running. `useBaseQuery` and `useQueries` no longer apply the `optimistic` fetching state when the observer will not subscribe, so `isFetching` and `fetchStatus` now stay consistent with the underlying query cache.

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -5980,6 +5980,40 @@ describe('useQuery', () => {
 
       expect(renders).toBe(1)
     })
+
+    it('should not report isFetching=true when subscribed is false and no fetch is running', async () => {
+      const key = queryKey()
+      const queryFn = vi.fn(() => Promise.resolve('data'))
+      const states: Array<UseQueryResult<unknown>> = []
+
+      function Page() {
+        const state = useQuery({
+          queryKey: key,
+          queryFn,
+          subscribed: false,
+        })
+        states.push(state)
+        return (
+          <div>
+            <span>
+              fetchStatus: {state.fetchStatus} isFetching:{' '}
+              {String(state.isFetching)}
+            </span>
+          </div>
+        )
+      }
+
+      const rendered = renderWithClient(queryClient, <Page />)
+
+      await vi.advanceTimersByTimeAsync(0)
+      rendered.getByText('fetchStatus: idle isFetching: false')
+
+      // No fetch is or will be running, so the observer must not advertise
+      // an optimistic fetching state.
+      expect(states.every((s) => s.isFetching === false)).toBe(true)
+      expect(states.every((s) => s.fetchStatus === 'idle')).toBe(true)
+      expect(queryFn).toHaveBeenCalledTimes(0)
+    })
   })
 
   it('should have status=error on mount when a query has failed', async () => {

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -75,9 +75,14 @@ export function useBaseQuery<
   }
 
   // Make sure results are optimistically set in fetching state before subscribing or updating options
+  // When `subscribed: false`, the observer will never subscribe, so no fetch will be triggered.
+  // In that case we must not flip the optimistic result into the fetching state, otherwise
+  // `isFetching` would be reported as `true` even though no fetch is or will be happening.
   defaultedOptions._optimisticResults = isRestoring
     ? 'isRestoring'
-    : 'optimistic'
+    : options.subscribed === false
+      ? undefined
+      : 'optimistic'
 
   ensureSuspenseTimers(defaultedOptions)
   ensurePreventErrorBoundaryRetry(defaultedOptions, errorResetBoundary, query)

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -224,6 +224,7 @@ export function useQueries<
   const isRestoring = useIsRestoring()
   const errorResetBoundary = useQueryErrorResetBoundary()
 
+  const subscribed = options.subscribed !== false
   const defaultedQueries = React.useMemo(
     () =>
       queries.map((opts) => {
@@ -231,14 +232,18 @@ export function useQueries<
           opts as QueryObserverOptions,
         )
 
-        // Make sure the results are already in fetching state before subscribing or updating options
+        // Make sure the results are already in fetching state before subscribing or updating options.
+        // When `subscribed: false`, the observer will never subscribe, so no fetch will be triggered.
+        // Skip the optimistic fetching state in that case so `isFetching` does not lie.
         defaultedOptions._optimisticResults = isRestoring
           ? 'isRestoring'
-          : 'optimistic'
+          : subscribed
+            ? 'optimistic'
+            : undefined
 
         return defaultedOptions
       }),
-    [queries, client, isRestoring],
+    [queries, client, isRestoring, subscribed],
   )
 
   defaultedQueries.forEach((queryOptions) => {


### PR DESCRIPTION
Fixes #10718.

When `useQuery` or `useQueries` is called with `subscribed: false`, the observer never subscribes to the query and no fetch is triggered. However, `useBaseQuery` and `useQueries` were unconditionally setting `_optimisticResults` to `'optimistic'`, which makes `QueryObserver.createResult` flip `fetchStatus` to `'fetching'` whenever `shouldFetchOnMount` returns true. The result was an inconsistent state where the returned object reported `isFetching: true` and `fetchStatus: 'fetching'` while the underlying query stayed at `fetchStatus: 'idle'` and `queryFn` was never called. This is exactly the pattern documented for React Native, where consumers toggle `subscribed` to pause queries on unfocused screens, so the inconsistency was easy to hit and confusing to debug.

The fix is small. In both `useBaseQuery` and `useQueries`, when `options.subscribed === false`, we skip the optimistic fetching state and leave `_optimisticResults` undefined so that the observer returns the actual cache state. The `isRestoring` branch is unchanged. Once `subscribed` flips back to true on a later render, the optimistic state kicks back in as before, so re-subscribe behavior is unaffected.

A regression test has been added under the existing `subscribed` describe block in `useQuery.test.tsx`. It renders a query with `subscribed: false`, checks that every recorded state has `isFetching: false` and `fetchStatus: 'idle'`, and asserts that `queryFn` is never called. I confirmed the test fails on `main` and passes with the fix. The full `@tanstack/react-query` and `@tanstack/query-core` vitest suites pass locally, type checks are clean, and a patch changeset is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect status reporting for unsubscribed queries, ensuring they correctly display as idle when no fetch is active.

* **Tests**
  * Added test coverage for query status behavior when subscriptions are disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->