### PR TITLE
test(query-persist-client-core/persist): add tests for 'persistQueryClient' restore-then-subscribe flow

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueriesObserver, QueryClient, dehydrate } from '@tanstack/query-core'
 import {
+  persistQueryClient,
   persistQueryClientRestore,
   persistQueryClientSubscribe,
 } from '../persist'
@@ -226,6 +227,47 @@ describe('persist', () => {
       })
 
       expect(persister.removeClient).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('persistQueryClient', () => {
+    it('should subscribe to the query cache after a successful restore', async () => {
+      const persister = createSpyPersister()
+      persister.restoreClient = () => Promise.resolve(undefined)
+
+      const [unsubscribe, restorePromise] = persistQueryClient({
+        queryClient,
+        persister,
+      })
+      await restorePromise
+
+      queryClient.setQueryData(['key'], 'data')
+
+      expect(persister.persistClient).toHaveBeenCalled()
+
+      unsubscribe()
+    })
+
+    it('should not subscribe when unsubscribed before the restore completes', async () => {
+      const persister = createSpyPersister()
+      let resolveRestore: () => void
+      persister.restoreClient = () =>
+        new Promise((resolve) => {
+          resolveRestore = () => resolve(undefined)
+        })
+
+      const [unsubscribe, restorePromise] = persistQueryClient({
+        queryClient,
+        persister,
+      })
+      // Unsubscribe before the restore resolves
+      unsubscribe()
+      resolveRestore!()
+      await restorePromise
+
+      queryClient.setQueryData(['key'], 'data')
+
+      expect(persister.persistClient).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds unit tests for `persistQueryClient`, which previously had no test coverage. The tests cover its two-step flow:

- After a successful restore, it subscribes to the query cache so subsequent changes are persisted.
- When `unsubscribe` is called before the restore completes, it never subscribes (the early-unsubscribe guard).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query persistence functionality, including validation of persistence subscription initialization after successful restoration and verification of proper cleanup behavior when operations are cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->