### PR TITLE
test(preact-query-devtools/PreactQueryDevtools{,Panel}): add tests for the full prop wiring matrix

### DIFF
--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -107,9 +107,7 @@ describe('PreactQueryDevtools', () => {
       { name: 'Network', initializer: () => new Error('Network') },
     ]
 
-    render(
-      <PreactQueryDevtools client={queryClient} errorTypes={errorTypes} />,
-    )
+    render(<PreactQueryDevtools client={queryClient} errorTypes={errorTypes} />)
 
     expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
   })

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/preact'
 import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
-import type { TanstackQueryDevtools } from '@tanstack/query-devtools'
+import { TanstackQueryDevtools } from '@tanstack/query-devtools'
 
 const mountMock = vi.fn()
 const unmountMock = vi.fn()
@@ -80,6 +80,118 @@ describe('PreactQueryDevtools', () => {
     render(<PreactQueryDevtools client={queryClient} position="left" />)
 
     expect(setPositionMock).toHaveBeenCalledWith('left')
+  })
+
+  it('should forward "initialIsOpen" to the devtools instance', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtools client={queryClient} initialIsOpen={true} />)
+
+    expect(setInitialIsOpenMock).toHaveBeenCalledWith(true)
+  })
+
+  it('should default "initialIsOpen" to "false" when the prop is omitted', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtools client={queryClient} />)
+
+    expect(setInitialIsOpenMock).toHaveBeenCalledWith(false)
+  })
+
+  it('should forward "errorTypes" to the devtools instance', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+    const errorTypes = [
+      { name: 'Network', initializer: () => new Error('Network') },
+    ]
+
+    render(
+      <PreactQueryDevtools client={queryClient} errorTypes={errorTypes} />,
+    )
+
+    expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
+  })
+
+  it('should default "errorTypes" to an empty array when the prop is omitted', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtools client={queryClient} />)
+
+    expect(setErrorTypesMock).toHaveBeenCalledWith([])
+  })
+
+  it('should forward "theme" to the devtools instance', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtools client={queryClient} theme="dark" />)
+
+    expect(setThemeMock).toHaveBeenCalledWith('dark')
+  })
+
+  it('should forward the resolved "QueryClient" via "setClient"', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtools client={queryClient} />)
+
+    expect(setClientMock).toHaveBeenCalledWith(queryClient)
+  })
+
+  it('should forward "styleNonce" to the devtools constructor', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtools client={queryClient} styleNonce="abc" />)
+
+    expect(TanstackQueryDevtools).toHaveBeenCalledWith(
+      expect.objectContaining({ styleNonce: 'abc' }),
+    )
+  })
+
+  it('should forward "shadowDOMTarget" to the devtools constructor', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+    const shadowDOMTarget = document
+      .createElement('div')
+      .attachShadow({ mode: 'open' })
+
+    render(
+      <PreactQueryDevtools
+        client={queryClient}
+        shadowDOMTarget={shadowDOMTarget}
+      />,
+    )
+
+    expect(TanstackQueryDevtools).toHaveBeenCalledWith(
+      expect.objectContaining({ shadowDOMTarget }),
+    )
+  })
+
+  it('should forward "hideDisabledQueries" to the devtools constructor', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    render(
+      <PreactQueryDevtools client={queryClient} hideDisabledQueries={true} />,
+    )
+
+    expect(TanstackQueryDevtools).toHaveBeenCalledWith(
+      expect.objectContaining({ hideDisabledQueries: true }),
+    )
+  })
+
+  it('should call "unmount" on the devtools instance when the component unmounts', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { unmount } = render(<PreactQueryDevtools client={queryClient} />)
+    unmount()
+
+    expect(unmountMock).toHaveBeenCalled()
   })
 
   it('should return null in non-development environments', async () => {

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/preact'
 import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
-import type { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
+import { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
 
 const mountMock = vi.fn()
 const unmountMock = vi.fn()
@@ -61,6 +61,177 @@ describe('PreactQueryDevtoolsPanel', () => {
       render(<PreactQueryDevtoolsPanel client={queryClient} />),
     ).not.toThrow()
     expect(mountMock).toHaveBeenCalled()
+  })
+
+  it('should forward "onClose" to the devtools instance', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+    const onClose = vi.fn()
+
+    render(
+      <PreactQueryDevtoolsPanel client={queryClient} onClose={onClose} />,
+    )
+
+    expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
+  })
+
+  it('should default "onClose" to a no-op function when the prop is omitted', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtoolsPanel client={queryClient} />)
+
+    expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
+  })
+
+  it('should forward "errorTypes" to the devtools instance', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+    const errorTypes = [
+      { name: 'Network', initializer: () => new Error('Network') },
+    ]
+
+    render(
+      <PreactQueryDevtoolsPanel
+        client={queryClient}
+        errorTypes={errorTypes}
+      />,
+    )
+
+    expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
+  })
+
+  it('should default "errorTypes" to an empty array when the prop is omitted', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtoolsPanel client={queryClient} />)
+
+    expect(setErrorTypesMock).toHaveBeenCalledWith([])
+  })
+
+  it('should forward "theme" to the devtools instance', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtoolsPanel client={queryClient} theme="dark" />)
+
+    expect(setThemeMock).toHaveBeenCalledWith('dark')
+  })
+
+  it('should forward the resolved "QueryClient" via "setClient"', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    render(<PreactQueryDevtoolsPanel client={queryClient} />)
+
+    expect(setClientMock).toHaveBeenCalledWith(queryClient)
+  })
+
+  it('should forward "styleNonce" to the devtools constructor', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    render(
+      <PreactQueryDevtoolsPanel client={queryClient} styleNonce="abc" />,
+    )
+
+    expect(TanstackQueryDevtoolsPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ styleNonce: 'abc' }),
+    )
+  })
+
+  it('should forward "shadowDOMTarget" to the devtools constructor', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+    const shadowDOMTarget = document
+      .createElement('div')
+      .attachShadow({ mode: 'open' })
+
+    render(
+      <PreactQueryDevtoolsPanel
+        client={queryClient}
+        shadowDOMTarget={shadowDOMTarget}
+      />,
+    )
+
+    expect(TanstackQueryDevtoolsPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ shadowDOMTarget }),
+    )
+  })
+
+  it('should forward "hideDisabledQueries" to the devtools constructor', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    render(
+      <PreactQueryDevtoolsPanel
+        client={queryClient}
+        hideDisabledQueries={true}
+      />,
+    )
+
+    expect(TanstackQueryDevtoolsPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ hideDisabledQueries: true }),
+    )
+  })
+
+  it('should preserve the default container height when "style" omits "height"', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    const { container } = render(
+      <PreactQueryDevtoolsPanel
+        client={queryClient}
+        style={{ width: '300px' }}
+      />,
+    )
+
+    expect(container.querySelector('.tsqd-parent-container')).toHaveStyle({
+      height: '500px',
+      width: '300px',
+    })
+  })
+
+  it('should let "style" override the default container height on the rendered element', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    const { container } = render(
+      <PreactQueryDevtoolsPanel
+        client={queryClient}
+        style={{ width: '300px', height: '300px' }}
+      />,
+    )
+
+    expect(container.querySelector('.tsqd-parent-container')).toHaveStyle({
+      height: '300px',
+      width: '300px',
+    })
+  })
+
+  it('should call "unmount" on the devtools instance when the component unmounts', async () => {
+    const { PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel')
+    const queryClient = new QueryClient()
+
+    const { unmount } = render(
+      <PreactQueryDevtoolsPanel client={queryClient} />,
+    )
+    unmount()
+
+    expect(unmountMock).toHaveBeenCalled()
   })
 
   it('should return null in non-development environments', async () => {

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -69,9 +69,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     const queryClient = new QueryClient()
     const onClose = vi.fn()
 
-    render(
-      <PreactQueryDevtoolsPanel client={queryClient} onClose={onClose} />,
-    )
+    render(<PreactQueryDevtoolsPanel client={queryClient} onClose={onClose} />)
 
     expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
   })
@@ -95,10 +93,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     ]
 
     render(
-      <PreactQueryDevtoolsPanel
-        client={queryClient}
-        errorTypes={errorTypes}
-      />,
+      <PreactQueryDevtoolsPanel client={queryClient} errorTypes={errorTypes} />,
     )
 
     expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
@@ -139,9 +134,7 @@ describe('PreactQueryDevtoolsPanel', () => {
       await import('../PreactQueryDevtoolsPanel')
     const queryClient = new QueryClient()
 
-    render(
-      <PreactQueryDevtoolsPanel client={queryClient} styleNonce="abc" />,
-    )
+    render(<PreactQueryDevtoolsPanel client={queryClient} styleNonce="abc" />)
 
     expect(TanstackQueryDevtoolsPanel).toHaveBeenCalledWith(
       expect.objectContaining({ styleNonce: 'abc' }),


### PR DESCRIPTION
## 🎯 Changes

Add test cases to both `PreactQueryDevtools` and `PreactQueryDevtoolsPanel` that cover the full prop wiring matrix, mirroring the matrix already in place for `SolidQueryDevtools` (#10823, #10824), `SolidQueryDevtoolsPanel` (#10827, #10828), and `ReactQueryDevtools{,Panel}` (#10851).

### `PreactQueryDevtools`

- `initialIsOpen` → `setInitialIsOpen` + default (`false` when omitted)
- `errorTypes` → `setErrorTypes` + default (`[]` when omitted)
- `theme` → `setTheme`
- resolved `QueryClient` → `setClient`
- constructor-only props (`styleNonce`, `shadowDOMTarget`, `hideDisabledQueries`)
- `unmount` cleanup

### `PreactQueryDevtoolsPanel`

- `onClose` → `setOnClose` + default (no-op function when omitted)
- `errorTypes` → `setErrorTypes` + default
- `theme` → `setTheme`
- resolved `QueryClient` → `setClient`
- constructor-only props (`styleNonce`, `shadowDOMTarget`, `hideDisabledQueries`)
- `style` merge contract (preserve default and override on conflict)
- `unmount` cleanup

All cases follow the existing mock pattern (\`vi.mock('@tanstack/query-devtools', ...)\` with per-method spies), and `style` cases use \`toHaveStyle\` from `@testing-library/jest-dom`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for PreactQueryDevtools with improved assertions for prop forwarding and default values.
  * Expanded PreactQueryDevtoolsPanel test suite to validate configuration handling and component lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->