### PR TITLE
test(query-devtools/contexts/PiPContext): add tests for 'requestPipWindow' resetting the PiP document title, body margin, and head/body contents

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -108,5 +108,41 @@ describe('PiPContext', () => {
         'true',
       )
     })
+
+    it('should set the PiP document title to "TanStack Query Devtools"', () => {
+      const { pipDocument } = stubPipWindow()
+
+      renderAndAct((pip) => pip().requestPipWindow(640, 480))
+
+      expect(pipDocument.title).toBe('TanStack Query Devtools')
+    })
+
+    it('should reset the PiP document body margin to "0"', () => {
+      const { pipDocument } = stubPipWindow()
+
+      renderAndAct((pip) => pip().requestPipWindow(640, 480))
+
+      expect(pipDocument.body.style.margin).toMatch(/^0(px)?$/)
+    })
+
+    it('should clear any existing nodes in the PiP document "head"', () => {
+      const { pipDocument } = stubPipWindow()
+      pipDocument.head.appendChild(pipDocument.createElement('meta'))
+
+      renderAndAct((pip) => pip().requestPipWindow(640, 480))
+
+      expect(pipDocument.head.querySelector('meta')).toBeNull()
+    })
+
+    it('should clear any existing nodes in the PiP document "body"', () => {
+      const { pipDocument } = stubPipWindow()
+      const leftover = pipDocument.createElement('div')
+      leftover.id = 'leftover'
+      pipDocument.body.appendChild(leftover)
+
+      renderAndAct((pip) => pip().requestPipWindow(640, 480))
+
+      expect(pipDocument.body.querySelector('#leftover')).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Cover the four document-level setup steps that `requestPipWindow` performs after opening the PiP window:

- `should set the PiP document title to "TanStack Query Devtools"`: verifies the title the module chose for the popup tab/window.
- `should reset the PiP document body margin to "0"`: verifies the body margin reset that lets the devtools panel fill the popup.
- `should clear any existing nodes in the PiP document "head"`: verifies that residue from a reused window (browsers reuse popups by `name`) is wiped before the module installs its own styles.
- `should clear any existing nodes in the PiP document "body"`: same reasoning for body residue.

Each case asserts on the `pipDocument` returned by `stubPipWindow()` so the test only reads the values the module actually touches.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).