### PR TITLE
test(query-persist-client-core/persist): add tests for removing an expired or busted cache in 'persistQueryClientRestore'

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -177,5 +177,39 @@ describe('persist', () => {
       expect(persister.removeClient).not.toHaveBeenCalled()
       expect(queryClient.getQueryData(['key'])).toBe('data')
     })
+
+    it('should remove the client when the persisted cache is expired', async () => {
+      persister.restoreClient = () =>
+        Promise.resolve({
+          buster: '',
+          clientState: { mutations: [], queries: [] },
+          timestamp: Date.now() - 1000,
+        })
+
+      await persistQueryClientRestore({
+        queryClient,
+        persister,
+        maxAge: 100,
+      })
+
+      expect(persister.removeClient).toHaveBeenCalledTimes(1)
+    })
+
+    it('should remove the client when the buster does not match', async () => {
+      persister.restoreClient = () =>
+        Promise.resolve({
+          buster: 'old-buster',
+          clientState: { mutations: [], queries: [] },
+          timestamp: Date.now(),
+        })
+
+      await persistQueryClientRestore({
+        queryClient,
+        persister,
+        buster: 'new-buster',
+      })
+
+      expect(persister.removeClient).toHaveBeenCalledTimes(1)
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds unit tests for `persistQueryClientRestore` covering the cache invalidation paths: the persisted client is removed when the cache is older than `maxAge` (expired) or when its `buster` does not match the configured one.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for query persistence, including verification that expired cached states are properly removed and that mismatched validation values trigger correct cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->