### PR TITLE
test(query-persist-client-core/createPersister): add test for 'retrieveQuery' returning data without a restore callback

### DIFF
--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -523,6 +523,23 @@ describe('createPersister', () => {
     })
   })
 
+  describe('retrieveQuery', () => {
+    it('should return the persisted data when called without a restore callback', async () => {
+      const storage = getFreshStorage()
+      const { persister, client, queryHash, queryKey } = setupPersister(
+        ['foo'],
+        { storage },
+      )
+
+      client.setQueryData(queryKey, 'baz')
+      await persister.persistQueryByKey(queryKey, client)
+
+      const restoredData = await persister.retrieveQuery(queryHash)
+
+      expect(restoredData).toBe('baz')
+    })
+  })
+
   describe('persisterGc', () => {
     it('should properly clean storage from busted entries', async () => {
       const storage = getFreshStorage()


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `retrieveQuery`, which is part of the persister's public API but was previously only exercised indirectly through `persisterFn`. Calling it directly without a restore callback returns the persisted data, covering the branch where no after-restore callback is scheduled.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query retrieval functionality to verify that previously persisted query data is correctly returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->