### PR TITLE
feat(query-core): pass failureCount to QueryCache onError callback

### DIFF
--- a/.changeset/feat-query-cache-on-error-failure-count.md
+++ b/.changeset/feat-query-cache-on-error-failure-count.md
@@ -1,0 +1,21 @@
+---
+"@tanstack/query-core": minor
+---
+
+feat(query-core): pass `failureCount` to `QueryCache` `onError` callback
+
+The `onError` callback in `QueryCacheConfig` now receives a third argument `failureCount: number` indicating how many retry attempts occurred before the final failure (0 means no retries happened).
+
+This allows differentiated error handling based on the retry count:
+
+```ts
+new QueryCache({
+  onError: (error, query, failureCount) => {
+    if (failureCount === 0) {
+      toast.error('Request failed')
+    } else {
+      toast.error(`Request failed after ${failureCount} retries`)
+    }
+  },
+})
+```

--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -325,11 +325,31 @@ describe('queryCache', () => {
       })
       await vi.advanceTimersByTimeAsync(100)
       const query = testCache.find({ queryKey: key })
-      expect(onError).toHaveBeenCalledWith('error', query)
+      expect(onError).toHaveBeenCalledWith('error', query, 0)
       expect(onError).toHaveBeenCalledTimes(1)
       expect(onSuccess).not.toHaveBeenCalled()
       expect(onSettled).toHaveBeenCalledTimes(1)
       expect(onSettled).toHaveBeenCalledWith(undefined, 'error', query)
+    })
+
+    it('should pass the retry count to onError when retries are exhausted', async () => {
+      const key = queryKey()
+      const onError = vi.fn()
+      const testCache = new QueryCache({ onError })
+      const testClient = new QueryClient({ queryCache: testCache })
+      testClient.prefetchQuery({
+        queryKey: key,
+        queryFn: () => Promise.reject<unknown>('error'),
+        retry: 2,
+        retryDelay: 10,
+      })
+      // advance past initial attempt + 2 retry delays
+      await vi.advanceTimersByTimeAsync(10)
+      await vi.advanceTimersByTimeAsync(10)
+      await vi.advanceTimersByTimeAsync(10)
+      const query = testCache.find({ queryKey: key })
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith('error', query, 2)
     })
   })
 

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -532,6 +532,8 @@ export class Query<
       this.#dispatch({ type: 'fetch', meta: context.fetchOptions?.meta })
     }
 
+    let retryCount = 0
+
     // Try to fetch the data
     this.#retryer = createRetryer({
       initialPromise: fetchOptions?.initialPromise as
@@ -548,6 +550,7 @@ export class Query<
         abortController.abort()
       },
       onFail: (failureCount, error) => {
+        retryCount = failureCount
         this.#dispatch({ type: 'failed', failureCount, error })
       },
       onPause: () => {
@@ -610,6 +613,7 @@ export class Query<
       this.#cache.config.onError?.(
         error as any,
         this as Query<any, any, any, any>,
+        retryCount,
       )
       this.#cache.config.onSettled?.(
         this.state.data,

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -20,6 +20,7 @@ interface QueryCacheConfig {
   onError?: (
     error: DefaultError,
     query: Query<unknown, unknown, unknown>,
+    failureCount: number,
   ) => void
   onSuccess?: (data: unknown, query: Query<unknown, unknown, unknown>) => void
   onSettled?: (


### PR DESCRIPTION
## Summary

Closes #10713.

Adds a third `failureCount` parameter to `QueryCacheConfig.onError`, indicating how many retry attempts occurred before the final failure:

- `0` — the initial attempt failed (no retries happened)
- `n` — `n` retries were exhausted before giving up

This makes it easy to implement differentiated error handling without having to derive the count from `query.state.fetchFailureCount`:

```ts
new QueryCache({
  onError: (error, query, failureCount) => {
    if (failureCount === 0) {
      toast.error('Request failed')
    } else {
      toast.error(`Request failed after ${failureCount} retries`)
    }
  },
})
```

The value is consistent with the `failureCount` convention already used in `ShouldRetryFunction` and `RetryDelayFunction`.

## Test plan

- [x] Updated existing `onError` test to assert `failureCount = 0` when no retries occur
- [x] Added new test asserting `failureCount` equals the configured `retry` count when retries are exhausted
- [x] All `@tanstack/query-core` tests pass (527 tests)
- [x] All `@tanstack/react-query` tests pass (542 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Error callbacks now receive a `failureCount` parameter indicating the number of retry attempts before the final error occurred. A value of 0 means no retries were attempted. This enables conditional error handling logic based on retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->