### PR TITLE
feat(useMutationState): add TMutation generic to propagate mutation types into select callback

### DIFF
--- a/.changeset/usemutationstate-generic-tmutation.md
+++ b/.changeset/usemutationstate-generic-tmutation.md
@@ -1,0 +1,10 @@
+---
+"@tanstack/react-query": patch
+"@tanstack/vue-query": patch
+"@tanstack/solid-query": patch
+"@tanstack/svelte-query": patch
+"@tanstack/preact-query": patch
+"@tanstack/lit-query": patch
+---
+
+feat(useMutationState): add TMutation generic to propagate mutation types into select callback

--- a/.changeset/usemutationstate-generic-tmutation.md
+++ b/.changeset/usemutationstate-generic-tmutation.md
@@ -1,10 +1,10 @@
 ---
-"@tanstack/react-query": patch
-"@tanstack/vue-query": patch
-"@tanstack/solid-query": patch
-"@tanstack/svelte-query": patch
-"@tanstack/preact-query": patch
-"@tanstack/lit-query": patch
+"@tanstack/react-query": minor
+"@tanstack/vue-query": minor
+"@tanstack/solid-query": minor
+"@tanstack/svelte-query": minor
+"@tanstack/preact-query": minor
+"@tanstack/lit-query": minor
 ---
 
 feat(useMutationState): add TMutation generic to propagate mutation types into select callback

--- a/packages/lit-query/src/useMutationState.ts
+++ b/packages/lit-query/src/useMutationState.ts
@@ -16,7 +16,17 @@ import { BaseController } from './controllers/BaseController.js'
 /**
  * Options accepted by `useMutationState`.
  */
-export type MutationStateOptions<TResult, TMutation extends Mutation<any, any, any, any> = Mutation> = {
+export type MutationStateOptions<
+  TResult,
+  /**
+   * Narrows the type of the `mutation` argument passed to `select`.
+   * This is a caller-side assertion — the mutation cache stores mutations as
+   * the base `Mutation` type, so it is the caller's responsibility to ensure
+   * `TMutation` matches the actual mutations in the cache (e.g. by specifying
+   * a `mutationKey` in `filters`).
+   */
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+> = {
   /** Filters used to select mutations from the mutation cache. */
   filters?: Accessor<MutationFilters>
   /** Maps each matching mutation to the value returned by the accessor. */

--- a/packages/lit-query/src/useMutationState.ts
+++ b/packages/lit-query/src/useMutationState.ts
@@ -16,11 +16,11 @@ import { BaseController } from './controllers/BaseController.js'
 /**
  * Options accepted by `useMutationState`.
  */
-export type MutationStateOptions<TResult> = {
+export type MutationStateOptions<TResult, TMutation extends Mutation<any, any, any, any> = Mutation> = {
   /** Filters used to select mutations from the mutation cache. */
   filters?: Accessor<MutationFilters>
   /** Maps each matching mutation to the value returned by the accessor. */
-  select?: (mutation: Mutation) => TResult
+  select?: (mutation: TMutation) => TResult
 }
 
 /**
@@ -34,13 +34,13 @@ export type MutationStateAccessor<TResult> = ValueAccessor<TResult[]> & {
   destroy: () => void
 }
 
-class MutationStateController<TResult> extends BaseController<TResult[]> {
+class MutationStateController<TResult, TMutation extends Mutation<any, any, any, any> = Mutation> extends BaseController<TResult[]> {
   private queryClient: QueryClient | undefined
   private unsubscribe: (() => void) | undefined
 
   constructor(
     host: ReactiveControllerHost,
-    private readonly options: MutationStateOptions<TResult>,
+    private readonly options: MutationStateOptions<TResult, TMutation>,
     queryClient?: QueryClient,
   ) {
     super(host, [], queryClient)
@@ -143,7 +143,7 @@ class MutationStateController<TResult> extends BaseController<TResult[]> {
 
     return mutations.map((mutation) => {
       if (select) {
-        return select(mutation)
+        return select(mutation as unknown as TMutation)
       }
 
       return mutation.state as TResult
@@ -186,12 +186,13 @@ class MutationStateController<TResult> extends BaseController<TResult[]> {
  */
 export function useMutationState<
   TResult = MutationState<unknown, unknown, unknown, unknown>,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
 >(
   host: ReactiveControllerHost,
-  options: MutationStateOptions<TResult> = {},
+  options: MutationStateOptions<TResult, TMutation> = {},
   queryClient?: QueryClient,
 ): MutationStateAccessor<TResult> {
-  const controller = new MutationStateController(host, options, queryClient)
+  const controller = new MutationStateController<TResult, TMutation>(host, options, queryClient)
   return Object.assign(
     createValueAccessor(() => controller.current),
     {

--- a/packages/preact-query/src/useMutationState.ts
+++ b/packages/preact-query/src/useMutationState.ts
@@ -24,6 +24,13 @@ export function useIsMutating(
 
 type MutationStateOptions<
   TResult = MutationState,
+  /**
+   * Narrows the type of the `mutation` argument passed to `select`.
+   * This is a caller-side assertion — the mutation cache stores mutations as
+   * the base `Mutation` type, so it is the caller's responsibility to ensure
+   * `TMutation` matches the actual mutations in the cache (e.g. by specifying
+   * a `mutationKey` in `filters`).
+   */
   TMutation extends Mutation<any, any, any, any> = Mutation,
 > = {
   filters?: MutationFilters

--- a/packages/preact-query/src/useMutationState.ts
+++ b/packages/preact-query/src/useMutationState.ts
@@ -22,25 +22,33 @@ export function useIsMutating(
   ).length
 }
 
-type MutationStateOptions<TResult = MutationState> = {
+type MutationStateOptions<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+> = {
   filters?: MutationFilters
-  select?: (mutation: Mutation) => TResult
+  select?: (mutation: TMutation) => TResult
 }
 
-function getResult<TResult = MutationState>(
+function getResult<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation>(
   mutationCache: MutationCache,
-  options: MutationStateOptions<TResult>,
+  options: MutationStateOptions<TResult, TMutation>,
 ): Array<TResult> {
   return mutationCache
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select ? options.select(mutation) : mutation.state) as TResult,
+        (options.select
+          ? options.select(mutation as unknown as TMutation)
+          : mutation.state) as TResult,
     )
 }
 
-export function useMutationState<TResult = MutationState>(
-  options: MutationStateOptions<TResult> = {},
+export function useMutationState<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+>(
+  options: MutationStateOptions<TResult, TMutation> = {},
   queryClient?: QueryClient,
 ): Array<TResult> {
   const mutationCache = useQueryClient(queryClient).getMutationCache()

--- a/packages/react-query/src/__tests__/useMutationState.test-d.tsx
+++ b/packages/react-query/src/__tests__/useMutationState.test-d.tsx
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { useMutationState } from '../useMutationState'
-import type { MutationState, MutationStatus } from '@tanstack/query-core'
+import type { Mutation, MutationState, MutationStatus } from '@tanstack/query-core'
 
 describe('useMutationState', () => {
   it('should default to QueryState', () => {
@@ -19,5 +19,32 @@ describe('useMutationState', () => {
     })
 
     expectTypeOf(result).toEqualTypeOf<Array<MutationStatus>>()
+  })
+  it('should propagate TMutation generics into select callback', () => {
+    type MyData = { id: number }
+    type MyError = { code: number }
+    type MyVariables = { name: string }
+
+    const result = useMutationState<
+      MutationState<MyData, MyError, MyVariables>,
+      Mutation<MyData, MyError, MyVariables>
+    >({
+      filters: { mutationKey: ['key'] },
+      select: (mutation) => {
+        expectTypeOf(mutation).toEqualTypeOf<
+          Mutation<MyData, MyError, MyVariables>
+        >()
+        expectTypeOf(mutation.state.data).toEqualTypeOf<MyData | undefined>()
+        expectTypeOf(mutation.state.error).toEqualTypeOf<MyError | null>()
+        expectTypeOf(mutation.state.variables).toEqualTypeOf<
+          MyVariables | undefined
+        >()
+        return mutation.state
+      },
+    })
+
+    expectTypeOf(result).toEqualTypeOf<
+      Array<MutationState<MyData, MyError, MyVariables>>
+    >()
   })
 })

--- a/packages/react-query/src/useMutationState.ts
+++ b/packages/react-query/src/useMutationState.ts
@@ -22,25 +22,33 @@ export function useIsMutating(
   ).length
 }
 
-type MutationStateOptions<TResult = MutationState> = {
+type MutationStateOptions<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+> = {
   filters?: MutationFilters
-  select?: (mutation: Mutation) => TResult
+  select?: (mutation: TMutation) => TResult
 }
 
-function getResult<TResult = MutationState>(
+function getResult<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation>(
   mutationCache: MutationCache,
-  options: MutationStateOptions<TResult>,
+  options: MutationStateOptions<TResult, TMutation>,
 ): Array<TResult> {
   return mutationCache
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select ? options.select(mutation) : mutation.state) as TResult,
+        (options.select
+          ? options.select(mutation as unknown as TMutation)
+          : mutation.state) as TResult,
     )
 }
 
-export function useMutationState<TResult = MutationState>(
-  options: MutationStateOptions<TResult> = {},
+export function useMutationState<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+>(
+  options: MutationStateOptions<TResult, TMutation> = {},
   queryClient?: QueryClient,
 ): Array<TResult> {
   const mutationCache = useQueryClient(queryClient).getMutationCache()

--- a/packages/solid-query/src/useMutationState.ts
+++ b/packages/solid-query/src/useMutationState.ts
@@ -10,25 +10,33 @@ import type {
 import type { Accessor } from 'solid-js'
 import type { QueryClient } from './QueryClient'
 
-type MutationStateOptions<TResult = MutationState> = {
+type MutationStateOptions<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+> = {
   filters?: MutationFilters
-  select?: (mutation: Mutation) => TResult
+  select?: (mutation: TMutation) => TResult
 }
 
-function getResult<TResult = MutationState>(
+function getResult<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation>(
   mutationCache: MutationCache,
-  options: MutationStateOptions<TResult>,
+  options: MutationStateOptions<TResult, TMutation>,
 ): Array<TResult> {
   return mutationCache
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select ? options.select(mutation) : mutation.state) as TResult,
+        (options.select
+          ? options.select(mutation as unknown as TMutation)
+          : mutation.state) as TResult,
     )
 }
 
-export function useMutationState<TResult = MutationState>(
-  options: Accessor<MutationStateOptions<TResult>> = () => ({}),
+export function useMutationState<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+>(
+  options: Accessor<MutationStateOptions<TResult, TMutation>> = () => ({}),
   queryClient?: Accessor<QueryClient>,
 ): Accessor<Array<TResult>> {
   const client = createMemo(() => useQueryClient(queryClient?.()))

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -139,6 +139,13 @@ export type CreateMutationResult<
 /** Options for useMutationState */
 export type MutationStateOptions<
   TResult = MutationState,
+  /**
+   * Narrows the type of the `mutation` argument passed to `select`.
+   * This is a caller-side assertion — the mutation cache stores mutations as
+   * the base `Mutation` type, so it is the caller's responsibility to ensure
+   * `TMutation` matches the actual mutations in the cache (e.g. by specifying
+   * a `mutationKey` in `filters`).
+   */
   TMutation extends Mutation<any, any, any, any> = Mutation,
 > = {
   filters?: MutationFilters

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -137,11 +137,12 @@ export type CreateMutationResult<
 > = CreateBaseMutationResult<TData, TError, TVariables, TOnMutateResult>
 
 /** Options for useMutationState */
-export type MutationStateOptions<TResult = MutationState> = {
+export type MutationStateOptions<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+> = {
   filters?: MutationFilters
-  select?: (
-    mutation: Mutation<unknown, DefaultError, unknown, unknown>,
-  ) => TResult
+  select?: (mutation: TMutation) => TResult
 }
 
 export type QueryClientProviderProps = {

--- a/packages/svelte-query/src/useMutationState.svelte.ts
+++ b/packages/svelte-query/src/useMutationState.svelte.ts
@@ -1,26 +1,32 @@
 import { replaceEqualDeep } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient.js'
 import type {
+  Mutation,
   MutationCache,
   MutationState,
   QueryClient,
 } from '@tanstack/query-core'
 import type { MutationStateOptions } from './types.js'
 
-function getResult<TResult = MutationState>(
+function getResult<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation>(
   mutationCache: MutationCache,
-  options: MutationStateOptions<TResult>,
+  options: MutationStateOptions<TResult, TMutation>,
 ): Array<TResult> {
   return mutationCache
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select ? options.select(mutation) : mutation.state) as TResult,
+        (options.select
+          ? options.select(mutation as unknown as TMutation)
+          : mutation.state) as TResult,
     )
 }
 
-export function useMutationState<TResult = MutationState>(
-  options: MutationStateOptions<TResult> = {},
+export function useMutationState<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+>(
+  options: MutationStateOptions<TResult, TMutation> = {},
   queryClient?: QueryClient,
 ): Array<TResult> {
   const mutationCache = useQueryClient(queryClient).getMutationCache()

--- a/packages/vue-query/src/useMutationState.ts
+++ b/packages/vue-query/src/useMutationState.ts
@@ -48,27 +48,35 @@ export function useIsMutating(
   return length
 }
 
-export type MutationStateOptions<TResult = MutationState> = {
+export type MutationStateOptions<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+> = {
   filters?: MutationFilters
-  select?: (mutation: Mutation) => TResult
+  select?: (mutation: TMutation) => TResult
 }
 
-function getResult<TResult = MutationState>(
+function getResult<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation>(
   mutationCache: MutationCache,
-  options: MutationStateOptions<TResult>,
+  options: MutationStateOptions<TResult, TMutation>,
 ): Array<TResult> {
   return mutationCache
     .findAll(options.filters)
     .map(
       (mutation): TResult =>
-        (options.select ? options.select(mutation) : mutation.state) as TResult,
+        (options.select
+          ? options.select(mutation as unknown as TMutation)
+          : mutation.state) as TResult,
     )
 }
 
-export function useMutationState<TResult = MutationState>(
+export function useMutationState<
+  TResult = MutationState,
+  TMutation extends Mutation<any, any, any, any> = Mutation,
+>(
   options:
-    | MutationStateOptions<TResult>
-    | (() => MutationStateOptions<TResult>) = {},
+    | MutationStateOptions<TResult, TMutation>
+    | (() => MutationStateOptions<TResult, TMutation>) = {},
   queryClient?: QueryClient,
 ): Readonly<Ref<Array<TResult>>> {
   const resolvedOptions = computed(() => {


### PR DESCRIPTION
## Summary

Fixes #9825

The `mutation` argument in the `select` callback of `useMutationState` always had type `Mutation<unknown, Error, unknown, unknown>`, losing any specific type information and requiring manual casts.

### Before

```ts
// ❌ mutation argument in select is always Mutation<unknown, Error, unknown, unknown>
// → manual cast required to access typed state
const result = useMutationState({
  filters: { mutationKey: ['KEY'] },
  select: (mutation) =>
    mutation.state as MutationState<MyData, MyError, MyVars>,
})
```

### After

```ts
// ✅ specifying TMutation resolves the type inside select
const result = useMutationState<
  MutationState<MyData, MyError, MyVars>,
  Mutation<MyData, MyError, MyVars>
>({
  filters: { mutationKey: ['KEY'] },
  select: (mutation) => mutation.state, // mutation is Mutation<MyData, MyError, MyVars>
})
```

### Changes

- Added `TMutation extends Mutation<any, any, any, any> = Mutation` generic to `MutationStateOptions` and `useMutationState` in all framework adapters:
  - `react-query`
  - `vue-query`
  - `solid-query`
  - `svelte-query`
  - `preact-query`
  - `lit-query`
- Added type test to `react-query` verifying that `TMutation` generics propagate correctly into the `select` callback
- The second generic parameter defaults to `Mutation` so **existing usage is fully backward compatible**

### Type safety note

`TMutation` is a caller-side assertion. `mutationCache.findAll()` always returns the base `Mutation` type, so the cast `mutation as unknown as TMutation` is type-only and erased at runtime. It is the caller's responsibility to ensure `TMutation` matches the actual mutations in the cache (e.g. by also specifying `mutationKey` in `filters`).

## Test plan

- [x] `npx nx run @tanstack/react-query:test:lib` — all runtime tests pass
- [x] `npx nx run @tanstack/react-query:test:types` — type tests pass on TS 5.4 through 6.0
- [x] New type test added: `useMutationState.test-d.tsx` — "should propagate TMutation generics into select callback"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
