### PR TITLE
fix(query-broadcast-client): handle postMessage errors

### DIFF
--- a/.changeset/broadcast-client-post-errors.md
+++ b/.changeset/broadcast-client-post-errors.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-broadcast-client-experimental': patch
+---
+
+Handle broadcast `postMessage` failures without surfacing unhandled rejections.

--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -1,15 +1,47 @@
 import { QueryClient } from '@tanstack/query-core'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { broadcastQueryClient } from '..'
 import type { QueryCache } from '@tanstack/query-core'
+
+const broadcastChannelMock = vi.hoisted(() => {
+  const channels: Array<{
+    postMessage: ReturnType<typeof vi.fn>
+    close: ReturnType<typeof vi.fn>
+    onmessage: ((message: unknown) => void) | null
+  }> = []
+
+  class BroadcastChannel {
+    onmessage: ((message: unknown) => void) | null = null
+    postMessage = vi.fn(() => Promise.resolve())
+    close = vi.fn()
+
+    constructor(_name: string, _options: unknown) {
+      channels.push(this)
+    }
+  }
+
+  return {
+    BroadcastChannel,
+    channels,
+  }
+})
+
+vi.mock('broadcast-channel', () => ({
+  BroadcastChannel: broadcastChannelMock.BroadcastChannel,
+}))
 
 describe('broadcastQueryClient', () => {
   let queryClient: QueryClient
   let queryCache: QueryCache
 
   beforeEach(() => {
+    broadcastChannelMock.channels.length = 0
     queryClient = new QueryClient()
     queryCache = queryClient.getQueryCache()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('should subscribe to the query cache', () => {
@@ -27,5 +59,42 @@ describe('broadcastQueryClient', () => {
     })
     unsubscribe()
     expect(queryCache.hasListeners()).toBe(false)
+  })
+
+  it('should report postMessage rejections without unhandled rejections', async () => {
+    const error = new DOMException('cannot clone', 'DataCloneError')
+    const onBroadcastError = vi.fn()
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+
+    broadcastQueryClient({
+      queryClient,
+      broadcastChannel: 'test_channel',
+      onBroadcastError,
+    })
+
+    const channel = broadcastChannelMock.channels[0]!
+    channel.postMessage.mockImplementation((message: { type: string }) =>
+      message.type === 'updated' ? Promise.reject(error) : Promise.resolve(),
+    )
+
+    queryClient.setQueryData(['stream'], new ReadableStream())
+
+    await vi.waitFor(() => {
+      expect(onBroadcastError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          type: 'updated',
+          queryHash: '["stream"]',
+          queryKey: ['stream'],
+        }),
+      )
+    })
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[broadcastQueryClient] failed to broadcast "updated" for queryHash "["stream"]"',
+      error,
+    )
   })
 })

--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -97,4 +97,44 @@ describe('broadcastQueryClient', () => {
       error,
     )
   })
+
+  it('should report synchronous postMessage throws', async () => {
+    const error = new DOMException('cannot clone', 'DataCloneError')
+    const onBroadcastError = vi.fn()
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+
+    broadcastQueryClient({
+      queryClient,
+      broadcastChannel: 'test_channel',
+      onBroadcastError,
+    })
+
+    const channel = broadcastChannelMock.channels[0]!
+    channel.postMessage.mockImplementation((message: { type: string }) => {
+      if (message.type === 'updated') {
+        throw error
+      }
+      return Promise.resolve()
+    })
+
+    queryClient.setQueryData(['stream'], new ReadableStream())
+
+    await vi.waitFor(() => {
+      expect(onBroadcastError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          type: 'updated',
+          queryHash: '["stream"]',
+          queryKey: ['stream'],
+        }),
+      )
+    })
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[broadcastQueryClient] failed to broadcast "updated" for queryHash "["stream"]"',
+      error,
+    )
+  })
 })

--- a/packages/query-broadcast-client-experimental/src/index.ts
+++ b/packages/query-broadcast-client-experimental/src/index.ts
@@ -1,17 +1,32 @@
 import { BroadcastChannel } from 'broadcast-channel'
 import type { BroadcastChannelOptions } from 'broadcast-channel'
-import type { QueryClient } from '@tanstack/query-core'
+import type { QueryClient, QueryKey, QueryState } from '@tanstack/query-core'
 
 interface BroadcastQueryClientOptions {
   queryClient: QueryClient
   broadcastChannel?: string
   options?: BroadcastChannelOptions
+  onBroadcastError?: (error: unknown, message: BroadcastMessage) => void
 }
+
+type BroadcastMessage =
+  | {
+      type: 'updated'
+      queryHash: string
+      queryKey: QueryKey
+      state: QueryState
+    }
+  | {
+      type: 'removed' | 'added'
+      queryHash: string
+      queryKey: QueryKey
+    }
 
 export function broadcastQueryClient({
   queryClient,
   broadcastChannel = 'tanstack-query',
   options,
+  onBroadcastError,
 }: BroadcastQueryClientOptions): () => void {
   let transaction = false
   const tx = (cb: () => void) => {
@@ -27,6 +42,27 @@ export function broadcastQueryClient({
 
   const queryCache = queryClient.getQueryCache()
 
+  const handleBroadcastError = (error: unknown, message: BroadcastMessage) => {
+    onBroadcastError?.(error, message)
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `[broadcastQueryClient] failed to broadcast "${message.type}" for queryHash "${message.queryHash}"`,
+        error,
+      )
+    }
+  }
+
+  const postMessage = (message: BroadcastMessage) => {
+    try {
+      void channel
+        .postMessage(message)
+        .catch((error) => handleBroadcastError(error, message))
+    } catch (error) {
+      handleBroadcastError(error, message)
+    }
+  }
+
   const unsubscribe = queryClient.getQueryCache().subscribe((queryEvent) => {
     if (transaction) {
       return
@@ -37,7 +73,7 @@ export function broadcastQueryClient({
     } = queryEvent
 
     if (queryEvent.type === 'updated' && queryEvent.action.type === 'success') {
-      channel.postMessage({
+      postMessage({
         type: 'updated',
         queryHash,
         queryKey,
@@ -46,7 +82,7 @@ export function broadcastQueryClient({
     }
 
     if (queryEvent.type === 'removed' && observers.length > 0) {
-      channel.postMessage({
+      postMessage({
         type: 'removed',
         queryHash,
         queryKey,
@@ -54,7 +90,7 @@ export function broadcastQueryClient({
     }
 
     if (queryEvent.type === 'added') {
-      channel.postMessage({
+      postMessage({
         type: 'added',
         queryHash,
         queryKey,


### PR DESCRIPTION
## Summary

Fixes #10542 and #10543.

`broadcastQueryClient` now sends cache events through a guarded `postMessage` helper. If the underlying `broadcast-channel` implementation rejects or throws for a non-cloneable payload, the rejection is handled instead of surfacing as an unhandled rejection. Consumers can also pass `onBroadcastError` to log the offending broadcast message in production, while development still gets a queryHash-aware warning.

## Testing

- `corepack pnpm --filter @tanstack/query-broadcast-client-experimental exec vitest run src/__tests__/index.test.ts`
- `corepack pnpm exec prettier --check .changeset/broadcast-client-post-errors.md packages/query-broadcast-client-experimental/src/index.ts packages/query-broadcast-client-experimental/src/__tests__/index.test.ts`
- `corepack pnpm exec eslint --concurrency=auto -c eslint.config.js packages/query-broadcast-client-experimental/src/index.ts packages/query-broadcast-client-experimental/src/__tests__/index.test.ts`
- `corepack pnpm exec tsc -p packages/query-broadcast-client-experimental/tsconfig.prod.json --noEmit --pretty false`
- `corepack pnpm exec tsup src/index.ts --no-config --format cjs,esm --target es2020,node16 --dts --sourcemap --clean --out-dir build/legacy --tsconfig tsconfig.prod.json`
- `git diff --check`

Note: the package `test:types:tscurrent` and `build` scripts still hit the existing Windows symlink-placeholder checkout issue for `root.eslint.config.js` / `root.tsup.config.js`, so I validated the changed source with the direct TypeScript and `tsup --no-config` commands above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `onBroadcastError` callback option to surface broadcast transmission failures.
  * Added development-time warnings for failed broadcasts including message type and query identifier.

* **Bug Fixes**
  * Prevented unhandled rejections from broadcast message posting failures.

* **Tests**
  * Added regression tests validating error reporting and warnings when broadcasts fail.

* **Documentation**
  * Added a changeset documenting the patch release handling broadcast postMessage failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->