### PR TITLE
test(query-core/queryObserver): add test for 'refetchInterval' as a function refetching at the returned interval

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -747,6 +747,24 @@ describe('queryObserver', () => {
     expect(count).toBe(2)
   })
 
+  it('should refetch at the interval returned when refetchInterval is a function', async () => {
+    const key = queryKey()
+    let count = 0
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => {
+        count++
+        return Promise.resolve('data')
+      },
+      refetchInterval: () => 10,
+    })
+    const unsubscribe = observer.subscribe(() => undefined)
+    expect(count).toBe(1)
+    await vi.advanceTimersByTimeAsync(10)
+    expect(count).toBe(2)
+    unsubscribe()
+  })
+
   it('should use placeholderData as non-cache data when pending a query with no data', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {


### PR DESCRIPTION
## 🎯 Changes

Adds a test in `queryObserver.test.tsx` covering the function form of `refetchInterval`.

Existing `refetchInterval` tests only use the number form (`refetchInterval: 10`). This test verifies that when `refetchInterval` is a function, the returned interval is actually applied, asserting the query refetches at that interval via the `count` side effect.

This covers the previously uncovered branch in `#computeRefetchInterval` where `refetchInterval` is called as a function.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the query observer's `refetchInterval` functionality to verify support for function-based interval values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->