### PR TITLE
test(solid-query-devtools/devtools): restore forwarding cases for 'buttonPosition' and 'position' props

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
@@ -35,6 +35,29 @@ describe('SolidQueryDevtools', () => {
     ).not.toThrow()
   })
 
+  it('should forward "buttonPosition" to the devtools instance', () => {
+    const setButtonPosition = vi.spyOn(
+      TanstackQueryDevtools.prototype,
+      'setButtonPosition',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => (
+      <SolidQueryDevtools client={queryClient} buttonPosition="top-left" />
+    ))
+
+    expect(setButtonPosition).toHaveBeenCalledWith('top-left')
+  })
+
+  it('should forward "position" to the devtools instance', () => {
+    const setPosition = vi.spyOn(TanstackQueryDevtools.prototype, 'setPosition')
+    const queryClient = new QueryClient()
+
+    render(() => <SolidQueryDevtools client={queryClient} position="left" />)
+
+    expect(setPosition).toHaveBeenCalledWith('left')
+  })
+
   it('should forward "initialIsOpen" to the devtools instance', () => {
     const setInitialIsOpen = vi.spyOn(
       TanstackQueryDevtools.prototype,


### PR DESCRIPTION
## 🎯 Changes

Restore the two forwarding test cases for `buttonPosition` and `position` that were inadvertently dropped while rewriting the suite in a previous PR.

Without these cases, the truthy branches of the two guarded `createEffect` blocks in `devtools.tsx` were not exercised (uncovered lines 82 and 89). Re-adding them brings `devtools.tsx` back to 100% statement coverage and 85.71% branch coverage, and keeps the wiring matrix consistent with the other `DevtoolsOptions` props.

- `buttonPosition="top-left"` → `setButtonPosition('top-left')`
- `position="left"` → `setPosition('left')`

Both cases use `vi.spyOn(TanstackQueryDevtools.prototype, ...)` so the real Solid devtools instance is constructed and mounted; only the setter calls are observed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying that `buttonPosition` and `position` configuration props are correctly forwarded to the underlying devtools component. Enhanced test suite ensures proper prop handling and confirms SolidQueryDevtools reliably passes customization options to its underlying implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->