### PR TITLE
test(query-core/utils): add test for exposing the signal on the query context in 'addConsumeAwareSignal'

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -606,6 +606,19 @@ describe('core/utils', () => {
   })
 
   describe('addConsumeAwareSignal', () => {
+    it('should expose the signal on the query context while preserving its properties', () => {
+      const controller = new AbortController()
+      const key = queryKey()
+      const context = addConsumeAwareSignal(
+        { queryKey: key, meta: undefined },
+        () => controller.signal,
+        vi.fn(),
+      )
+
+      expect(context.queryKey).toBe(key)
+      expect(context.signal).toBe(controller.signal)
+    })
+
     it('should call onCancelled immediately when the signal is already aborted on first access', () => {
       const controller = new AbortController()
       controller.abort()


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `addConsumeAwareSignal` covering its core contract: the helper attaches a lazy `signal` property to the given query context object while preserving the object's original properties.

This mirrors how `streamedQuery` and `infiniteQueryBehavior` rely on the helper to expose an `AbortSignal` on the query function context.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for signal handling in query context, verifying proper signal factory behavior and context exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/query/pull/10863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->