### PR TITLE
fix(eslint-plugin-query): track custom query hook wrappers in deps

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -276,6 +276,74 @@ const baseTestCases = {
             },
           ],
         },
+      ])
+      .concat([
+        {
+          name: `result of custom useMutation wrapper is passed to ${reactHookInvocation} as dependency`,
+          code: `
+            ${reactHookImport}
+            import { useMutation } from "@tanstack/react-query";
+
+            const useMyMutation = () =>
+              useMutation({ mutationFn: (value: string) => value });
+
+            function Component() {
+              const mutation = useMyMutation();
+              const callback = ${reactHookInvocation}(() => { mutation.mutate('hello') }, [mutation]);
+              return;
+            }
+          `,
+          errors: [
+            {
+              messageId: 'noUnstableDeps',
+              data: { reactHook: reactHookAlias, queryHook: 'useMutation' },
+            },
+          ],
+        },
+        {
+          name: `result of custom useQuery wrapper is passed to ${reactHookInvocation} as dependency`,
+          code: `
+            ${reactHookImport}
+            import { useQuery } from "@tanstack/react-query";
+
+            const useMyQuery = () =>
+              useQuery({ queryFn: (value: string) => value });
+
+            function Component() {
+              const query = useMyQuery();
+              const callback = ${reactHookInvocation}(() => { query.refetch() }, [query]);
+              return;
+            }
+          `,
+          errors: [
+            {
+              messageId: 'noUnstableDeps',
+              data: { reactHook: reactHookAlias, queryHook: 'useQuery' },
+            },
+          ],
+        },
+        {
+          name: `result of custom useQuery wrapper in useMemo is passed to dependency array`,
+          code: `
+            ${reactHookImport}
+            import { useQuery } from "@tanstack/react-query";
+
+            const useTodoQuery = (queryKeyValue: string) =>
+              useQuery({ queryKey: ['todo', queryKeyValue], queryFn: () => queryKeyValue });
+
+            function Component({ queryKeyValue }: { queryKeyValue: string }) {
+              const query = useTodoQuery(queryKeyValue);
+              const value = ${reactHookInvocation}(() => query.data, [query]);
+              return;
+            }
+          `,
+          errors: [
+            {
+              messageId: 'noUnstableDeps',
+              data: { reactHook: reactHookAlias, queryHook: 'useQuery' },
+            },
+          ],
+        },
       ]),
 }
 

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -37,6 +37,15 @@ export const rule = createRule({
   create: detectTanstackQueryImports((context, _options, helpers) => {
     const trackedVariables: Record<string, string> = {}
     const hookAliasMap: Record<string, string> = {}
+    const trackedCustomHooks: Record<string, string> = {}
+    const pendingCustomHookAssignments: Array<{
+      id: TSESTree.BindingName
+      calleeName: string
+    }> = []
+    const reactHookDependencies: Array<{
+      node: TSESTree.Identifier
+      reactHook: string
+    }> = []
 
     function getReactHook(node: TSESTree.CallExpression): string | undefined {
       if (node.callee.type === 'Identifier') {
@@ -98,6 +107,71 @@ export const rule = createRule({
       )
     }
 
+    function getReturnedHookName(
+      expression: TSESTree.Expression,
+    ): string | undefined {
+      if (expression.type === AST_NODE_TYPES.ParenthesizedExpression) {
+        return getReturnedHookName(expression.expression)
+      }
+
+      if (expression.type !== AST_NODE_TYPES.CallExpression) {
+        return undefined
+      }
+
+      if (
+        expression.callee.type !== AST_NODE_TYPES.Identifier ||
+        !expression.callee.name.startsWith('use') ||
+        !helpers.isTanstackQueryImport(expression.callee)
+      ) {
+        return undefined
+      }
+
+      return expression.callee.name
+    }
+
+    function getFunctionReturnedHookName(
+      node:
+        | TSESTree.ArrowFunctionExpression
+        | TSESTree.FunctionDeclaration
+        | TSESTree.FunctionExpression,
+    ): string | undefined {
+      const returnedNode =
+        node.body.type === AST_NODE_TYPES.BlockStatement
+          ? node.body.body.find(
+              (statement) =>
+                statement.type === AST_NODE_TYPES.ReturnStatement &&
+                statement.argument !== null,
+            )?.argument
+          : node.body
+
+      if (!returnedNode) {
+        return undefined
+      }
+
+      return getReturnedHookName(returnedNode)
+    }
+
+    function resolveTrackedHook(
+      calleeName: string,
+      visited: Set<string> = new Set(),
+    ): string | undefined {
+      if (allHookNames.includes(calleeName)) {
+        return calleeName
+      }
+
+      if (visited.has(calleeName)) {
+        return undefined
+      }
+
+      const nestedHookName = trackedCustomHooks[calleeName]
+      if (!nestedHookName) {
+        return undefined
+      }
+
+      visited.add(calleeName)
+      return resolveTrackedHook(nestedHookName, visited)
+    }
+
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
         if (
@@ -118,24 +192,65 @@ export const rule = createRule({
         }
       },
 
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        if (!node.id || node.id.type !== AST_NODE_TYPES.Identifier) {
+          return
+        }
+
+        const returnedHookName = getFunctionReturnedHookName(node)
+        if (!returnedHookName) {
+          return
+        }
+
+        trackedCustomHooks[node.id.name] = returnedHookName
+      },
+
       VariableDeclarator(node) {
         if (
+          node.id.type === AST_NODE_TYPES.Identifier &&
+          node.id.name.startsWith('use') &&
           node.init !== null &&
-          node.init.type === AST_NODE_TYPES.CallExpression &&
-          node.init.callee.type === AST_NODE_TYPES.Identifier &&
-          allHookNames.includes(node.init.callee.name) &&
-          helpers.isTanstackQueryImport(node.init.callee)
+          (node.init.type === AST_NODE_TYPES.FunctionExpression ||
+            node.init.type === AST_NODE_TYPES.ArrowFunctionExpression)
         ) {
-          // Special case for useQueries/useSuspenseQueries with combine property - it's stable
-          if (
-            (node.init.callee.name === 'useQueries' ||
-              node.init.callee.name === 'useSuspenseQueries') &&
-            hasCombineProperty(node.init)
-          ) {
-            // Don't track useQueries/useSuspenseQueries with combine as unstable
+          const returnedHookName = getFunctionReturnedHookName(node.init)
+          if (!returnedHookName) {
             return
           }
-          collectVariableNames(node.id, node.init.callee.name)
+
+          trackedCustomHooks[node.id.name] = returnedHookName
+        }
+
+        if (
+          node.init?.type !== AST_NODE_TYPES.CallExpression ||
+          node.init.callee.type !== AST_NODE_TYPES.Identifier ||
+          !node.init.callee.name.startsWith('use')
+        ) {
+          return
+        }
+
+        const calleeName = node.init.callee.name
+        const resolvedQueryHook = resolveTrackedHook(calleeName)
+
+        if (allHookNames.includes(calleeName)) {
+          if (!helpers.isTanstackQueryImport(node.init.callee)) {
+            return
+          }
+
+          if (
+            (calleeName === 'useQueries' ||
+              calleeName === 'useSuspenseQueries') &&
+            hasCombineProperty(node.init)
+          ) {
+            return
+          }
+
+          collectVariableNames(node.id, calleeName)
+          return
+        }
+
+        if (resolvedQueryHook) {
+          pendingCustomHookAssignments.push({ id: node.id, calleeName })
         }
       },
       CallExpression: (node) => {
@@ -147,23 +262,39 @@ export const rule = createRule({
         ) {
           const depsArray = node.arguments[1].elements
           depsArray.forEach((dep) => {
-            if (
-              dep !== null &&
-              dep.type === AST_NODE_TYPES.Identifier &&
-              trackedVariables[dep.name] !== undefined
-            ) {
-              const queryHook = trackedVariables[dep.name]
-              context.report({
-                node: dep,
-                messageId: 'noUnstableDeps',
-                data: {
-                  queryHook,
-                  reactHook,
-                },
-              })
+            if (dep !== null && dep.type === AST_NODE_TYPES.Identifier) {
+              reactHookDependencies.push({ node: dep, reactHook })
             }
           })
         }
+      },
+
+      'Program:exit'() {
+        pendingCustomHookAssignments.forEach(({ id, calleeName }) => {
+          const queryHook = resolveTrackedHook(calleeName)
+          if (!queryHook) {
+            return
+          }
+
+          collectVariableNames(id, queryHook)
+        })
+
+        reactHookDependencies.forEach(({ node, reactHook }) => {
+          const queryHook = trackedVariables[node.name]
+
+          if (!queryHook) {
+            return
+          }
+
+          context.report({
+            node,
+            messageId: 'noUnstableDeps',
+            data: {
+              queryHook,
+              reactHook,
+            },
+          })
+        })
       },
     }
   }),


### PR DESCRIPTION
## Description

Handle custom TanStack Query React hook wrappers (including function declarations and nested custom hooks) in the eslint-plugin no-unstable-deps rule.

## Changes
- Track use* custom hooks by resolving returned query hook from:
  - const arrow/function assignments
  - function declarations
  - nested custom wrappers
- Defer dependency reporting until Program exit so wrapper tracking is complete.
- Add tests covering:
  - custom useMutation wrapper in hook callback dependency
  - custom useQuery wrapper in hook callback dependency
  - custom useQuery with parameters passed through another hook and consumed in dependency array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the no-unstable-deps ESLint rule to properly detect unstable dependencies when custom hooks wrap TanStack Query hooks. The rule now tracks wrapped query and mutation results across custom hook layers.

* **Tests**
  * Added test cases for custom wrapper hook patterns to ensure comprehensive rule coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->