### PR TITLE
fix: retry remounted queries after error reset

### DIFF
--- a/.changeset/error-boundary-remount-retry.md
+++ b/.changeset/error-boundary-remount-retry.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Preserve error boundary reset retries for remounted queries when another query clears the reset state first.

--- a/packages/react-query/src/QueryErrorResetBoundary.tsx
+++ b/packages/react-query/src/QueryErrorResetBoundary.tsx
@@ -5,21 +5,29 @@ import * as React from 'react'
 export type QueryErrorResetFunction = () => void
 export type QueryErrorIsResetFunction = () => boolean
 export type QueryErrorClearResetFunction = () => void
+export type QueryErrorResetCountFunction = () => number
 
 export interface QueryErrorResetBoundaryValue {
   clearReset: QueryErrorClearResetFunction
+  getResetCount?: QueryErrorResetCountFunction
   isReset: QueryErrorIsResetFunction
   reset: QueryErrorResetFunction
 }
 
 function createValue(): QueryErrorResetBoundaryValue {
   let isReset = false
+  let resetCount = 0
+
   return {
     clearReset: () => {
       isReset = false
     },
+    getResetCount: () => {
+      return resetCount
+    },
     reset: () => {
       isReset = true
+      resetCount++
     },
     isReset: () => {
       return isReset

--- a/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx
@@ -9,6 +9,7 @@ import {
   QueryErrorResetBoundary,
   useQueries,
   useQuery,
+  useQueryErrorResetBoundary,
   useSuspenseQueries,
   useSuspenseQuery,
 } from '..'
@@ -87,6 +88,104 @@ describe('QueryErrorResetBoundary', () => {
       fireEvent.click(rendered.getByText('retry'))
       await vi.advanceTimersByTimeAsync(11)
       expect(rendered.getByText('data')).toBeInTheDocument()
+
+      consoleMock.mockRestore()
+    })
+
+    it('should retry a remounted error query when another query mounted after reset', async () => {
+      const consoleMock = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined)
+      const errorKey = queryKey()
+      const otherKey = queryKey()
+
+      let succeed = false
+
+      const queryFn = vi.fn(() =>
+        sleep(10).then(() => {
+          if (!succeed) {
+            throw new Error('Error')
+          }
+          return 'data'
+        }),
+      )
+
+      function ErrorFallback() {
+        const { reset } = useQueryErrorResetBoundary()
+
+        React.useEffect(() => {
+          return () => {
+            reset()
+          }
+        }, [reset])
+
+        return <div>error boundary</div>
+      }
+
+      function ErrorPage() {
+        const { data } = useSuspenseQuery({
+          queryKey: errorKey,
+          queryFn,
+          retry: false,
+          retryOnMount: true,
+        })
+
+        return <div>{data}</div>
+      }
+
+      function OtherPage() {
+        const { data } = useSuspenseQuery({
+          queryKey: otherKey,
+          queryFn: () => sleep(10).then(() => 'other'),
+        })
+
+        return <div>{data}</div>
+      }
+
+      function App() {
+        const [showErrorPage, setShowErrorPage] = React.useState(true)
+
+        return (
+          <div>
+            <button onClick={() => setShowErrorPage((show) => !show)}>
+              toggle
+            </button>
+            {showErrorPage ? (
+              <ErrorBoundary fallback={<ErrorFallback />}>
+                <React.Suspense fallback="loading">
+                  <ErrorPage />
+                </React.Suspense>
+              </ErrorBoundary>
+            ) : (
+              <React.Suspense fallback="loading">
+                <OtherPage />
+              </React.Suspense>
+            )}
+          </div>
+        )
+      }
+
+      const rendered = renderWithClient(
+        queryClient,
+        <QueryErrorResetBoundary>
+          <App />
+        </QueryErrorResetBoundary>,
+      )
+
+      await act(() => vi.advanceTimersByTimeAsync(10))
+      expect(rendered.getByText('error boundary')).toBeInTheDocument()
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      fireEvent.click(rendered.getByText('toggle'))
+      await act(() => vi.advanceTimersByTimeAsync(10))
+      expect(rendered.getByText('other')).toBeInTheDocument()
+
+      succeed = true
+
+      fireEvent.click(rendered.getByText('toggle'))
+      await act(() => vi.advanceTimersByTimeAsync(10))
+      expect(rendered.getByText('data')).toBeInTheDocument()
+      expect(queryFn).toHaveBeenCalledTimes(2)
 
       consoleMock.mockRestore()
     })

--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -10,6 +10,69 @@ import type {
 } from '@tanstack/query-core'
 import type { QueryErrorResetBoundaryValue } from './QueryErrorResetBoundary'
 
+const queryResetCounts = new WeakMap<
+  QueryErrorResetBoundaryValue,
+  WeakMap<object, number>
+>()
+
+function getResetCount(errorResetBoundary: QueryErrorResetBoundaryValue) {
+  return errorResetBoundary.getResetCount?.()
+}
+
+function getQueryResetCounts(errorResetBoundary: QueryErrorResetBoundaryValue) {
+  let resetCounts = queryResetCounts.get(errorResetBoundary)
+
+  if (!resetCounts) {
+    resetCounts = new WeakMap()
+    queryResetCounts.set(errorResetBoundary, resetCounts)
+  }
+
+  return resetCounts
+}
+
+function isResetForQuery<
+  TQueryFnData,
+  TError,
+  TQueryData,
+  TQueryKey extends QueryKey,
+>(
+  errorResetBoundary: QueryErrorResetBoundaryValue,
+  query: Query<TQueryFnData, TError, TQueryData, TQueryKey> | undefined,
+) {
+  const resetCount = getResetCount(errorResetBoundary)
+
+  if (errorResetBoundary.isReset()) {
+    if (query && resetCount) {
+      getQueryResetCounts(errorResetBoundary).set(query, resetCount)
+    }
+
+    return resetCount === undefined || resetCount > 0
+  }
+
+  if (!query) {
+    return false
+  }
+
+  const resetCounts = getQueryResetCounts(errorResetBoundary)
+  const queryResetCount = resetCounts.get(query)
+
+  if (queryResetCount === undefined) {
+    resetCounts.set(query, resetCount ?? 0)
+    return false
+  }
+
+  if (!resetCount) {
+    return false
+  }
+
+  if (resetCount > queryResetCount) {
+    resetCounts.set(query, resetCount)
+    return true
+  }
+
+  return false
+}
+
 export const ensurePreventErrorBoundaryRetry = <
   TQueryFnData,
   TError,
@@ -38,7 +101,7 @@ export const ensurePreventErrorBoundaryRetry = <
     throwOnError
   ) {
     // Prevent retrying failed query if the error boundary has not been reset yet
-    if (!errorResetBoundary.isReset()) {
+    if (!isResetForQuery(errorResetBoundary, query)) {
       options.retryOnMount = false
     }
   }

--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -14,6 +14,9 @@ const queryResetCounts = new WeakMap<
   QueryErrorResetBoundaryValue,
   WeakMap<object, number>
 >()
+// Track reset generations per live Query instance. If a query is garbage
+// collected between unmount and remount, a future Query instance starts fresh
+// instead of inheriting retry state from a different lifecycle.
 
 function getResetCount(errorResetBoundary: QueryErrorResetBoundaryValue) {
   return errorResetBoundary.getResetCount?.()


### PR DESCRIPTION
## 🎯 Changes

Fixes #2712.

React Query currently stores error boundary reset state as a single boolean. When an errored query is unmounted, the fallback can call `reset()`, but another query mounted before the original query remounts can clear that reset state. The original query then remounts with `retryOnMount: false` and stays in the error boundary instead of retrying.

This PR tracks reset generations per query instance so a remounted errored query can still observe that a reset happened after it last mounted, even if another query has already cleared the global reset flag.

It also adds a regression test for the route/page switch case where:

- the first query errors into an error boundary
- the fallback calls `reset()` on unmount
- another query mounts and clears the reset state
- the original query remounts and retries successfully

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

`pnpm run test:pr` was attempted with `NX_DAEMON=false`, but Nx failed locally before running project targets with `Failed to start plugin worker`.

Targeted verification completed locally:

- `npx pnpm@11.1.0 --filter @tanstack/react-query exec vitest run src/__tests__/QueryResetErrorBoundary.test.tsx`
- `npx pnpm@11.1.0 --filter @tanstack/react-query run test:types:tscurrent`
- `npx pnpm@11.1.0 --filter @tanstack/react-query run test:eslint`
- `npx pnpm@11.1.0 exec prettier --experimental-cli --check .changeset/error-boundary-remount-retry.md packages/react-query/src/QueryErrorResetBoundary.tsx packages/react-query/src/errorBoundaryUtils.ts packages/react-query/src/__tests__/QueryResetErrorBoundary.test.tsx`
- `git diff --check`

`test:eslint` completed with existing warnings in unrelated test files.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional `getResetCount` function to the Query Error Reset Boundary for tracking how many times the boundary has been reset.

* **Bug Fixes**
  * Improved error boundary reset behavior for remounted queries: retry/reset handling is now preserved correctly even if another query clears the reset state first.

* **Tests**
  * Added coverage for reset behavior across unmount/remount and query switching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->