### PR TITLE
test(solid-query/useIsFetching): centralize 'queryClient' setup with 'beforeEach' and rename injected client to 'customClient'

### DIFF
--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -12,18 +12,22 @@ import {
 import { setActTimeout } from './utils'
 
 describe('useIsFetching', () => {
+  let queryCache: QueryCache
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryCache = new QueryCache()
+    queryClient = new QueryClient({ queryCache })
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    queryClient.clear()
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/105
   it('should update as queries start and stop fetching', async () => {
-    const queryCache = new QueryCache()
-    const queryClient = new QueryClient({ queryCache })
     const key = queryKey()
 
     function IsFetching() {
@@ -68,9 +72,6 @@ describe('useIsFetching', () => {
   })
 
   it('should not update state while rendering', async () => {
-    const queryCache = new QueryCache()
-    const queryClient = new QueryClient({ queryCache })
-
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -137,7 +138,6 @@ describe('useIsFetching', () => {
   })
 
   it('should be able to filter', async () => {
-    const queryClient = new QueryClient()
     const key1 = queryKey()
     const key2 = queryKey()
 
@@ -203,7 +203,6 @@ describe('useIsFetching', () => {
   })
 
   it('should show the correct fetching state when mounted after a query', async () => {
-    const queryClient = new QueryClient()
     const key = queryKey()
 
     function Page() {
@@ -233,7 +232,7 @@ describe('useIsFetching', () => {
   })
 
   it('should use provided custom queryClient', async () => {
-    const queryClient = new QueryClient()
+    const customClient = new QueryClient()
     const key = queryKey()
 
     function Page() {
@@ -242,10 +241,10 @@ describe('useIsFetching', () => {
           queryKey: key,
           queryFn: () => sleep(10).then(() => 'test'),
         }),
-        () => queryClient,
+        () => customClient,
       )
 
-      const isFetching = useIsFetching(undefined, () => queryClient)
+      const isFetching = useIsFetching(undefined, () => customClient)
 
       return (
         <div>


### PR DESCRIPTION
## 🎯 Changes

Centralize the per-test `new QueryClient()` setup into a shared `let queryClient` declared at the `describe` level and created in `beforeEach`, matching the pattern already used by `useMutation.test.tsx`. `afterEach` now calls `queryClient.clear()`.

- 4 cases now use the centralized client.
- The `should use provided custom queryClient` case is intentionally left with its own client, renamed to `customClient`, since it verifies passing a client directly via `() => customClient` without a `QueryClientProvider`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test infrastructure for `useIsFetching` by optimizing instance creation and reuse patterns to enhance test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->