### PR TITLE
fix(vue-query): avoid mounting QueryClient on server

### DIFF
--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isVue2, isVue3, ref } from 'vue-demi'
+import { environmentManager } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { VueQueryPlugin } from '../vueQueryPlugin'
@@ -217,6 +218,19 @@ describe('VueQueryPlugin', () => {
         VUE_QUERY_CLIENT,
         customClient,
       )
+    })
+
+    it('should not mount client when in a server environment', () => {
+      environmentManager.setIsServer(() => true)
+      try {
+        const appMock = getAppMock()
+        const customClient = { mount: vi.fn() } as unknown as QueryClient
+        VueQueryPlugin.install(appMock, { queryClient: customClient })
+
+        expect(customClient.mount).not.toHaveBeenCalled()
+      } finally {
+        environmentManager.setIsServer(() => false)
+      }
     })
   })
 

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -1,5 +1,5 @@
 import { isVue2 } from 'vue-demi'
-import { isServer } from '@tanstack/query-core'
+import { environmentManager } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
 import { getClientKey } from './utils'
@@ -38,7 +38,7 @@ export const VueQueryPlugin = {
       client = new QueryClient(clientConfig)
     }
 
-    if (!isServer) {
+    if (!environmentManager.isServer()) {
       client.mount()
     }
 


### PR DESCRIPTION
## Summary
- Use @tanstack/query-core environmentManager.isServer() in VueQueryPlugin install path instead of importing deprecated isServer flag.
- Add regression test ensuring custom QueryClient is not mounted when running in a server environment.

This keeps SSR behavior explicit and aligned with environmentManager runtime detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query client initialization to properly detect and respond to server-side rendering environments using updated environment detection.

* **Tests**
  * Added test coverage verifying query client behavior in server-side rendering scenarios, ensuring mount operations are properly controlled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->