### PR TITLE
test(query-devtools/contexts/PiPContext): add tests for the 'pip_open' auto-open createEffect

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -337,7 +337,10 @@ describe('PiPContext', () => {
     })
 
     it('should reset "pip_open"/"open" and log when "window.open" returns null on auto-open', () => {
-      vi.stubGlobal('open', vi.fn(() => null))
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => null),
+      )
       const consoleError = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {})

--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -29,12 +29,19 @@ function stubPipWindow(overrides: FakePipWindowOverrides = {}) {
 describe('PiPContext', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    localStorage.clear()
   })
 
   function renderAndAct(
     action: (pip: ReturnType<typeof usePiPWindow>) => void,
-    options: { disabled?: boolean } = {},
+    options: {
+      disabled?: boolean
+      initialStorage?: Record<string, string>
+    } = {},
   ) {
+    Object.entries(options.initialStorage ?? {}).forEach(([key, value]) => {
+      localStorage.setItem(key, value)
+    })
     render(() => {
       const [localStore, setLocalStore] = createLocalStorage({
         prefix: 'TanstackQueryDevtools',
@@ -304,6 +311,67 @@ describe('PiPContext', () => {
       )
 
       expect(fakeWindow.close).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('"pip_open" auto-open createEffect', () => {
+    it('should auto-open a PiP window when "pip_open" is "true" on mount', () => {
+      const { open } = stubPipWindow()
+
+      renderAndAct(() => {}, {
+        initialStorage: { 'TanstackQueryDevtools.pip_open': 'true' },
+      })
+
+      expect(open).toHaveBeenCalled()
+    })
+
+    it('should not auto-open a PiP window when "disabled" is true', () => {
+      const { open } = stubPipWindow()
+
+      renderAndAct(() => {}, {
+        disabled: true,
+        initialStorage: { 'TanstackQueryDevtools.pip_open': 'true' },
+      })
+
+      expect(open).not.toHaveBeenCalled()
+    })
+
+    it('should reset "pip_open"/"open" and log when "window.open" returns null on auto-open', () => {
+      vi.stubGlobal('open', vi.fn(() => null))
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      try {
+        renderAndAct(() => {}, {
+          initialStorage: { 'TanstackQueryDevtools.pip_open': 'true' },
+        })
+
+        expect(consoleError).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to open popup'),
+        )
+        expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
+          'false',
+        )
+        expect(localStorage.getItem('TanstackQueryDevtools.open')).toBe('false')
+      } finally {
+        consoleError.mockRestore()
+      }
+    })
+
+    it('should re-throw non-"PipOpenError" errors from "window.open" on auto-open', () => {
+      vi.stubGlobal(
+        'open',
+        vi.fn(() => {
+          throw new Error('unexpected')
+        }),
+      )
+
+      expect(() =>
+        renderAndAct(() => {}, {
+          initialStorage: { 'TanstackQueryDevtools.pip_open': 'true' },
+        }),
+      ).toThrow('unexpected')
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Cover the four branches of the auto-open `createEffect` at `PiPContext.tsx:136-154`. This is the effect that restores PiP state after a reload (and the one `DevtoolsPanelComponent` deliberately disables), so each branch maps to a real user / integrator scenario:

- `should auto-open a PiP window when "pip_open" is "true" on mount`: verifies the reload-restore path — `localStorage.pip_open === 'true'` triggers `requestPipWindow` (and therefore `window.open`) on the very first effect run.
- `should not auto-open a PiP window when "disabled" is true`: verifies the `disabled` short-circuit that `DevtoolsPanelComponent` relies on (`<PiPProvider disabled>` so the panel-only mode never auto-spawns a PiP popup).
- `should reset "pip_open"/"open" and log when "window.open" returns null on auto-open`: verifies the popup-blocker recovery path — `window.open` returning `null` makes `requestPipWindow` throw `PipOpenError`, which the effect catches, logs to `console.error`, and uses to reset both `pip_open` and `open` so the next reload doesn't loop into the same failure.
- `should re-throw non-"PipOpenError" errors from "window.open" on auto-open`: verifies that unexpected `window.open` failures (anything other than `PipOpenError`) are surfaced instead of being silently swallowed by the `try/catch`.

The `renderAndAct` helper gains a small `initialStorage` option (and a matching `localStorage.clear()` in `afterEach`) so each case can seed `pip_open` / `open` before mount without leaking state into siblings. The empty `action` callback is intentional — these cases assert on the effect that runs at mount, not on anything the actor does afterward.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by clearing storage state between test runs.
  * Extended test helper to support custom storage initialization.
  * Added comprehensive test coverage for auto-open behavior under various conditions and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->