### PR TITLE
test(svelte-query): align 'advanceTimersByTimeAsync' with 'sleep' duration in wait-for-fire cases

### DIFF
--- a/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
+++ b/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
@@ -39,7 +39,7 @@ describe('HydrationBoundary', () => {
     })
 
     expect(rendered.getByText('data: stringCached')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(21)
+    await vi.advanceTimersByTimeAsync(20)
     expect(rendered.getByText('data: string')).toBeInTheDocument()
   })
 })

--- a/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
@@ -25,7 +25,7 @@ describe('QueryClientProvider', () => {
       },
     })
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: test')).toBeInTheDocument()
 
     expect(queryCache.find({ queryKey: ['hello'] })).toBeDefined()

--- a/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.svelte.test.ts
@@ -30,7 +30,7 @@ describe('createInfiniteQuery', () => {
       },
     })
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Status: success')).toBeInTheDocument()
 
     expect(states.value).toHaveLength(2)
@@ -120,7 +120,7 @@ describe('createInfiniteQuery', () => {
       },
     })
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('count: 1')).toBeInTheDocument()
 
     expect(states.value).toHaveLength(2)
@@ -143,13 +143,13 @@ describe('createInfiniteQuery', () => {
       },
     })
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(
       rendered.getByText('Data: {"pages":[0],"pageParams":[0]}'),
     ).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /setPages/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(
       rendered.getByText('Data: {"pages":[7,8],"pageParams":[7,8]}'),
     ).toBeInTheDocument()

--- a/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
@@ -288,7 +288,7 @@ describe('createQueries', () => {
     expect(queryFn1).toHaveBeenCalledTimes(0)
     expect(queryFn2).toHaveBeenCalledTimes(0)
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
 
     expect(rendered.getByTestId('status1')).toHaveTextContent('pending')
     expect(rendered.getByTestId('status2')).toHaveTextContent('pending')
@@ -319,7 +319,7 @@ describe('createQueries', () => {
     expect(queryFn1).toHaveBeenCalledTimes(0)
     expect(queryFn2).toHaveBeenCalledTimes(0)
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
 
     expect(rendered.getByTestId('status1')).toHaveTextContent('pending')
     expect(rendered.getByTestId('status2')).toHaveTextContent('pending')

--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -1630,7 +1630,7 @@ describe('createQuery', () => {
     expect(rendered.getByTestId('data')).toHaveTextContent('undefined')
     expect(queryFn).toHaveBeenCalledTimes(0)
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
 
     expect(rendered.getByTestId('status')).toHaveTextContent('pending')
     expect(rendered.getByTestId('fetchStatus')).toHaveTextContent('idle')

--- a/packages/svelte-query/tests/mutationOptions/mutationOptions.svelte.test.ts
+++ b/packages/svelte-query/tests/mutationOptions/mutationOptions.svelte.test.ts
@@ -52,7 +52,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('isMutating: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(51)
+    await vi.advanceTimersByTimeAsync(50)
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
   })
 
@@ -70,7 +70,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('isMutating: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(51)
+    await vi.advanceTimersByTimeAsync(50)
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
   })
 
@@ -98,7 +98,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('isMutating: 2')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(51)
+    await vi.advanceTimersByTimeAsync(50)
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
   })
 
@@ -127,7 +127,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('isMutating: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(51)
+    await vi.advanceTimersByTimeAsync(50)
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
   })
 
@@ -151,7 +151,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('clientIsMutating: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(501)
+    await vi.advanceTimersByTimeAsync(500)
     expect(rendered.getByText('clientIsMutating: 0')).toBeInTheDocument()
   })
 
@@ -169,7 +169,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('clientIsMutating: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(501)
+    await vi.advanceTimersByTimeAsync(500)
     expect(rendered.getByText('clientIsMutating: 0')).toBeInTheDocument()
   })
 
@@ -197,7 +197,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('clientIsMutating: 2')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(501)
+    await vi.advanceTimersByTimeAsync(500)
     expect(rendered.getByText('clientIsMutating: 0')).toBeInTheDocument()
   })
 
@@ -226,7 +226,7 @@ describe('mutationOptions', () => {
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('clientIsMutating: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(501)
+    await vi.advanceTimersByTimeAsync(500)
     expect(rendered.getByText('clientIsMutating: 0')).toBeInTheDocument()
   })
 
@@ -253,7 +253,7 @@ describe('mutationOptions', () => {
     expect(rendered.getByText('mutationState: []')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('mutationState: ["data"]')).toBeInTheDocument()
   })
 
@@ -275,7 +275,7 @@ describe('mutationOptions', () => {
     expect(rendered.getByText('mutationState: []')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('mutationState: ["data"]')).toBeInTheDocument()
   })
 
@@ -304,7 +304,7 @@ describe('mutationOptions', () => {
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate1/i }))
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(
       rendered.getByText('mutationState: ["data1","data2"]'),
     ).toBeInTheDocument()
@@ -338,7 +338,7 @@ describe('mutationOptions', () => {
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate1/i }))
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('mutationState: ["data1"]')).toBeInTheDocument()
   })
 })

--- a/packages/svelte-query/tests/useIsFetching/useIsFetching.svelte.test.ts
+++ b/packages/svelte-query/tests/useIsFetching/useIsFetching.svelte.test.ts
@@ -26,7 +26,7 @@ describe('useIsFetching', () => {
     fireEvent.click(rendered.getByRole('button', { name: /setReady/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('isFetching: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('isFetching: 0')).toBeInTheDocument()
   })
 })

--- a/packages/svelte-query/tests/useIsMutating/useIsMutating.svelte.test.ts
+++ b/packages/svelte-query/tests/useIsMutating/useIsMutating.svelte.test.ts
@@ -26,7 +26,7 @@ describe('useIsMutating', () => {
     fireEvent.click(rendered.getByRole('button', { name: /Trigger/i }))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('isMutating: 1')).toBeInTheDocument()
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('isMutating: 0')).toBeInTheDocument()
   })
 })

--- a/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
+++ b/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
@@ -44,12 +44,12 @@ describe('useMutationState', () => {
     })
 
     fireEvent.click(rendered.getByRole('button', { name: /Success/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(successMutationFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('Data: ["success"]')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /Error/i }))
-    await vi.advanceTimersByTimeAsync(21)
+    await vi.advanceTimersByTimeAsync(20)
     expect(errorMutationFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('Data: ["success","error"]')).toBeInTheDocument()
   })
@@ -82,12 +82,12 @@ describe('useMutationState', () => {
     })
 
     fireEvent.click(rendered.getByRole('button', { name: /Success/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(successMutationFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('Data: []')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /Error/i }))
-    await vi.advanceTimersByTimeAsync(21)
+    await vi.advanceTimersByTimeAsync(20)
     expect(errorMutationFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('Data: ["error"]')).toBeInTheDocument()
   })
@@ -147,12 +147,12 @@ describe('useMutationState', () => {
     })
 
     fireEvent.click(rendered.getByRole('button', { name: /Success/i }))
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(successMutationFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('Data: ["success"]')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /Error/i }))
-    await vi.advanceTimersByTimeAsync(21)
+    await vi.advanceTimersByTimeAsync(20)
     expect(errorMutationFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('Data: ["success"]')).toBeInTheDocument()
   })


### PR DESCRIPTION
## 🎯 Changes

Where a test advances fake timers solely to wait for a `sleep(N)` timer to fire and deliver data/state, align the `vi.advanceTimersByTimeAsync(...)` value with the corresponding `sleep` duration:

- `sleep(10)` → `advanceTimersByTimeAsync(10)` (was `11`)
- `sleep(20)` → `advanceTimersByTimeAsync(20)` (was `21`)
- `sleep(50)` → `advanceTimersByTimeAsync(50)` (was `51`)
- `sleep(500)` → `advanceTimersByTimeAsync(500)` (was `501`)

A `setTimeout(fn, N)` (which `sleep` uses) fires exactly at `N`ms, so `advanceTimersByTimeAsync(N)` is enough to flush it and the following microtasks; the extra `+1` was unnecessary.

Threshold-crossing advances (e.g. `staleTime` boundaries that compare with strict `>`) are intentionally left as-is, since those genuinely need to advance past the boundary.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted fake-timer advancement values across multiple test suites to use more precise timing thresholds for assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->