### PR TITLE
test(solid-query-devtools/devtools): add tests for forwarding 'buttonPosition' and 'position' props to the devtools instance

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
@@ -50,15 +50,10 @@ describe('SolidQueryDevtools', () => {
   })
 
   it('should forward "position" to the devtools instance', () => {
-    const setPosition = vi.spyOn(
-      TanstackQueryDevtools.prototype,
-      'setPosition',
-    )
+    const setPosition = vi.spyOn(TanstackQueryDevtools.prototype, 'setPosition')
     const queryClient = new QueryClient()
 
-    render(() => (
-      <SolidQueryDevtools client={queryClient} position="left" />
-    ))
+    render(() => <SolidQueryDevtools client={queryClient} position="left" />)
 
     expect(setPosition).toHaveBeenCalledWith('left')
   })

--- a/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@solidjs/testing-library'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
+import { TanstackQueryDevtools } from '@tanstack/query-devtools'
 import SolidQueryDevtools from '../devtools'
 
 describe('SolidQueryDevtools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('should throw an error if no query client has been set', () => {
     expect(() => render(() => <SolidQueryDevtools />)).toThrow(
       'No QueryClient set, use QueryClientProvider to set one',
@@ -28,5 +33,33 @@ describe('SolidQueryDevtools', () => {
     expect(() =>
       render(() => <SolidQueryDevtools client={queryClient} />),
     ).not.toThrow()
+  })
+
+  it('should forward "buttonPosition" to the devtools instance', () => {
+    const setButtonPosition = vi.spyOn(
+      TanstackQueryDevtools.prototype,
+      'setButtonPosition',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => (
+      <SolidQueryDevtools client={queryClient} buttonPosition="top-left" />
+    ))
+
+    expect(setButtonPosition).toHaveBeenCalledWith('top-left')
+  })
+
+  it('should forward "position" to the devtools instance', () => {
+    const setPosition = vi.spyOn(
+      TanstackQueryDevtools.prototype,
+      'setPosition',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => (
+      <SolidQueryDevtools client={queryClient} position="left" />
+    ))
+
+    expect(setPosition).toHaveBeenCalledWith('left')
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Mirrors the React (#10817) and Preact (#10818) adapter PRs for the Solid adapter. Until now `SolidQueryDevtools` only had smoke cases (no `QueryClient`, context, props); the two `createEffect`s that thread `buttonPosition` / `position` into the core devtools instance (`devtools.tsx:79-84` and `:86-91`) were entirely uncovered.

Because both \`solid-query-devtools\` and the underlying \`@tanstack/query-devtools\` are written in Solid, no module-level mock is needed — \`vi.spyOn(TanstackQueryDevtools.prototype, ...)\` observes the real instance while it runs:

- `should forward "buttonPosition" to the devtools instance`: spies on \`TanstackQueryDevtools.prototype.setButtonPosition\`, renders \`<SolidQueryDevtools buttonPosition="top-left" />\`, and asserts the spy was called with \`'top-left'\`, locking in the \`if (buttonPos) devtools.setButtonPosition(buttonPos)\` branch.
- `should forward "position" to the devtools instance`: same shape for the \`position\` prop / \`setPosition\` call.

An \`afterEach(vi.restoreAllMocks)\` resets the prototype spies between cases so the existing smoke cases stay isolated.

Coverage for \`devtools.tsx\` goes 93.33% → 100% statements / 71.42% → 85.71% branches / 92% → 100% lines.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage to verify proper prop forwarding in the devtools component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->