### PR TITLE
test(query-core/utils): add test for already-aborted signal in 'addConsumeAwareSignal'

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '..'
 import {
+  addConsumeAwareSignal,
   addToEnd,
   addToStart,
   ensureQueryFn,
@@ -601,6 +602,24 @@ describe('core/utils', () => {
       expect(shouldThrowError(true, [new Error('test error')])).toBe(true)
       expect(shouldThrowError(false, [new Error('test error')])).toBe(false)
       expect(shouldThrowError(undefined, [new Error('test error')])).toBe(false)
+    })
+  })
+
+  describe('addConsumeAwareSignal', () => {
+    it('should call onCancelled immediately when the signal is already aborted on first access', () => {
+      const controller = new AbortController()
+      controller.abort()
+      const onCancelled = vi.fn()
+      const object = addConsumeAwareSignal(
+        {},
+        () => controller.signal,
+        onCancelled,
+      )
+
+      // Access the signal to consume it
+      void object.signal
+
+      expect(onCancelled).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `addConsumeAwareSignal`, which previously had no direct unit test.

The test covers the already-aborted branch: when the provided signal is already aborted at the time `signal` is first accessed (consumed), `onCancelled` is invoked immediately instead of registering an `abort` listener.

This covers the previously-uncovered `if (signal.aborted)` true branch in `packages/query-core/src/utils.ts`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify proper handling of pre-aborted signal scenarios, enhancing reliability assurance for existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->