### PR TITLE
fix(examples): replace deprecated 'isServer' with 'environmentManager.isServer()' in remaining Next.js examples

### DIFF
--- a/examples/react/nextjs-app-prefetching/app/get-query-client.ts
+++ b/examples/react/nextjs-app-prefetching/app/get-query-client.ts
@@ -1,7 +1,7 @@
 import {
   QueryClient,
   defaultShouldDehydrateQuery,
-  isServer,
+  environmentManager,
 } from '@tanstack/react-query'
 
 function makeQueryClient() {
@@ -23,7 +23,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined
 
 export function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {

--- a/examples/react/nextjs-suspense-streaming/src/app/providers.tsx
+++ b/examples/react/nextjs-suspense-streaming/src/app/providers.tsx
@@ -3,7 +3,7 @@
 import {
   QueryClient,
   QueryClientProvider,
-  isServer,
+  environmentManager,
 } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import * as React from 'react'
@@ -22,7 +22,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined
 
 function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     return makeQueryClient()
   } else {
     if (!browserQueryClient) browserQueryClient = makeQueryClient()


### PR DESCRIPTION
## 🎯 Changes

Continues the `isServer` → `environmentManager.isServer()` migration kicked off by #10199 and continued through:

- #10826 — `vue-query`
- #10857 — `react-query-next-experimental`
- #10858 — Next.js examples + integrations (3 files)

Two example files were missed by #10858 and still import the deprecated `isServer` export. This PR migrates them:

- `examples/react/nextjs-app-prefetching/app/get-query-client.ts`
- `examples/react/nextjs-suspense-streaming/src/app/providers.tsx`

Without these updates, users copy-pasting the Next.js example snippets into their own projects pull in the deprecated `isServer` export and see the `@deprecated` warning in their IDE.

No behavior change — `environmentManager.isServer()` performs the same check by default while allowing host environments to override it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated NextJS examples to use the new environment detection API from `@tanstack/react-query`. Both the app prefetching and suspense streaming examples now utilize the recommended approach for distinguishing between server and browser runtime contexts. This change improves code consistency, ensures more reliable behavior across deployment scenarios, and aligns with current React Query best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->