### PR TITLE
fix(solid-query): Avoid context lookup inside memo

### DIFF
--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -62,6 +62,17 @@
     "src",
     "!src/__tests__"
   ],
+  "peerDependencies": {
+    "@kobalte/core": "^0.13.4",
+    "@solid-primitives/keyed": "^1.2.2",
+    "@solid-primitives/resize-observer": "^2.0.26",
+    "@solid-primitives/storage": "^1.3.11",
+    "@tanstack/match-sorter-utils": "^8.19.4",
+    "clsx": "^2.1.1",
+    "goober": "^2.1.16",
+    "solid-js": "^1.9.7",
+    "solid-transition-group": "^0.2.3"
+  },
   "devDependencies": {
     "@kobalte/core": "^0.13.4",
     "@solid-primitives/keyed": "^1.2.2",

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -10,9 +10,10 @@ import {
   createSignal,
   on,
   onCleanup,
+  useContext,
 } from 'solid-js'
 import { createStore, reconcile, unwrap } from 'solid-js/store'
-import { useQueryClient } from './QueryClientProvider'
+import { QueryClientContext } from './QueryClientProvider'
 import { useIsRestoring } from './isRestoring'
 import type { UseBaseQueryOptions } from './types'
 import type { Accessor, Signal } from 'solid-js'
@@ -115,7 +116,17 @@ export function useBaseQuery<
 ) {
   type ResourceData = QueryObserverResult<TData, TError>
 
-  const client = createMemo(() => useQueryClient(queryClient?.()))
+  const queryClientFromContext = useContext(QueryClientContext)
+  const client = createMemo(() => {
+    const clientFromOptions = queryClient?.()
+    if (clientFromOptions) {
+      return clientFromOptions
+    }
+    if (!queryClientFromContext) {
+      throw new Error('No QueryClient set, use QueryClientProvider to set one')
+    }
+    return queryClientFromContext()
+  })
   const isRestoring = useIsRestoring()
   // There are times when we run a query on the server but the resource is never read
   // This could lead to times when the queryObserver is unsubscribed before the resource has loaded


### PR DESCRIPTION
## Summary

- avoid calling `useQueryClient` from inside the Solid `createMemo` callback by reading `QueryClientContext` once at setup time
- preserve explicit `queryClient` option behavior before falling back to context
- declare the Solid devtools runtime dependencies as peers so package consumers get the required Solid/Kobalte primitives

## Verification

- `pnpm --filter @tanstack/solid-query test:types:tscurrent`
- `pnpm --filter @tanstack/query-devtools test:types:tscurrent`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Clarified peer dependency requirements for the query-devtools package, specifying required Solid.js and related library versions to ensure proper installation and compatibility.
  * Internal refactoring for improved dependency resolution and initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->