### PR TITLE
test(query-devtools/{DevtoolsComponent,DevtoolsPanelComponent}): add tests for rendering with all props

### DIFF
--- a/packages/query-devtools/src/__tests__/DevtoolsComponent.test.tsx
+++ b/packages/query-devtools/src/__tests__/DevtoolsComponent.test.tsx
@@ -61,7 +61,7 @@ describe('DevtoolsComponent', () => {
     queryClient.clear()
   })
 
-  it('should render without throwing', () => {
+  it('should render without throwing when only required props are provided', () => {
     expect(() =>
       render(() => (
         <DevtoolsComponent
@@ -69,6 +69,27 @@ describe('DevtoolsComponent', () => {
           queryFlavor="TanStack Query"
           version="5"
           onlineManager={onlineManager}
+        />
+      )),
+    ).not.toThrow()
+  })
+
+  it('should render without throwing when all props are provided', () => {
+    expect(() =>
+      render(() => (
+        <DevtoolsComponent
+          client={queryClient}
+          queryFlavor="TanStack Query"
+          version="5"
+          onlineManager={onlineManager}
+          buttonPosition="top-left"
+          position="left"
+          initialIsOpen={true}
+          errorTypes={[
+            { name: 'NetworkError', initializer: () => new Error('Network') },
+          ]}
+          hideDisabledQueries={true}
+          theme="dark"
         />
       )),
     ).not.toThrow()

--- a/packages/query-devtools/src/__tests__/DevtoolsPanelComponent.test.tsx
+++ b/packages/query-devtools/src/__tests__/DevtoolsPanelComponent.test.tsx
@@ -77,7 +77,7 @@ describe('DevtoolsPanelComponent', () => {
     document.documentElement.style.fontSize = previousRootFontSize
   })
 
-  it('should render the panel without throwing', () => {
+  it('should render the panel without throwing when only required props are provided', () => {
     expect(() =>
       render(() => (
         <DevtoolsPanelComponent
@@ -85,6 +85,25 @@ describe('DevtoolsPanelComponent', () => {
           queryFlavor="TanStack Query"
           version="5"
           onlineManager={onlineManager}
+        />
+      )),
+    ).not.toThrow()
+  })
+
+  it('should render the panel without throwing when all props are provided', () => {
+    expect(() =>
+      render(() => (
+        <DevtoolsPanelComponent
+          client={queryClient}
+          queryFlavor="TanStack Query"
+          version="5"
+          onlineManager={onlineManager}
+          errorTypes={[
+            { name: 'NetworkError', initializer: () => new Error('Network') },
+          ]}
+          hideDisabledQueries={true}
+          theme="dark"
+          onClose={() => {}}
         />
       )),
     ).not.toThrow()


### PR DESCRIPTION
## 🎯 Changes

Extend the smoke tests for `DevtoolsComponent` and `DevtoolsPanelComponent` to cover the explicit-theme branch (`preference !== 'system'`) by adding an "all props" variant that exercises every optional prop in addition to the required ones. The existing required-only case is renamed to make the contrast explicit, and the new case asserts the component still renders without throwing when every supported prop is provided.

Added cases (1 per file):

- `DevtoolsComponent.test.tsx` — `should render without throwing when all props are provided`
- `DevtoolsPanelComponent.test.tsx` — `should render the panel without throwing when all props are provided`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for devtools UI to verify components render without errors when only required inputs are provided.
  * Added tests confirming safe rendering when all optional configuration options (positioning, open state, error handling, query toggles, theme, close handler) are supplied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->