### PR TITLE
test(query-devtools/Devtools): add tests for clearing edit error on refocus and 'Cancel' button

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -707,6 +707,43 @@ describe('Devtools', () => {
 
       expect(rendered.getByText('Invalid Value')).toBeInTheDocument()
     })
+
+    it('should clear the error state when the textarea is focused after a submit failure', () => {
+      queryClient.setQueryData(['edit-refocus'], { name: 'a' })
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["edit-refocus"\]/))
+      fireEvent.click(rendered.getByLabelText('Bulk Edit Data'))
+
+      const textarea = rendered.getByLabelText('Edit query data as JSON')
+      fireEvent.input(textarea, { target: { value: 'not json' } })
+      fireEvent.submit(textarea.closest('form')!)
+
+      expect(rendered.getByText('Invalid Value')).toBeInTheDocument()
+
+      fireEvent.focus(textarea)
+
+      expect(rendered.queryByText('Invalid Value')).toBeNull()
+    })
+
+    it('should return to the data view when the editor "Cancel" button is clicked', () => {
+      queryClient.setQueryData(['edit-cancel'], { name: 'a' })
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByLabelText(/Query key \["edit-cancel"\]/))
+      fireEvent.click(rendered.getByLabelText('Bulk Edit Data'))
+
+      expect(
+        rendered.getByLabelText('Edit query data as JSON'),
+      ).toBeInTheDocument()
+
+      fireEvent.click(rendered.getByText('Cancel'))
+
+      expect(
+        rendered.queryByLabelText('Edit query data as JSON'),
+      ).toBeNull()
+      expect(rendered.getByLabelText('Bulk Edit Data')).toBeInTheDocument()
+    })
   })
 
   describe('error type select', () => {

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -739,9 +739,7 @@ describe('Devtools', () => {
 
       fireEvent.click(rendered.getByText('Cancel'))
 
-      expect(
-        rendered.queryByLabelText('Edit query data as JSON'),
-      ).toBeNull()
+      expect(rendered.queryByLabelText('Edit query data as JSON')).toBeNull()
       expect(rendered.getByLabelText('Bulk Edit Data')).toBeInTheDocument()
     })
   })


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with tests that lock two escape paths in the Bulk Edit Data editor — recovering from a submit error by refocusing the textarea, and bailing out of edit mode via the editor's `Cancel` button.

Added cases (`data edit`, 2):

- `should clear the error state when the textarea is focused after a submit failure` — submits invalid JSON to trigger the `Invalid Value` error, then refocuses the textarea and asserts the error message disappears.
- `should return to the data view when the editor "Cancel" button is clicked` — enters edit mode, clicks the inline `Cancel` button, and asserts the editor is unmounted and `Bulk Edit Data` is available again.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added UI test verifying error message clears when focusing the edit textarea in the data editor
  * Added UI test verifying the JSON editor "Cancel" button returns to the data view

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->