### PR TITLE
test(query-devtools/Devtools): add test for PiP panel narrow layout below the second breakpoint

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -415,7 +415,11 @@ describe('Devtools', () => {
       | 'close'
     >
 
-    function stubPipWindow() {
+    function stubPipWindow(
+      overrides: Partial<
+        Pick<FakePipWindow, 'innerWidth' | 'innerHeight'>
+      > = {},
+    ) {
       const pipDocument = document.implementation.createHTMLDocument('PiP')
       const listeners = new Map<string, EventListener>()
       const fakeWindow: FakePipWindow = {
@@ -429,6 +433,7 @@ describe('Devtools', () => {
           listeners.delete(event)
         }),
         close: vi.fn(),
+        ...overrides,
       }
       const open = vi.fn(() => fakeWindow)
       vi.stubGlobal('open', open)
@@ -525,6 +530,27 @@ describe('Devtools', () => {
       expect(
         rendered.getByLabelText('Open in picture-in-picture mode'),
       ).toBeInTheDocument()
+    })
+
+    it('should render the PiP panel with the narrow layout when the PiP window is below the second breakpoint', () => {
+      // secondBreakpoint = 796; pick a width comfortably below it so the
+      // PiP panel evaluates its narrow (`flex-direction: column`) branch.
+      const { pipDocument } = stubPipWindow({ innerWidth: 500 })
+      queryClient.setQueryData(['narrow-pip-query'], { hello: 'world' })
+      const rendered = renderDevtools({ initialIsOpen: true })
+
+      fireEvent.click(
+        rendered.getByLabelText('Open in picture-in-picture mode'),
+      )
+
+      expect(
+        pipDocument.querySelector(
+          '[aria-label="Close Tanstack query devtools"]',
+        ),
+      ).not.toBeNull()
+      expect(
+        pipDocument.querySelector('[aria-label*="narrow-pip-query"]'),
+      ).not.toBeNull()
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

Extend `Devtools.test.tsx` with a test that exercises the PiP panel's narrow-layout branch (`panelWidth() < secondBreakpoint`). The existing PiP cases use `innerWidth: 800`, so the wide branch was the only one covered; the narrow `flex-direction: column` arm in `getPanelDynamicStyles` was unreachable.

Added cases (`picture-in-picture`, 1):

- `should render the PiP panel with the narrow layout when the PiP window is below the second breakpoint` — stubs the PiP window with `innerWidth: 500` (well below the 796 breakpoint), opens the PiP window, and asserts that the panel is portalled into the PiP document and the query cache is surfaced inside it.

`stubPipWindow` now accepts an `overrides` argument so individual cases can opt into a different `innerWidth` / `innerHeight`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for Picture-in-Picture panel narrow window scenarios, including validation of UI elements displayed in constrained layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->