### PR TITLE
refactor(examples/nextjs-suspense-streaming): drop unnecessary 'as string' cast

### DIFF
--- a/examples/react/nextjs-suspense-streaming/src/app/page.tsx
+++ b/examples/react/nextjs-suspense-streaming/src/app/page.tsx
@@ -30,7 +30,7 @@ function useWaitQuery(props: { wait: number }) {
     },
   })
 
-  return [query.data as string, query] as const
+  return [query.data, query] as const
 }
 
 function MyComponent(props: { wait: number }) {


### PR DESCRIPTION
## 🎯 Changes

Drop the unnecessary `as string` cast on `query.data` in `useWaitQuery`. The `queryFn` is already annotated with `const res: string = ...`, so TypeScript infers `query.data` as `string` and the cast is redundant — `@typescript-eslint/no-unnecessary-type-assertion` flags it as well.

```diff
-  return [query.data as string, query] as const
+  return [query.data, query] as const
```

Found while updating this file in #10858 (`isServer` → `environmentManager.isServer()` migration).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \`pnpm run test:pr\`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type handling in query management to improve code reliability and alignment with framework conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->