### PR TITLE
fix(query-core): set dataUpdatedAt for streamed queries that resolve before hydration (#10603)

### DIFF
--- a/.changeset/streamed-query-dataupdatedat.md
+++ b/.changeset/streamed-query-dataupdatedat.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Fix `dataUpdatedAt` not being updated for streamed queries that resolve before hydration. When a dehydrated pending query's promise resolves synchronously during hydration, the query correctly transitions to `success` but `dataUpdatedAt` remained `0`. Now it is set to `Date.now()` in this case.

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -1804,4 +1804,102 @@ describe('dehydration and rehydration', () => {
     clientQueryClient.clear()
     serverQueryClient.clear()
   })
+
+  // #10603 — dataUpdatedAt should not be 0 when a streamed query resolves before hydration
+  it('should set dataUpdatedAt when hydrating a pending query that resolved before hydration (new query)', async () => {
+    const key = queryKey()
+    // --- server ---
+    const serverQueryClient = new QueryClient({
+      defaultOptions: {
+        dehydrate: { shouldDehydrateQuery: () => true },
+      },
+    })
+
+    let resolvePrefetch: undefined | ((value?: unknown) => void)
+    const prefetchPromise = new Promise((res) => {
+      resolvePrefetch = res
+    })
+    void serverQueryClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => prefetchPromise,
+    })
+    const dehydrated = dehydrate(serverQueryClient)
+    expect(dehydrated.queries[0]?.state.status).toBe('pending')
+    expect(dehydrated.queries[0]?.state.dataUpdatedAt).toBe(0)
+
+    // Simulate the promise resolving before hydration
+    resolvePrefetch?.('server data')
+    // @ts-expect-error - Simulate a synchronously resolved thenable
+    dehydrated.queries[0].promise.then = (cb) => {
+      cb?.('server data')
+      // @ts-expect-error
+      return dehydrated.queries[0].promise
+    }
+
+    // --- client ---
+    const clientQueryClient = new QueryClient()
+    hydrate(clientQueryClient, dehydrated)
+
+    const state = clientQueryClient.getQueryState(key)
+    expect(state?.status).toBe('success')
+    expect(state?.data).toBe('server data')
+    expect(state?.dataUpdatedAt).toBeGreaterThan(0)
+    expect(state?.dataUpdatedAt).not.toBe(0)
+
+    clientQueryClient.clear()
+    serverQueryClient.clear()
+  })
+
+  it('should set dataUpdatedAt when hydrating a pending query that resolved before hydration (existing query)', async () => {
+    const key = queryKey()
+    // --- server ---
+    const serverQueryClient = new QueryClient({
+      defaultOptions: {
+        dehydrate: { shouldDehydrateQuery: () => true },
+      },
+    })
+
+    let resolvePrefetch: undefined | ((value?: unknown) => void)
+    const prefetchPromise = new Promise((res) => {
+      resolvePrefetch = res
+    })
+    void serverQueryClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => prefetchPromise,
+    })
+    const dehydrated = dehydrate(serverQueryClient)
+
+    // Simulate the promise resolving before hydration
+    resolvePrefetch?.('server data')
+    // @ts-expect-error - Simulate a synchronously resolved thenable
+    dehydrated.queries[0].promise.then = (cb) => {
+      cb?.('server data')
+      // @ts-expect-error
+      return dehydrated.queries[0].promise
+    }
+
+    // --- client ---
+    // Query already exists in the cache in a pending state
+    const clientQueryClient = new QueryClient()
+    void clientQueryClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => {
+        throw new Error('QueryFn on client should not be called')
+      },
+    })
+
+    const query = clientQueryClient.getQueryCache().find({ queryKey: key })!
+    expect(query.state.status).toBe('pending')
+    expect(query.state.dataUpdatedAt).toBe(0)
+
+    hydrate(clientQueryClient, dehydrated)
+
+    expect(clientQueryClient.getQueryData(key)).toBe('server data')
+    expect(query.state.status).toBe('success')
+    expect(query.state.dataUpdatedAt).toBeGreaterThan(0)
+    expect(query.state.dataUpdatedAt).not.toBe(0)
+
+    clientQueryClient.clear()
+    serverQueryClient.clear()
+  })
 })

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -257,6 +257,11 @@ export function hydrate(
                 ...(!existingQueryIsFetching && {
                   fetchStatus: 'idle' as const,
                 }),
+                // A pending query that resolved before hydration won't have
+                // a valid dataUpdatedAt, so we set it to the current time.
+                ...(state.dataUpdatedAt === 0 && {
+                  dataUpdatedAt: Date.now(),
+                }),
               }),
           })
         }
@@ -284,6 +289,13 @@ export function hydrate(
               state.status === 'pending' && data !== undefined
                 ? 'success'
                 : state.status,
+            // A pending query that resolved before hydration won't have
+            // a valid dataUpdatedAt, so we set it to the current time.
+            ...(state.status === 'pending' &&
+              data !== undefined &&
+              state.dataUpdatedAt === 0 && {
+                dataUpdatedAt: Date.now(),
+              }),
           },
         )
       }


### PR DESCRIPTION
Fixes #10603

## Summary

When a dehydrated pending query's promise resolves synchronously during hydration (e.g., a React streamed query that completed before the client hydrated), the query correctly transitions to `success` but `dataUpdatedAt` remained `0`.

This happened because PR #10444 removed the unnecessary `query.fetch()` call for already-resolved promises — which was correct for avoiding unnecessary fetch setup, but it also removed the side effect that set `dataUpdatedAt`.

## Fix

The fix sets `dataUpdatedAt` to `Date.now()` in the hydration path when:
- The dehydrated query was pending (`status: 'pending'`)
- It resolved to have data (`data !== undefined`)
- `dataUpdatedAt` is `0` (its default for pending queries that never completed on the server)

This applies to both:
1. **New queries** — when a query is built from the dehydrated state (the `else` branch)
2. **Existing queries** — when updating a query already in the cache (the `if` branch)

## Testing

Added two test cases:
- New query: verifies `dataUpdatedAt` > 0 after hydrating a resolved pending query
- Existing query: verifies same for queries already in the cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query timestamp metadata is now correctly updated during streamed query rehydration with synchronously resolved data.

* **Tests**
  * Added test coverage for streamed query rehydration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->