### PR TITLE
test(solid-query-devtools/devtoolsPanel): use 'toHaveStyle' matcher in the 'style' merge cases

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -130,12 +130,11 @@ describe('SolidQueryDevtoolsPanel', () => {
         style={{ width: '300px' }}
       />
     ))
-    const panel = container.querySelector(
-      '.tsqd-parent-container',
-    ) as HTMLElement
 
-    expect(panel.style.height).toBe('500px')
-    expect(panel.style.width).toBe('300px')
+    expect(container.querySelector('.tsqd-parent-container')).toHaveStyle({
+      height: '500px',
+      width: '300px',
+    })
   })
 
   it('should let "style" override the default container height on the rendered element', () => {
@@ -147,12 +146,11 @@ describe('SolidQueryDevtoolsPanel', () => {
         style={{ width: '300px', height: '300px' }}
       />
     ))
-    const panel = container.querySelector(
-      '.tsqd-parent-container',
-    ) as HTMLElement
 
-    expect(panel.style.height).toBe('300px')
-    expect(panel.style.width).toBe('300px')
+    expect(container.querySelector('.tsqd-parent-container')).toHaveStyle({
+      height: '300px',
+      width: '300px',
+    })
   })
 
   it('should call "unmount" on the devtools instance when the component unmounts', () => {


### PR DESCRIPTION
## 🎯 Changes

Replace the manual `as HTMLElement` casts and `.style.height`/`.style.width` checks in the two `style` merge test cases with the `toHaveStyle` matcher from `@testing-library/jest-dom`.

This is now possible thanks to #10845, which added `test-setup.ts` to the tsconfig `include` so jest-dom matcher type augmentations are picked up.

Before:
```ts
const panel = container.querySelector(
  '.tsqd-parent-container',
) as HTMLElement

expect(panel.style.height).toBe('500px')
expect(panel.style.width).toBe('300px')
```

After:
```ts
expect(container.querySelector('.tsqd-parent-container')).toHaveStyle({
  height: '500px',
  width: '300px',
})
```

Benefits:
- No `as HTMLElement` cast — the matcher accepts `Element | null` directly
- Single `expect` reads the assertion as one logical step
- Null-safe — `toHaveStyle` reports a clear failure when the element is missing

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated devtools panel styling test assertions for improved accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->