### PR TITLE
test(query-devtools/contexts/PiPContext): add test for the 'pagehide' listener resetting the 'pipWindow' signal and 'pip_open'

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -4,26 +4,22 @@ import { createEffect } from 'solid-js'
 import { createLocalStorage } from '@solid-primitives/storage'
 import { PiPProvider, usePiPWindow } from '../../contexts'
 
-type FakePipWindow = Pick<
-  Window,
-  | 'document'
-  | 'innerWidth'
-  | 'innerHeight'
-  | 'addEventListener'
-  | 'removeEventListener'
-  | 'close'
->
+type FakePipWindowOverrides = {
+  document?: Document
+  innerWidth?: number
+  innerHeight?: number
+}
 
-function stubPipWindow(overrides: Partial<FakePipWindow> = {}) {
-  const pipDocument = document.implementation.createHTMLDocument('PiP')
-  const fakeWindow: FakePipWindow = {
+function stubPipWindow(overrides: FakePipWindowOverrides = {}) {
+  const pipDocument =
+    overrides.document ?? document.implementation.createHTMLDocument('PiP')
+  const fakeWindow = {
     document: pipDocument,
-    innerWidth: 800,
-    innerHeight: 600,
+    innerWidth: overrides.innerWidth ?? 800,
+    innerHeight: overrides.innerHeight ?? 600,
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
     close: vi.fn(),
-    ...overrides,
   }
   const open = vi.fn(() => fakeWindow)
   vi.stubGlobal('open', open)
@@ -37,13 +33,18 @@ describe('PiPContext', () => {
 
   function renderAndAct(
     action: (pip: ReturnType<typeof usePiPWindow>) => void,
+    options: { disabled?: boolean } = {},
   ) {
     render(() => {
       const [localStore, setLocalStore] = createLocalStorage({
         prefix: 'TanstackQueryDevtools',
       })
       return (
-        <PiPProvider localStore={localStore} setLocalStore={setLocalStore}>
+        <PiPProvider
+          localStore={localStore}
+          setLocalStore={setLocalStore}
+          disabled={options.disabled}
+        >
           <PiPActor run={action} />
         </PiPProvider>
       )
@@ -54,9 +55,13 @@ describe('PiPContext', () => {
     run: (pip: ReturnType<typeof usePiPWindow>) => void
   }) {
     const pip = usePiPWindow()
+    let hasRun = false
     createEffect(() => {
       pip()
-      props.run(pip)
+      if (!hasRun) {
+        hasRun = true
+        props.run(pip)
+      }
     })
     return null
   }
@@ -229,6 +234,31 @@ describe('PiPContext', () => {
       } finally {
         sheetSpy.mockRestore()
       }
+    })
+  })
+
+  describe('"pagehide" lifecycle', () => {
+    it('should reset the "pipWindow" signal and "pip_open" when the "pagehide" event fires on the opened window', () => {
+      const { fakeWindow } = stubPipWindow()
+      const observed: Array<Window | null> = []
+
+      renderAndAct(
+        (pip) => {
+          pip().requestPipWindow(640, 480)
+          observed.push(pip().pipWindow)
+          const pagehideHandler = fakeWindow.addEventListener.mock.calls.find(
+            ([event]) => event === 'pagehide',
+          )?.[1]
+          pagehideHandler?.()
+          observed.push(pip().pipWindow)
+        },
+        { disabled: true },
+      )
+
+      expect(observed).toEqual([fakeWindow, null])
+      expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
+        'false',
+      )
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Cover the lifecycle hook the module owns at `PiPContext.tsx:77-81`: the `pagehide` listener it attaches to the PiP window so that closing the popup from the OS / browser brings the in-page state back in sync.

Open the window via `requestPipWindow`, push `pip().pipWindow` into an `observed` array once after the open and once after invoking the captured `pagehide` handler directly, then assert the open → null transition together with the localStore flip:

- `observed` resolves to `[fakeWindow, null]` (proves both that `requestPipWindow` opened it and that `pagehide` flipped it back, so `<Show when={pip().pipWindow && …}>` stops mounting the Portal into a closed window).
- `localStorage['TanstackQueryDevtools.pip_open']` flips to `'false'` (so the `pip_open` createEffect doesn't auto-reopen the window the user just closed).

The case mounts with `{ disabled: true }` so the auto-open createEffect doesn't race the explicit `requestPipWindow` / `pagehide` sequence the test is exercising.

While here, two small helper-shape changes make the file easier to extend in the rest of the series:

- `FakePipWindow` was a `Pick<Window, …>`, which typed `addEventListener` as the real `EventListener` overload set and forced `as ReturnType<typeof vi.fn>` casts at every use site. Replace it with a narrow inferred shape from `vi.fn()`, dropping every cast in this file.
- `PiPActor` re-ran its action every time the inner memo invalidated, which made the auto-open + `pagehide` sequence loop forever. Gate the action behind a one-shot `hasRun` flag so it runs exactly once per mount — the previous cases all relied on `requestPipWindow`'s `pipWindow() != null` early-return for idempotency, which doesn't apply here.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).