### PR TITLE
test(*): move 'vi.useRealTimers' to the end of 'afterEach' so cleanup runs under fake timers

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
@@ -47,8 +47,8 @@ describe('PendingTasks Integration', () => {
 
   afterEach(() => {
     onlineManager.setOnline(true)
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   describe('Synchronous Resolution', () => {

--- a/packages/angular-query-experimental/src/__tests__/with-devtools.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/with-devtools.test.ts
@@ -58,8 +58,8 @@ describe('withDevtools feature', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
-    vi.useRealTimers()
     TestBed.resetTestingModule()
+    vi.useRealTimers()
   })
 
   it.each([

--- a/packages/preact-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
+++ b/packages/preact-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
@@ -44,8 +44,8 @@ describe('useQueries with persist and memoized combine (preact)', () => {
 
   afterEach(() => {
     cleanup()
-    vi.useRealTimers()
     Object.keys(storage).forEach((key) => delete storage[key])
+    vi.useRealTimers()
   })
 
   it('updates UI when combine is memoized with persisted results', async () => {

--- a/packages/preact-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/preact-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -27,8 +27,8 @@ describe('QueryErrorResetBoundary', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   describe('useQuery', () => {

--- a/packages/preact-query/src/__tests__/fine-grained-persister.test.tsx
+++ b/packages/preact-query/src/__tests__/fine-grained-persister.test.tsx
@@ -20,8 +20,8 @@ describe('fine grained persister', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should restore query state from persister and not refetch', async () => {

--- a/packages/preact-query/src/__tests__/ssr.test.tsx
+++ b/packages/preact-query/src/__tests__/ssr.test.tsx
@@ -26,8 +26,8 @@ describe('Server Side Rendering', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should not trigger fetch', () => {

--- a/packages/preact-query/src/__tests__/suspense.test.tsx
+++ b/packages/preact-query/src/__tests__/suspense.test.tsx
@@ -52,8 +52,8 @@ describe('Suspense Timer Tests', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should enforce minimum staleTime of 1000ms when using suspense with number', async () => {

--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -62,8 +62,8 @@ describe('useInfiniteQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct states for a successful query', async () => {

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -28,8 +28,8 @@ describe('useMutation', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should be able to reset `data`', async () => {

--- a/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -52,9 +52,9 @@ describe('usePrefetchInfiniteQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
     Fallback.mockClear()
+    vi.useRealTimers()
   })
 
   const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)

--- a/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -31,8 +31,8 @@ describe('usePrefetchQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   function Suspended<TData = unknown>(props: {

--- a/packages/preact-query/src/__tests__/useQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useQueries.test.tsx
@@ -41,8 +41,8 @@ describe('useQueries', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct states', async () => {

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -47,8 +47,8 @@ describe('useQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/105

--- a/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -34,10 +34,10 @@ describe('useSuspenseQueries', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
     onSuspend.mockClear()
     onQueriesResolution.mockClear()
+    vi.useRealTimers()
   })
 
   function SuspenseFallback() {

--- a/packages/preact-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -32,8 +32,8 @@ describe('useSuspenseQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   /**

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -89,12 +89,12 @@ describe('Devtools', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     vi.unstubAllGlobals()
     Object.keys(storage).forEach((key) => delete storage[key])
     queryClient.clear()
     onlineManager.setOnline(true)
     document.documentElement.style.fontSize = previousRootFontSize
+    vi.useRealTimers()
   })
 
   function renderDevtools(

--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -24,8 +24,8 @@ describe('Explorer', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   function renderExplorer(

--- a/packages/react-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
@@ -33,8 +33,8 @@ describe('useQueries with persist and memoized combine', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     Object.keys(storage).forEach((key) => delete storage[key])
+    vi.useRealTimers()
   })
 
   it('should update UI when combine is memoized with persist', async () => {

--- a/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -25,8 +25,8 @@ describe('QueryErrorResetBoundary', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   describe('useQuery', () => {

--- a/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
+++ b/packages/react-query/src/__tests__/fine-grained-persister.test.tsx
@@ -19,8 +19,8 @@ describe('fine grained persister', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should restore query state from persister and not refetch', async () => {

--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -28,8 +28,8 @@ describe('Server Side Rendering', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should not trigger fetch', () => {

--- a/packages/react-query/src/__tests__/suspense.test.tsx
+++ b/packages/react-query/src/__tests__/suspense.test.tsx
@@ -50,8 +50,8 @@ describe('Suspense Timer Tests', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should enforce minimum staleTime of 1000ms when using suspense with number', async () => {

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -63,8 +63,8 @@ describe('useInfiniteQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct states for a successful query', async () => {

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -27,8 +27,8 @@ describe('useMutation', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should be able to reset `data`', async () => {

--- a/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -53,8 +53,8 @@ describe('usePrefetchInfiniteQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   function Suspended<T = unknown>(props: {

--- a/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -30,8 +30,8 @@ describe('usePrefetchQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   function Suspended<TData = unknown>(props: {

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -40,8 +40,8 @@ describe('useQueries', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct states', async () => {

--- a/packages/react-query/src/__tests__/useQuery.promise.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.promise.test.tsx
@@ -35,8 +35,8 @@ describe('useQuery().promise', { timeout: 10_000 }, () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should work with a basic test', async () => {

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -39,8 +39,8 @@ describe('useQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/105

--- a/packages/react-query/src/__tests__/useSuspenseInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseInfiniteQuery.test.tsx
@@ -22,8 +22,8 @@ describe('useSuspenseInfiniteQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct states for a successful infinite query', async () => {

--- a/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -32,10 +32,10 @@ describe('useSuspenseQueries', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
     onSuspend.mockClear()
     onQueriesResolution.mockClear()
+    vi.useRealTimers()
   })
 
   function SuspenseFallback() {

--- a/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -30,8 +30,8 @@ describe('useSuspenseQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should render the correct amount of times in Suspense mode', async () => {

--- a/packages/solid-query/src/__tests__/mutationOptions.test.tsx
+++ b/packages/solid-query/src/__tests__/mutationOptions.test.tsx
@@ -21,8 +21,8 @@ describe('mutationOptions', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the object received as a parameter without any modification (with mutationKey in mutationOptions)', () => {

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -29,8 +29,8 @@ describe("useQuery's in Suspense mode", () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should render the correct amount of times in Suspense mode', async () => {

--- a/packages/solid-query/src/__tests__/transition.test.tsx
+++ b/packages/solid-query/src/__tests__/transition.test.tsx
@@ -15,8 +15,8 @@ describe("useQuery's in Suspense mode with transitions", () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should render the content when the transition is done', async () => {

--- a/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -61,8 +61,8 @@ describe('useInfiniteQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct states for a successful query', async () => {

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -22,8 +22,8 @@ describe('useIsFetching', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/105

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -20,8 +20,8 @@ describe('useIsMutating', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the number of fetching mutations', async () => {

--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -30,8 +30,8 @@ describe('useMutation', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should be able to reset `data`', async () => {

--- a/packages/solid-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutationState.test.tsx
@@ -18,8 +18,8 @@ describe('useMutationState', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return all mutation states when called without options', async () => {

--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -37,8 +37,8 @@ describe('useQueries', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct states', async () => {

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -54,8 +54,8 @@ describe('useQuery', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it('should return the correct types', () => {

--- a/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
+++ b/packages/svelte-query/tests/createQueries/createQueries.svelte.test.ts
@@ -15,8 +15,8 @@ describe('createQueries', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     queryClient.clear()
+    vi.useRealTimers()
   })
 
   it(

--- a/packages/vue-query/src/__tests__/mutationOptions.test.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test.ts
@@ -14,8 +14,8 @@ describe('mutationOptions', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     useQueryClient().clear()
+    vi.useRealTimers()
   })
 
   it('should return the object received as a parameter without any modification (with mutationKey in mutationOptions)', () => {


### PR DESCRIPTION
## 🎯 Changes

Move `vi.useRealTimers()` to the **last line** of each `afterEach`/`afterAll` block, so all teardown (`queryClient.clear()`, storage resets, `*.mockClear()`, `TestBed.resetTestingModule()`, etc.) runs while fake timers are still active, and the timer regime is restored only after cleanup completes.

### Why

`queryClient.clear()` reaches `Removable.destroy()` → `clearGcTimeout()` → `timeoutManager.clearTimeout()`, i.e. cleanup touches timers. Running teardown while fake timers are still installed keeps it under the same timer regime used during the test, which is slightly more defensive: any future cleanup logic that depends on the timer environment stays correct without surprises. Several suites in the repo (e.g. most of `svelte-query`) already follow this `clear()` → `useRealTimers()` order; this brings the rest in line.

This is a pure reorder — behavior is unchanged (each diff is a single line moved; 44 insertions / 44 deletions). All affected test suites pass locally.

### Scope

Applied repo-wide across every `afterEach`/`afterAll` that restored real timers before finishing cleanup (44 files):

- `react-query` (14), `preact-query` (12), `solid-query` (10), `query-devtools` (2), `angular-query-experimental` (2), `react-query-persist-client` (1), `preact-query-persist-client` (1), `svelte-query` (1), `vue-query` (1)

The rule was "move `useRealTimers` to the end of the block", not a blind two-line swap, so blocks with extra teardown are handled correctly — `useRealTimers` was moved past **all** preceding cleanup, not just one line:

- `angular .../pending-tasks.test.ts`, `angular .../with-devtools.test.ts`: moved `useRealTimers` after `onlineManager.setOnline(true)` / `vi.restoreAllMocks()` / `TestBed.resetTestingModule()`.
- `react/preact .../useSuspenseQueries.test.tsx`, `preact .../usePrefetchInfiniteQuery.test.tsx`: moved `useRealTimers` after the `*.mockClear()` calls.
- `react/preact persist-client .../use-queries-with-persist.test.tsx`: moved `useRealTimers` after `Object.keys(storage).forEach(delete ...)`.
- `query-devtools .../Devtools.test.tsx`: moved `useRealTimers` after all storage/online/style resets.

it-body calls to `vi.useRealTimers()` (where a specific test opts out of fake timers) and `afterAll` blocks that already end with it are intentionally left unchanged.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).