### PR TITLE
test(query-persist-client-core/persist): add test for hydrating a valid persisted cache in 'persistQueryClientRestore'

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { QueriesObserver, QueryClient } from '@tanstack/query-core'
+import { QueriesObserver, QueryClient, dehydrate } from '@tanstack/query-core'
 import {
   persistQueryClientRestore,
   persistQueryClientSubscribe,
@@ -154,5 +154,28 @@ describe('persistQueryClientRestore', () => {
         persister,
       }),
     ).rejects.toBe(removeError)
+  })
+
+  it('should hydrate the query client when the persisted cache is valid', async () => {
+    const sourceClient = new QueryClient()
+    sourceClient.setQueryData(['key'], 'data')
+
+    const queryClient = new QueryClient()
+    const persister = createSpyPersister()
+
+    persister.restoreClient = () =>
+      Promise.resolve({
+        buster: '',
+        clientState: dehydrate(sourceClient),
+        timestamp: Date.now(),
+      })
+
+    await persistQueryClientRestore({
+      queryClient,
+      persister,
+    })
+
+    expect(persister.removeClient).not.toHaveBeenCalled()
+    expect(queryClient.getQueryData(['key'])).toBe('data')
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `persistQueryClientRestore` covering the happy path: when the restored cache is valid (has a timestamp, is not expired, and the buster matches), the query client is hydrated with the persisted data and the client is not removed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing for query client persistence restoration to verify correct handling of cached data during hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->