### PR TITLE
test(query-devtools/Explorer): add test for action buttons rendered inside a paginated page

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -435,9 +435,10 @@ describe('Explorer', () => {
     })
 
     it('should render action buttons for items inside a paginated page', () => {
-      const value: Array<Array<number>> = Array.from({ length: 200 }, (_, i) => [
-        i,
-      ])
+      const value: Array<Array<number>> = Array.from(
+        { length: 200 },
+        (_, i) => [i],
+      )
       queryClient.setQueryData(['data'], value)
 
       const rendered = renderExplorer({

--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -433,6 +433,29 @@ describe('Explorer', () => {
       expect(rendered.queryByText('"item-0"')).toBeNull()
       expect(rendered.getByText('"item-100"')).toBeInTheDocument()
     })
+
+    it('should render action buttons for items inside a paginated page', () => {
+      const value: Array<Array<number>> = Array.from({ length: 200 }, (_, i) => [
+        i,
+      ])
+      queryClient.setQueryData(['data'], value)
+
+      const rendered = renderExplorer({
+        label: 'Data',
+        value,
+        defaultExpanded: ['Data'],
+        editable: true,
+        activeQuery: queryClient
+          .getQueryCache()
+          .find({ queryKey: ['data'] }) as Query,
+      })
+
+      fireEvent.click(rendered.getByText('[0...99]'))
+
+      expect(
+        rendered.getAllByLabelText('Remove all items').length,
+      ).toBeGreaterThan(1)
+    })
   })
 
   describe('inline edit', () => {


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with a test that locks the prop propagation from a parent `Explorer` to its paginated children — when a paginated page is opened, each child item should receive `activeQuery` and `editable` so its action menu renders the same as a non-paginated child.

Added cases (`pagination`, 1):

- `should render action buttons for items inside a paginated page` — uses a 200-element `Array<Array<number>>` so the parent paginates and each child is itself an array, then opens the first page and asserts that more than one `Remove all items` button is rendered (one for the parent plus one per array child inside the page).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify action controls render correctly when exploring paginated data sets in the Explorer interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->