### PR TITLE
test(query-devtools/Explorer): add test for rendering under the 'light' theme

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -28,7 +28,11 @@ describe('Explorer', () => {
     queryClient.clear()
   })
 
-  function renderExplorer(props: Parameters<typeof Explorer>[0]) {
+  function renderExplorer(
+    props: Parameters<typeof Explorer>[0],
+    options: { theme?: 'dark' | 'light' } = {},
+  ) {
+    const theme = options.theme ?? 'dark'
     return render(() => (
       <QueryDevtoolsContext.Provider
         value={{
@@ -38,7 +42,7 @@ describe('Explorer', () => {
           onlineManager,
         }}
       >
-        <ThemeContext.Provider value={() => 'dark'}>
+        <ThemeContext.Provider value={() => theme}>
           <Explorer {...props} />
         </ThemeContext.Provider>
       </QueryDevtoolsContext.Provider>
@@ -560,6 +564,28 @@ describe('Explorer', () => {
       fireEvent.click(within(nameRow).getByLabelText('Delete item'))
 
       expect(queryClient.getQueryData(['data'])).toEqual({})
+    })
+  })
+
+  describe('theme', () => {
+    it('should render without throwing under the "light" theme', () => {
+      const value = { items: ['a'], flag: true }
+      queryClient.setQueryData(['data'], value)
+
+      expect(() =>
+        renderExplorer(
+          {
+            label: 'Data',
+            value,
+            defaultExpanded: ['Data'],
+            editable: true,
+            activeQuery: queryClient
+              .getQueryCache()
+              .find({ queryKey: ['data'] }) as Query,
+          },
+          { theme: 'light' },
+        ),
+      ).not.toThrow()
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with a test that locks the `light`-theme branch across the explorer and its inline action buttons. The existing suite only exercises the `dark` path, so the `lightStyles` function and the `light` arms of `theme() === 'dark' ? darkStyles(css) : lightStyles(css)` in `Explorer`, `CopyButton`, `ClearArrayButton`, `DeleteItemButton`, and `ToggleValueButton` were all uncovered.

Added cases (`theme`, 1):

- `should render without throwing under the "light" theme` — renders the `Explorer` with `theme: 'light'` and a value that mounts every inline action button (`{ items: ['a'], flag: true }` covers `ClearArrayButton`, `DeleteItemButton`, and `ToggleValueButton`), asserting it renders without throwing.

`renderExplorer` now takes an optional `options.theme` (defaults to `'dark'` to preserve the existing cases unchanged).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage to verify Explorer component renders correctly with both dark and light themes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->