### PR TITLE
test(preact-query-devtools/PreactQueryDevtools): add tests for forwarding 'buttonPosition' and 'position' props to the devtools instance

### DIFF
--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -62,6 +62,26 @@ describe('PreactQueryDevtools', () => {
     expect(mountMock).toHaveBeenCalled()
   })
 
+  it('should forward "buttonPosition" to the devtools instance', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(
+      <PreactQueryDevtools client={queryClient} buttonPosition="top-left" />,
+    )
+
+    expect(setButtonPositionMock).toHaveBeenCalledWith('top-left')
+  })
+
+  it('should forward "position" to the devtools instance', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtools client={queryClient} position="left" />)
+
+    expect(setPositionMock).toHaveBeenCalledWith('left')
+  })
+
   it('should return null in non-development environments', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     vi.resetModules()


### PR DESCRIPTION
## 🎯 Changes

Mirrors the React adapter PR for the Preact adapter: `PreactQueryDevtools` already had `setButtonPositionMock` / `setPositionMock` declared on the mocked `TanstackQueryDevtools`, but no case actually asserted on them. The two reactive effects that thread `buttonPosition` / `position` into the core devtools instance (`PreactQueryDevtools.tsx:95-99` and `:101-105`) were entirely uncovered.

Add two adapter-responsibility cases that exercise the wiring contract:

- `should forward "buttonPosition" to the devtools instance`: renders `<PreactQueryDevtools buttonPosition="top-left" />` and asserts `setButtonPosition` is called with `'top-left'`, locking in the `if (buttonPosition) devtools.setButtonPosition(buttonPosition)` branch.
- `should forward "position" to the devtools instance`: same shape for the `position` prop / `setPosition` call.

This brings `PreactQueryDevtools.tsx` to 100% statements / 90% branches and keeps the adapter test surface in step with the matching React adapter PR.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for `PreactQueryDevtools` prop forwarding validation.

**Note:** This release contains internal test improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->