### PR TITLE
fix(query-core): snapshot resetQueries match set before mutating state

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1692,6 +1692,77 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(0)
       expect(didSkipTokenRun).toBe(false)
     })
+
+    it('should refetch queries selected via a state-based predicate', async () => {
+      // Regression test for #10705 — when `resetQueries` is called with a
+      // predicate keyed on `query.state.status`, reset() mutates the status
+      // before refetchQueries re-evaluates the predicate, so the matched set
+      // collapses and no refetch happens.
+      const erroredKey = queryKey()
+      const successKey = queryKey()
+      const erroredQueryFn = vi
+        .fn<(...args: Array<unknown>) => Promise<string>>()
+        .mockRejectedValue(new Error('boom'))
+      const successQueryFn = vi
+        .fn<(...args: Array<unknown>) => string>()
+        .mockReturnValue('ok')
+
+      // Seed the queries directly (fetchQuery returns a Promise — works under
+      // vi.useFakeTimers because no setTimeout is involved).
+      await queryClient
+        .fetchQuery({
+          queryKey: erroredKey,
+          queryFn: erroredQueryFn,
+          retry: false,
+        })
+        .catch(() => undefined)
+      await queryClient.fetchQuery({
+        queryKey: successKey,
+        queryFn: successQueryFn,
+      })
+      expect(queryClient.getQueryState(erroredKey)?.status).toBe('error')
+      expect(queryClient.getQueryState(successKey)?.status).toBe('success')
+
+      // Mount observers so the queries are "active" — refetch only runs for
+      // queries with observers. The observers may also auto-refetch on mount
+      // because the data is stale; the test re-resets the mocks AFTER that
+      // settles so the only thing the assertion counts is the resetQueries
+      // refetch under test.
+      const erroredObserver = new QueryObserver(queryClient, {
+        queryKey: erroredKey,
+        queryFn: erroredQueryFn,
+        retry: false,
+      })
+      const successObserver = new QueryObserver(queryClient, {
+        queryKey: successKey,
+        queryFn: successQueryFn,
+      })
+      erroredObserver.subscribe(() => undefined)
+      successObserver.subscribe(() => undefined)
+
+      // Let any mount-time fetches settle so the errored query is back in
+      // 'error' state when we call resetQueries.
+      await vi.runOnlyPendingTimersAsync()
+
+      erroredQueryFn.mockClear()
+      successQueryFn.mockClear()
+
+      expect(queryClient.getQueryState(erroredKey)?.status).toBe('error')
+
+      await queryClient
+        .resetQueries({
+          predicate: (query) => query.state.status === 'error',
+        })
+        .catch(() => undefined)
+
+      // The errored query was reset AND re-fetched.
+      expect(erroredQueryFn).toHaveBeenCalledTimes(1)
+      // The successful query stayed untouched.
+      expect(successQueryFn).toHaveBeenCalledTimes(0)
+
+      successObserver.destroy()
+      erroredObserver.destroy()
+    })
   })
 
   describe('focusManager and onlineManager', () => {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -260,13 +260,20 @@ export class QueryClient {
     const queryCache = this.#queryCache
 
     return notifyManager.batch(() => {
-      queryCache.findAll(filters).forEach((query) => {
+      // Snapshot matched queries BEFORE calling reset, because reset() mutates
+      // each query's state (e.g. status flips from "error"/"success" to
+      // "pending"). Re-running the same state-based predicate afterwards would
+      // no longer match the same set, so refetch would skip the queries we
+      // just reset. Match by identity instead — query references are stable
+      // across reset.
+      const matchedQueries = queryCache.findAll(filters)
+      matchedQueries.forEach((query) => {
         query.reset()
       })
       return this.refetchQueries(
         {
           type: 'active',
-          ...filters,
+          predicate: (query) => matchedQueries.includes(query),
         },
         options,
       )


### PR DESCRIPTION
Closes #10705.

## What was broken

`queryClient.resetQueries({ predicate: q => q.state.status === 'error' })` reset the matched queries but never re-fetched them — they stayed stuck in `pending` forever.

## Root cause

`resetQueries` ran the caller's filter twice:

1. First, to pick the queries to reset.
2. Second, inside the `refetchQueries({ type: 'active', ...filters })` call, to pick the queries to re-fetch.

`query.reset()` mutates each query's state — for example, the status flips from `"error"` to `"pending"`. When `filters` contains a state-based predicate like `q => q.state.status === 'error'`, the second pass evaluates against the already-mutated state and the matched set collapses, so the re-fetch step silently does nothing.

The original issue author traced this exactly: <https://github.com/TanStack/query/issues/10705>

## Fix

Snapshot the matched queries _before_ calling `reset()`, then refetch the same set by identity (`matchedQueries.includes(query)`), still scoped to `type: 'active'`. Query references are stable across `reset()`, so the identity predicate is a faithful replacement for the caller's filter without the state-mutation hazard.

```ts
return notifyManager.batch(() => {
  const matchedQueries = queryCache.findAll(filters)
  matchedQueries.forEach((query) => {
    query.reset()
  })
  return this.refetchQueries(
    {
      type: 'active',
      predicate: (query) => matchedQueries.includes(query),
    },
    options,
  )
})
```

## Test

Added a regression test in `queryClient.test.tsx` covering the exact scenario from the issue: two active queries (one errored, one successful), call `resetQueries({ predicate: status === 'error' })`, assert the errored query's `queryFn` was called once and the successful one's wasn't.

- Fails on `main` (errored `queryFn` called `0` times — bug behaviour).
- Passes with the fix.

Full `queryClient.test.tsx` suite: 108 passed (one new test added). Lint clean on changed files.

## Note on scope

The same two-pass pattern exists in `invalidateQueries`, but `invalidate()` only flips `isInvalidated` (which the caller's predicate is unlikely to key on) and the `refetchType: 'none'` short-circuit covers the obvious case. Leaving that alone to keep this PR scoped to the reported bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query reset with predicates to correctly refetch only matching queries, preventing unintended query refetches due to state mutations.

* **Tests**
  * Added regression test for predicate-based query reset and refetch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->