### PR TITLE
docs(angular-query): fix "allows to" grammar in JSDoc comments

### DIFF
--- a/packages/angular-query-experimental/src/infinite-query-options.ts
+++ b/packages/angular-query-experimental/src/infinite-query-options.ts
@@ -79,7 +79,7 @@ export type DefinedInitialDataInfiniteOptions<
 }
 
 /**
- * Allows to share and re-use infinite query options in a type-safe way.
+ * Allows sharing and re-using infinite query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  * @param options - The infinite query options to tag with the type from `queryFn`.
@@ -110,7 +110,7 @@ export function infiniteQueryOptions<
 }
 
 /**
- * Allows to share and re-use infinite query options in a type-safe way.
+ * Allows sharing and re-using infinite query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  * @param options - The infinite query options to tag with the type from `queryFn`.
@@ -141,7 +141,7 @@ export function infiniteQueryOptions<
 }
 
 /**
- * Allows to share and re-use infinite query options in a type-safe way.
+ * Allows sharing and re-using infinite query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  * @param options - The infinite query options to tag with the type from `queryFn`.
@@ -172,7 +172,7 @@ export function infiniteQueryOptions<
 }
 
 /**
- * Allows to share and re-use infinite query options in a type-safe way.
+ * Allows sharing and re-using infinite query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  * @param options - The infinite query options to tag with the type from `queryFn`.

--- a/packages/angular-query-experimental/src/mutation-options.ts
+++ b/packages/angular-query-experimental/src/mutation-options.ts
@@ -2,7 +2,7 @@ import type { DefaultError, WithRequired } from '@tanstack/query-core'
 import type { CreateMutationOptions } from './types'
 
 /**
- * Allows to share and re-use mutation options in a type-safe way.
+ * Allows sharing and re-using mutation options in a type-safe way.
  *
  * **Example**
  *
@@ -66,7 +66,7 @@ export function mutationOptions<
 >
 
 /**
- * Allows to share and re-use mutation options in a type-safe way.
+ * Allows sharing and re-using mutation options in a type-safe way.
  *
  * **Example**
  *

--- a/packages/angular-query-experimental/src/providers.ts
+++ b/packages/angular-query-experimental/src/providers.ts
@@ -32,7 +32,7 @@ export function provideQueryClient(
 /**
  * Sets up providers necessary to enable TanStack Query functionality for Angular applications.
  *
- * Allows to configure a `QueryClient` and optional features such as developer tools.
+ * Allows configuring a `QueryClient` and optional features such as developer tools.
  *
  * **Example - standalone**
  *
@@ -115,7 +115,7 @@ export function provideTanStackQuery(
 /**
  * Sets up providers necessary to enable TanStack Query functionality for Angular applications.
  *
- * Allows to configure a `QueryClient`.
+ * Allows configuring a `QueryClient`.
  * @param queryClient - A `QueryClient` instance.
  * @returns A set of providers to set up TanStack Query.
  * @see https://tanstack.com/query/v5/docs/framework/angular/quick-start

--- a/packages/angular-query-experimental/src/query-options.ts
+++ b/packages/angular-query-experimental/src/query-options.ts
@@ -53,7 +53,7 @@ export type DefinedInitialDataOptions<
 }
 
 /**
- * Allows to share and re-use query options in a type-safe way.
+ * Allows sharing and re-using query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  *
@@ -85,7 +85,7 @@ export function queryOptions<
 }
 
 /**
- * Allows to share and re-use query options in a type-safe way.
+ * Allows sharing and re-using query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  *
@@ -117,7 +117,7 @@ export function queryOptions<
 }
 
 /**
- * Allows to share and re-use query options in a type-safe way.
+ * Allows sharing and re-using query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  *
@@ -149,7 +149,7 @@ export function queryOptions<
 }
 
 /**
- * Allows to share and re-use query options in a type-safe way.
+ * Allows sharing and re-using query options in a type-safe way.
  *
  * The `queryKey` will be tagged with the type from `queryFn`.
  *


### PR DESCRIPTION
## 🎯 Changes

`allows to <verb>` is ungrammatical: `allow` needs an object (`allow X to ...`) or a gerund. The JSDoc comments on the Angular adapter's `*Options` helpers and `provideTanStackQuery` use it, so they're switched to the gerund: `Allows sharing and re-using ...` and `Allows configuring ...`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JSDoc documentation text for query options, infinite query options, mutation options, and providers in the Angular Query package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->