### PR TITLE
test(query-devtools/Devtools): add test for rendering without a 'ThemeContext.Provider'

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -1516,4 +1516,36 @@ describe('Devtools', () => {
       ).not.toBeInTheDocument()
     })
   })
+
+  describe('default theme', () => {
+    it('should render without throwing when no "ThemeContext.Provider" wraps it', () => {
+      expect(() =>
+        render(() => {
+          const [localStore, setLocalStore] = createLocalStorage({
+            prefix: 'TanstackQueryDevtools',
+          })
+          return (
+            <QueryDevtoolsContext.Provider
+              value={{
+                client: queryClient,
+                queryFlavor: 'TanStack Query',
+                version: '5',
+                onlineManager,
+              }}
+            >
+              <PiPProvider
+                localStore={localStore}
+                setLocalStore={setLocalStore}
+              >
+                <Devtools
+                  localStore={localStore}
+                  setLocalStore={setLocalStore}
+                />
+              </PiPProvider>
+            </QueryDevtoolsContext.Provider>
+          )
+        }),
+      ).not.toThrow()
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add a case in `Devtools.test.tsx` that mounts `Devtools` without a `ThemeContext.Provider` and asserts it does not throw.

This naturally exercises the default value of `ThemeContext` (`() => 'dark' as const` in `src/contexts/ThemeContext.ts`), which the production wrappers (`DevtoolsComponent`, `DevtoolsPanelComponent`) always shadow with a real provider.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for default theme behavior in Devtools component.

---

**Note:** This release contains test improvements only. There are no user-facing changes or new features in this update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->