### PR TITLE
test(query-devtools/contexts/PiPContext): add test for 'usePiPWindow' throwing outside a 'PiPProvider'

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@solidjs/testing-library'
+import { usePiPWindow } from '../../contexts'
+
+describe('PiPContext', () => {
+  describe('usePiPWindow', () => {
+    it('should throw when used outside a "PiPProvider"', () => {
+      function PiPProbe() {
+        usePiPWindow()
+        return null
+      }
+
+      expect(() => render(() => <PiPProbe />)).toThrow(
+        'usePiPWindow must be used within a PiPProvider',
+      )
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Open a `src/__tests__/contexts/PiPContext.test.tsx` (matching the `ThemeContext` / `QueryDevtoolsContext` splits from #10787 / #10793) with one case: `usePiPWindow` must throw outside a `PiPProvider`. This is the hand-written guard the module owns to surface a clear error instead of letting consumers read from a missing context.

Use the same `render` + probe-component pattern as the sibling context test files so the helper shape stays consistent across the directory. `usePiPWindow` wraps the context lookup in `createMemo`, which Solid evaluates immediately when the probe mounts, so the `render` call itself raises the error.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation ensuring `usePiPWindow` properly throws an error when invoked outside the required context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->