### PR TITLE
test(query-persist-client-core/createPersister): add tests for removing entries that fail to deserialize

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -542,6 +542,17 @@ describe('createPersister', () => {
       await persister.persisterGc()
       expect(await storage.entries()).toHaveLength(0)
     })
+
+    it('should remove entries that cannot be deserialized', async () => {
+      const storage = getFreshStorage()
+      const { persister } = setupPersister(['foo'], { storage })
+
+      await storage.setItem(`${PERSISTER_KEY_PREFIX}-["foo"]`, 'not-json{')
+      expect(await storage.entries()).toHaveLength(1)
+
+      await persister.persisterGc()
+      expect(await storage.entries()).toHaveLength(0)
+    })
   })
 
   describe('restoreQueries', () => {
@@ -674,6 +685,19 @@ describe('createPersister', () => {
       })
       expect(client.getQueryCache().getAll()).toHaveLength(1)
     })
+
+    it('should remove entries that cannot be deserialized', async () => {
+      const storage = getFreshStorage()
+      const { persister, client } = setupPersister(['foo'], { storage })
+
+      await storage.setItem(`${PERSISTER_KEY_PREFIX}-["foo"]`, 'not-json{')
+      expect(await storage.entries()).toHaveLength(1)
+
+      await persister.restoreQueries(client)
+
+      expect(await storage.entries()).toHaveLength(0)
+      expect(client.getQueryCache().getAll()).toHaveLength(0)
+    })
   })
 
   describe('removeQueries', () => {
@@ -761,6 +785,18 @@ describe('createPersister', () => {
         queryKey: queryKey,
         exact: true,
       })
+      expect(await storage.entries()).toHaveLength(0)
+    })
+
+    it('should remove entries that cannot be deserialized', async () => {
+      const storage = getFreshStorage()
+      const { persister } = setupPersister(['foo'], { storage })
+
+      await storage.setItem(`${PERSISTER_KEY_PREFIX}-["foo"]`, 'not-json{')
+      expect(await storage.entries()).toHaveLength(1)
+
+      await persister.removeQueries({ queryKey: ['foo'] })
+
       expect(await storage.entries()).toHaveLength(0)
     })
   })


### PR DESCRIPTION
## 🎯 Changes

Adds unit tests for `persisterGc`, `restoreQueries`, and `removeQueries` covering the case where a stored entry cannot be deserialized: the corrupted entry is removed from storage and iteration continues.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for data validation and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->