### PR TITLE
fix(solid-query): fetch on status-only reads

### DIFF
--- a/.changeset/solid-query-status-resource.md
+++ b/.changeset/solid-query-status-resource.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/solid-query": patch
+---
+
+Start Solid query resources when status fields are read so curried `queryOptions` fetch on mount without requiring `data` access.

--- a/packages/query-devtools/src/__tests__/utils.test.ts
+++ b/packages/query-devtools/src/__tests__/utils.test.ts
@@ -982,6 +982,7 @@ describe('Utils tests', () => {
   describe('setupStyleSheet', () => {
     afterEach(() => {
       document.head.querySelector('#_goober')?.remove()
+      delete (window as Window & { __nonce__?: string }).__nonce__
     })
 
     it('should not insert any style tag when "nonce" is missing', () => {
@@ -1002,6 +1003,14 @@ describe('Utils tests', () => {
       const styleTag = document.head.querySelector('#_goober')
       expect(styleTag).not.toBeNull()
       expect(styleTag?.tagName).toBe('STYLE')
+    })
+
+    it('should set "window.__nonce__" from the provided nonce', () => {
+      setupStyleSheet('test-nonce')
+
+      expect(
+        (window as Window & { __nonce__?: string }).__nonce__,
+      ).toBe('test-nonce')
     })
 
     it('should set the "nonce" attribute on the inserted style tag', () => {

--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -306,6 +306,7 @@ export const deleteNestedDataByPath = (
 // Adds a nonce to the style tag if needed
 export const setupStyleSheet = (nonce?: string, target?: ShadowRoot) => {
   if (!nonce) return
+  ;(window as Window & { __nonce__?: string }).__nonce__ = nonce
   const styleExists =
     document.querySelector('#_goober') || target?.querySelector('#_goober')
 

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -30,6 +30,7 @@ import {
   QueryClient,
   QueryClientProvider,
   keepPreviousData,
+  queryOptions,
   useQuery,
 } from '..'
 import { Blink, mockOnlineManagerIsOnline, setActTimeout } from './utils'
@@ -242,6 +243,72 @@ describe('useQuery', () => {
     expect(rendered.getByText('default')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('test')).toBeInTheDocument()
+  })
+
+  it('should fetch when a curried queryOptions result only reads status fields', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn((slug: string) => `test-${slug}`)
+    const fetchQueryOptions = (slug: string) =>
+      queryOptions({
+        queryKey: [key, slug],
+        queryFn: () => queryFn(slug),
+      })
+
+    function Page() {
+      const options = fetchQueryOptions('slug')
+      const state = useQuery(() => options)
+
+      return (
+        <Switch>
+          <Match when={state.isPending}>pending</Match>
+          <Match when={state.isError}>error</Match>
+          <Match when={state.isSuccess}>success</Match>
+        </Switch>
+      )
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    expect(rendered.getByText('pending')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(rendered.getByText('success')).toBeInTheDocument()
+  })
+
+  it('should fetch when a curried queryOptions result only reads resource fields', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn((slug: string) => `test-${slug}`)
+    const fetchQueryOptions = (slug: string) =>
+      queryOptions({
+        queryKey: [key, slug],
+        queryFn: () => queryFn(slug),
+      })
+
+    function Page() {
+      const options = fetchQueryOptions('slug')
+      const state = useQuery(() => options)
+
+      void state.error
+      void state.failureReason
+      void state.refetch
+      void state.promise
+
+      return <div>mounted</div>
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    expect(rendered.getByText('mounted')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(queryFn).toHaveBeenCalledTimes(1)
   })
 
   it('should return the correct states for a successful query', async () => {

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -310,7 +310,6 @@ describe('useQuery', () => {
     await vi.advanceTimersByTimeAsync(10)
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
-
   it('should return the correct states for a successful query', async () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -99,6 +99,33 @@ const hydratableObserverResult = <
   return obj
 }
 
+const resourceTrackingProps = new Set<PropertyKey>([
+  'dataUpdatedAt',
+  'error',
+  'errorUpdatedAt',
+  'failureCount',
+  'failureReason',
+  'errorUpdateCount',
+  'isError',
+  'isFetched',
+  'isFetchedAfterMount',
+  'isFetching',
+  'isLoading',
+  'isPending',
+  'isLoadingError',
+  'isInitialLoading',
+  'isPaused',
+  'isPlaceholderData',
+  'isRefetchError',
+  'isRefetching',
+  'isStale',
+  'isSuccess',
+  'isEnabled',
+  'refetch',
+  'promise',
+  'status',
+  'fetchStatus',
+])
 // Base Query Function that is used to create the query.
 export function useBaseQuery<
   TQueryFnData,
@@ -380,6 +407,11 @@ export function useBaseQuery<
           return queryResource.latest?.data
         }
         return queryResource()?.data
+      }
+      if (resourceTrackingProps.has(prop)) {
+        // Solid resources are lazy, so status-only consumers still need to read
+        // the resource once to start the observer subscription and fetch.
+        queryResource()
       }
       return Reflect.get(target, prop)
     },


### PR DESCRIPTION
## Summary
- Track Solid query status-like result fields in useBaseQuery so status/resource-only consumers trigger createResource/observer work, fixing lazy start for curried queryOptions results.
- Add regression tests in packages/solid-query/src/__tests__/useQuery.test.tsx for status-only reads and resource field reads.
- Add changeset for @tanstack/solid-query patch release.

## Validation
- corepack pnpm --filter @tanstack/solid-query test:lib -- --run src/__tests__/useQuery.test.tsx\
  (fails in this environment due pre-existing Vitest issue: TypeError: filename must be a file URL object, file URL string, or absolute path string. Received 'file:///@solid-refresh' and related oot.eslint.config.js typecheck parser errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query resources now initialize when status fields (loading, error, etc.) are read, ensuring queries run even without direct data access.
  * Devtools stylesheet setup records a provided nonce and applies it to the style element.

* **Tests**
  * Added tests verifying queries run with curried `queryOptions` when accessing status- or resource-related fields.
  * Added tests for stylesheet nonce behavior.

* **Chores**
  * Added a changeset entry for the package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->