### PR TITLE
fix(examples/integrations): replace deprecated 'isServer' with 'environmentManager.isServer()' in the Next.js examples

### DIFF
--- a/examples/react/nextjs-suspense-streaming/src/app/page.tsx
+++ b/examples/react/nextjs-suspense-streaming/src/app/page.tsx
@@ -1,11 +1,11 @@
 'use client'
-import { isServer, useSuspenseQuery } from '@tanstack/react-query'
+import { environmentManager, useSuspenseQuery } from '@tanstack/react-query'
 import { Suspense } from 'react'
 
 export const runtime = 'edge' // 'nodejs' (default) | 'edge'
 
 function getBaseURL() {
-  if (!isServer) {
+  if (!environmentManager.isServer()) {
     return ''
   }
   if (process.env.VERCEL_URL) {

--- a/integrations/react-next-15/app/providers.tsx
+++ b/integrations/react-next-15/app/providers.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 // Since QueryClientProvider relies on useContext under the hood, we have to put 'use client' on top
-import { QueryClientProvider, isServer } from '@tanstack/react-query'
+import { QueryClientProvider, environmentManager } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import type { QueryClient } from '@tanstack/react-query'
 import { makeQueryClient } from '@/app/make-query-client'
@@ -10,7 +10,7 @@ import { makeQueryClient } from '@/app/make-query-client'
 let browserQueryClient: QueryClient | undefined = undefined
 
 function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {

--- a/integrations/react-next-16/app/providers.tsx
+++ b/integrations/react-next-16/app/providers.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 // Since QueryClientProvider relies on useContext under the hood, we have to put 'use client' on top
-import { QueryClientProvider, isServer } from '@tanstack/react-query'
+import { QueryClientProvider, environmentManager } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import type { QueryClient } from '@tanstack/react-query'
 import { makeQueryClient } from '@/app/make-query-client'
@@ -10,7 +10,7 @@ import { makeQueryClient } from '@/app/make-query-client'
 let browserQueryClient: QueryClient | undefined = undefined
 
 function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {


### PR DESCRIPTION
## 🎯 Changes

Migrate the remaining `isServer` usages in the Next.js examples and integrations to `environmentManager.isServer()`, matching the migration already done for `react-query`/`preact-query` (#10199), `vue-query` (#10826), and `react-query-next-experimental` (#10857).

Updated files:

- `integrations/react-next-15/app/providers.tsx`
- `integrations/react-next-16/app/providers.tsx`
- `examples/react/nextjs-suspense-streaming/src/app/page.tsx`

Without these updates, users copy-pasting the Next.js provider snippet from the integration examples would import the deprecated `isServer` export and see the `@deprecated` warning in their IDE.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal server-vs-browser detection across example apps and React/Next.js providers to a more current implementation.  
  * No user-facing behavior or public APIs changed; existing functionality and rendering remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->