### PR TITLE
test(query-devtools/Devtools): add assertion for default theme falling back to 'dark' without a 'ThemeContext.Provider'

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -3,7 +3,12 @@ import { QueryClient, QueryObserver, onlineManager } from '@tanstack/query-core'
 import { fireEvent, render } from '@solidjs/testing-library'
 import { createLocalStorage } from '@solid-primitives/storage'
 import { Devtools } from '../Devtools'
-import { PiPProvider, QueryDevtoolsContext, ThemeContext } from '../contexts'
+import {
+  PiPProvider,
+  QueryDevtoolsContext,
+  ThemeContext,
+  useTheme,
+} from '../contexts'
 import type { QueryDevtoolsProps } from '../contexts'
 
 // `solid-transition-group` internally imports from
@@ -1518,34 +1523,39 @@ describe('Devtools', () => {
   })
 
   describe('default theme', () => {
-    it('should render without throwing when no "ThemeContext.Provider" wraps it', () => {
-      expect(() =>
-        render(() => {
-          const [localStore, setLocalStore] = createLocalStorage({
-            prefix: 'TanstackQueryDevtools',
-          })
-          return (
-            <QueryDevtoolsContext.Provider
-              value={{
-                client: queryClient,
-                queryFlavor: 'TanStack Query',
-                version: '5',
-                onlineManager,
-              }}
-            >
-              <PiPProvider
-                localStore={localStore}
-                setLocalStore={setLocalStore}
-              >
-                <Devtools
-                  localStore={localStore}
-                  setLocalStore={setLocalStore}
-                />
-              </PiPProvider>
-            </QueryDevtoolsContext.Provider>
-          )
-        }),
-      ).not.toThrow()
+    it('should fall back to the "dark" theme when no "ThemeContext.Provider" wraps it', () => {
+      let resolvedTheme: ReturnType<ReturnType<typeof useTheme>> | undefined
+      function ThemeProbe() {
+        const theme = useTheme()
+        resolvedTheme = theme()
+        return null
+      }
+
+      const rendered = render(() => {
+        const [localStore, setLocalStore] = createLocalStorage({
+          prefix: 'TanstackQueryDevtools',
+        })
+        return (
+          <QueryDevtoolsContext.Provider
+            value={{
+              client: queryClient,
+              queryFlavor: 'TanStack Query',
+              version: '5',
+              onlineManager,
+            }}
+          >
+            <PiPProvider localStore={localStore} setLocalStore={setLocalStore}>
+              <Devtools localStore={localStore} setLocalStore={setLocalStore} />
+              <ThemeProbe />
+            </PiPProvider>
+          </QueryDevtoolsContext.Provider>
+        )
+      })
+
+      expect(resolvedTheme).toBe('dark')
+      expect(
+        rendered.getByLabelText('Open Tanstack query devtools'),
+      ).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Strengthen the case added in #10785: the previous assertion only verified that mounting `Devtools` without a `ThemeContext.Provider` does not throw, which would still pass even if the default value were `'light'` or anything else.

Mount a small `ThemeProbe` next to `Devtools` that reads `useTheme()` directly, then assert the resolved theme is `'dark'`. Also assert the trigger button is in the document so the case still covers the `Devtools` render path that hits the default accessor (`ThemeContext.ts` L5).

`resolvedTheme` is typed as `ReturnType<ReturnType<typeof useTheme>> | undefined` so the union stays in sync with the `ThemeContext` definition without duplicating the `'light' | 'dark'` literal.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite to verify default theme resolution falls back to 'dark' and the devtools button renders correctly without explicit theme configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->