### PR TITLE
fix(vue-query): replace deprecated isServer with environmentManager.isServer()

### DIFF
--- a/.changeset/tired-crews-pull.md
+++ b/.changeset/tired-crews-pull.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query': patch
+---
+
+Replace deprecated isServer with environmentManager.isServer()

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -1,5 +1,5 @@
 import { isVue2 } from 'vue-demi'
-import { isServer } from '@tanstack/query-core'
+import { environmentManager } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
 import { getClientKey } from './utils'
@@ -38,7 +38,7 @@ export const VueQueryPlugin = {
       client = new QueryClient(clientConfig)
     }
 
-    if (!isServer) {
+    if (!environmentManager.isServer()) {
       client.mount()
     }
 


### PR DESCRIPTION
## Summary
Fixes defect - #10821
Migrates `vue-query` from the deprecated `isServer` export to `environmentManager.isServer()`, matching the migration done for `react-query` and `preact-query` in #10199.

## 🎯 Changes
- Updated `packages/vue-query/src/vueQueryPlugin.ts` to import and use `environmentManager`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## Verification

- `npx nx run @tanstack/vue-query:test:lib` passes
- `pnpm run test:pr` passes
- `npx nx run @tanstack/vue-query:test:eslint` passes
- `npx nx run @tanstack/vue-query:test:libs` passes
- `npx nx run @tanstack/vue-query:test:types` passes
- No behavior change; this is a pure API migration

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal server-environment detection logic to use the updated mechanism.

* **Chores**
  * Updated an internal dependency to a patch release and removed a deprecated reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->