### PR TITLE
fix(query-devtools): set window.__nonce__ in setupStyleSheet

### DIFF
--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -982,6 +982,7 @@ describe('Utils tests', () => {
   describe('setupStyleSheet', () => {
     afterEach(() => {
       document.head.querySelector('#_goober')?.remove()
+      ;(window as { __nonce__?: string }).__nonce__ = undefined
     })
 
     it('should not insert any style tag when "nonce" is missing', () => {
@@ -1010,6 +1011,12 @@ describe('Utils tests', () => {
       expect(
         document.head.querySelector('#_goober')?.getAttribute('nonce'),
       ).toBe('test-nonce')
+    })
+
+    it('should set the global "__nonce__" on window', () => {
+      setupStyleSheet('test-nonce')
+
+      expect((window as { __nonce__?: string }).__nonce__).toBe('test-nonce')
     })
 
     it('should not insert a duplicate style tag when "document.head" already has one', () => {

--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -306,6 +306,8 @@ export const deleteNestedDataByPath = (
 // Adds a nonce to the style tag if needed
 export const setupStyleSheet = (nonce?: string, target?: ShadowRoot) => {
   if (!nonce) return
+  ;(window as { __nonce__?: string }).__nonce__ = nonce
+
   const styleExists =
     document.querySelector('#_goober') || target?.querySelector('#_goober')
 


### PR DESCRIPTION
### Description

This fixes CSP `styleNonce` handling in Query Devtools.

## Problem
`setupStyleSheet` sets a nonce attribute on the injected `<style id=_goober>`, but it never sets `window.__nonce__`. goober (v2.1.17+) reads `window.__nonce__` when accessing style nodes and overwrites the nonce, which can clear it and break CSP.

## Fix
- Set `window.__nonce__` when `setupStyleSheet` receives a nonce.
- Keep existing insertion logic intact so this still works as a pre-creation fallback.
- Add a regression test in `packages/query-devtools/src/__tests__/utils.test.ts` to assert `window.__nonce__` is set.

## Validation
- `npx pnpm@11 --filter @tanstack/query-devtools exec vitest run src/__tests__/utils.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for global nonce value handling to ensure security nonce side effects are properly verified.

* **Bug Fixes**
  * Improved nonce tracking by storing provided nonce values in global state during stylesheet setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->