### PR TITLE
fix(react-query-next-experimental): replace deprecated 'isServer' with 'environmentManager.isServer()'

### DIFF
--- a/.changeset/react-query-next-experimental-environment-manager-isserver.md
+++ b/.changeset/react-query-next-experimental-environment-manager-isserver.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query-next-experimental': patch
+---
+
+fix(react-query-next-experimental): replace deprecated 'isServer' with 'environmentManager.isServer()'

--- a/packages/react-query-next-experimental/src/HydrationStreamProvider.tsx
+++ b/packages/react-query-next-experimental/src/HydrationStreamProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { isServer } from '@tanstack/react-query'
+import { environmentManager } from '@tanstack/react-query'
 import { useServerInsertedHTML } from 'next/navigation'
 import * as React from 'react'
 import { htmlEscapeJsonString } from './htmlescape'
@@ -106,7 +106,7 @@ export function createHydrationStreamProvider<TShape>() {
 
     // <server stuff>
     const [stream] = React.useState<Array<TShape>>(() => {
-      if (!isServer) {
+      if (!environmentManager.isServer()) {
         return {
           push() {
             // no-op on the client
@@ -154,7 +154,7 @@ export function createHydrationStreamProvider<TShape>() {
     // the initial render so children have access to the data immediately
     // This is important to avoid the client suspending during the initial render
     // if the data has not yet been hydrated.
-    if (!isServer) {
+    if (!environmentManager.isServer()) {
       const win = window as any
       if (!win[id]?.initialized) {
         // Client: consume cache:

--- a/packages/react-query-next-experimental/src/ReactQueryStreamedHydration.tsx
+++ b/packages/react-query-next-experimental/src/ReactQueryStreamedHydration.tsx
@@ -3,8 +3,8 @@
 import {
   defaultShouldDehydrateQuery,
   dehydrate,
+  environmentManager,
   hydrate,
-  isServer,
   useQueryClient,
 } from '@tanstack/react-query'
 import * as React from 'react'
@@ -42,7 +42,7 @@ export function ReactQueryStreamedHydration(props: {
   const [trackedKeys] = React.useState(() => new Set<string>())
 
   // <server only>
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Do we need to care about unsubscribing? I don't think so to be honest
     queryClient.getQueryCache().subscribe((event) => {
       switch (event.type) {


### PR DESCRIPTION
## 🎯 Changes

Migrate `react-query-next-experimental` from the deprecated `isServer` export to `environmentManager.isServer()`, matching the migration already done for `react-query`/`preact-query` in #10199 and for `vue-query` in #10826.

Updated files:

- `packages/react-query-next-experimental/src/HydrationStreamProvider.tsx`
- `packages/react-query-next-experimental/src/ReactQueryStreamedHydration.tsx`

No behavior change — `environmentManager.isServer()` calls the same underlying check by default while allowing host environments (frameworks, SSR runtimes, tests) to override the server detection.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@tanstack/react-query-next-experimental` to use the current environment detection method instead of the deprecated approach, ensuring better long-term compatibility and alignment with package standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->