### PR TITLE
test(solid-query/useMutationState): centralize 'queryClient' setup with 'beforeEach'

### DIFF
--- a/packages/solid-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutationState.test.tsx
@@ -10,16 +10,19 @@ import {
 } from '..'
 
 describe('useMutationState', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    queryClient.clear()
   })
 
   it('should return all mutation states when called without options', async () => {
-    const queryClient = new QueryClient()
     const mutationKey = queryKey()
 
     function States() {
@@ -67,7 +70,6 @@ describe('useMutationState', () => {
   })
 
   it('should return variables after calling mutate', async () => {
-    const queryClient = new QueryClient()
     const variables: Array<Array<unknown>> = []
     const mutationKey = queryKey()
 


### PR DESCRIPTION
## 🎯 Changes

Centralize the per-test `new QueryClient()` setup into a shared `let queryClient` declared at the `describe` level and created in `beforeEach`, matching the pattern already used by `useMutation.test.tsx`. `afterEach` now calls `queryClient.clear()`.

Both cases that previously created their own `new QueryClient()` now use the centralized client.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite for improved efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->