### PR TITLE
fix(react-query): enforce TData consistency when select is not used

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -6,6 +6,7 @@ import type { OmitKeyof, QueryFunction, UseQueryOptions } from '..'
 
 describe('useQuery', () => {
   const key = queryKey()
+  type Post = { title: string }
 
   // unspecified query function should default to unknown
   const noQueryFn = useQuery({ queryKey: key })
@@ -55,6 +56,29 @@ describe('useQuery', () => {
   // should error when the query function result does not match with the specified type
   // @ts-expect-error
   useQuery<number>({ queryKey: key, queryFn: () => 'test' })
+
+  // should error when specifying TData that does not match queryFn data and no select transform is used
+  // @ts-expect-error
+  useQuery<Post[], Error, number, string[]>({
+    queryKey: ['posts'],
+    queryFn: () =>
+      Promise.resolve([
+        {
+          title: 'Post',
+        } as Post,
+      ]),
+  })
+
+  useQuery<Post[], Error, number, string[]>({
+    queryKey: ['posts'],
+    queryFn: () =>
+      Promise.resolve([
+        {
+          title: 'Post',
+        } as Post,
+      ]),
+    select: (posts) => posts.length,
+  })
 
   // it should infer the result type from a generic query function
   function queryFn<T = string>(): Promise<T> {

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -12,23 +12,54 @@ import type {
   UndefinedInitialDataOptions,
 } from './queryOptions'
 
-export function useQuery<
+type UseQueryOptionsWithSelect<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
+> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  select: Exclude<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>['select'],
+    undefined
+  >
+}
+
+type UseQueryOptionsWithoutSelect<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'select'>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData extends TQueryFnData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
 >(
-  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+    UseQueryOptionsWithoutSelect<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<NoInfer<TData>, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
+  TData extends TQueryFnData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+    UseQueryOptionsWithoutSelect<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
+): UseQueryResult<NoInfer<TData>, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData extends TQueryFnData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UseQueryOptionsWithoutSelect<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
 ): UseQueryResult<NoInfer<TData>, TError>
 
@@ -38,7 +69,7 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UseQueryOptionsWithSelect<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
 ): UseQueryResult<NoInfer<TData>, TError>
 


### PR DESCRIPTION
## Summary
- Add useQuery overloads in eact-query that enforce TData extends TQueryFnData when select is not provided.
- Preserve current select behavior via separate overload so transformed result types remain supported.
- Add a type regression test in useQuery.test-d.tsx for the mismatch case.

## Validation
- Focused TypeScript check: 
ode ../../node_modules/typescript59/lib/tsc.js --pretty false --noEmit --strict --skipLibCheck --moduleResolution bundler --module ESNext --target ES2020 --jsx react-jsx src/useQuery.ts src/__tests__/useQuery.test-d.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added TypeScript compile-time validation tests for `useQuery` to ensure type compatibility with the `select` parameter.

* **Chores**
  * Refined TypeScript type signatures for `useQuery` to better distinguish between uses with and without the `select` parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->