### PR TITLE
test(query-devtools/contexts/ThemeContext): split 'ThemeContext' tests into a unit test file mirroring the 'src/contexts' structure

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -3,12 +3,7 @@ import { QueryClient, QueryObserver, onlineManager } from '@tanstack/query-core'
 import { fireEvent, render } from '@solidjs/testing-library'
 import { createLocalStorage } from '@solid-primitives/storage'
 import { Devtools } from '../Devtools'
-import {
-  PiPProvider,
-  QueryDevtoolsContext,
-  ThemeContext,
-  useTheme,
-} from '../contexts'
+import { PiPProvider, QueryDevtoolsContext, ThemeContext } from '../contexts'
 import type { QueryDevtoolsProps } from '../contexts'
 
 // `solid-transition-group` internally imports from
@@ -1519,43 +1514,6 @@ describe('Devtools', () => {
       expect(
         rendered.queryByLabelText('Tanstack query devtools'),
       ).not.toBeInTheDocument()
-    })
-  })
-
-  describe('default theme', () => {
-    it('should fall back to the "dark" theme when no "ThemeContext.Provider" wraps it', () => {
-      let resolvedTheme: ReturnType<ReturnType<typeof useTheme>> | undefined
-      function ThemeProbe() {
-        const theme = useTheme()
-        resolvedTheme = theme()
-        return null
-      }
-
-      const rendered = render(() => {
-        const [localStore, setLocalStore] = createLocalStorage({
-          prefix: 'TanstackQueryDevtools',
-        })
-        return (
-          <QueryDevtoolsContext.Provider
-            value={{
-              client: queryClient,
-              queryFlavor: 'TanStack Query',
-              version: '5',
-              onlineManager,
-            }}
-          >
-            <PiPProvider localStore={localStore} setLocalStore={setLocalStore}>
-              <Devtools localStore={localStore} setLocalStore={setLocalStore} />
-              <ThemeProbe />
-            </PiPProvider>
-          </QueryDevtoolsContext.Provider>
-        )
-      })
-
-      expect(resolvedTheme).toBe('dark')
-      expect(
-        rendered.getByLabelText('Open Tanstack query devtools'),
-      ).toBeInTheDocument()
     })
   })
 })

--- a/packages/query-devtools/src/__tests__/contexts/ThemeContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/ThemeContext.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@solidjs/testing-library'
+import { createEffect, createSignal } from 'solid-js'
+import { ThemeContext, useTheme } from '../../contexts'
+
+type Theme = ReturnType<ReturnType<typeof useTheme>>
+
+function renderThemeProbe(provider?: () => Theme) {
+  let resolvedTheme: Theme | undefined
+  function ThemeProbe() {
+    const theme = useTheme()
+    resolvedTheme = theme()
+    return null
+  }
+
+  render(() =>
+    provider ? (
+      <ThemeContext.Provider value={provider}>
+        <ThemeProbe />
+      </ThemeContext.Provider>
+    ) : (
+      <ThemeProbe />
+    ),
+  )
+
+  return resolvedTheme
+}
+
+describe('ThemeContext', () => {
+  describe('default value', () => {
+    it('should resolve to "dark" when no "ThemeContext.Provider" wraps the consumer', () => {
+      expect(renderThemeProbe()).toBe('dark')
+    })
+  })
+
+  describe('with a "ThemeContext.Provider"', () => {
+    it('should resolve to the value provided by the "Provider"', () => {
+      expect(renderThemeProbe(() => 'light')).toBe('light')
+      expect(renderThemeProbe(() => 'dark')).toBe('dark')
+    })
+
+    it('should reflect updates when the "Provider" value is a reactive "Accessor"', () => {
+      const [theme, setTheme] = createSignal<Theme>('dark')
+      let observed: Theme | undefined
+      function ThemeProbe() {
+        const resolved = useTheme()
+        createEffect(() => {
+          observed = resolved()
+        })
+        return null
+      }
+
+      render(() => (
+        <ThemeContext.Provider value={theme}>
+          <ThemeProbe />
+        </ThemeContext.Provider>
+      ))
+
+      expect(observed).toBe('dark')
+
+      setTheme('light')
+      expect(observed).toBe('light')
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Move the `ThemeContext` module-level case added in #10786 out of `Devtools.test.tsx` into a dedicated `src/__tests__/contexts/ThemeContext.test.tsx`, mirroring the `src/contexts` directory layout. The settings-menu Theme UI cases stay in `Devtools.test.tsx` because they exercise the `Devtools` dropdown menu and `localStorage` persistence, not the `ThemeContext` module itself.

Drop the `QueryDevtoolsContext` + `PiPProvider` + `Devtools` mount boilerplate and replace it with a small `renderThemeProbe` helper that mounts only a `ThemeProbe` consumer.

The new file covers the three behaviors that make up the `ThemeContext` module's contract:

- `default value`: resolves to `'dark'` when no `ThemeContext.Provider` wraps the consumer.
- `with a "ThemeContext.Provider"` → value resolution: resolves to the value provided by the `Provider` (`'light'` / `'dark'`).
- `with a "ThemeContext.Provider"` → reactive `Accessor`: reflects updates when the `Provider` value is a reactive `Accessor`, which is the production pattern that motivates `createContext<Accessor<…>>`.

A local `type Theme = ReturnType<ReturnType<typeof useTheme>>` keeps every `'light' | 'dark'` literal in sync with the `ThemeContext` definition.

Coverage:
- `src/contexts/ThemeContext.ts`: **100%** (Stmts / Branch / Funcs / Lines) from this file alone.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced theme context test coverage with additional scenarios for reactive updates and provider configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->