### PR TITLE
docs(framework/vue/devtools): correct 'your React app' typo to 'your Vue app' in the Embedded Mode section

### DIFF
--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -88,7 +88,7 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
 
 Embedded mode will show the development tools as a fixed element in your application, so you can use our panel in your own development tools.
 
-Place the following code as high in your React app as you can. The closer it is to the root of the page, the better it will work!
+Place the following code as high in your Vue app as you can. The closer it is to the root of the page, the better it will work!
 
 ```vue
 <script setup>


### PR DESCRIPTION
## 🎯 Changes

The Vue devtools `## Embedded Mode` section instructs users to place the code "as high in your **React** app as you can", which is a copy-paste leftover from the original React docs. Vue users should be told to place it in their **Vue** app.

```diff
-Place the following code as high in your React app as you can. The closer it is to the root of the page, the better it will work!
+Place the following code as high in your Vue app as you can. The closer it is to the root of the page, the better it will work!
```

Found while comparing the Embedded Mode sections across all four adapter docs in #10853. React, Preact, and Solid already say "your <framework> app" correctly.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected framework reference in Embedded Mode instructions documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->