### PR TITLE
test(query-devtools/Explorer): add test for rendering with a 'shadowDOMTarget'

### DIFF
--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -588,4 +588,46 @@ describe('Explorer', () => {
       ).not.toThrow()
     })
   })
+
+  describe('"shadowDOMTarget"', () => {
+    it('should render without throwing when a "shadowDOMTarget" is provided', () => {
+      const host = document.createElement('div')
+      document.body.appendChild(host)
+      const shadowRoot = host.attachShadow({ mode: 'open' })
+      const value = { items: ['a'], flag: true }
+      queryClient.setQueryData(['data'], value)
+
+      try {
+        expect(() =>
+          render(() => (
+            <QueryDevtoolsContext.Provider
+              value={{
+                client: queryClient,
+                queryFlavor: 'TanStack Query',
+                version: '5',
+                onlineManager,
+                shadowDOMTarget: shadowRoot,
+              }}
+            >
+              <ThemeContext.Provider value={() => 'dark'}>
+                <Explorer
+                  label="Data"
+                  value={value}
+                  defaultExpanded={['Data']}
+                  editable={true}
+                  activeQuery={
+                    queryClient
+                      .getQueryCache()
+                      .find({ queryKey: ['data'] }) as Query
+                  }
+                />
+              </ThemeContext.Provider>
+            </QueryDevtoolsContext.Provider>
+          )),
+        ).not.toThrow()
+      } finally {
+        host.remove()
+      }
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Extend `Explorer.test.tsx` with a test that locks the `shadowDOMTarget` branch across the explorer and its inline action buttons. The existing suite only covers the no-shadow path, so the `useQueryDevtoolsContext().shadowDOMTarget ? goober.css.bind({ target: ... }) : goober.css` shadow arm in `Expander`, `CopyButton`, `ClearArrayButton`, `DeleteItemButton`, `ToggleValueButton`, and the default `Explorer` export were all uncovered.

Added cases (`"shadowDOMTarget"`, 1):

- `should render without throwing when a "shadowDOMTarget" is provided` — renders the `Explorer` inside a `QueryDevtoolsContext.Provider` that exposes a real `ShadowRoot` as `shadowDOMTarget`, and uses a value that mounts every inline action button (`{ items: ['a'], flag: true }` covers `ClearArrayButton`, `DeleteItemButton`, and `ToggleValueButton`), asserting it renders without throwing.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage to ensure component stability when used with shadow DOM targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->