### PR TITLE
test(query-core/utils): add tests for consumed signal cancellation and single consumption in 'addConsumeAwareSignal'

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -634,5 +634,36 @@ describe('core/utils', () => {
 
       expect(onCancelled).toHaveBeenCalledTimes(1)
     })
+
+    it('should flag cancellation when the consumed signal aborts, mirroring streamed/infinite queries', () => {
+      const controller = new AbortController()
+      let cancelled = false
+      const context = addConsumeAwareSignal(
+        { queryKey: queryKey() },
+        () => controller.signal,
+        () => (cancelled = true),
+      )
+
+      void context.signal
+      expect(cancelled).toBe(false)
+
+      controller.abort()
+      expect(cancelled).toBe(true)
+    })
+
+    it('should consume the signal only once across repeated accesses', () => {
+      const controller = new AbortController()
+      const addEventListener = vi.spyOn(controller.signal, 'addEventListener')
+      const context = addConsumeAwareSignal(
+        { queryKey: queryKey() },
+        () => controller.signal,
+        vi.fn(),
+      )
+
+      expect(context.signal).toBe(controller.signal)
+      expect(context.signal).toBe(controller.signal)
+
+      expect(addEventListener).toHaveBeenCalledTimes(1)
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds two unit tests for `addConsumeAwareSignal` covering the behavior of the signal after it has been consumed:

- When the consumed signal aborts later, `onCancelled` is invoked, mirroring how `streamedQuery` and `infiniteQueryBehavior` flip a `cancelled` flag to stop fetching further pages/chunks.
- Accessing the signal multiple times consumes it only once, so the `abort` listener is registered a single time.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for signal consumption logic with additional test cases verifying cancellation callback behavior and signal consumption deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->