### PR TITLE
chore(solid-query-devtools/tsconfig): include 'test-setup.ts' for jest-dom matcher typings

### DIFF
--- a/packages/solid-query-devtools/tsconfig.json
+++ b/packages/solid-query-devtools/tsconfig.json
@@ -6,6 +6,12 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src", "*.config.ts", "*.config.js", "package.json"],
+  "include": [
+    "src",
+    "test-setup.ts",
+    "*.config.ts",
+    "*.config.js",
+    "package.json"
+  ],
   "references": [{ "path": "../query-devtools" }, { "path": "../solid-query" }]
 }


### PR DESCRIPTION
## 🎯 Changes

Add `"test-setup.ts"` to the `include` array in `packages/solid-query-devtools/tsconfig.json` so the `@testing-library/jest-dom/vitest` type augmentation is picked up by the TypeScript compiler.

Today, the file is loaded at runtime via `vite.config.ts`'s `test.setupFiles`, so jest-dom matchers work in tests. However, because the file is not part of the TypeScript project, matchers like `toHaveStyle`, `toBeInTheDocument`, and `toHaveClass` are not recognized by the type checker and require workarounds such as `as HTMLElement` casts.

All other devtools/query packages that use a `test-setup.ts` already include it in their tsconfig (`query-devtools`, `react-query-devtools`, `preact-query-devtools`, `solid-query`, `react-query`, `preact-query`, etc.). This brings `solid-query-devtools` in line with that convention.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reformatted build configuration for improved organization and readability.
  * Updated the build/include paths to incorporate additional test setup so tests are discovered during runs.
  * No changes to public APIs or exported interfaces; no user-facing behavior altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->