### PR TITLE
fix(query-core): infer setQueriesData data type from query filters

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -293,7 +293,7 @@ describe('fully typed usage', () => {
     >()
     expectTypeOf(queryData3).toEqualTypeOf<TData | undefined>()
 
-    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' }) // TODO: types here are wrong and coming up undefined
+    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' })
     type SetQueriesDataUpdaterArg = Parameters<
       typeof queryClient.setQueriesData<unknown, typeof queryFilters>
     >[1]
@@ -301,7 +301,7 @@ describe('fully typed usage', () => {
     expectTypeOf<SetQueriesDataUpdaterArg>().toEqualTypeOf<
       Updater<unknown, unknown>
     >()
-    expectTypeOf(queriesData2).toEqualTypeOf<Array<[QueryKey, unknown]>>()
+    expectTypeOf(queriesData2).toEqualTypeOf<Array<[QueryKey, TData | undefined]>>()
 
     const queryState = queryClient.getQueryState(filterKey)
     expectTypeOf(queryState).toEqualTypeOf<
@@ -432,7 +432,7 @@ describe('fully typed usage', () => {
     >()
     expectTypeOf(queryData3).toEqualTypeOf<unknown>()
 
-    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' }) // TODO: types here are wrong and coming up undefined
+    const queriesData2 = queryClient.setQueriesData(queryFilters, { foo: '' })
     type SetQueriesDataUpdaterArg = Parameters<
       typeof queryClient.setQueriesData<unknown, typeof queryFilters>
     >[1]

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -54,6 +54,11 @@ interface MutationDefaults {
   defaultOptions: MutationOptions<any, any, any, any>
 }
 
+type QueryDataForFilters<TQueryFilters extends QueryFilters> =
+  TQueryFilters extends QueryFilters<infer TQueryKey>
+    ? InferDataFromTag<unknown, TQueryKey>
+    : unknown
+
 // CLASS
 
 export class QueryClient {
@@ -206,6 +211,27 @@ export class QueryClient {
       .setData(data, { ...options, manual: true })
   }
 
+  setQueriesData<TQueryFilters extends QueryFilters<any>>(
+    filters: TQueryFilters,
+    updater: Updater<
+      NoInfer<QueryDataForFilters<TQueryFilters>> | undefined,
+      NoInfer<QueryDataForFilters<TQueryFilters>> | undefined
+    >,
+    options?: SetDataOptions,
+  ): Array<
+    [QueryKey, QueryDataForFilters<TQueryFilters> | undefined]
+  >
+  setQueriesData<
+    TQueryFnData,
+    TQueryFilters extends QueryFilters<any> = QueryFilters,
+  >(
+    filters: TQueryFilters,
+    updater: Updater<
+      NoInfer<TQueryFnData> | undefined,
+      NoInfer<TQueryFnData> | undefined
+    >,
+    options?: SetDataOptions,
+  ): Array<[QueryKey, TQueryFnData | undefined]>
   setQueriesData<
     TQueryFnData,
     TQueryFilters extends QueryFilters<any> = QueryFilters,


### PR DESCRIPTION
## Summary
Fix QueryClient.setQueriesData typing so filtered-query overloads infer cached data types from tagged query keys when queryKey is provided in filters.

## Changes
- Add QueryDataForFilters helper in queryClient for `InferDataFromTag` over QueryFilters.
- Add a dedicated overload for setQueriesData using that helper.
- Update queryClient type tests by removing the outdated TODO and asserting inferred return type.

## Validation
- corepack pnpm exec tsc -p tsconfig.legacy.json --pretty false --noEmit (packages/query-core)
- corepack pnpm exec vitest run src/__tests__/queryClient.test-d.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated type-level assertions for `setQueriesData` validation

* **Improvements**
  * Enhanced type inference for the `setQueriesData` method to provide more accurate data type information based on query filters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->