### PR TITLE
test(query-core/utils): add test for recursion depth limit in 'replaceEqualDeep'

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -421,6 +421,29 @@ describe('core/utils', () => {
 
       expect(next).toBe(current)
     })
+
+    it('should stop structural sharing once the recursion depth exceeds the limit', () => {
+      const nest = (depth: number, leaf: number) => {
+        let value: any = { leaf }
+        for (let i = 0; i < depth; i++) {
+          value = { child: value }
+        }
+        return value
+      }
+
+      const prev = nest(502, 1)
+      const next = nest(502, 2)
+      const result = replaceEqualDeep(prev, next)
+
+      let resultNode = result
+      let nextNode = next
+      for (let i = 0; i < 502; i++) {
+        resultNode = resultNode.child
+        nextNode = nextNode.child
+      }
+
+      expect(resultNode).toBe(nextNode)
+    })
   })
 
   describe('matchMutation', () => {


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `replaceEqualDeep` covering its recursion depth guard (`if (depth > 500) return b`).

Existing tests only exercise shallowly-nested values, so the depth limit was never reached. This test builds a deeply-nested structure (over 500 levels) and asserts that once the limit is exceeded, `replaceEqualDeep` stops structural sharing and returns the next value's node as-is.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for recursion depth handling in utility functions to ensure proper behavior under deep nesting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->