### PR TITLE
test(solid-query/useIsMutating): centralize 'queryClient' setup with 'beforeEach' and rename injected/spied clients

### DIFF
--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -12,17 +12,20 @@ import {
 import { setActTimeout } from './utils'
 
 describe('useIsMutating', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.useFakeTimers()
+    queryClient = new QueryClient()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    queryClient.clear()
   })
 
   it('should return the number of fetching mutations', async () => {
     const isMutatingArray: Array<number> = []
-    const queryClient = new QueryClient()
     const mutationKey1 = queryKey()
     const mutationKey2 = queryKey()
 
@@ -78,7 +81,6 @@ describe('useIsMutating', () => {
 
   it('should filter correctly by mutationKey', async () => {
     const isMutatingArray: Array<number> = []
-    const queryClient = new QueryClient()
     const mutationKey1 = queryKey()
     const mutationKey2 = queryKey()
 
@@ -124,7 +126,6 @@ describe('useIsMutating', () => {
 
   it('should filter correctly by predicate', async () => {
     const isMutatingArray: Array<number> = []
-    const queryClient = new QueryClient()
     const mutationKey1 = queryKey()
     const mutationKey2 = queryKey()
 
@@ -172,17 +173,17 @@ describe('useIsMutating', () => {
   })
 
   it('should use provided custom queryClient', async () => {
-    const queryClient = new QueryClient()
+    const customClient = new QueryClient()
     const mutationKey1 = queryKey()
 
     function Page() {
-      const isMutating = useIsMutating(undefined, () => queryClient)
+      const isMutating = useIsMutating(undefined, () => customClient)
       const { mutate } = useMutation(
         () => ({
           mutationKey: mutationKey1,
           mutationFn: () => sleep(20).then(() => 'data'),
         }),
-        () => queryClient,
+        () => customClient,
       )
 
       createEffect(() => {
@@ -224,7 +225,9 @@ describe('useIsMutating', () => {
         return new MutationCacheMock(fn)
       })
 
-    const queryClient = new QueryClient()
+    // Create the client after mocking MutationCache so it uses the mock,
+    // not the centralized client from beforeEach
+    const spiedClient = new QueryClient()
     const mutationKey1 = queryKey()
 
     function IsMutating() {
@@ -255,7 +258,7 @@ describe('useIsMutating', () => {
     }
 
     const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={spiedClient}>
         <Page />
       </QueryClientProvider>
     ))


### PR DESCRIPTION
## 🎯 Changes

Centralize the per-test `new QueryClient()` setup into a shared `let queryClient` declared at the `describe` level and created in `beforeEach`, matching the pattern already used by `useMutation.test.tsx`. `afterEach` now calls `queryClient.clear()`.

- 3 cases now use the centralized client.
- The `should use provided custom queryClient` case keeps its own client, renamed to `customClient`, since it verifies passing a client directly via `() => customClient` without a `QueryClientProvider`.
- The `should not change state if unmounted` case keeps its own client, renamed to `spiedClient`, because it must be created **after** the `MutationCache` is spied so the client uses the mock — the centralized client (created in `beforeEach`) would not.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite efficiency by optimizing test client management and reducing redundant setup across test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->