### PR TITLE
fix(query-devtools): handle missing query row state

### DIFF
--- a/.changeset/query-devtools-missing-state.md
+++ b/.changeset/query-devtools-missing-state.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-devtools': patch
+---
+
+Avoid crashing devtools query rows when a cached query state is temporarily unavailable.

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -1438,7 +1438,7 @@ const QueryRow: Component<{ query: Query }> = (props) => {
 
   const color = createMemo(() =>
     getQueryStatusColor({
-      queryState: queryState()!,
+      queryState: queryState(),
       observerCount: observers(),
       isStale: isStale(),
     }),

--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1573,6 +1573,16 @@ describe('Utils tests', () => {
       ).toBe('gray')
     })
 
+    it('should return "gray" when the query state is unavailable', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: undefined,
+          observerCount: 0,
+          isStale: false,
+        }),
+      ).toBe('gray')
+    })
+
     it('should return "purple" when fetchStatus is "paused"', () => {
       expect(
         getQueryStatusColor({

--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -31,15 +31,15 @@ export function getQueryStatusColor({
   observerCount,
   isStale,
 }: {
-  queryState: Query['state']
+  queryState: Query['state'] | undefined
   observerCount: number
   isStale: boolean
 }) {
-  return queryState.fetchStatus === 'fetching'
+  return queryState?.fetchStatus === 'fetching'
     ? 'blue'
     : !observerCount
       ? 'gray'
-      : queryState.fetchStatus === 'paused'
+      : queryState?.fetchStatus === 'paused'
         ? 'purple'
         : isStale
           ? 'yellow'


### PR DESCRIPTION
## Summary

Fixes #10744.

The query devtools row color calculation assumed the cache lookup always returns a query state. When the row and cache subscription are briefly out of sync, that path can receive `undefined` and crash while reading `fetchStatus`. This makes the status-color helper tolerate a missing state and treat that transient row as inactive/gray until the row is removed or refreshed.

## Tests

- `corepack pnpm --filter @tanstack/query-devtools exec vitest run src/__tests__/utils.test.ts`
- `corepack pnpm --dir packages/query-devtools exec vitest run --config vitest.local.config.ts src/__tests__/Devtools.test.tsx src/__tests__/DevtoolsPanelComponent.test.tsx src/__tests__/utils.test.ts` with a temporary local config matching the package config but `solid({ hot: false })`, because the default Windows run fails before loading suites with `file:///@solid-refresh`
- `corepack pnpm exec prettier --check .changeset/query-devtools-missing-state.md packages/query-devtools/src/Devtools.tsx packages/query-devtools/src/utils.tsx packages/query-devtools/src/__tests__/utils.test.ts`
- `corepack pnpm exec eslint --concurrency=auto -c eslint.config.js packages/query-devtools/src/Devtools.tsx packages/query-devtools/src/utils.tsx packages/query-devtools/src/__tests__/utils.test.ts`
- `corepack pnpm exec tsc -p packages/query-devtools/tsconfig.prod.json --noEmit --pretty false`
- `corepack pnpm --filter @tanstack/query-devtools build`
- `git diff --check`

Note: the package `test:eslint` and `test:types:tscurrent` scripts hit the existing Windows symlink-placeholder issue for checked-in files such as `root.eslint.config.js`, so I validated the same changed files with the root ESLint config and the production TypeScript config directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented query devtools rows from crashing when a cached query state is temporarily unavailable, improving stability during rapid state changes.

* **Tests**
  * Added coverage to verify devtools correctly handle undefined query state when determining status color.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->