### PR TITLE
test(solid-query-devtools/devtools{,Panel}): add tests for the non-development fallback

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
@@ -151,4 +151,20 @@ describe('SolidQueryDevtools', () => {
 
     expect(unmount).toHaveBeenCalled()
   })
+
+  it('should return null in non-development environments', async () => {
+    vi.doMock('solid-js/web', async (importOriginal) => {
+      const actual = await importOriginal()
+      return Object.assign({}, actual, { isDev: false })
+    })
+    vi.resetModules()
+
+    try {
+      const { SolidQueryDevtools: ProductionDevtools } = await import('..')
+      expect(ProductionDevtools({})).toBeNull()
+    } finally {
+      vi.doUnmock('solid-js/web')
+      vi.resetModules()
+    }
+  })
 })

--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -164,4 +164,21 @@ describe('SolidQueryDevtoolsPanel', () => {
 
     expect(unmount).toHaveBeenCalled()
   })
+
+  it('should return null in non-development environments', async () => {
+    vi.doMock('solid-js/web', async (importOriginal) => {
+      const actual = await importOriginal()
+      return Object.assign({}, actual, { isDev: false })
+    })
+    vi.resetModules()
+
+    try {
+      const { SolidQueryDevtoolsPanel: ProductionDevtoolsPanel } =
+        await import('..')
+      expect(ProductionDevtoolsPanel({})).toBeNull()
+    } finally {
+      vi.doUnmock('solid-js/web')
+      vi.resetModules()
+    }
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Add a non-development fallback test case to both `SolidQueryDevtools` and `SolidQueryDevtoolsPanel`, mirroring the matrix that already exists for the React, Preact, and Vue adapters.

Unlike React/Preact/Vue, Solid does not switch on `process.env.NODE_ENV`. The `index.tsx` of `@tanstack/solid-query-devtools` reads `isDev` from `solid-js/web`, which is a build-time constant, so the usual `vi.stubEnv('NODE_ENV', 'production')` approach has no effect here. The new case swaps `isDev` to `false` via per-test `vi.doMock('solid-js/web', ...)` and dynamically imports the module to exercise the fallback branch.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage ensuring devtools UI and panel remain disabled (return null) when the runtime reports a non-development environment, including safeguards to avoid test cross-contamination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->