### PR TITLE
chore: add react-query next bugs metadata

### DIFF
--- a/packages/react-query-next-experimental/package.json
+++ b/packages/react-query-next-experimental/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/react-query-next-experimental"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
## 🎯 Changes

- Add the standard `bugs.url` metadata entry for `@tanstack/react-query-next-experimental`.
- Point package consumers to the canonical TanStack Query issue tracker.
- Keep repository, homepage, funding, exports, dependencies, and runtime code unchanged.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
  - Not applicable for this package-metadata-only change. I ran the focused validation commands below instead.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
  - Not applicable: this does not change runtime behavior, public APIs, docs, or generated output.
- [x] This change is docs/CI/dev-only (no release).
  - Treated as no-release package metadata maintenance.

## Validation

- `node -e "const p=require('./packages/react-query-next-experimental/package.json'); if (p.name !== '@tanstack/react-query-next-experimental' || p.bugs?.url !== 'https://github.com/TanStack/query/issues') throw new Error(JSON.stringify({name:p.name, bugs:p.bugs})); console.log(JSON.stringify({name:p.name, version:p.version, repository:p.repository, homepage:p.homepage, bugs:p.bugs}))"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `packages/react-query-next-experimental`

The dry-run package includes the updated `package.json` and the existing `src` files.
