### PR TITLE
feat(query-core): add retryAttempt to query error callback context

### DIFF
--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -325,11 +325,35 @@ describe('queryCache', () => {
       })
       await vi.advanceTimersByTimeAsync(100)
       const query = testCache.find({ queryKey: key })
-      expect(onError).toHaveBeenCalledWith('error', query)
+      expect(onError).toHaveBeenCalledWith('error', query, {
+        retryAttempt: 0,
+      })
       expect(onError).toHaveBeenCalledTimes(1)
       expect(onSuccess).not.toHaveBeenCalled()
       expect(onSettled).toHaveBeenCalledTimes(1)
       expect(onSettled).toHaveBeenCalledWith(undefined, 'error', query)
+    })
+
+    it('should include retryAttempt in the onError context', async () => {
+      const key = queryKey()
+      const onError = vi.fn()
+      const testCache = new QueryCache({ onError })
+      const testClient = new QueryClient({ queryCache: testCache })
+
+      testClient.prefetchQuery({
+        queryKey: key,
+        queryFn: () => sleep(0).then(() => Promise.reject('error')),
+        retry: 2,
+        retryDelay: 0,
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      const query = testCache.find({ queryKey: key })
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith('error', query, {
+        retryAttempt: 2,
+      })
     })
   })
 

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -533,6 +533,7 @@ export class Query<
     }
 
     // Try to fetch the data
+    let latestFailureRetryCount = 0
     this.#retryer = createRetryer({
       initialPromise: fetchOptions?.initialPromise as
         | Promise<TData>
@@ -548,6 +549,7 @@ export class Query<
         abortController.abort()
       },
       onFail: (failureCount, error) => {
+        latestFailureRetryCount = failureCount
         this.#dispatch({ type: 'failed', failureCount, error })
       },
       onPause: () => {
@@ -610,6 +612,7 @@ export class Query<
       this.#cache.config.onError?.(
         error as any,
         this as Query<any, any, any, any>,
+        { retryAttempt: latestFailureRetryCount },
       )
       this.#cache.config.onSettled?.(
         this.state.data,

--- a/packages/query-core/src/queryCache.ts
+++ b/packages/query-core/src/queryCache.ts
@@ -20,6 +20,9 @@ interface QueryCacheConfig {
   onError?: (
     error: DefaultError,
     query: Query<unknown, unknown, unknown>,
+    context: {
+      retryAttempt: number
+    },
   ) => void
   onSuccess?: (data: unknown, query: Query<unknown, unknown, unknown>) => void
   onSettled?: (


### PR DESCRIPTION
Closes #10713
\nThis thread-safe fix adds the retry attempt count to query cache onError context as requested.
\n- Query cache callback now receives (error, query, { retryAttempt }).
- Retry attempt tracks the latest failed retry count from Retryer before final failure.
- Added focused queryCache tests for both default and retried failure cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error callbacks now include retry attempt information in their context, providing developers with visibility into which retry iteration encountered the error during query execution. This enables more precise error tracking, enhanced debugging capabilities, and better failure analysis for troubleshooting query issues across applications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->