### PR TITLE
test(query-core/queryObserver): add test for 'refetchInterval' as a function called with the query

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -765,6 +765,22 @@ describe('queryObserver', () => {
     unsubscribe()
   })
 
+  it('should call refetchInterval with the query when it is a function', async () => {
+    const key = queryKey()
+    const refetchInterval = vi.fn(() => 10)
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+      refetchInterval,
+    })
+    const unsubscribe = observer.subscribe(() => undefined)
+    await vi.advanceTimersByTimeAsync(10)
+    expect(refetchInterval).toHaveBeenCalledWith(
+      queryClient.getQueryCache().find({ queryKey: key }),
+    )
+    unsubscribe()
+  })
+
   it('should use placeholderData as non-cache data when pending a query with no data', async () => {
     const key = queryKey()
     const observer = new QueryObserver(queryClient, {


### PR DESCRIPTION
## 🎯 Changes

Adds a test in `queryObserver.test.tsx` verifying that when `refetchInterval` is a function, it is called with the query.

This complements the existing test covering the function form of `refetchInterval`, which only asserts the returned interval is applied. This one asserts the query is passed to the function via `toHaveBeenCalledWith`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for query observer refetch functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->