### PR TITLE
test(query-persist-client-core/createPersister): add test for 'persisterGc' keeping valid entries

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -553,6 +553,25 @@ describe('createPersister', () => {
       await persister.persisterGc()
       expect(await storage.entries()).toHaveLength(0)
     })
+
+    it('should keep entries that are neither expired nor busted', async () => {
+      const storage = getFreshStorage()
+      const { persister, client, query, queryKey } = setupPersister(['foo'], {
+        storage,
+      })
+      query.setState({
+        dataUpdatedAt: Date.now(),
+        data: 'foo',
+      })
+      client.getQueryCache().add(query)
+
+      await persister.persistQueryByKey(queryKey, client)
+
+      expect(await storage.entries()).toHaveLength(1)
+
+      await persister.persisterGc()
+      expect(await storage.entries()).toHaveLength(1)
+    })
   })
 
   describe('restoreQueries', () => {


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `persisterGc` covering the case where a stored entry is neither expired nor busted: the entry is kept in storage instead of being removed.

The existing tests only cover the removal path, so this fills in the complementary "keep valid entry" branch.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for garbage collection behavior to verify storage entries persist when neither expired nor invalidated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->