### PR TITLE
fix(query-core): infer query data from query filters

### DIFF
--- a/.changeset/query-devtools-missing-state.md
+++ b/.changeset/query-devtools-missing-state.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-devtools': patch
+---
+
+Avoid crashing devtools query rows when a cached query state is temporarily unavailable.

--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -280,7 +280,7 @@ describe('fully typed usage', () => {
 
     const queriesData = queryClient.getQueriesData(queryFilters)
     expectTypeOf(queriesData).toEqualTypeOf<
-      Array<[ReadonlyArray<unknown>, unknown]>
+      Array<[ReadonlyArray<unknown>, TData | undefined]>
     >()
 
     const queryData3 = queryClient.setQueryData(filterKey, { foo: '' })
@@ -293,15 +293,17 @@ describe('fully typed usage', () => {
     >()
     expectTypeOf(queryData3).toEqualTypeOf<TData | undefined>()
 
-    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' }) // TODO: types here are wrong and coming up undefined
+    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' })
     type SetQueriesDataUpdaterArg = Parameters<
-      typeof queryClient.setQueriesData<unknown, typeof queryFilters>
+      typeof queryClient.setQueriesData<TData, typeof queryFilters>
     >[1]
 
     expectTypeOf<SetQueriesDataUpdaterArg>().toEqualTypeOf<
-      Updater<unknown, unknown>
+      Updater<TData | undefined, TData | undefined>
     >()
-    expectTypeOf(queriesData2).toEqualTypeOf<Array<[QueryKey, unknown]>>()
+    expectTypeOf(queriesData2).toEqualTypeOf<
+      Array<[QueryKey, TData | undefined]>
+    >()
 
     const queryState = queryClient.getQueryState(filterKey)
     expectTypeOf(queryState).toEqualTypeOf<
@@ -432,7 +434,7 @@ describe('fully typed usage', () => {
     >()
     expectTypeOf(queryData3).toEqualTypeOf<unknown>()
 
-    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' }) // TODO: types here are wrong and coming up undefined
+    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' })
     type SetQueriesDataUpdaterArg = Parameters<
       typeof queryClient.setQueriesData<unknown, typeof queryFilters>
     >[1]

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -44,6 +44,13 @@ import type { MutationFilters, QueryFilters, Updater } from './utils'
 
 // TYPES
 
+type FilteredQueryData<
+  TQueryFilters extends QueryFilters<any>,
+  TQueryFnData = unknown,
+> = TQueryFilters extends QueryFilters<infer TTaggedQueryKey>
+  ? InferDataFromTag<TQueryFnData, TTaggedQueryKey>
+  : TQueryFnData
+
 interface QueryDefaults {
   queryKey: QueryKey
   defaultOptions: OmitKeyof<QueryOptions<any, any, any>, 'queryKey'>
@@ -161,6 +168,10 @@ export class QueryClient {
     return Promise.resolve(cachedData)
   }
 
+  getQueriesData<TQueryFilters extends QueryFilters<any>>(
+    filters: TQueryFilters,
+  ): Array<[QueryKey, FilteredQueryData<TQueryFilters> | undefined]>
+
   getQueriesData<
     TQueryFnData = unknown,
     TQueryFilters extends QueryFilters<any> = QueryFilters,
@@ -206,8 +217,17 @@ export class QueryClient {
       .setData(data, { ...options, manual: true })
   }
 
+  setQueriesData<TQueryFilters extends QueryFilters<any>>(
+    filters: TQueryFilters,
+    updater: Updater<
+      NoInfer<FilteredQueryData<TQueryFilters>> | undefined,
+      NoInfer<FilteredQueryData<TQueryFilters>> | undefined
+    >,
+    options?: SetDataOptions,
+  ): Array<[QueryKey, FilteredQueryData<TQueryFilters> | undefined]>
+
   setQueriesData<
-    TQueryFnData,
+    TQueryFnData = unknown,
     TQueryFilters extends QueryFilters<any> = QueryFilters,
   >(
     filters: TQueryFilters,

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -1438,7 +1438,7 @@ const QueryRow: Component<{ query: Query }> = (props) => {
 
   const color = createMemo(() =>
     getQueryStatusColor({
-      queryState: queryState()!,
+      queryState: queryState(),
       observerCount: observers(),
       isStale: isStale(),
     }),

--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -1573,6 +1573,16 @@ describe('Utils tests', () => {
       ).toBe('gray')
     })
 
+    it('should return "gray" when the query state is unavailable', () => {
+      expect(
+        getQueryStatusColor({
+          queryState: undefined,
+          observerCount: 0,
+          isStale: false,
+        }),
+      ).toBe('gray')
+    })
+
     it('should return "purple" when fetchStatus is "paused"', () => {
       expect(
         getQueryStatusColor({

--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -31,15 +31,15 @@ export function getQueryStatusColor({
   observerCount,
   isStale,
 }: {
-  queryState: Query['state']
+  queryState: Query['state'] | undefined
   observerCount: number
   isStale: boolean
 }) {
-  return queryState.fetchStatus === 'fetching'
+  return queryState?.fetchStatus === 'fetching'
     ? 'blue'
     : !observerCount
       ? 'gray'
-      : queryState.fetchStatus === 'paused'
+      : queryState?.fetchStatus === 'paused'
         ? 'purple'
         : isStale
           ? 'yellow'


### PR DESCRIPTION
## Summary
- Infer getQueriesData and setQueriesData generic data types from QueryFilters generic, so tags propagate to typed data/update signatures.
- Add type test coverage in queryClient.test-d.tsx for typed queryFilters with DataTag.

## Validation
- corepack pnpm --filter @tanstack/query-core test:types:ts59
- corepack pnpm --filter @tanstack/query-core test:types:ts60
- corepack pnpm --filter @tanstack/query-core test:lib (passes tests, but reports existing config parse errors in oot.eslint.config.js and oot.tsup.config.js)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TypeScript type inference for query data methods to better preserve data types across operations

* **Bug Fixes**
  * Resolved devtools crashes when cached query state is temporarily unavailable during query row rendering

* **Tests**
  * Added test case to verify proper status color determination when query state is undefined

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->