### PR TITLE
fix(query-core): preserve refetch targets in resetQueries when predicate depends on mutable state

### DIFF
--- a/.changeset/quiet-ducks-begin.md
+++ b/.changeset/quiet-ducks-begin.md
@@ -1,0 +1,4 @@
+---
+"@tanstack/query-core": patch
+
+fix(query-core): `resetQueries` now correctly refetches queries even when the filter predicate depends on mutable state (`status`, `data`, etc.). Previously, `query.reset()` mutated the query state before `refetchQueries` could match the same queries, causing them to be skipped.

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1692,6 +1692,57 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(0)
       expect(didSkipTokenRun).toBe(false)
     })
+
+    it('should refetch queries matched by a state-dependent predicate even though reset() mutates state', async () => {
+      const key1 = queryKey()
+      const key2 = queryKey()
+      const queryFn1 = vi
+        .fn<(...args: Array<unknown>) => string>()
+        .mockReturnValue('data')
+      const queryFn2 = vi
+        .fn<(...args: Array<unknown>) => string>()
+        .mockRejectedValue('error')
+
+      const observer1 = new QueryObserver(queryClient, {
+        queryKey: key1,
+        queryFn: queryFn1,
+      })
+      const observer2 = new QueryObserver(queryClient, {
+        queryKey: key2,
+        queryFn: queryFn2,
+        retry: false,
+      })
+
+      observer1.subscribe(() => undefined)
+      observer2.subscribe(() => undefined)
+
+      await vi.waitFor(() => {
+        expect(queryClient.getQueryState(key1)?.status).toBe('success')
+        expect(queryClient.getQueryState(key2)?.status).toBe('error')
+      })
+
+      expect(queryFn1).toHaveBeenCalledTimes(1)
+      expect(queryFn2).toHaveBeenCalledTimes(1)
+
+      // reset + refetch only success queries by predicate
+      await queryClient.resetQueries({
+        predicate: (query) => query.state.status === 'success',
+      })
+
+      expect(queryFn1).toHaveBeenCalledTimes(2)
+      expect(queryFn2).toHaveBeenCalledTimes(1)
+
+      // reset + refetch only error queries by predicate
+      await queryClient.resetQueries({
+        predicate: (query) => query.state.status === 'error',
+      })
+
+      expect(queryFn1).toHaveBeenCalledTimes(2)
+      expect(queryFn2).toHaveBeenCalledTimes(2)
+
+      observer1.destroy()
+      observer2.destroy()
+    })
   })
 
   describe('focusManager and onlineManager', () => {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -260,13 +260,16 @@ export class QueryClient {
     const queryCache = this.#queryCache
 
     return notifyManager.batch(() => {
-      queryCache.findAll(filters).forEach((query) => {
+      const matched = queryCache.findAll(filters)
+      const matchedHashes = new Set(matched.map((query) => query.queryHash))
+      matched.forEach((query) => {
         query.reset()
       })
       return this.refetchQueries(
         {
           type: 'active',
           ...filters,
+          predicate: (query) => matchedHashes.has(query.queryHash),
         },
         options,
       )


### PR DESCRIPTION
Closes [#10705](https://github.com/TanStack/query/issues/10705).

## 🐛 The Bug

`resetQueries(filters)` calls `query.reset()` on matched queries *before* passing the same `filters` to `refetchQueries`. When the filter predicate reads mutable state like `query.state.status === "error"`, `query.reset()` changes status from `"error"` → `"pending"`. The subsequent `refetchQueries.findAll(filters)` finds zero matches and skips the refetch entirely.

```ts
// This leaves errored queries stuck in "pending" forever:
queryClient.resetQueries({
  predicate: (query) => query.state.status === "error",
})
```

## 🔧 The Fix

Save the matched query hashes *before* the reset loop, then pass an identity-based `predicate` override to `refetchQueries` (last-wins after the `...filters` spread):

```ts
const matched = queryCache.findAll(filters)
const matchedHashes = new Set(matched.map((query) => query.queryHash))
matched.forEach((query) => { query.reset() })
return this.refetchQueries(
  { type: "active", ...filters, predicate: (q) => matchedHashes.has(q.queryHash) },
  options,
)
```

This ensures `refetchQueries` finds the exact same queries regardless of state changes.

## ✅ Verification

- [x] All 536 existing query-core tests pass
- [x] New test confirms state-dependent predicates (both `status === "success"` and `status === "error"`) correctly trigger refetch
- [x] TypeScript clean (no type errors)
- [x] Prettier formatted
- [x] Changeset included (`@tanstack/query-core` patch)

> **Note:** PR [#10704](https://github.com/TanStack/query/pull/10704) by @alZyad independently identified the same root cause and fix approach. This PR supersedes it with a cleaner commit, more thorough test coverage, and a changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `resetQueries` to correctly refetch queries when using predicates that depend on mutable query state (such as status or data). State mutations during the reset operation are now properly handled to ensure accurate predicate matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->