### PR TITLE
test(query-devtools/Devtools): add test for 'static' indicator on a query with 'staleTime: static'

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -356,6 +356,24 @@ describe('Devtools', () => {
 
       expect(rendered.getByLabelText(/disabled/)).toBeInTheDocument()
     })
+
+    it('should render a "static" indicator for a query with "staleTime: \'static\'"', () => {
+      const query = queryClient.getQueryCache().build(queryClient, {
+        queryKey: ['static-q'],
+        queryFn: () => 'x',
+      })
+      const observer = new QueryObserver(queryClient, {
+        queryKey: ['static-q'],
+        queryFn: () => 'x',
+        staleTime: 'static',
+      })
+      query.addObserver(observer)
+      query.setState({ ...query.state, data: 'x' })
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      expect(rendered.getByText('static')).toBeInTheDocument()
+      expect(rendered.getByLabelText(/, static/)).toBeInTheDocument()
+    })
   })
 
   describe('status counts', () => {


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with a test that locks the `static` indicator rendered next to a query whose observer is configured with `staleTime: 'static'` — both the visible label and the accessible name on the row are asserted.

Added cases (`disabled and static queries`, 1):

- `should render a "static" indicator for a query with "staleTime: 'static'"` — builds a query in the cache, attaches a `QueryObserver` with `staleTime: 'static'`, seeds data on the query, and asserts both the `static` text node and the `, static` segment in the row's `aria-label` are present.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the Query Devtools to verify static query indicators render correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->