### PR TITLE
test(query-core/queryObserver): add test for promise not rejecting when 'experimental_prefetchInRender' is enabled

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1462,6 +1462,24 @@ describe('queryObserver', () => {
     queryClient2.clear()
   })
 
+  it('should not reject promise when experimental_prefetchInRender is enabled', async () => {
+    const key = queryKey()
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+    })
+
+    const unsubscribe = observer.subscribe(() => undefined)
+    const tracked = observer.trackResult(observer.getCurrentResult())
+    const promise = tracked.promise
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    await expect(promise).resolves.toBe('data')
+
+    unsubscribe()
+  })
+
   it('should not refetchOnMount when set to "always" when staleTime is Static', async () => {
     const key = queryKey()
     const queryFn = vi.fn(() => 'data')


### PR DESCRIPTION
## 🎯 Changes

Adds a unit test for `QueryObserver.trackResult` covering the case where `experimental_prefetchInRender` is enabled: reading the tracked `promise` resolves with the data instead of rejecting.

This complements the existing test that asserts the promise rejects when the flag is disabled, covering the other side of the guard.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying that enabling experimental prefetch-in-render causes a tracked query result's promise to resolve (instead of reject) when the observer completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->