### PR TITLE
docs(framework/{preact,solid}/devtools): add the 'Embedded Mode' section

### DIFF
--- a/docs/framework/preact/devtools.md
+++ b/docs/framework/preact/devtools.md
@@ -88,3 +88,50 @@ function App() {
 - `theme?: "light" | "dark" | "system"`
   - Defaults to `system`.
   - Set this to change the theme of the devtools panel.
+
+## Embedded Mode
+
+Embedded mode will show the development tools as a fixed element in your application, so you can use our panel in your own development tools.
+
+Place the following code as high in your Preact app as you can. The closer it is to the root of the page, the better it will work!
+
+```tsx
+import { useState } from 'preact/hooks'
+import { PreactQueryDevtoolsPanel } from '@tanstack/preact-query-devtools'
+
+function App() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {/* The rest of your application */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+      >{`${isOpen ? 'Close' : 'Open'} the devtools panel`}</button>
+      {isOpen && <PreactQueryDevtoolsPanel onClose={() => setIsOpen(false)} />}
+    </QueryClientProvider>
+  )
+}
+```
+
+### Options
+
+- `style?: CSSProperties`
+  - Custom styles for the devtools panel
+  - Default: `{ height: '500px' }`
+  - Example: `{ height: '100%' }`
+  - Example: `{ height: '100%', width: '100%' }`
+- `onClose?: () => void`
+  - Callback function that is called when the devtools panel is closed
+- `client?: QueryClient`,
+  - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
+- `errorTypes?: { name: string; initializer: (query: Query) => TError}[]`
+  - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
+- `styleNonce?: string`
+  - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.
+- `shadowDOMTarget?: ShadowRoot`
+  - Default behavior will apply the devtool's styles to the head tag within the DOM.
+  - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.

--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -88,3 +88,52 @@ function App() {
 - `theme?: "light" | "dark" | "system"`
   - Defaults to `system`.
   - Set this to change the theme of the devtools panel.
+
+## Embedded Mode
+
+Embedded mode will show the development tools as a fixed element in your application, so you can use our panel in your own development tools.
+
+Place the following code as high in your Solid app as you can. The closer it is to the root of the page, the better it will work!
+
+```tsx
+import { createSignal, Show } from 'solid-js'
+import { SolidQueryDevtoolsPanel } from '@tanstack/solid-query-devtools'
+
+function App() {
+  const [isOpen, setIsOpen] = createSignal(false)
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {/* The rest of your application */}
+      <button
+        onClick={() => setIsOpen(!isOpen())}
+      >{`${isOpen() ? 'Close' : 'Open'} the devtools panel`}</button>
+      <Show when={isOpen()}>
+        <SolidQueryDevtoolsPanel onClose={() => setIsOpen(false)} />
+      </Show>
+    </QueryClientProvider>
+  )
+}
+```
+
+### Options
+
+- `style?: JSX.CSSProperties`
+  - Custom styles for the devtools panel
+  - Default: `{ height: '500px' }`
+  - Example: `{ height: '100%' }`
+  - Example: `{ height: '100%', width: '100%' }`
+- `onClose?: () => void`
+  - Callback function that is called when the devtools panel is closed
+- `client?: QueryClient`,
+  - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
+- `errorTypes?: { name: string; initializer: (query: Query) => TError}[]`
+  - Use this to predefine some errors that can be triggered on your queries. Initializer will be called (with the specific query) when that error is toggled on from the UI. It must return an Error.
+- `styleNonce?: string`
+  - Use this to pass a nonce to the style tag that is added to the document head. This is useful if you are using a Content Security Policy (CSP) nonce to allow inline styles.
+- `shadowDOMTarget?: ShadowRoot`
+  - Default behavior will apply the devtool's styles to the head tag within the DOM.
+  - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.


### PR DESCRIPTION
## 🎯 Changes

Add the `## Embedded Mode` section to the Preact and Solid devtools docs, mirroring the section that already exists for React and Vue.

Both adapters expose a `DevtoolsPanel` component (`PreactQueryDevtoolsPanel`, `SolidQueryDevtoolsPanel`), but the Embedded Mode usage and options were never documented. Users had to discover the component and infer its options from the source.

The new sections follow the same shape as the React/Vue sections:

- a short explanation of what Embedded Mode does
- a copy-pasteable usage example (using `useState` from `preact/hooks` for Preact, and `createSignal` + `Show` for Solid)
- an `### Options` list covering `style`, `onClose`, `client`, `errorTypes`, `styleNonce`, `shadowDOMTarget`, and `theme`

The option types use each adapter's own type alias (`CSSProperties` for Preact, `JSX.CSSProperties` for Solid) to match the production components.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added Embedded Mode documentation for Preact Query and Solid Query devtools, covering how to embed devtools panels directly into your application with configuration options for custom styling, theming, error handling, lifecycle callbacks, and Shadow DOM integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->