### PR TITLE
test(query-core/queryCache): add test for 'remove' only deleting the instance currently stored under its 'queryHash'

### DIFF
--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -380,6 +380,22 @@ describe('queryCache', () => {
     })
   })
 
+  describe('QueryCache.remove', () => {
+    it('should only delete the instance currently stored under its queryHash', () => {
+      const key = queryKey()
+
+      const staleQuery = queryCache.build(queryClient, { queryKey: key })
+      queryCache.remove(staleQuery)
+
+      const currentQuery = queryCache.build(queryClient, { queryKey: key })
+      expect(currentQuery).not.toBe(staleQuery)
+
+      queryCache.remove(staleQuery)
+
+      expect(queryCache.get(hashKey(key))).toBe(currentQuery)
+    })
+  })
+
   describe('QueryCache.add', () => {
     it('should not try to add a query already added to the cache', async () => {
       const key = queryKey()


### PR DESCRIPTION
## 🎯 Changes

Adds a test for `QueryCache.remove` covering the `queryInMap === query` guard.

When a stale `Query` reference is removed after a new instance has taken its place under the same `queryHash`, `remove` must only delete the instance currently stored in the cache — not the newer one. The test builds a query, removes it to leave a stale reference, builds a fresh instance with the same key, then removes via the stale reference and asserts `queryCache.get(hashKey(key))` still returns the current instance.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This release contains internal improvements with no user-facing changes.

* **Tests**
  * Added and improved tests around query cache removal to ensure removing stale instances does not delete the active cached query, increasing cache reliability and preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->