### PR TITLE
test(query-core/queryObserver): unify all test descriptions to start with 'should'

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -747,7 +747,7 @@ describe('queryObserver', () => {
     expect(count).toBe(2)
   })
 
-  it('uses placeholderData as non-cache data when pending a query with no data', async () => {
+  it('should use placeholderData as non-cache data when pending a query with no data', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -806,7 +806,7 @@ describe('queryObserver', () => {
     ).toThrow('Expected enabled to be a boolean')
   })
 
-  it('getCurrentQuery should return the current query', () => {
+  it('should return the current query from getCurrentQuery', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -1120,7 +1120,7 @@ describe('queryObserver', () => {
     expect(stableSelect.mock.calls[1]![0]).toEqual(data2)
   })
 
-  it('setOptions should notify cache listeners', () => {
+  it('should notify cache listeners when setOptions is called', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -1140,7 +1140,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  it('disabled observers should not be stale', () => {
+  it('should not be stale for disabled observers', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -1294,7 +1294,7 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
-  it('shouldFetchOnWindowFocus should return true when refetchOnWindowFocus is true', () => {
+  it('should return true from shouldFetchOnWindowFocus when refetchOnWindowFocus is true', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -1306,7 +1306,7 @@ describe('queryObserver', () => {
     expect(observer.shouldFetchOnWindowFocus()).toBe(true)
   })
 
-  it('shouldFetchOnWindowFocus should return false when refetchOnWindowFocus is false', () => {
+  it('should return false from shouldFetchOnWindowFocus when refetchOnWindowFocus is false', () => {
     const key = queryKey()
 
     const observer = new QueryObserver(queryClient, {
@@ -1318,7 +1318,7 @@ describe('queryObserver', () => {
     expect(observer.shouldFetchOnWindowFocus()).toBe(false)
   })
 
-  it('fetchOptimistic should fetch and return optimistic result', async () => {
+  it('should fetch and return optimistic result via fetchOptimistic', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {
       queryKey: key,


### PR DESCRIPTION
## 🎯 Changes

Unify all test descriptions in `queryObserver.test.tsx` to start with `should`, so every `it` follows the same convention.

- Method-name prefixes are rewritten as `should ...`, keeping the method name where it identifies the behavior (`from getCurrentQuery`, `when setOptions is called`, `via fetchOptimistic`).
- `shouldFetchOnWindowFocus should return true/false ...` is rewritten as `should return true/false from shouldFetchOnWindowFocus ...`, removing the duplicated `should` while still describing exactly what is asserted (the method return value).
- `uses placeholderData ...` becomes `should use placeholderData ...`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified and improved several human-readable test descriptions to make intent and expected behaviors easier to understand (covering placeholder data handling, current-query reporting, cache listener notifications on option changes, observer staleness when disabled, window-focus refetch behavior, and optimistic-result scenarios). No functional behavior or assertions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->