### PR TITLE
test(query-devtools/Devtools): add test for rendering an idle mutation row

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -339,6 +339,22 @@ describe('Devtools', () => {
         rendered.getByLabelText(/Mutation submitted at/),
       ).toBeInTheDocument()
     })
+
+    it('should render an idle mutation that has been built but not executed', async () => {
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(rendered.getByText('Mutations'))
+
+      queryClient.getMutationCache().build(queryClient, {
+        mutationKey: ['idle-mut'],
+        mutationFn: () => Promise.resolve('ok'),
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(
+        rendered.getByLabelText(/Mutation submitted at/),
+      ).toBeInTheDocument()
+    })
   })
 
   describe('disabled and static queries', () => {


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with a test that locks the mutations view's idle path — when a `useMutation` hook is mounted but has not been triggered yet, the mutation cache holds an idle entry whose row should still render (covering the `color() === 'gray'` branch of `getObserverCountColorStyles`).

Added cases (`view toggle`, 1):

- `should render an idle mutation that has been built but not executed` — switches to the mutations view, builds a mutation in the cache without calling `execute`, and asserts the mutation row appears.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the mutations view in devtools to ensure proper behavior across different mutation states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->