### PR TITLE
docs(framework/vue/devtools): align the 'Embedded Mode' example with the other adapters and add the missing 'ref' import

### DIFF
--- a/docs/framework/vue/devtools.md
+++ b/docs/framework/vue/devtools.md
@@ -92,17 +92,20 @@ Place the following code as high in your Vue app as you can. The closer it is to
 
 ```vue
 <script setup>
+import { ref } from 'vue'
 import { VueQueryDevtoolsPanel } from '@tanstack/vue-query-devtools'
-const isDevtoolsOpen = ref(false)
+const isOpen = ref(false)
 function toggleDevtools() {
-  isDevtoolsOpen.value = !isDevtoolsOpen.value
+  isOpen.value = !isOpen.value
 }
 </script>
 
 <template>
   <h1>The app!</h1>
-  <button @click="toggleDevtools">Open Devtools</button>
-  <VueQueryDevtoolsPanel v-if="isDevtoolsOpen" :onClose="toggleDevtools" />
+  <button @click="toggleDevtools">
+    {{ isOpen ? 'Close' : 'Open' }} the devtools panel
+  </button>
+  <VueQueryDevtoolsPanel v-if="isOpen" :onClose="toggleDevtools" />
 </template>
 ```
 


### PR DESCRIPTION
## 🎯 Changes

Align the Vue `## Embedded Mode` example with the other adapter docs (React/Preact/Solid) and add the missing `ref` import so the snippet is actually usable when copy-pasted into a plain Vue 3 project:

- add `import { ref } from 'vue'` — without auto-import (Nuxt, `unplugin-auto-import`, etc.) the original snippet would throw `ref is not defined`
- rename the reactive flag from `isDevtoolsOpen` to `isOpen` so it matches the variable used in the React/Preact/Solid examples
- switch the button label from the static `Open Devtools` to the dynamic `${isOpen ? 'Close' : 'Open'} the devtools panel`, mirroring how the React/Preact/Solid examples reflect the current panel state

```diff
 <script setup>
+import { ref } from 'vue'
 import { VueQueryDevtoolsPanel } from '@tanstack/vue-query-devtools'
-const isDevtoolsOpen = ref(false)
+const isOpen = ref(false)
 function toggleDevtools() {
-  isDevtoolsOpen.value = !isDevtoolsOpen.value
+  isOpen.value = !isOpen.value
 }
 </script>

 <template>
   <h1>The app!</h1>
-  <button @click="toggleDevtools">Open Devtools</button>
-  <VueQueryDevtoolsPanel v-if="isDevtoolsOpen" :onClose="toggleDevtools" />
+  <button @click="toggleDevtools">
+    {{ isOpen ? 'Close' : 'Open' }} the devtools panel
+  </button>
+  <VueQueryDevtoolsPanel v-if="isOpen" :onClose="toggleDevtools" />
 </template>
```

The Vue-idiomatic parts of the snippet — `<script setup>` with a named `toggleDevtools` function, `v-if` for conditional rendering, and the `<h1>The app!</h1>` placeholder — are intentionally preserved so the example still reads like idiomatic Vue 3.

Found while comparing the Embedded Mode sections across all four adapter docs in #10853. The missing `ref` import was flagged by CodeRabbit during review.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vue Devtools embedded-mode example: simplified open/close handling, introduced a single toggle-driven state for the panel, and adjusted the example button to reflect and control panel visibility dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->