### PR TITLE
test(query-persist-client-core/retryStrategies): add test for 'removeOldestQuery' returning undefined when there are no queries

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/retryStrategies.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/retryStrategies.test.ts
@@ -73,4 +73,16 @@ describe('removeOldestQuery', () => {
       ['b'],
     ])
   })
+
+  it('should return undefined when there are no queries to remove', () => {
+    const persistedClient = createPersistedClient([])
+
+    const result = removeOldestQuery({
+      persistedClient,
+      error: new Error('full'),
+      errorCount: 1,
+    })
+
+    expect(result).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `removeOldestQuery` covering the case where the persisted client has no queries to remove: it returns `undefined`, which signals the persister to stop retrying instead of looping forever.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `removeOldestQuery` function behavior when no queries are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->