### PR TITLE
test(query-core/queryObserver): add tests for 'notifyOnChangeProps' as a function controlling listener notification

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -747,6 +747,52 @@ describe('queryObserver', () => {
     expect(count).toBe(2)
   })
 
+  it('should notify listeners when notifyOnChangeProps is a function returning props that changed', async () => {
+    const key = queryKey()
+
+    queryClient.setQueryData(key, 'data')
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'new data'),
+      staleTime: Infinity,
+      notifyOnChangeProps: () => ['data'],
+    })
+    const listener = vi.fn()
+
+    const unsubscribe = observer.subscribe(listener)
+    listener.mockClear()
+
+    observer.refetch()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+  })
+
+  it('should not notify listeners when notifyOnChangeProps is a function returning props that did not change', async () => {
+    const key = queryKey()
+
+    queryClient.setQueryData(key, 'data')
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+      staleTime: Infinity,
+      notifyOnChangeProps: () => ['data'],
+    })
+    const listener = vi.fn()
+
+    const unsubscribe = observer.subscribe(listener)
+    listener.mockClear()
+
+    observer.refetch()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(listener).not.toHaveBeenCalled()
+
+    unsubscribe()
+  })
+
   it('should use placeholderData as non-cache data when pending a query with no data', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {


### PR DESCRIPTION
## 🎯 Changes

Adds two tests in `queryObserver.test.tsx` covering the function form of `notifyOnChangeProps`.

`queryObserver.test.tsx` previously had no `notifyOnChangeProps` tests at all. These verify that when `notifyOnChangeProps` is a function, its returned value controls whether listeners are notified:

- listeners are notified when a returned prop (`data`) changes
- listeners are not notified when a returned prop (`data`) does not change

This covers the previously uncovered branch in `shouldNotifyListeners` where `notifyOnChangeProps` is called as a function.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying observer listeners trigger when a function-based change detector reports an actual data change after a refetch.
  * Added tests ensuring listeners are not triggered when the detector reports no meaningful data change after a refetch.
  * Tests use controlled timing to validate listener invocation behavior across refetch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->