### PR TITLE
docs(reference/QueryCache): correct the 'find' and 'findAll' options to match their filter types

### DIFF
--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -57,7 +57,8 @@ const query = queryCache.find({ queryKey })
 
 **Options**
 
-- `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
+- `filters: QueryFilters`: [Query Filters](../framework/react/guides/filters#query-filters)
+  - `queryKey: QueryKey`: [Query Keys](../framework/react/guides/query-keys.md)
 
 **Returns**
 
@@ -76,7 +77,6 @@ const queries = queryCache.findAll({ queryKey })
 
 **Options**
 
-- `queryKey?: QueryKey`: [Query Keys](../framework/react/guides/query-keys.md)
 - `filters?: QueryFilters`: [Query Filters](../framework/react/guides/filters.md#query-filters)
 
 **Returns**


### PR DESCRIPTION
## 🎯 Changes

Corrects the options listed for `find` and `findAll` in the QueryCache reference to match their actual filter types:

- `find(filters: WithRequired<QueryFilters, 'queryKey'>)` — both `filters` and its `queryKey` are required, so `filters` is no longer marked optional and `queryKey` is documented as a required nested option.
- `findAll(filters: QueryFilters = {})` — `filters` is optional; `queryKey` is just one of its properties (covered by the linked Query Filters), so the misplaced top-level `queryKey` entry is removed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation for `queryCache.find` method: `filters` parameter is now required.
  * Updated `queryCache.findAll` method's options section structure and parameter documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->