### PR TITLE
fix: vue devtools class attribute

### DIFF
--- a/.changeset/fix-vue-devtools-class-attribute.md
+++ b/.changeset/fix-vue-devtools-class-attribute.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query-devtools': patch
+---
+
+fix(vue-query-devtools): use class instead of className in templates

--- a/packages/vue-query-devtools/src/devtools.vue
+++ b/packages/vue-query-devtools/src/devtools.vue
@@ -40,5 +40,5 @@ onMounted(() => {
 </script>
 
 <template>
-  <div className="tsqd-parent-container" ref="div"></div>
+  <div class="tsqd-parent-container" ref="div"></div>
 </template>

--- a/packages/vue-query-devtools/src/devtoolsPanel.vue
+++ b/packages/vue-query-devtools/src/devtoolsPanel.vue
@@ -45,5 +45,5 @@ onMounted(() => {
 </script>
 
 <template>
-  <div :style="style" className="tsqd-parent-container" ref="div"></div>
+  <div :style="style" class="tsqd-parent-container" ref="div"></div>
 </template>


### PR DESCRIPTION
## 🎯 Changes

Use the Vue `class` attribute instead of React-style `className` in Vue devtools template containers.

The `devtools.vue` and `devtoolsPanel.vue` components were using `className` in their `<template>` blocks, which is a React-ism. Vue templates should use `class` for CSS class binding.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vue DevTools components to use correct Vue template syntax for styling attributes, ensuring proper styling rendering across the DevTools interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->