### PR TITLE
test(query-devtools/Devtools): add test for 'pip_open' reset when the popup is blocked

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -430,6 +430,32 @@ describe('Devtools', () => {
 
       expect(open).toHaveBeenCalled()
     })
+
+    it('should log and reset "pip_open" when the browser blocks the popup', () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => null),
+      )
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      try {
+        renderDevtools(
+          { initialIsOpen: true },
+          { 'TanstackQueryDevtools.pip_open': 'true' },
+        )
+
+        expect(consoleError).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to open popup'),
+        )
+        expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
+          'false',
+        )
+      } finally {
+        consoleError.mockRestore()
+      }
+    })
   })
 
   describe('status counts', () => {


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with a test that locks the popup-blocked fallback for the picture-in-picture window — when `window.open` returns `null`, the `pip_open` reactive effect should log the failure and reset the persisted `pip_open` flag so the user is not left in a broken state.

Added cases (`picture-in-picture`, 1):

- `should log and reset "pip_open" when the browser blocks the popup` — stubs `window.open` to return `null`, seeds `pip_open=true` in localStorage to trigger the auto-open effect, and asserts both the `console.error` call and that `pip_open` is reset to `"false"`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test covering popup/picture-in-picture blocking: verifies an error is logged when the popup is blocked and that the UI state flag in local storage is reset.
  * Ensures robust handling of blocked popups to prevent stale stored state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->