### PR TITLE
fix(preact-query): infer infinite pageParam in useInfiniteQuery return type

### DIFF
--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -61,9 +61,8 @@ describe('select', () => {
       getNextPageParam: () => undefined,
     })
 
-    // TODO: Order of generics prevents pageParams to be typed correctly. Using `unknown` for now
     expectTypeOf(infiniteQuery.data).toEqualTypeOf<
-      InfiniteData<number, unknown> | undefined
+      InfiniteData<number, number> | undefined
     >()
   })
 
@@ -113,9 +112,8 @@ describe('getNextPageParam / getPreviousPageParam', () => {
       },
     })
 
-    // TODO: Order of generics prevents pageParams to be typed correctly. Using `unknown` for now
     expectTypeOf(infiniteQuery.data).toEqualTypeOf<
-      InfiniteData<string, unknown> | undefined
+      InfiniteData<string, number> | undefined
     >()
   })
 })

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -18,6 +18,19 @@ import type {
 } from './types'
 import { useBaseQuery } from './useBaseQuery'
 
+type IsUnknown<T> = unknown extends T
+  ? [T] extends [never]
+    ? false
+    : true
+  : false
+
+type ResolvePageParamData<TQueryFnData, TData, TPageParam> =
+  TData extends InfiniteData<TQueryFnData, infer TDataPageParam>
+    ? IsUnknown<TDataPageParam> extends true
+      ? InfiniteData<TQueryFnData, TPageParam>
+      : TData
+    : TData
+
 export function useInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
@@ -33,7 +46,10 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): DefinedUseInfiniteQueryResult<TData, TError>
+): DefinedUseInfiniteQueryResult<
+  ResolvePageParamData<TQueryFnData, TData, TPageParam>,
+  TError
+>
 
 export function useInfiniteQuery<
   TQueryFnData,
@@ -50,7 +66,10 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<
+  ResolvePageParamData<TQueryFnData, TData, TPageParam>,
+  TError
+>
 
 export function useInfiniteQuery<
   TQueryFnData,
@@ -67,7 +86,10 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<
+  ResolvePageParamData<TQueryFnData, TData, TPageParam>,
+  TError
+>
 
 export function useInfiniteQuery(
   options: UseInfiniteQueryOptions,


### PR DESCRIPTION
## Summary
- Improve preact-query useInfiniteQuery return typing so the default InfiniteData pageParam infers TPageParam instead of staying unknown.
- Update type tests in packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx to assert concrete InfiniteData<..., number> for default data with initialPageParam: number.

## Validation
- corepack pnpm exec prettier --check packages/preact-query/src/useInfiniteQuery.ts packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx 
- corepack pnpm --filter @tanstack/preact-query test:lib (passes tests, but reports pre-existing typecheck errors on oot.eslint.config.js and oot.tsup.config.js).
- corepack pnpm --filter @tanstack/preact-query test:types:tscurrent (fails for same workspace config parse issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type safety and inference for infinite query operations to correctly resolve page parameter types in return values.

* **Tests**
  * Updated type assertions to reflect corrected type inference behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->