### PR TITLE
test(query-devtools/contexts/PiPContext): add tests for 'closePipWindow' guard and reset

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -261,4 +261,49 @@ describe('PiPContext', () => {
       )
     })
   })
+
+  describe('"closePipWindow"', () => {
+    it('should be a noop when no window is open', () => {
+      const { fakeWindow } = stubPipWindow()
+
+      renderAndAct((pip) => {
+        pip().closePipWindow()
+      })
+
+      expect(fakeWindow.close).not.toHaveBeenCalled()
+    })
+
+    it('should call "close" on the opened window and reset the "pipWindow" signal', () => {
+      const { fakeWindow } = stubPipWindow()
+      const observed: Array<Window | null> = []
+
+      renderAndAct(
+        (pip) => {
+          pip().requestPipWindow(640, 480)
+          observed.push(pip().pipWindow)
+          pip().closePipWindow()
+          observed.push(pip().pipWindow)
+        },
+        { disabled: true },
+      )
+
+      expect(fakeWindow.close).toHaveBeenCalledTimes(1)
+      expect(observed).toEqual([fakeWindow, null])
+    })
+
+    it('should call "close" only once when "closePipWindow" runs twice in a row', () => {
+      const { fakeWindow } = stubPipWindow()
+
+      renderAndAct(
+        (pip) => {
+          pip().requestPipWindow(640, 480)
+          pip().closePipWindow()
+          pip().closePipWindow()
+        },
+        { disabled: true },
+      )
+
+      expect(fakeWindow.close).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Cover the public `closePipWindow` API the module exposes through `usePiPWindow().closePipWindow` (`PiPContext.tsx:40-46`). Devtools itself doesn't call it today, but it's part of the `PiPContextType` contract external integrators can call.

Three cases pin down the guard and the cleanup it owns:

- `should be a noop when no window is open`: verifies the `if (w != null)` guard that prevents a `null.close()` `TypeError` when there's no PiP window yet.
- `should call "close" on the opened window and reset the "pipWindow" signal`: verifies the happy path — `requestPipWindow` → `closePipWindow` calls `close` exactly once and the `pipWindow` accessor transitions from `fakeWindow` → `null` (asserted via the `observed` array, matching the `"pagehide" lifecycle` style).
- `should call "close" only once when "closePipWindow" runs twice in a row`: verifies the same guard from the post-close lifecycle phase — a second call after the signal is already `null` must stay a noop, protecting integrators against accidental double-invocation.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for the Picture-in-Picture window closing functionality, including edge cases such as closing when no window is open and handling multiple close calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->