### PR TITLE
fix(vue-query): use environmentManager.isServer in plugin

### DIFF
--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isVue2, isVue3, ref } from 'vue-demi'
+import { environmentManager } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { VueQueryPlugin } from '../vueQueryPlugin'
@@ -194,6 +195,21 @@ describe('VueQueryPlugin', () => {
   })
 
   describe('when called with custom client', () => {
+    it('should not call mount when running on server', () => {
+      const appMock = getAppMock()
+      const customClient = { mount: vi.fn() } as unknown as QueryClient
+      const previousIsServer = environmentManager.isServer()
+
+      environmentManager.setIsServer(() => true)
+
+      try {
+        VueQueryPlugin.install(appMock, { queryClient: customClient })
+        expect(customClient.mount).toHaveBeenCalledTimes(0)
+      } finally {
+        environmentManager.setIsServer(() => previousIsServer)
+      }
+    })
+
     itIf(isVue2)('should provide that custom client', () => {
       const appMock = getAppMock()
       const customClient = { mount: vi.fn() } as unknown as QueryClient

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -1,5 +1,5 @@
 import { isVue2 } from 'vue-demi'
-import { isServer } from '@tanstack/query-core'
+import { environmentManager } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
 import { getClientKey } from './utils'
@@ -38,7 +38,7 @@ export const VueQueryPlugin = {
       client = new QueryClient(clientConfig)
     }
 
-    if (!isServer) {
+    if (!environmentManager.isServer()) {
       client.mount()
     }
 


### PR DESCRIPTION
## Summary
- Use query core \environmentManager.isServer()\ in \VueQueryPlugin\ instead of importing \isServer\ directly.
- Add regression test ensuring \client.mount()\ is skipped when server mode is forced via \environmentManager.setIsServer()\.

## Testing
- npx -y pnpm@11.1.0 --dir packages/vue-query test path: itest via pnpm exec (command below)
  - \
px -y pnpm@11.1.0 --dir C:\\Users\\raash\\Desktop\\open-source-contribution\\tanstack-query-8639 --filter @tanstack/vue-query exec vitest run src/__tests__/vueQueryPlugin.test.ts --no-coverage\
