### PR TITLE
test(query-persist-client-core/retryStrategies): add tests for 'removeOldestQuery' removing the oldest query

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/retryStrategies.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/retryStrategies.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { QueryClient, dehydrate } from '@tanstack/query-core'
+import { removeOldestQuery } from '../retryStrategies'
+import type { PersistedClient } from '../persist'
+
+type PersistedQuery = PersistedClient['clientState']['queries'][number]
+
+describe('removeOldestQuery', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  function createQuery(
+    queryHash: string,
+    dataUpdatedAt: number,
+  ): PersistedQuery {
+    queryClient.setQueryData([queryHash], 'data')
+    const query = dehydrate(queryClient).queries.find(
+      (dehydratedQuery) => dehydratedQuery.queryHash === `["${queryHash}"]`,
+    )!
+    return { ...query, state: { ...query.state, dataUpdatedAt } }
+  }
+
+  function createPersistedClient(
+    queries: Array<PersistedQuery>,
+    mutations: PersistedClient['clientState']['mutations'] = [],
+  ): PersistedClient {
+    return {
+      timestamp: 0,
+      buster: '',
+      clientState: { queries, mutations },
+    }
+  }
+
+  it('should remove the query with the oldest dataUpdatedAt', () => {
+    const persistedClient = createPersistedClient([
+      createQuery('a', 30),
+      createQuery('b', 10),
+      createQuery('c', 20),
+    ])
+
+    const result = removeOldestQuery({
+      persistedClient,
+      error: new Error('full'),
+      errorCount: 1,
+    })
+
+    expect(result?.clientState.queries.map((query) => query.queryKey)).toEqual([
+      ['a'],
+      ['c'],
+    ])
+  })
+
+  it('should remove only a single query when multiple share the oldest dataUpdatedAt', () => {
+    const persistedClient = createPersistedClient([
+      createQuery('a', 10),
+      createQuery('b', 10),
+    ])
+
+    const result = removeOldestQuery({
+      persistedClient,
+      error: new Error('full'),
+      errorCount: 1,
+    })
+
+    expect(result?.clientState.queries.map((query) => query.queryKey)).toEqual([
+      ['b'],
+    ])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Adds unit tests for the `removeOldestQuery` predefined retry strategy, which previously had no direct unit test in its defining package.

These tests cover its core behavior: it removes the single query with the oldest `dataUpdatedAt`, and when several queries share that oldest timestamp only one of them is removed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for query removal functionality to ensure correct behavior when managing query cache with timestamp-based ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->