### PR TITLE
test(query-devtools/contexts/PiPContext): add tests for the '#_goober' MutationObserver observing and mirroring parent style mutations

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -408,10 +408,9 @@ describe('PiPContext', () => {
       stubPipWindow()
 
       try {
-        renderAndAct(
-          (pip) => pip().requestPipWindow(640, 480),
-          { disabled: true },
-        )
+        renderAndAct((pip) => pip().requestPipWindow(640, 480), {
+          disabled: true,
+        })
 
         expect(observeSpy).toHaveBeenCalledWith(
           gooberStyle,
@@ -452,6 +451,5 @@ describe('PiPContext', () => {
         gooberStyle.remove()
       }
     })
-
   })
 })

--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -377,4 +377,81 @@ describe('PiPContext', () => {
       ).toThrow('unexpected')
     })
   })
+
+  describe('"#_goober" MutationObserver', () => {
+    function stubMutationObserver() {
+      let observerCallback: MutationCallback | undefined
+      const observeSpy = vi.fn()
+      const disconnectSpy = vi.fn()
+      class FakeMutationObserver {
+        observe = observeSpy
+        disconnect = disconnectSpy
+        takeRecords = () => []
+        constructor(cb: MutationCallback) {
+          observerCallback = cb
+        }
+      }
+      vi.stubGlobal('MutationObserver', FakeMutationObserver)
+      return {
+        observeSpy,
+        disconnectSpy,
+        fire: () => observerCallback?.([], {} as MutationObserver),
+      }
+    }
+
+    it('should observe the parent "#_goober" style for childList and subtree mutations', () => {
+      const gooberStyle = document.createElement('style')
+      gooberStyle.id = '_goober'
+      gooberStyle.textContent = '.initial { color: red; }'
+      document.head.appendChild(gooberStyle)
+      const { observeSpy } = stubMutationObserver()
+      stubPipWindow()
+
+      try {
+        renderAndAct(
+          (pip) => pip().requestPipWindow(640, 480),
+          { disabled: true },
+        )
+
+        expect(observeSpy).toHaveBeenCalledWith(
+          gooberStyle,
+          expect.objectContaining({ childList: true, subtree: true }),
+        )
+      } finally {
+        gooberStyle.remove()
+      }
+    })
+
+    it('should copy parent "#_goober" "textContent" into the PiP mirror when the observer fires', () => {
+      const gooberStyle = document.createElement('style')
+      gooberStyle.id = '_goober'
+      gooberStyle.textContent = '.initial { color: red; }'
+      document.head.appendChild(gooberStyle)
+      const { fire } = stubMutationObserver()
+      const { pipDocument } = stubPipWindow()
+
+      try {
+        const pipGooberStyle = pipDocument.createElement('style')
+        pipGooberStyle.id = '_goober'
+
+        renderAndAct(
+          (pip) => {
+            pip().requestPipWindow(640, 480)
+            // `requestPipWindow` clears the PiP document head, so install
+            // the goober mirror style after that point.
+            pipDocument.head.appendChild(pipGooberStyle)
+          },
+          { disabled: true },
+        )
+
+        gooberStyle.textContent = '.next { color: blue; }'
+        fire()
+
+        expect(pipGooberStyle.textContent).toBe('.next { color: blue; }')
+      } finally {
+        gooberStyle.remove()
+      }
+    })
+
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Cover the runtime style sync that keeps an open PiP window in step with goober's lazy CSS injection (`PiPContext.tsx:156-180`). Once the popup is open, any new CSS rule goober appends to the in-page `#_goober` style needs to flow into the PiP `#_goober` mirror, otherwise UI surfaces that render after the popup opens (e.g. a newly clicked query's detail panel) end up unstyled.

Two cases pin down the two responsibilities of the module's `createEffect`:

- `should observe the parent "#_goober" style for childList and subtree mutations`: asserts on `observe` arguments only — the target is the in-page `#_goober` style and the options include `childList: true` and `subtree: true`, so any descendant change reaches the callback.
- `should copy parent "#_goober" "textContent" into the PiP mirror when the observer fires`: drives the captured `MutationObserver` callback directly after mutating the parent `textContent`, then asserts the PiP mirror's `textContent` follows.

A small `stubMutationObserver` helper installs a fake `MutationObserver` that captures the callback and exposes spies plus a `fire()` helper, so each case stays focused on one contract instead of asserting on both responsibilities at once.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for style element synchronization in Picture-in-Picture mode, ensuring proper observer behavior and style consistency between the main document and PiP window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->