### PR TITLE
test(query-devtools/contexts/PiPContext): add tests for 'requestPipWindow' copying parent stylesheets into the PiP document head

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -145,4 +145,90 @@ describe('PiPContext', () => {
       expect(pipDocument.body.querySelector('#leftover')).toBeNull()
     })
   })
+
+  describe('styleSheet propagation', () => {
+    type FakeCssRule = { readonly cssText: string }
+    type FakeStyleSheet = {
+      readonly cssRules?: ArrayLike<FakeCssRule>
+      readonly href?: string | null
+      readonly type?: string
+      readonly media?: { toString: () => string }
+      readonly ownerNode?: Element | null
+    }
+
+    function makeCssRules(...cssTexts: Array<string>): ArrayLike<FakeCssRule> {
+      return cssTexts.map((cssText) => ({ cssText }))
+    }
+
+    function stubParentStyleSheet(sheet: FakeStyleSheet) {
+      return vi
+        .spyOn(document, 'styleSheets', 'get')
+        .mockReturnValue([sheet] as unknown as StyleSheetList)
+    }
+
+    it('should copy parent stylesheets as "<style>" with the same id into the PiP document head', () => {
+      const sourceStyle = document.createElement('style')
+      sourceStyle.id = 'tsqd-source'
+      const sheetSpy = stubParentStyleSheet({
+        cssRules: makeCssRules('.tsqd { color: red; }'),
+        ownerNode: sourceStyle,
+      })
+      const { pipDocument } = stubPipWindow()
+
+      try {
+        renderAndAct((pip) => pip().requestPipWindow(640, 480))
+
+        const copied = pipDocument.head.querySelector('style#tsqd-source')
+        expect(copied).not.toBeNull()
+        expect(copied?.textContent).toBe('.tsqd { color: red; }')
+      } finally {
+        sheetSpy.mockRestore()
+      }
+    })
+
+    it('should fall back to a "<link>" for cross-origin stylesheets whose "cssRules" throw', () => {
+      const sheetSpy = stubParentStyleSheet({
+        get cssRules(): CSSRuleList {
+          throw new DOMException('blocked', 'SecurityError')
+        },
+        href: 'https://example.com/external.css',
+        type: 'text/css',
+        media: { toString: () => 'all' },
+      })
+      const { pipDocument } = stubPipWindow()
+
+      try {
+        renderAndAct((pip) => pip().requestPipWindow(640, 480))
+
+        const link = pipDocument.head.querySelector<HTMLLinkElement>(
+          'link[href="https://example.com/external.css"]',
+        )
+        expect(link).not.toBeNull()
+        expect(link?.rel).toBe('stylesheet')
+      } finally {
+        sheetSpy.mockRestore()
+      }
+    })
+
+    it('should skip the "<link>" fallback when the cross-origin stylesheet has no "href"', () => {
+      const sheetSpy = stubParentStyleSheet({
+        get cssRules(): CSSRuleList {
+          throw new DOMException('blocked', 'SecurityError')
+        },
+        href: null,
+        type: 'text/css',
+        media: { toString: () => 'all' },
+      })
+      const { pipDocument } = stubPipWindow()
+
+      try {
+        renderAndAct((pip) => pip().requestPipWindow(640, 480))
+
+        expect(pipDocument.head.querySelector('link')).toBeNull()
+        expect(pipDocument.head.querySelector('style')).toBeNull()
+      } finally {
+        sheetSpy.mockRestore()
+      }
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Cover the three branches of the stylesheet copy loop in `requestPipWindow` (`PiPContext.tsx:85-117`) — the logic the module owns to make Devtools render styled inside the popup that wouldn't otherwise inherit any parent CSS:

- `should copy parent stylesheets as "<style>" with the same id into the PiP document head`: verifies the same-origin path — `cssText` is concatenated into a new `<style>` and the source `id` is propagated so goober's `#_goober` mirror keeps working.
- `should fall back to a "<link>" for cross-origin stylesheets whose "cssRules" throw`: verifies the cross-origin path — when reading `cssRules` raises (Google Fonts, CDN-served CSS), the module reattaches the same `href` as a `<link>` so the popup can still load it.
- `should skip the "<link>" fallback when the cross-origin stylesheet has no "href"`: verifies the `href == null` guard that prevents an empty `<link>` from being appended.

A small `stubParentStyleSheet(sheet)` helper plus a `FakeStyleSheet` type wraps `vi.spyOn(document, 'styleSheets', 'get')` so each case only declares the fields the production loop actually reads (`cssRules`, `href`, `type`, `media`, `ownerNode`). A `makeCssRules(...cssTexts)` helper builds the `ArrayLike` shape the production spread expects without an `as unknown as CSSRuleList` cast at the call sites.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for stylesheet propagation in Picture-in-Picture windows, ensuring styles are properly replicated when using the PiP feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->