### PR TITLE
test(query-devtools/contexts/QueryDevtoolsContext): add test for 'Provider' value reactivity via getter properties

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/QueryDevtoolsContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/QueryDevtoolsContext.test.tsx
@@ -2,10 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { render } from '@solidjs/testing-library'
 import { createEffect, createSignal } from 'solid-js'
 import { QueryClient, onlineManager } from '@tanstack/query-core'
-import {
-  QueryDevtoolsContext,
-  useQueryDevtoolsContext,
-} from '../../contexts'
+import { QueryDevtoolsContext, useQueryDevtoolsContext } from '../../contexts'
 
 describe('QueryDevtoolsContext', () => {
   it('should reflect updates when the "Provider" value exposes a reactive getter', () => {

--- a/packages/query-devtools/src/__tests__/contexts/QueryDevtoolsContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/QueryDevtoolsContext.test.tsx
@@ -37,5 +37,8 @@ describe('QueryDevtoolsContext', () => {
 
     setClient(nextClient)
     expect(observed).toEqual([initialClient, nextClient])
+
+    initialClient.clear()
+    nextClient.clear()
   })
 })

--- a/packages/query-devtools/src/__tests__/contexts/QueryDevtoolsContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/QueryDevtoolsContext.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@solidjs/testing-library'
+import { createEffect, createSignal } from 'solid-js'
+import { QueryClient, onlineManager } from '@tanstack/query-core'
+import {
+  QueryDevtoolsContext,
+  useQueryDevtoolsContext,
+} from '../../contexts'
+
+describe('QueryDevtoolsContext', () => {
+  it('should reflect updates when the "Provider" value exposes a reactive getter', () => {
+    const initialClient = new QueryClient()
+    const nextClient = new QueryClient()
+    const [client, setClient] = createSignal(initialClient)
+    const observed: Array<QueryClient> = []
+    function ContextProbe() {
+      const ctx = useQueryDevtoolsContext()
+      createEffect(() => {
+        observed.push(ctx.client)
+      })
+      return null
+    }
+
+    render(() => (
+      <QueryDevtoolsContext.Provider
+        value={{
+          queryFlavor: 'TanStack Query',
+          version: '5',
+          onlineManager,
+          get client() {
+            return client()
+          },
+        }}
+      >
+        <ContextProbe />
+      </QueryDevtoolsContext.Provider>
+    ))
+
+    expect(observed).toEqual([initialClient])
+
+    setClient(nextClient)
+    expect(observed).toEqual([initialClient, nextClient])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add a dedicated `src/__tests__/contexts/QueryDevtoolsContext.test.tsx` mirroring the `src/contexts` directory layout (matching the `ThemeContext.test.tsx` split from #10787).

The file locks down the one behavior that the module adds on top of `solid-js`'s context primitives: a `Provider` value whose fields are reactive getters must propagate signal updates to consumers — the pattern that `TanstackQueryDevtools` uses (`get client() { return client() }`) to flow `setClient` / `setTheme` / `setErrorTypes` etc. into the rendered `Devtools`.

A bare value pass-through case and a default-value case were considered but dropped because they would only exercise `solid-js` itself, not anything the module contributes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test suite for QueryDevtoolsContext that verifies consumers observe reactive updates to the context's client, confirms the client value updates as expected, and ensures proper client cleanup after changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->