### PR TITLE
fix: retry error boundary queries on remount

### DIFF
--- a/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -294,7 +294,7 @@ describe('QueryErrorResetBoundary', () => {
       consoleMock.mockRestore()
     })
 
-    it('should not retry fetch if the reset error boundary has not been reset', async () => {
+    it('should retry fetch on remount even if the reset error boundary has not been reset', async () => {
       const consoleMock = vi
         .spyOn(console, 'error')
         .mockImplementation(() => undefined)
@@ -302,12 +302,14 @@ describe('QueryErrorResetBoundary', () => {
       const key = queryKey()
 
       let succeed = false
+      let fetchCount = 0
 
       function Page() {
         const { data } = useQuery({
           queryKey: key,
           queryFn: () =>
             sleep(10).then(() => {
+              fetchCount++
               if (!succeed) throw new Error('Error')
               return 'data'
             }),
@@ -350,7 +352,8 @@ describe('QueryErrorResetBoundary', () => {
 
       fireEvent.click(rendered.getByText('retry'))
       await vi.advanceTimersByTimeAsync(11)
-      expect(rendered.getByText('error boundary')).toBeInTheDocument()
+      expect(rendered.getByText('data')).toBeInTheDocument()
+      expect(fetchCount).toBe(2)
 
       consoleMock.mockRestore()
     })
@@ -419,7 +422,7 @@ describe('QueryErrorResetBoundary', () => {
       consoleMock.mockRestore()
     })
 
-    it('should not retry fetch if the reset error boundary has not been reset after a previous reset', async () => {
+    it('should retry fetch on remount if the reset error boundary has not been reset after a previous reset', async () => {
       const consoleMock = vi
         .spyOn(console, 'error')
         .mockImplementation(() => undefined)
@@ -486,13 +489,6 @@ describe('QueryErrorResetBoundary', () => {
 
       succeed = true
       shouldReset = false
-
-      fireEvent.click(rendered.getByText('retry'))
-      await vi.advanceTimersByTimeAsync(11)
-      expect(rendered.getByText('error boundary')).toBeInTheDocument()
-
-      succeed = true
-      shouldReset = true
 
       fireEvent.click(rendered.getByText('retry'))
       await vi.advanceTimersByTimeAsync(11)

--- a/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -483,6 +483,7 @@ describe('QueryErrorResetBoundary', () => {
       succeed = false
       shouldReset = true
 
+      fireEvent.click(rendered.getByText('retry'))
       await vi.advanceTimersByTimeAsync(11)
       expect(rendered.getByText('error boundary')).toBeInTheDocument()
       expect(rendered.getByText('retry')).toBeInTheDocument()

--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -37,8 +37,13 @@ export const ensurePreventErrorBoundaryRetry = <
     options.experimental_prefetchInRender ||
     throwOnError
   ) {
-    // Prevent retrying failed query if the error boundary has not been reset yet
-    if (!errorResetBoundary.isReset()) {
+    // Prevent retrying failed query if the error boundary has not been reset yet.
+    // Allow retries on a fresh mount after the error boundary has unmounted the
+    // failed observer.
+    if (
+      !errorResetBoundary.isReset() &&
+      (options.suspense || query?.getObserversCount())
+    ) {
       options.retryOnMount = false
     }
   }


### PR DESCRIPTION
Fixes #2712

## Summary
- Allow non-suspense error-boundary queries to retry on a fresh mount after the failed observer has been unmounted.
- Keep retry suppression while the failed observer is still mounted, and preserve the existing suspense error-boundary behavior.
- Update React Query error-boundary tests to cover retry-on-remount behavior.

## Validation
- `..\..\node_modules\.bin\vitest.CMD QueryResetErrorBoundary.test.tsx --run` from `packages\react-query` (14 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error boundary behavior refined so queries can retry on remount while respecting reset state.
  * Retry prevention now considers suspense mode and whether a query has active observers.

* **Tests**
  * Updated tests to assert retry-on-remount behavior and to track query execution counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->