### PR TITLE
fix(query-codemods): skip key transformation without react-query import

### DIFF
--- a/packages/query-codemods/src/v4/__testfixtures__/no-react-query-import.input.tsx
+++ b/packages/query-codemods/src/v4/__testfixtures__/no-react-query-import.input.tsx
@@ -1,0 +1,7 @@
+const title = 'No React Query usage'
+
+export function Example() {
+  const greeting = title.toUpperCase()
+
+  return <div>{greeting}</div>
+}

--- a/packages/query-codemods/src/v4/__testfixtures__/no-react-query-import.output.tsx
+++ b/packages/query-codemods/src/v4/__testfixtures__/no-react-query-import.output.tsx
@@ -1,0 +1,7 @@
+const title = 'No React Query usage'
+
+export function Example() {
+  const greeting = title.toUpperCase()
+
+  return <div>{greeting}</div>
+}

--- a/packages/query-codemods/src/v4/__tests__/key-transformation.test.cjs
+++ b/packages/query-codemods/src/v4/__tests__/key-transformation.test.cjs
@@ -35,3 +35,7 @@ defineTest(
 defineTest(__dirname, 'key-transformation.cjs', null, 'type-arguments', {
   parser: 'tsx',
 })
+
+defineTest(__dirname, 'key-transformation.cjs', null, 'no-react-query-import', {
+  parser: 'tsx',
+})

--- a/packages/query-codemods/src/v4/key-transformation.cjs
+++ b/packages/query-codemods/src/v4/key-transformation.cjs
@@ -145,7 +145,17 @@ module.exports = (file, api) => {
   const jscodeshift = api.jscodeshift
   const root = jscodeshift(file.source)
 
-  // TODO: Execute the transformers only when it contains a `react-query` import!
+  const hasReactQueryImport = root
+    .find(jscodeshift.ImportDeclaration, {
+      source: {
+        value: 'react-query',
+      },
+    })
+    .paths().length
+
+  if (!hasReactQueryImport) {
+    return file.source
+  }
 
   const utils = createUtilsObject({ root, jscodeshift })
   const filePath = file.path


### PR DESCRIPTION
## Summary

Avoids running the v4 key transformation codemod when a file does not import eact-query.

- Adds an early import check in packages/query-codemods/src/v4/key-transformation.cjs.
- Returns original source when no eact-query import is found.
- Adds a fixture/test to assert no-op behavior for non-React Query files.

## Verification

- 
px -y pnpm@11.1.0 -C tanstack-query --filter @tanstack/query-codemods test:lib
- pnpm test:eslint (direct pnpm) is blocked in this environment by toolchain mismatch; this is unrelated to the code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed codemod to properly handle files without React Query imports by skipping transformation.

* **Tests**
  * Added test fixtures and test cases for scenarios without React Query imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->