### PR TITLE
fix(solid-query): fetch queries on status-only reads

### DIFF
--- a/.changeset/solid-query-status-resource.md
+++ b/.changeset/solid-query-status-resource.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/solid-query": patch
+---
+
+Start Solid query resources when status fields are read so curried `queryOptions` fetch on mount without requiring `data` access.

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -279,6 +279,38 @@ describe('useQuery', () => {
     expect(rendered.getByText('success')).toBeInTheDocument()
   })
 
+  it('should fetch when a curried queryOptions result only reads resource fields', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn((slug: string) => `test-${slug}`)
+    const fetchQueryOptions = (slug: string) =>
+      queryOptions({
+        queryKey: [key, slug],
+        queryFn: () => queryFn(slug),
+      })
+
+    function Page() {
+      const options = fetchQueryOptions('slug')
+      const state = useQuery(() => options)
+
+      void state.error
+      void state.failureReason
+      void state.refetch
+      void state.promise
+
+      return <div>mounted</div>
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    expect(rendered.getByText('mounted')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+  })
+
   it('should return the correct states for a successful query', async () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -30,6 +30,7 @@ import {
   QueryClient,
   QueryClientProvider,
   keepPreviousData,
+  queryOptions,
   useQuery,
 } from '..'
 import { Blink, mockOnlineManagerIsOnline, setActTimeout } from './utils'
@@ -242,6 +243,40 @@ describe('useQuery', () => {
     expect(rendered.getByText('default')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('test')).toBeInTheDocument()
+  })
+
+  it('should fetch when a curried queryOptions result only reads status fields', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn((slug: string) => `test-${slug}`)
+    const fetchQueryOptions = (slug: string) =>
+      queryOptions({
+        queryKey: [key, slug],
+        queryFn: () => queryFn(slug),
+      })
+
+    function Page() {
+      const options = fetchQueryOptions('slug')
+      const state = useQuery(() => options)
+
+      return (
+        <Switch>
+          <Match when={state.isPending}>pending</Match>
+          <Match when={state.isError}>error</Match>
+          <Match when={state.isSuccess}>success</Match>
+        </Switch>
+      )
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    expect(rendered.getByText('pending')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(rendered.getByText('success')).toBeInTheDocument()
   })
 
   it('should return the correct states for a successful query', async () => {

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -99,6 +99,30 @@ const hydratableObserverResult = <
   return obj
 }
 
+const resourceTrackingProps = new Set<PropertyKey>([
+  'dataUpdatedAt',
+  'errorUpdatedAt',
+  'failureCount',
+  'errorUpdateCount',
+  'isError',
+  'isFetched',
+  'isFetchedAfterMount',
+  'isFetching',
+  'isLoading',
+  'isPending',
+  'isLoadingError',
+  'isInitialLoading',
+  'isPaused',
+  'isPlaceholderData',
+  'isRefetchError',
+  'isRefetching',
+  'isStale',
+  'isSuccess',
+  'isEnabled',
+  'status',
+  'fetchStatus',
+])
+
 // Base Query Function that is used to create the query.
 export function useBaseQuery<
   TQueryFnData,
@@ -380,6 +404,11 @@ export function useBaseQuery<
           return queryResource.latest?.data
         }
         return queryResource()?.data
+      }
+      if (resourceTrackingProps.has(prop)) {
+        // Solid resources are lazy, so status-only consumers still need to read
+        // the resource once to start the observer subscription and fetch.
+        queryResource()
       }
       return Reflect.get(target, prop)
     },

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -101,8 +101,10 @@ const hydratableObserverResult = <
 
 const resourceTrackingProps = new Set<PropertyKey>([
   'dataUpdatedAt',
+  'error',
   'errorUpdatedAt',
   'failureCount',
+  'failureReason',
   'errorUpdateCount',
   'isError',
   'isFetched',
@@ -119,6 +121,8 @@ const resourceTrackingProps = new Set<PropertyKey>([
   'isStale',
   'isSuccess',
   'isEnabled',
+  'refetch',
+  'promise',
   'status',
   'fetchStatus',
 ])


### PR DESCRIPTION
Fixes #10751

## Summary
- start the Solid query resource when derived status fields are read, so status-only consumers still subscribe and fetch on mount
- keep `error`, `failureReason`, `refetch`, and `promise` reads from eagerly touching the resource to preserve error-boundary behavior
- add regression coverage for curried `queryOptions` used with `isPending` / `isError` / `isSuccess`
- add a patch changeset for `@tanstack/solid-query`

## Tests
- `corepack pnpm --filter @tanstack/solid-query exec vitest run --config vitest.local.config.ts src/__tests__/useQuery.test.tsx` using a temporary local copy of the package config with `solid({ hot: false })`; the default Windows run fails before imports with `file:///@solid-refresh`
- `corepack pnpm exec prettier --check .changeset/solid-query-status-resource.md packages/solid-query/src/useBaseQuery.ts packages/solid-query/src/__tests__/useQuery.test.tsx`
- `corepack pnpm exec eslint --concurrency=auto -c eslint.config.js packages/solid-query/src/useBaseQuery.ts packages/solid-query/src/__tests__/useQuery.test.tsx`
- `corepack pnpm --filter @tanstack/solid-query build`
- `git diff --check`

Local script note: `corepack pnpm --filter @tanstack/solid-query test:eslint` and `test:types:tscurrent` fail on this Windows checkout before reaching source files because checked-in symlink placeholders such as `packages/solid-query/root.eslint.config.js` are materialized as plain text (`../../eslint.config.js`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resources now initialize when status-only fields (e.g., pending/error/success flags) are read, preventing missing fetches for components that don't access data directly.
* **Tests**
  * Added coverage verifying status-only and resource-only consumers trigger a single fetch and transition to success.
* **Documentation**
  * Patch release note describing the behavior change for Solid Query resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->