### PR TITLE
test(query-core/queryObserver): split 'shouldFetchOnWindowFocus' test by 'refetchOnWindowFocus' value

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1294,22 +1294,28 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  it('shouldFetchOnWindowFocus should respect refetchOnWindowFocus option', () => {
+  it('shouldFetchOnWindowFocus should return true when refetchOnWindowFocus is true', () => {
     const key = queryKey()
 
-    const observer1 = new QueryObserver(queryClient, {
+    const observer = new QueryObserver(queryClient, {
       queryKey: key,
       queryFn: () => 'data',
       refetchOnWindowFocus: true,
     })
-    expect(observer1.shouldFetchOnWindowFocus()).toBe(true)
 
-    const observer2 = new QueryObserver(queryClient, {
+    expect(observer.shouldFetchOnWindowFocus()).toBe(true)
+  })
+
+  it('shouldFetchOnWindowFocus should return false when refetchOnWindowFocus is false', () => {
+    const key = queryKey()
+
+    const observer = new QueryObserver(queryClient, {
       queryKey: key,
       queryFn: () => 'data',
       refetchOnWindowFocus: false,
     })
-    expect(observer2.shouldFetchOnWindowFocus()).toBe(false)
+
+    expect(observer.shouldFetchOnWindowFocus()).toBe(false)
   })
 
   it('fetchOptimistic should fetch and return optimistic result', async () => {


### PR DESCRIPTION
## 🎯 Changes

Splits the single `shouldFetchOnWindowFocus should respect refetchOnWindowFocus option` test into two focused tests, one per `refetchOnWindowFocus` value:

- `shouldFetchOnWindowFocus` returns `true` when `refetchOnWindowFocus` is `true`
- `shouldFetchOnWindowFocus` returns `false` when `refetchOnWindowFocus` is `false`

The two cases are independent (no shared state or ordering between them), so splitting them isolates failures and makes each test title describe a single behavior. The assertions are unchanged.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for window focus refresh behavior with separate assertions for enabled and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->