### PR TITLE
docs(framework/react/guides): replace deprecated 'isServer' with 'environmentManager.isServer()'

### DIFF
--- a/docs/framework/react/guides/advanced-ssr.md
+++ b/docs/framework/react/guides/advanced-ssr.md
@@ -31,7 +31,7 @@ The first step of any React Query setup is always to create a `queryClient` and 
 
 // Since QueryClientProvider relies on useContext under the hood, we have to put 'use client' on top
 import {
-  isServer,
+  environmentManager,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
@@ -51,7 +51,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined
 
 function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {
@@ -376,7 +376,7 @@ We will also need to move the `getQueryClient()` function out of our `app/provid
 ```tsx
 // app/get-query-client.ts
 import {
-  isServer,
+  environmentManager,
   QueryClient,
   defaultShouldDehydrateQuery,
 } from '@tanstack/react-query'
@@ -408,7 +408,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined
 
 export function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {
@@ -564,7 +564,7 @@ To achieve this, wrap your app in the `ReactQueryStreamedHydration` component:
 'use client'
 
 import {
-  isServer,
+  environmentManager,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
@@ -586,7 +586,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined
 
 function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {

--- a/docs/framework/react/guides/suspense.md
+++ b/docs/framework/react/guides/suspense.md
@@ -120,7 +120,7 @@ To achieve this, wrap your app in the `ReactQueryStreamedHydration` component:
 'use client'
 
 import {
-  isServer,
+  environmentManager,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
@@ -142,7 +142,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined
 
 function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {


### PR DESCRIPTION
## 🎯 Changes

Replaces the deprecated `isServer` import with `environmentManager.isServer()` in the React SSR guides, matching the recommended API used elsewhere in the codebase.

- `docs/framework/react/guides/suspense.md`: the streamed hydration provider example
- `docs/framework/react/guides/advanced-ssr.md`: the three `getQueryClient()` examples (providers, `get-query-client.ts`, and the streamed hydration provider)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React Query + Next.js Server Components and Suspense documentation with improved code examples for enhanced server-environment detection patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->