### PR TITLE
test(query-core/onlineManager): add test for online status updates from window events

### DIFF
--- a/packages/query-core/src/__tests__/onlineManager.test.tsx
+++ b/packages/query-core/src/__tests__/onlineManager.test.tsx
@@ -157,6 +157,20 @@ describe('onlineManager', () => {
     unsubscribe2()
   })
 
+  it('should update online status from window online and offline events', () => {
+    const unsubscribe = onlineManager.subscribe(() => undefined)
+
+    expect(onlineManager.isOnline()).toBe(true)
+
+    window.dispatchEvent(new Event('offline'))
+    expect(onlineManager.isOnline()).toBe(false)
+
+    window.dispatchEvent(new Event('online'))
+    expect(onlineManager.isOnline()).toBe(true)
+
+    unsubscribe()
+  })
+
   it('should call listeners when setOnline is called', () => {
     const listener = vi.fn()
 


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `OnlineManager` covering the default window event listeners: dispatching the browser `offline` and `online` events updates the online status accordingly.

The existing tests only assert that the listeners are registered/removed; this covers the listener callbacks actually reacting to the events.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test that verifies the online/offline manager detects simulated network state changes.
  * Confirms the manager's reported status updates correctly when connectivity changes.
  * Ensures subscription listeners are properly removed during cleanup to prevent leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->