### PR TITLE
test(query-devtools/Devtools): add tests for opening a picture-in-picture window

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -376,6 +376,62 @@ describe('Devtools', () => {
     })
   })
 
+  describe('picture-in-picture', () => {
+    type FakePipWindow = Pick<
+      Window,
+      | 'document'
+      | 'innerWidth'
+      | 'innerHeight'
+      | 'addEventListener'
+      | 'removeEventListener'
+      | 'close'
+    >
+
+    function stubPipWindow() {
+      const pipDocument = document.implementation.createHTMLDocument('PiP')
+      const fakeWindow: FakePipWindow = {
+        document: pipDocument,
+        innerWidth: 800,
+        innerHeight: 600,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        close: vi.fn(),
+      }
+      const open = vi.fn(() => fakeWindow)
+      vi.stubGlobal('open', open)
+      return { pipDocument, fakeWindow, open }
+    }
+
+    it('should open a PiP window when the picture-in-picture button is clicked', () => {
+      const { open } = stubPipWindow()
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText('Open in picture-in-picture mode'),
+      )
+
+      expect(open).toHaveBeenCalledWith(
+        '',
+        'TSQD-Devtools-Panel',
+        expect.stringMatching(/^width=\d+,height=\d+,popup$/),
+      )
+      expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
+        'true',
+      )
+    })
+
+    it('should automatically open a PiP window when "pip_open" is "true" in "localStorage"', () => {
+      const { open } = stubPipWindow()
+
+      renderDevtools(
+        { initialIsOpen: true },
+        { 'TanstackQueryDevtools.pip_open': 'true' },
+      )
+
+      expect(open).toHaveBeenCalled()
+    })
+  })
+
   describe('status counts', () => {
     it('should render status count badges', () => {
       const rendered = renderDevtools({ initialIsOpen: true })


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with tests that lock the entry points for the Devtools picture-in-picture window — clicking the inline PiP button opens a popup window with the expected target / features and persists `pip_open`, and a stored `pip_open=true` triggers the same auto-open on mount.

Added cases (`picture-in-picture`, 2):

- `should open a PiP window when the picture-in-picture button is clicked` — stubs `window.open` with a fake PiP window, clicks the inline PiP button, and asserts the open call shape and the `pip_open` localStorage value.
- `should automatically open a PiP window when "pip_open" is "true" in "localStorage"` — seeds `pip_open=true` in localStorage and asserts the `pip_open` reactive effect calls `window.open` on mount without any explicit click.

The new `picture-in-picture` describe ships a typed `FakePipWindow` (`Pick<Window, ...>`) and a `stubPipWindow()` helper so subsequent PiP scenarios (popup blocked, in-page panel toggle, pagehide) can reuse the same setup.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Picture-in-Picture functionality in DevTools, verifying window opening behavior and state persistence through local storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->