### PR TITLE
test(query-devtools/Devtools): add tests for in-page panel visibility while a PiP window is open

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -389,17 +389,29 @@ describe('Devtools', () => {
 
     function stubPipWindow() {
       const pipDocument = document.implementation.createHTMLDocument('PiP')
+      const listeners = new Map<string, EventListener>()
       const fakeWindow: FakePipWindow = {
         document: pipDocument,
         innerWidth: 800,
         innerHeight: 600,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
+        addEventListener: vi.fn((event: string, handler: EventListener) => {
+          listeners.set(event, handler)
+        }),
+        removeEventListener: vi.fn((event: string) => {
+          listeners.delete(event)
+        }),
         close: vi.fn(),
       }
       const open = vi.fn(() => fakeWindow)
       vi.stubGlobal('open', open)
-      return { pipDocument, fakeWindow, open }
+      return {
+        pipDocument,
+        fakeWindow,
+        open,
+        fire: (event: string) => {
+          listeners.get(event)?.(new Event(event))
+        },
+      }
     }
 
     it('should open a PiP window when the picture-in-picture button is clicked', () => {
@@ -455,6 +467,36 @@ describe('Devtools', () => {
       } finally {
         consoleError.mockRestore()
       }
+    })
+
+    it('should hide the in-page panel while a PiP window is open', () => {
+      stubPipWindow()
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText('Open in picture-in-picture mode'),
+      )
+
+      expect(
+        rendered.container.querySelector('.tsqd-main-panel-container'),
+      ).toBeNull()
+    })
+
+    it('should restore the in-page panel and reset "pip_open" when the PiP window is closed', () => {
+      const { fire } = stubPipWindow()
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText('Open in picture-in-picture mode'),
+      )
+      fire('pagehide')
+
+      expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
+        'false',
+      )
+      expect(
+        rendered.getByLabelText('Open in picture-in-picture mode'),
+      ).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with tests that lock the in-page panel visibility around the picture-in-picture lifecycle — the in-page panel should disappear while a PiP window is open, and reappear (with `pip_open` cleared from localStorage) once the PiP window is closed.

Added cases (`picture-in-picture`, 2):

- `should hide the in-page panel while a PiP window is open` — opens the PiP window via the inline button and asserts the in-page `.tsqd-main-panel-container` is no longer rendered.
- `should restore the in-page panel and reset "pip_open" when the PiP window is closed` — opens the PiP window, invokes the registered `pagehide` listener directly to simulate the PiP window closing, and asserts that the in-page open button is back and `pip_open` is reset to `"false"`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for picture-in-picture devtools panel behavior, including deterministic simulation of PiP lifecycle events and panel visibility management.
  * Added tests ensuring the in-page panel is restored after PiP closes and the persisted PiP-open state is cleared.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->