### PR TITLE
test(query-core/queryObserver): add test for 'refetchOnWindowFocus' as "always" in 'shouldFetchOnWindowFocus'

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1318,6 +1318,25 @@ describe('queryObserver', () => {
     expect(observer.shouldFetchOnWindowFocus()).toBe(false)
   })
 
+  it('should return true from shouldFetchOnWindowFocus when refetchOnWindowFocus is "always" even if the query is fresh', async () => {
+    const key = queryKey()
+
+    queryClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+      staleTime: Infinity,
+      refetchOnWindowFocus: 'always',
+    })
+
+    expect(observer.shouldFetchOnWindowFocus()).toBe(true)
+  })
+
   it('should fetch and return optimistic result via fetchOptimistic', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {


### PR DESCRIPTION
## 🎯 Changes

Add a test covering the `refetchOnWindowFocus: 'always'` case in `shouldFetchOnWindowFocus`.

The existing tests only cover `true` and `false`. With a stale query, an `'always'` test would pass even if the `value === 'always'` branch were removed, since the `value !== false && isStale(query, options)` condition alone yields `true`. To isolate the `'always'` branch, the query is kept fresh via `staleTime: Infinity`, so `isStale` is `false` and only `value === 'always'` can make the result `true`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for window-focus refetch behavior when refetchOnWindowFocus is set to "always". The new test verifies the system triggers a refetch on window focus even if the query is fresh, using a prefetched cache and a long stale time to simulate freshness. This ensures consistent refetch decisions across focus events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->