### PR TITLE
fix(query-devtools): look up selected queries by hash

### DIFF
--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -1853,64 +1853,49 @@ const QueryDetails = () => {
   const [restoringLoading, setRestoringLoading] = createSignal(false)
   const [dataMode, setDataMode] = createSignal<'view' | 'edit'>('view')
   const [dataEditError, setDataEditError] = createSignal<boolean>(false)
+  const getSelectedQuery = (queryCache: Accessor<QueryCache>) => {
+    const queryHash = selectedQueryHash()
+    return queryHash ? queryCache().get(queryHash) : undefined
+  }
 
   const errorTypes = createMemo(() => {
     return useQueryDevtoolsContext().errorTypes || []
   })
 
   const activeQuery = createSubscribeToQueryCacheBatcher(
-    (queryCache) =>
-      queryCache()
-        .getAll()
-        .find((query) => query.queryHash === selectedQueryHash()),
+    getSelectedQuery,
     false,
   )
 
-  const activeQueryFresh = createSubscribeToQueryCacheBatcher((queryCache) => {
-    return queryCache()
-      .getAll()
-      .find((query) => query.queryHash === selectedQueryHash())
-  }, false)
+  const activeQueryFresh = createSubscribeToQueryCacheBatcher(
+    getSelectedQuery,
+    false,
+  )
 
   const activeQueryState = createSubscribeToQueryCacheBatcher(
-    (queryCache) =>
-      queryCache()
-        .getAll()
-        .find((query) => query.queryHash === selectedQueryHash())?.state,
+    (queryCache) => getSelectedQuery(queryCache)?.state,
     false,
   )
 
   const activeQueryStateData = createSubscribeToQueryCacheBatcher(
-    (queryCache) => {
-      return queryCache()
-        .getAll()
-        .find((query) => query.queryHash === selectedQueryHash())?.state.data
-    },
+    (queryCache) => getSelectedQuery(queryCache)?.state.data,
     false,
   )
 
   const statusLabel = createSubscribeToQueryCacheBatcher((queryCache) => {
-    const query = queryCache()
-      .getAll()
-      .find((q) => q.queryHash === selectedQueryHash())
+    const query = getSelectedQuery(queryCache)
     if (!query) return 'inactive'
     return getQueryStatusLabel(query)
   })
 
   const queryStatus = createSubscribeToQueryCacheBatcher((queryCache) => {
-    const query = queryCache()
-      .getAll()
-      .find((q) => q.queryHash === selectedQueryHash())
+    const query = getSelectedQuery(queryCache)
     if (!query) return 'pending'
     return query.state.status
   })
 
   const observerCount = createSubscribeToQueryCacheBatcher(
-    (queryCache) =>
-      queryCache()
-        .getAll()
-        .find((query) => query.queryHash === selectedQueryHash())
-        ?.getObserversCount() ?? 0,
+    (queryCache) => getSelectedQuery(queryCache)?.getObserversCount() ?? 0,
   )
 
   const color = createMemo(() => getQueryStatusColorByLabel(statusLabel()))

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -1863,12 +1863,12 @@ const QueryDetails = () => {
   })
 
   const activeQuery = createSubscribeToQueryCacheBatcher(
-    getSelectedQuery,
+    (queryCache) => getSelectedQuery(queryCache),
     false,
   )
 
   const activeQueryFresh = createSubscribeToQueryCacheBatcher(
-    getSelectedQuery,
+    (queryCache) => getSelectedQuery(queryCache),
     false,
   )
 

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -402,6 +402,22 @@ describe('Devtools', () => {
         rendered.getByLabelText(/Query key \["mutable-key",\{"page":1\}\]/),
       ).toBeInTheDocument()
     })
+
+    it('should render query details for a custom query hash', () => {
+      const query = queryClient.getQueryCache().build(queryClient, {
+        queryKey: ['custom-query-hash'],
+        queryFn: () => 'x',
+        queryKeyHashFn: () => 'custom-query-hash-value',
+      })
+      query.setData('x')
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText('Query key custom-query-hash-value'),
+      )
+
+      expect(rendered.getByText('Query Details')).toBeInTheDocument()
+    })
   })
 
   describe('picture-in-picture', () => {


### PR DESCRIPTION
﻿## Summary

- look up the selected devtools query with `queryCache.get(queryHash)`
- reuse that lookup for query details state, status, and observer count
- add coverage for opening details when a query uses a custom `queryKeyHashFn`

## Why

Devtools already stores the selected query by hash. Looking it up directly avoids repeatedly scanning the cache and aligns the details pane with the lower-level hash lookup suggested in #6958.

Fixes #6958.

## Tests

- `pnpm exec eslint packages/query-devtools/src/Devtools.tsx packages/query-devtools/src/__tests__/Devtools.test.tsx`
- `pnpm exec prettier --check packages/query-devtools/src/Devtools.tsx packages/query-devtools/src/__tests__/Devtools.test.tsx`
- `git diff --check`
- `pnpm --filter @tanstack/query-devtools build`

Package-local checks that are currently blocked in this Windows checkout:

- `pnpm --filter @tanstack/query-devtools test:lib -- src/__tests__/Devtools.test.tsx --coverage.enabled=false` fails before running the devtools suite with `file:///@solid-refresh`
- `pnpm --filter @tanstack/query-devtools test:types:tscurrent` fails because symlink forwarding files such as `root.eslint.config.js` are checked out as plain text (`../../eslint.config.js`) and TypeScript tries to parse them


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Improved DevTools query selection internals to make query detail behavior more reliable and responsive.

* **Tests**
  * Added coverage to ensure the Query Details panel opens correctly when clicking a query key label, including cases with custom query key hashing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->