### PR TITLE
test(query-persist-client-core/persist): hoist 'queryClient' and 'persister' setup into 'beforeEach' and clear in 'afterEach'

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueriesObserver, QueryClient, dehydrate } from '@tanstack/query-core'
 import {
   persistQueryClientRestore,
@@ -64,6 +64,18 @@ describe('persistQueryClientSave', () => {
 })
 
 describe('persistQueryClientRestore', () => {
+  let queryClient: QueryClient
+  let persister: ReturnType<typeof createSpyPersister>
+
+  beforeEach(() => {
+    queryClient = new QueryClient()
+    persister = createSpyPersister()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
   it('should rethrow exceptions in `restoreClient`', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')
@@ -73,11 +85,7 @@ describe('persistQueryClientRestore', () => {
       .spyOn(console, 'warn')
       .mockImplementation(() => undefined)
 
-    const queryClient = new QueryClient()
-
     const restoreError = new Error('Error restoring client')
-
-    const persister = createSpyPersister()
 
     persister.restoreClient = () => Promise.reject(restoreError)
 
@@ -105,12 +113,8 @@ describe('persistQueryClientRestore', () => {
       .spyOn(console, 'warn')
       .mockImplementation(() => undefined)
 
-    const queryClient = new QueryClient()
-
     const restoreError = new Error('Error restoring client')
     const removeError = new Error('Error removing client')
-
-    const persister = createSpyPersister()
 
     persister.restoreClient = () => Promise.reject(restoreError)
     persister.removeClient = () => Promise.reject(removeError)
@@ -131,9 +135,6 @@ describe('persistQueryClientRestore', () => {
   })
 
   it('should rethrow error in `removeClient`', async () => {
-    const queryClient = new QueryClient()
-
-    const persister = createSpyPersister()
     const removeError = new Error('Error removing client')
 
     persister.removeClient = () => Promise.reject(removeError)
@@ -159,9 +160,6 @@ describe('persistQueryClientRestore', () => {
   it('should hydrate the query client when the persisted cache is valid', async () => {
     const sourceClient = new QueryClient()
     sourceClient.setQueryData(['key'], 'data')
-
-    const queryClient = new QueryClient()
-    const persister = createSpyPersister()
 
     persister.restoreClient = () =>
       Promise.resolve({


### PR DESCRIPTION
## 🎯 Changes

Hoists the repeated `queryClient` and `persister` instantiation in the `persistQueryClientRestore` test suite into a shared `beforeEach`, and clears the query client in `afterEach`, removing the duplicated setup from each test.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite to use shared setup and cleanup, improving organization and maintainability.
  * Clarified and localized simulated error scenarios within individual tests to improve isolation and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->