### PR TITLE
test(query-persist-client-core/persist): add test for ignoring mutation observer events in 'persistQueryClientSubscribe'

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/persist.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/persist.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { QueriesObserver, QueryClient, dehydrate } from '@tanstack/query-core'
+import {
+  MutationObserver,
+  QueriesObserver,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/query-core'
 import {
   persistQueryClient,
   persistQueryClientRestore,
@@ -66,6 +71,28 @@ describe('persist', () => {
       // 3. When setQueryData is called
       // All events fired by manipulating observers are ignored
       expect(persister.persistClient).toHaveBeenCalledTimes(3)
+
+      unsubscribe()
+    })
+
+    it('should not be triggered on mutation observer type events', () => {
+      const persister = createSpyPersister()
+
+      const unsubscribe = persistQueryClientSubscribe({
+        queryClient,
+        persister,
+      })
+
+      const observer = new MutationObserver(queryClient, {
+        mutationFn: () => Promise.resolve('data'),
+      })
+      const unsubscribeObserver = observer.subscribe(vi.fn())
+      observer.setOptions({ mutationKey: ['test'] })
+      unsubscribeObserver()
+
+      // Events fired by manipulating the mutation observer are not cache
+      // events, so they must not trigger a persist.
+      expect(persister.persistClient).not.toHaveBeenCalled()
 
       unsubscribe()
     })


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `persistQueryClientSubscribe` covering the mutation cache subscription: events fired by manipulating a mutation observer (e.g. `observerAdded`, `observerOptionsUpdated`, `observerRemoved`) are not cache events, so they must not trigger a persist.

This mirrors the existing query-observer test and covers the previously-untested `isCacheEventType` guard on the mutation cache subscription.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for query client persistence behavior with mutation observer events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->