### PR TITLE
test(query-persist-client-core/persist): add test for removing a cache without a timestamp in 'persistQueryClientRestore'

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -211,5 +211,21 @@ describe('persist', () => {
 
       expect(persister.removeClient).toHaveBeenCalledTimes(1)
     })
+
+    it('should remove the client when the persisted cache has no timestamp', async () => {
+      persister.restoreClient = () =>
+        Promise.resolve({
+          buster: '',
+          clientState: { mutations: [], queries: [] },
+          timestamp: 0,
+        })
+
+      await persistQueryClientRestore({
+        queryClient,
+        persister,
+      })
+
+      expect(persister.removeClient).toHaveBeenCalledTimes(1)
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `persistQueryClientRestore` covering the case where the persisted client has no timestamp: the client is removed instead of being hydrated.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query client persistence restoration edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->