### PR TITLE
fix: correct errorTypes type from TError to Error in devtools docs

### DIFF
--- a/docs/framework/angular/devtools.md
+++ b/docs/framework/angular/devtools.md
@@ -153,7 +153,7 @@ Of these options `loadDevtools`, `client`, `position`, `errorTypes`, `buttonPosi
   - The position of the Angular Query devtools panel
 - `client?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the QueryClient provided through `provideTanStackQuery` will be injected.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}[]`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}[]`
   - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.

--- a/docs/framework/preact/devtools.md
+++ b/docs/framework/preact/devtools.md
@@ -78,7 +78,7 @@ function App() {
   - The position of the Preact Query devtools panel
 - `client?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}`
   - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.

--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -85,7 +85,7 @@ function App() {
   - The position of the React Query devtools panel
 - `client?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}[]`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}[]`
   - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.
@@ -131,7 +131,7 @@ function App() {
   - Callback function that is called when the devtools panel is closed
 - `client?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}[]`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}[]`
   - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.

--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -78,7 +78,7 @@ function App() {
   - The position of the Solid Query devtools panel
 - `client?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}`
   - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.

--- a/docs/framework/svelte/devtools.md
+++ b/docs/framework/svelte/devtools.md
@@ -72,7 +72,7 @@ Place the following code as high in your Svelte app as you can. The closer it is
   - The position of the Svelte Query devtools panel
 - `client?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}`
   - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.

--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -73,7 +73,7 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
   - The position of the Vue Query devtools panel.
 - `client?: QueryClient`
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}`
   - Use this to predefine some errors that can be triggered on your queries. The initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.
@@ -117,7 +117,7 @@ function toggleDevtools() {
   - Callback function that is called when the devtools panel is closed
 - `client?: QueryClient`,
   - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
-- `errorTypes?: { name: string; initializer: (query: Query) => TError}[]`
+- `errorTypes?: { name: string; initializer: (query: Query) => Error}[]`
   - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
 - `styleNonce?: string`
   - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.


### PR DESCRIPTION
## 🎯 Changes

Correct the `errorTypes` type signature in all framework devtools docs to match the actual exported type.

The `DevtoolsErrorType` interface in `packages/query-devtools/src/contexts/QueryDevtoolsContext.ts` defines `initializer` as `(query: Query) => Error`, but all framework docs listed `(query: Query) => TError`. This updates the docs to use the concrete `Error` type instead of the generic `TError`.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated devtools configuration documentation across all framework guides (Angular, Preact, React, Solid, Svelte, Vue) to clarify the return type of the `errorTypes` option's `initializer` callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->