### PR TITLE
fix(query-core): add bugs.url to package manifest

### DIFF
--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/query-core"
   },
   "homepage": "https://tanstack.com/query",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
Adds missing `bugs.url` field to `@tanstack/query-core` package.json, pointing to the repository issues page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include bug reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->