### PR TITLE
test(query-devtools/Devtools): add test for restoring 'width' to the rendered minimum after a drag clamp

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1341,6 +1341,60 @@ describe('Devtools', () => {
       )
     })
 
+    it('should restore "width" to the rendered minimum when the panel is dragged below its content width', () => {
+      const initialWidth = 400
+      // The panel uses `min-width: min-content`, so the rendered width may
+      // exceed the 192px `minWidth` constant when its children are wider; any
+      // value > 192 here triggers the `localStore.width < newWidth` restore
+      // branch.
+      const renderedMinWidth = 250
+      const rendered = renderDevtools(
+        { position: 'left', initialIsOpen: true },
+        { 'TanstackQueryDevtools.width': String(initialWidth) },
+      )
+
+      const handle = rendered.getByLabelText('Resize devtools panel')
+      const panel = handle.parentElement
+      expect(panel).toBeInstanceOf(HTMLElement)
+      const getBoundingClientRect = vi
+        .spyOn(panel!, 'getBoundingClientRect')
+        .mockReturnValueOnce({
+          height: 0,
+          width: initialWidth,
+          x: 0,
+          y: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          toJSON: () => ({}),
+        })
+      getBoundingClientRect.mockReturnValue({
+        height: 0,
+        width: renderedMinWidth,
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      })
+
+      // Drag 300px left shrinks the panel to 100 — below `minWidth`, so the
+      // clamp + restore branches both fire.
+      fireEvent.mouseDown(handle, { clientX: 300, clientY: 0 })
+      fireEvent(
+        document,
+        new MouseEvent('mousemove', { clientX: 0, clientY: 0 }),
+      )
+      fireEvent(document, new MouseEvent('mouseup'))
+
+      expect(Number(localStorage.getItem('TanstackQueryDevtools.width'))).toBe(
+        renderedMinWidth,
+      )
+    })
+
     it('should close the query details panel when dragging shrinks the panel below the minimum height', () => {
       queryClient.setQueryData(['shrink-below-min-height'], [{ id: 1 }])
       const rendered = renderDevtools({


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with a test that locks the `localStore.width < newWidth` restore branch in the resize drag handler — when a drag clamps the stored width down to `minWidth` (192px) but the panel's `min-width: min-content` keeps it rendered wider than that, production should write the rendered width back to `localStore.width` to keep open/close transitions smooth.

Added cases (`resize handle`, 1):

- `should restore "width" to the rendered minimum when the panel is dragged below its content width` — sits next to the existing clamp-only case but mocks `getBoundingClientRect` so that the rendered width (250px) stays above `minWidth` after the drag, then asserts that `localStorage.width` is restored from the clamped 192px back up to 250px.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).