### PR TITLE
test(solid-query-devtools/devtoolsPanel): add tests for the 'style' merge contract (preserve default and override on conflict)

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -121,20 +121,20 @@ describe('SolidQueryDevtoolsPanel', () => {
     expect(setClient).toHaveBeenCalledWith(queryClient)
   })
 
-  it('should merge "style" with the default container height on the rendered element', () => {
+  it('should let "style" override the default container height on the rendered element', () => {
     const queryClient = new QueryClient()
 
     const { container } = render(() => (
       <SolidQueryDevtoolsPanel
         client={queryClient}
-        style={{ width: '300px' }}
+        style={{ width: '300px', height: '300px' }}
       />
     ))
     const panel = container.querySelector(
       '.tsqd-parent-container',
     ) as HTMLElement
 
-    expect(panel.style.height).toBe('500px')
+    expect(panel.style.height).toBe('300px')
     expect(panel.style.width).toBe('300px')
   })
 

--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -121,6 +121,23 @@ describe('SolidQueryDevtoolsPanel', () => {
     expect(setClient).toHaveBeenCalledWith(queryClient)
   })
 
+  it('should merge "style" with the default container height on the rendered element', () => {
+    const queryClient = new QueryClient()
+
+    const { container } = render(() => (
+      <SolidQueryDevtoolsPanel
+        client={queryClient}
+        style={{ width: '300px' }}
+      />
+    ))
+    const panel = container.querySelector(
+      '.tsqd-parent-container',
+    ) as HTMLElement
+
+    expect(panel.style.height).toBe('500px')
+    expect(panel.style.width).toBe('300px')
+  })
+
   it('should call "unmount" on the devtools instance when the component unmounts', () => {
     const unmount = vi.spyOn(TanstackQueryDevtoolsPanel.prototype, 'unmount')
     const queryClient = new QueryClient()

--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -121,6 +121,23 @@ describe('SolidQueryDevtoolsPanel', () => {
     expect(setClient).toHaveBeenCalledWith(queryClient)
   })
 
+  it('should preserve the default container height when "style" omits "height"', () => {
+    const queryClient = new QueryClient()
+
+    const { container } = render(() => (
+      <SolidQueryDevtoolsPanel
+        client={queryClient}
+        style={{ width: '300px' }}
+      />
+    ))
+    const panel = container.querySelector(
+      '.tsqd-parent-container',
+    ) as HTMLElement
+
+    expect(panel.style.height).toBe('500px')
+    expect(panel.style.width).toBe('300px')
+  })
+
   it('should let "style" override the default container height on the rendered element', () => {
     const queryClient = new QueryClient()
 


### PR DESCRIPTION
## 🎯 Changes

Add two test cases that assert the `style` prop merge contract on `SolidQueryDevtoolsPanel`'s `.tsqd-parent-container` element:

1. **Preserve default** — when `style={{ width: '300px' }}` omits `height`, the default `height: '500px'` is preserved.
2. **Override on conflict** — when `style={{ width: '300px', height: '300px' }}` provides `height`, the user-provided value overrides the default `'500px'`.

Together, these cases guard against two regression shapes:

- **Default dropped** (e.g. `{ ...props.style }` removing the default base) — caught by case 1
- **Merge order flipped** (e.g. `{ ...props.style, height: '500px' }` clobbering user input) — caught by case 2

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for the DevTools panel verifying inline style behavior on the panel container:
    * Omitting height preserves the default container height while allowing a custom width.
    * Providing both width and height overrides the defaults so both dimensions use the supplied values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->