### PR TITLE
test(query-devtools/Devtools): remove PiP auto-open and popup-blocker cases now covered by 'PiPContext.test.tsx'

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -465,43 +465,6 @@ describe('Devtools', () => {
       )
     })
 
-    it('should automatically open a PiP window when "pip_open" is "true" in "localStorage"', () => {
-      const { open } = stubPipWindow()
-
-      renderDevtools(
-        { initialIsOpen: true },
-        { 'TanstackQueryDevtools.pip_open': 'true' },
-      )
-
-      expect(open).toHaveBeenCalled()
-    })
-
-    it('should log and reset "pip_open" when the browser blocks the popup', () => {
-      vi.stubGlobal(
-        'open',
-        vi.fn(() => null),
-      )
-      const consoleError = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-
-      try {
-        renderDevtools(
-          { initialIsOpen: true },
-          { 'TanstackQueryDevtools.pip_open': 'true' },
-        )
-
-        expect(consoleError).toHaveBeenCalledWith(
-          expect.stringContaining('Failed to open popup'),
-        )
-        expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
-          'false',
-        )
-      } finally {
-        consoleError.mockRestore()
-      }
-    })
-
     it('should hide the in-page panel while a PiP window is open', () => {
       stubPipWindow()
       const rendered = renderDevtools({ initialIsOpen: true })


### PR DESCRIPTION
## 🎯 Changes

The recent `PiPContext.test.tsx` series (#10797–#10804) re-covered two cases that previously lived in `Devtools.test.tsx`'s `picture-in-picture` describe at the wrong layer (they were exercising `PiPContext`'s `createEffect`, not anything `Devtools` itself does):

- `should automatically open a PiP window when "pip_open" is "true" in "localStorage"` — duplicated by `PiPContext.test.tsx` → `"pip_open" auto-open createEffect` → `should auto-open a PiP window when "pip_open" is "true" on mount`.
- `should log and reset "pip_open" when the browser blocks the popup` — duplicated by `PiPContext.test.tsx` → `"pip_open" auto-open createEffect` → `should reset "pip_open"/"open" and log when "window.open" returns null on auto-open`.

Drop both from `Devtools.test.tsx` so the auto-open `createEffect` is only asserted in the `PiPContext` unit file. Coverage for `PiPContext.tsx` stays at 100% / 95.23% (stmts / branch) and `Devtools.tsx` is unchanged, since the removed cases weren't exercising any `Devtools.tsx` line the surviving PiP cases don't already hit.

The remaining `picture-in-picture` describe keeps the cases that are genuinely about `Devtools` UI — opening the PiP via the button, hiding/restoring the in-page panel, and the narrow PiP layout.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test cases related to picture-in-picture functionality for the query devtools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->