### PR TITLE
fix(query-devtools): set window.__nonce__ for goober CSP support

### DIFF
--- a/packages/query-devtools/src/utils.tsx
+++ b/packages/query-devtools/src/utils.tsx
@@ -306,6 +306,12 @@ export const deleteNestedDataByPath = (
 // Adds a nonce to the style tag if needed
 export const setupStyleSheet = (nonce?: string, target?: ShadowRoot) => {
   if (!nonce) return
+
+  // goober 2.1.17+ reads window.__nonce__ to set the nonce on every style
+  // element access. We must set it here so goober picks it up instead of
+  // overwriting our nonce with undefined.
+  ;(window as any).__nonce__ = nonce
+
   const styleExists =
     document.querySelector('#_goober') || target?.querySelector('#_goober')
 


### PR DESCRIPTION
## Issue

The `styleNonce` prop on `<ReactQueryDevtools>` no longer works under a strict CSP `style-src` policy. Passing a nonce results in CSP violations because the injected `<style id="_goober">` element ends up with an empty nonce.

Fixes #10820

## Root cause

goober 2.1.17+ introduced automatic nonce handling: on every access to the shared `<style id="_goober">` element, it sets `el.nonce = window.__nonce__`. The `setupStyleSheet` function set the nonce via `setAttribute("nonce", value)` on the pre-created element, but goober would immediately overwrite it with `undefined` since `window.__nonce__` was never set.

## Fix

Set `window.__nonce__` inside `setupStyleSheet` before any goober code runs, so goober reads the correct nonce instead of `undefined`.

#### Manual testing

1. Create a React app with Vite and install `@tanstack/react-query` / `@tanstack/react-query-devtools` at a version that includes goober 2.1.18+
2. Add a `Content-Security-Policy` header with `style-src nonce-<your-nonce>`
3. Pass the same nonce to `<ReactQueryDevtools styleNonce="<your-nonce>" />`
4. Verify no CSP violation errors appear for the `#_goober` style element

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed security attribute handling for dynamically generated stylesheets to ensure proper application across supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->