### PR TITLE
test(react-query-devtools/ReactQueryDevtools): add tests for forwarding 'buttonPosition' and 'position' props to the devtools instance

### DIFF
--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
@@ -66,7 +66,9 @@ describe('ReactQueryDevtools', () => {
     const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
     const queryClient = new QueryClient()
 
-    render(<ReactQueryDevtools client={queryClient} buttonPosition="top-left" />)
+    render(
+      <ReactQueryDevtools client={queryClient} buttonPosition="top-left" />,
+    )
 
     expect(setButtonPositionMock).toHaveBeenCalledWith('top-left')
   })

--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
@@ -62,6 +62,24 @@ describe('ReactQueryDevtools', () => {
     expect(mountMock).toHaveBeenCalled()
   })
 
+  it('should forward "buttonPosition" to the devtools instance', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<ReactQueryDevtools client={queryClient} buttonPosition="top-left" />)
+
+    expect(setButtonPositionMock).toHaveBeenCalledWith('top-left')
+  })
+
+  it('should forward "position" to the devtools instance', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<ReactQueryDevtools client={queryClient} position="left" />)
+
+    expect(setPositionMock).toHaveBeenCalledWith('left')
+  })
+
   it('should return null in non-development environments', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     vi.resetModules()


### PR DESCRIPTION
## 🎯 Changes

`ReactQueryDevtools` already had `setButtonPositionMock` / `setPositionMock` declared on the mocked `TanstackQueryDevtools`, but no case actually asserted on them — the existing tests only exercised the smoke paths (no `QueryClient`, context, props, production fallback). The two reactive effects that thread `buttonPosition` / `position` into the core devtools instance were entirely uncovered (`ReactQueryDevtools.tsx:93-97` and `:99-103`).

Wire the existing spies up by adding two adapter-responsibility cases:

- `should forward "buttonPosition" to the devtools instance`: renders `<ReactQueryDevtools buttonPosition="top-left" />` and asserts `setButtonPosition` is called with `'top-left'`, locking in the `if (buttonPosition) devtools.setButtonPosition(buttonPosition)` branch.
- `should forward "position" to the devtools instance`: same shape for the `position` prop / `setPosition` call, locking in the sibling effect.

The adapter is the boundary between the host framework and `@tanstack/query-devtools` core — pass-through wiring is exactly the responsibility a unit test for it should pin down, and this is the first case in the file that exercises that contract instead of just smoke-checking the render. Coverage for `ReactQueryDevtools.tsx` goes 91.66% → 100% statements / 70% → 90% branches.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for property forwarding in React Query Devtools, ensuring correct prop handling and data flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->