### PR TITLE
test(query-core/queryObserver): add tests for 'refetchOnWindowFocus' as a function in 'shouldFetchOnWindowFocus'

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1337,6 +1337,61 @@ describe('queryObserver', () => {
     expect(observer.shouldFetchOnWindowFocus()).toBe(true)
   })
 
+  it('should return true from shouldFetchOnWindowFocus when refetchOnWindowFocus is a function returning true', () => {
+    const key = queryKey()
+    const refetchOnWindowFocus = vi.fn(() => true)
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => 'data',
+      refetchOnWindowFocus,
+    })
+
+    expect(observer.shouldFetchOnWindowFocus()).toBe(true)
+    expect(refetchOnWindowFocus).toHaveBeenCalledWith(
+      queryClient.getQueryCache().find({ queryKey: key }),
+    )
+  })
+
+  it('should return false from shouldFetchOnWindowFocus when refetchOnWindowFocus is a function returning false', () => {
+    const key = queryKey()
+    const refetchOnWindowFocus = vi.fn(() => false)
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => 'data',
+      refetchOnWindowFocus,
+    })
+
+    expect(observer.shouldFetchOnWindowFocus()).toBe(false)
+    expect(refetchOnWindowFocus).toHaveBeenCalledWith(
+      queryClient.getQueryCache().find({ queryKey: key }),
+    )
+  })
+
+  it('should return true from shouldFetchOnWindowFocus when refetchOnWindowFocus is a function returning "always" even if the query is fresh', async () => {
+    const key = queryKey()
+    const refetchOnWindowFocus = vi.fn(() => 'always' as const)
+
+    queryClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+      staleTime: Infinity,
+      refetchOnWindowFocus,
+    })
+
+    expect(observer.shouldFetchOnWindowFocus()).toBe(true)
+    expect(refetchOnWindowFocus).toHaveBeenCalledWith(
+      queryClient.getQueryCache().find({ queryKey: key }),
+    )
+  })
+
   it('should fetch and return optimistic result via fetchOptimistic', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {


### PR DESCRIPTION
## 🎯 Changes

Add tests covering `refetchOnWindowFocus` as a function in `shouldFetchOnWindowFocus`.

The existing tests only cover the value forms (`true`, `false`, `"always"`), which all take the `: field` branch of `typeof field === "function" ? field(query) : field`. These add the function forms so the `field(query)` branch is covered.

Each function is a `vi.fn` and asserts it is called with the query (`toHaveBeenCalledWith`), so the function-call path and the query argument are both verified:

- a function returning `true`
- a function returning `false`
- a function returning `"always"`, kept fresh via `staleTime: Infinity` so only the `"always"` path can make it `true`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).