### PR TITLE
Add bugs metadata to published packages

### DIFF
--- a/.changeset/quiet-bugs-report.md
+++ b/.changeset/quiet-bugs-report.md
@@ -1,0 +1,12 @@
+---
+"@tanstack/angular-query-experimental": patch
+"@tanstack/eslint-plugin-query": patch
+"@tanstack/query-core": patch
+"@tanstack/react-query": patch
+"@tanstack/react-query-devtools": patch
+"@tanstack/solid-query": patch
+"@tanstack/svelte-query": patch
+"@tanstack/vue-query": patch
+---
+
+Add npm bugs metadata pointing to the TanStack Query issue tracker.

--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/angular-query-experimental"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/eslint-plugin-query"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/query-core"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/react-query-devtools"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/react-query"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/solid-query"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/svelte-query"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"

--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/vue-query"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
## Changes

- Add standard npm `bugs.url` metadata for the published TanStack Query packages in this repo.
- Point the issue tracker link at the public TanStack Query issues page.
- Add a changeset so the metadata update can be published.

Covered packages:

- `@tanstack/query-core`
- `@tanstack/react-query`
- `@tanstack/vue-query`
- `@tanstack/solid-query`
- `@tanstack/svelte-query`
- `@tanstack/angular-query-experimental`
- `@tanstack/react-query-devtools`
- `@tanstack/eslint-plugin-query`

The published packages currently expose homepage and repository metadata, but do not expose a usable `bugs` link in npm package metadata.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

Local metadata-only verification performed instead:

- `node -e "const dirs=['query-core','react-query','vue-query','solid-query','svelte-query','angular-query-experimental','react-query-devtools','eslint-plugin-query']; const out={}; for (const d of dirs){ const p=require('./packages/'+d+'/package.json'); out[p.name]=p.bugs; if(p.bugs?.url!=='https://github.com/TanStack/query/issues') process.exitCode=1; } console.log(JSON.stringify(out,null,2));"`
- `git diff --check`

## Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bug-reporting/issue-report links across multiple packages to make filing issues easier.
  * Updated release metadata (changeset) to mark affected packages for a patch release reflecting the metadata additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->