### PR TITLE
fix(query-persist-client-core): restore undefined persisted query payloads

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -309,6 +309,26 @@ describe('createPersister', () => {
     expect(query.fetch).toHaveBeenCalledTimes(0)
   })
 
+  it('should restore persisted undefined data from storage', async () => {
+    const storage = getFreshStorage()
+    const { context, persister, query, queryFn } = setupPersister(['foo'], {
+      storage,
+      refetchOnRestore: false,
+    })
+
+    query.setData(undefined)
+    await persister.persistQuery(query)
+
+    query.fetch = vi.fn()
+    await persister.persisterFn(queryFn, context, query)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(queryFn).toHaveBeenCalledTimes(0)
+    expect(query.fetch).toHaveBeenCalledTimes(0)
+    expect(query.state.data).toBe(undefined)
+  })
+
   it('should store item after successful fetch', async () => {
     const storage = getFreshStorage()
     const {

--- a/packages/query-persist-client-core/src/createPersister.ts
+++ b/packages/query-persist-client-core/src/createPersister.ts
@@ -13,6 +13,10 @@ import type {
   QueryState,
 } from '@tanstack/query-core'
 
+type PersistedResult<T> = {
+  data: T
+}
+
 export interface PersistedQuery {
   buster: string
   queryHash: string
@@ -125,7 +129,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
   async function retrieveQuery<T>(
     queryHash: string,
     afterRestoreMacroTask?: (persistedQuery: PersistedQuery) => void,
-  ) {
+  ): Promise<PersistedResult<T> | undefined> {
     if (storage != null) {
       const storageKey = `${prefix}-${queryHash}`
       try {
@@ -149,7 +153,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
               )
             }
             // We must resolve the promise here, as otherwise we will have `loading` state in the app until `queryFn` resolves
-            return persistedQuery.state.data as T
+            return { data: persistedQuery.state.data as T }
           }
         }
       } catch (err) {
@@ -209,7 +213,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
 
     // Try to restore only if we do not have any data in the cache and we have persister defined
     if (matchesFilter && query.state.data === undefined && storage != null) {
-      const restoredData = await retrieveQuery(
+      const restoredData = await retrieveQuery<T>(
         query.queryHash,
         (persistedQuery: PersistedQuery) => {
           // Set proper updatedAt, since resolving in the first pass overrides those values
@@ -228,7 +232,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
       )
 
       if (restoredData !== undefined) {
-        return Promise.resolve(restoredData as T)
+        return Promise.resolve(restoredData.data)
       }
     }
 

--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isVue2, isVue3, ref } from 'vue-demi'
+import { environmentManager } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { VueQueryPlugin } from '../vueQueryPlugin'
@@ -217,6 +218,19 @@ describe('VueQueryPlugin', () => {
         VUE_QUERY_CLIENT,
         customClient,
       )
+    })
+
+    it('should not mount client when in a server environment', () => {
+      environmentManager.setIsServer(() => true)
+      try {
+        const appMock = getAppMock()
+        const customClient = { mount: vi.fn() } as unknown as QueryClient
+        VueQueryPlugin.install(appMock, { queryClient: customClient })
+
+        expect(customClient.mount).not.toHaveBeenCalled()
+      } finally {
+        environmentManager.setIsServer(() => false)
+      }
     })
   })
 

--- a/packages/vue-query/src/vueQueryPlugin.ts
+++ b/packages/vue-query/src/vueQueryPlugin.ts
@@ -1,5 +1,5 @@
 import { isVue2 } from 'vue-demi'
-import { isServer } from '@tanstack/query-core'
+import { environmentManager } from '@tanstack/query-core'
 
 import { QueryClient } from './queryClient'
 import { getClientKey } from './utils'
@@ -38,7 +38,7 @@ export const VueQueryPlugin = {
       client = new QueryClient(clientConfig)
     }
 
-    if (!isServer) {
+    if (!environmentManager.isServer()) {
       client.mount()
     }
 


### PR DESCRIPTION
## Summary
- Return restored query payload in experimental_createQueryPersister as a presence-preserving result so persisted undefined data is treated as a real restore hit.
- Add regression test in createPersister.test.ts to ensure persisted undefined payloads are reused without refetching when efetchOnRestore: false.

## Validation
- 
px -y pnpm@11.0.0 vitest run packages/query-persist-client-core/src/__tests__/createPersister.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persister restoration to correctly handle queries with `undefined` data.

* **Improvements**
  * Enhanced server-environment detection in the VueQuery plugin for better server-side rendering support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->