### PR TITLE
test(solid-query-devtools/devtoolsPanel): add wiring and default-value cases for 'onClose', 'errorTypes', 'theme', 'setClient', and 'unmount'

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@solidjs/testing-library'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
+import { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
 import SolidQueryDevtoolsPanel from '../devtoolsPanel'
 
 describe('SolidQueryDevtoolsPanel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('should throw an error if no query client has been set', () => {
     expect(() => render(() => <SolidQueryDevtoolsPanel />)).toThrow(
       'No QueryClient set, use QueryClientProvider to set one',
@@ -28,5 +33,112 @@ describe('SolidQueryDevtoolsPanel', () => {
     expect(() =>
       render(() => <SolidQueryDevtoolsPanel client={queryClient} />),
     ).not.toThrow()
+  })
+
+  it('should forward "onClose" to the devtools instance', () => {
+    const setOnClose = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'setOnClose',
+    )
+    const queryClient = new QueryClient()
+    const onClose = vi.fn()
+
+    render(() => (
+      <SolidQueryDevtoolsPanel client={queryClient} onClose={onClose} />
+    ))
+
+    expect(setOnClose).toHaveBeenCalledWith(onClose)
+  })
+
+  it('should default "onClose" to a no-op function when the prop is omitted', () => {
+    const setOnClose = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'setOnClose',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => <SolidQueryDevtoolsPanel client={queryClient} />)
+
+    expect(setOnClose).toHaveBeenCalledWith(expect.any(Function))
+  })
+
+  it('should forward "errorTypes" to the devtools instance', () => {
+    const setErrorTypes = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'setErrorTypes',
+    )
+    const queryClient = new QueryClient()
+    const errorTypes = [
+      { name: 'Network', initializer: () => new Error('Network') },
+    ]
+
+    render(() => (
+      <SolidQueryDevtoolsPanel client={queryClient} errorTypes={errorTypes} />
+    ))
+
+    expect(setErrorTypes).toHaveBeenCalledWith(errorTypes)
+  })
+
+  it('should default "errorTypes" to an empty array when the prop is omitted', () => {
+    const setErrorTypes = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'setErrorTypes',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => <SolidQueryDevtoolsPanel client={queryClient} />)
+
+    expect(setErrorTypes).toHaveBeenCalledWith([])
+  })
+
+  it('should forward "theme" to the devtools instance', () => {
+    const setTheme = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'setTheme',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => <SolidQueryDevtoolsPanel client={queryClient} theme="dark" />)
+
+    expect(setTheme).toHaveBeenCalledWith('dark')
+  })
+
+  it('should default "theme" to "system" when the prop is omitted', () => {
+    const setTheme = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'setTheme',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => <SolidQueryDevtoolsPanel client={queryClient} />)
+
+    expect(setTheme).toHaveBeenCalledWith('system')
+  })
+
+  it('should forward the resolved "QueryClient" via "setClient"', () => {
+    const setClient = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'setClient',
+    )
+    const queryClient = new QueryClient()
+
+    render(() => <SolidQueryDevtoolsPanel client={queryClient} />)
+
+    expect(setClient).toHaveBeenCalledWith(queryClient)
+  })
+
+  it('should call "unmount" on the devtools instance when the component unmounts', () => {
+    const unmount = vi.spyOn(
+      TanstackQueryDevtoolsPanel.prototype,
+      'unmount',
+    )
+    const queryClient = new QueryClient()
+
+    const { unmount: unmountComponent } = render(() => (
+      <SolidQueryDevtoolsPanel client={queryClient} />
+    ))
+    unmountComponent()
+
+    expect(unmount).toHaveBeenCalled()
   })
 })

--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -92,10 +92,7 @@ describe('SolidQueryDevtoolsPanel', () => {
   })
 
   it('should forward "theme" to the devtools instance', () => {
-    const setTheme = vi.spyOn(
-      TanstackQueryDevtoolsPanel.prototype,
-      'setTheme',
-    )
+    const setTheme = vi.spyOn(TanstackQueryDevtoolsPanel.prototype, 'setTheme')
     const queryClient = new QueryClient()
 
     render(() => <SolidQueryDevtoolsPanel client={queryClient} theme="dark" />)
@@ -104,10 +101,7 @@ describe('SolidQueryDevtoolsPanel', () => {
   })
 
   it('should default "theme" to "system" when the prop is omitted', () => {
-    const setTheme = vi.spyOn(
-      TanstackQueryDevtoolsPanel.prototype,
-      'setTheme',
-    )
+    const setTheme = vi.spyOn(TanstackQueryDevtoolsPanel.prototype, 'setTheme')
     const queryClient = new QueryClient()
 
     render(() => <SolidQueryDevtoolsPanel client={queryClient} />)
@@ -128,10 +122,7 @@ describe('SolidQueryDevtoolsPanel', () => {
   })
 
   it('should call "unmount" on the devtools instance when the component unmounts', () => {
-    const unmount = vi.spyOn(
-      TanstackQueryDevtoolsPanel.prototype,
-      'unmount',
-    )
+    const unmount = vi.spyOn(TanstackQueryDevtoolsPanel.prototype, 'unmount')
     const queryClient = new QueryClient()
 
     const { unmount: unmountComponent } = render(() => (


### PR DESCRIPTION
## 🎯 Changes

Add prop wiring and default-value test cases to `SolidQueryDevtoolsPanel` so that the full prop-to-setter forwarding contract is asserted, mirroring the matrix introduced for `SolidQueryDevtools`.

### Forwarding

The existing test file only covered the three smoke cases (throw without client, context resolution, props resolution). This PR adds the remaining `DevtoolsPanelOptions` props that flow into the `TanstackQueryDevtoolsPanel` instance via `createEffect`:

- `onClose` → `setOnClose`
- `errorTypes` → `setErrorTypes`
- `theme` → `setTheme`
- resolved `QueryClient` → `setClient`

It also adds an `unmount` case that asserts the `onCleanup` callback calls `devtools.unmount()` on component teardown.

### Default values

To document and guard the fallback logic in `devtoolsPanel.tsx`, default-value cases are added for omitted props:

- `onClose` omitted → `setOnClose(expect.any(Function))` (a no-op function)
- `errorTypes` omitted → `setErrorTypes([])`
- `theme` omitted → `setTheme('system')`

All cases use `vi.spyOn(TanstackQueryDevtoolsPanel.prototype, ...)` so the real Solid devtools instance is constructed and mounted; only the setter calls are observed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for SolidQueryDevtoolsPanel.
  * Verifies prop forwarding for onClose, errorTypes, and theme, including defaults (onClose -> function, errorTypes -> [], theme -> "system").
  * Confirms QueryClient is forwarded via setClient.
  * Asserts unmounting the component triggers the devtools instance’s unmount.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->