### PR TITLE
docs(reference/QueryCache): use the v5 filters-object form in 'find' and 'findAll' examples

### DIFF
--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -22,7 +22,7 @@ const queryCache = new QueryCache({
   },
 })
 
-const query = queryCache.find(['posts'])
+const query = queryCache.find({ queryKey: ['posts'] })
 ```
 
 Its available methods are:
@@ -52,7 +52,7 @@ Its available methods are:
 > Note: This is not typically needed for most applications, but can come in handy when needing more information about a query in rare scenarios (eg. Looking at the query.state.dataUpdatedAt timestamp to decide whether a query is fresh enough to be used as an initial value)
 
 ```tsx
-const query = queryCache.find(queryKey)
+const query = queryCache.find({ queryKey })
 ```
 
 **Options**
@@ -71,7 +71,7 @@ const query = queryCache.find(queryKey)
 > Note: This is not typically needed for most applications, but can come in handy when needing more information about a query in rare scenarios
 
 ```tsx
-const queries = queryCache.findAll(queryKey)
+const queries = queryCache.findAll({ queryKey })
 ```
 
 **Options**


### PR DESCRIPTION
## Description

The `QueryCache` reference examples call `find` / `findAll` with a **positional** query key — the v4 signature. In v5, both take a single **filters object**, which is what this page's own Options already document (`filters?: QueryFilters`). The examples are therefore out of date and won't type-check / behave as shown on v5.

Updated the three examples to the v5 form:

```ts
queryCache.find({ queryKey: ['posts'] })
queryCache.find({ queryKey })
queryCache.findAll({ queryKey })
```

Docs-only; brings the examples in line with the v5 API and the Options already listed on the page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated QueryCache documentation examples with corrected method signatures for find and findAll operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->