### PR TITLE
fix(query-core): shallowEqualObjects ignores key-set differences when counts match

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -59,6 +59,17 @@ describe('core/utils', () => {
     it('should return false if b is undefined', () => {
       expect(shallowEqualObjects({ a: 1 }, undefined)).toEqual(false)
     })
+
+    it('should return `false` for same-length objects with different keys', () => {
+      // Both objects have the same number of keys, but the key sets differ.
+      // `b` is missing on the second object and `c` is missing on the first,
+      // so they are not shallowly equal even though both differing values
+      // happen to be `undefined`.
+      expect(
+        shallowEqualObjects({ a: 1, b: undefined }, { a: 1, c: undefined }),
+      ).toEqual(false)
+      expect(shallowEqualObjects({ a: 1, b: 2 }, { a: 1, c: 2 })).toEqual(false)
+    })
   })
   describe('isPlainObject', () => {
     it('should return `true` for a plain object', () => {

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -330,7 +330,7 @@ export function shallowEqualObjects<T extends Record<string, any>>(
   }
 
   for (const key in a) {
-    if (a[key] !== b[key]) {
+    if (!hasOwn.call(b, key) || a[key] !== b[key]) {
       return false
     }
   }


### PR DESCRIPTION
## What
`shallowEqualObjects` now returns `false` when two objects have the same number of keys but different key *names* (e.g. `{ a: 1, b: undefined }` vs `{ a: 1, c: undefined }`).

## Why
The function only iterated over `a`'s keys and compared `a[key] !== b[key]`. A key present on `a` but missing from `b` reads as `undefined` on `b`; if `a`'s value for that key is also `undefined` (or otherwise equal), the objects compared as equal despite having different key sets — violating the documented "shallow compare objects" contract. Real call site: `QueryObserver.setOptions` gates the `observerOptionsUpdated` notification with this comparison, so swapping one defaulted option key for another between renders could silently suppress that notification.

## Safety
Pure utility change; an additive own-property guard. No existing test asserted the old (incorrect) behaviour. Result-object comparisons (which use fixed-shape objects) are unaffected, so there is no behavioural or performance regression for the common path.

## Testing
Added `should return 'false' for same-length objects with different keys` to `utils.test.tsx`: it fails on the current code (`expected true to deeply equal false`) and passes after the fix. Full query-core runtime suite green (**480/480**), typecheck clean.

## Impact
Tighter, contract-correct shallow equality — restores correct change-detection for option updates that swap keys without changing key count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed object comparison logic to correctly identify differences when objects contain different properties, improving accuracy of equality checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->