### PR TITLE
test(query-devtools/Devtools): drop the 'pip_open' localStorage assertion from the PiP restore case now covered by 'PiPContext.test.tsx'

### DIFF
--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -478,7 +478,7 @@ describe('Devtools', () => {
       ).toBeNull()
     })
 
-    it('should restore the in-page panel and reset "pip_open" when the PiP window is closed', () => {
+    it('should restore the in-page panel when the PiP window is closed', () => {
       const { fire } = stubPipWindow()
       const rendered = renderDevtools({ initialIsOpen: true })
 
@@ -487,9 +487,6 @@ describe('Devtools', () => {
       )
       fire('pagehide')
 
-      expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
-        'false',
-      )
       expect(
         rendered.getByLabelText('Open in picture-in-picture mode'),
       ).toBeInTheDocument()


### PR DESCRIPTION
## 🎯 Changes

The `should restore the in-page panel and reset "pip_open" when the PiP window is closed` case asserted on two things that belonged to different layers:

- `localStorage["TanstackQueryDevtools.pip_open"] === "false"` — the `PiPContext` `pagehide` handler's side effect, now covered directly in `PiPContext.test.tsx` → `"pagehide" lifecycle` (#10801).
- `<button aria-label="Open in picture-in-picture mode">` is back in the document — the `Devtools` UI's reaction to `pip().pipWindow` flipping to `null`, which is the responsibility this file should be checking.

Drop the `localStorage` assertion (now redundant with `PiPContext.test.tsx`) and rename the case to match the single remaining responsibility (`should restore the in-page panel when the PiP window is closed`). `Devtools.tsx` coverage is unchanged and `PiPContext.tsx` stays at 100% / 95.23%.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated picture-in-picture mode test case to refine validation of control visibility after closing the PiP window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->