### PR TITLE
test(query-persist-client-core/retryStrategies): add test for 'removeOldestQuery' preserving mutations

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/retryStrategies.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/retryStrategies.test.ts
@@ -85,4 +85,27 @@ describe('removeOldestQuery', () => {
 
     expect(result).toBeUndefined()
   })
+
+  it('should preserve mutations when removing the oldest query', () => {
+    queryClient.getMutationCache().build(queryClient, {
+      mutationFn: () => Promise.resolve('data'),
+    })
+    const { mutations } = dehydrate(queryClient, {
+      shouldDehydrateMutation: () => true,
+    })
+
+    const persistedClient = createPersistedClient(
+      [createQuery('a', 10)],
+      mutations,
+    )
+
+    const result = removeOldestQuery({
+      persistedClient,
+      error: new Error('full'),
+      errorCount: 1,
+    })
+
+    expect(result?.clientState.queries).toEqual([])
+    expect(result?.clientState.mutations).toEqual(mutations)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `removeOldestQuery` verifying that it only removes queries and leaves the persisted mutations untouched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for query persistence to verify that mutations remain preserved when removing older persisted queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->