### PR TITLE
test(query-devtools/contexts/ThemeContext): drop the 'Provider' value pass-through case in favor of the reactive 'Accessor' case

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/ThemeContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/ThemeContext.test.tsx
@@ -5,47 +5,30 @@ import { ThemeContext, useTheme } from '../../contexts'
 
 type Theme = ReturnType<ReturnType<typeof useTheme>>
 
-function renderThemeProbe(provider?: () => Theme) {
-  let resolvedTheme: Theme | undefined
-  function ThemeProbe() {
-    const theme = useTheme()
-    resolvedTheme = theme()
-    return null
-  }
-
-  render(() =>
-    provider ? (
-      <ThemeContext.Provider value={provider}>
-        <ThemeProbe />
-      </ThemeContext.Provider>
-    ) : (
-      <ThemeProbe />
-    ),
-  )
-
-  return resolvedTheme
-}
-
 describe('ThemeContext', () => {
   describe('default value', () => {
     it('should resolve to "dark" when no "ThemeContext.Provider" wraps the consumer', () => {
-      expect(renderThemeProbe()).toBe('dark')
+      let resolvedTheme: Theme | undefined
+      function ThemeProbe() {
+        const theme = useTheme()
+        resolvedTheme = theme()
+        return null
+      }
+
+      render(() => <ThemeProbe />)
+
+      expect(resolvedTheme).toBe('dark')
     })
   })
 
   describe('with a "ThemeContext.Provider"', () => {
-    it('should resolve to the value provided by the "Provider"', () => {
-      expect(renderThemeProbe(() => 'light')).toBe('light')
-      expect(renderThemeProbe(() => 'dark')).toBe('dark')
-    })
-
     it('should reflect updates when the "Provider" value is a reactive "Accessor"', () => {
       const [theme, setTheme] = createSignal<Theme>('dark')
-      let observed: Theme | undefined
+      const observed: Array<Theme> = []
       function ThemeProbe() {
         const resolved = useTheme()
         createEffect(() => {
-          observed = resolved()
+          observed.push(resolved())
         })
         return null
       }
@@ -56,10 +39,10 @@ describe('ThemeContext', () => {
         </ThemeContext.Provider>
       ))
 
-      expect(observed).toBe('dark')
+      expect(observed).toEqual(['dark'])
 
       setTheme('light')
-      expect(observed).toBe('light')
+      expect(observed).toEqual(['dark', 'light'])
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Drop the `should resolve to the value provided by the "Provider"` case added in #10787 — it only re-asserts the `solid-js` context primitive (a `Provider` value flows through `useContext`), which is not behavior our module contributes.

The remaining cases each lock down a design choice that is ours, not `solid-js`'s:

- `default value`: the default accessor returns `'dark'`. Choosing `'dark'` (vs. `'light'` or `undefined`) is the module's decision, and `useTheme` is exported so callers outside a `Provider` rely on it.
- `with a "ThemeContext.Provider"` → reactive `Accessor`: typing the context value as `Accessor<'light' | 'dark'>` is the module's decision, and the assertions now record the full `observed` sequence so a future change that flattens the accessor or otherwise breaks reactivity fails loudly.

Also inline the small `renderThemeProbe` helper — it was only reachable from the `default value` case once the pass-through case was removed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved theme context test reliability with better test data capture and assertions.

---

**Note:** This release contains no user-facing changes. All updates are internal test maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->