### PR TITLE
fix(solid-query): don't hang async SSR when a disabled query is rendered

### DIFF
--- a/.changeset/solid-query-ssr-disabled-hang.md
+++ b/.changeset/solid-query-ssr-disabled-hang.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Fix `renderToStringAsync` hanging during SSR when a query is disabled: strip the unserializable `experimental_prefetchInRender` promise from the hydratable observer result, since a disabled query's promise never settles and the SSR serializer would await it forever.

--- a/packages/solid-query/src/__tests__/ssr.test.tsx
+++ b/packages/solid-query/src/__tests__/ssr.test.tsx
@@ -42,4 +42,31 @@ describe('useQuery on the server', () => {
     expect(state!.refetch).toBeUndefined()
     expect(state!.promise).toBeUndefined()
   })
+
+  it('resolves an enabled query with data and without unserializable fields', async () => {
+    const client = new QueryClient()
+    let state: UseQueryResult<string> | undefined
+
+    function Page() {
+      const query = useQuery(() => ({
+        queryKey: ['enabled-ssr'],
+        queryFn: () => Promise.resolve('server data'),
+      }))
+      state = query
+      return <div>data: {String(query.data)}</div>
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={client}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    await waitFor(() => rendered.getByText('data: server data'))
+
+    expect(state!.data).toBe('server data')
+    expect(state!.isSuccess).toBe(true)
+    expect(state!.refetch).toBeUndefined()
+    expect(state!.promise).toBeUndefined()
+  })
 })

--- a/packages/solid-query/src/__tests__/ssr.test.tsx
+++ b/packages/solid-query/src/__tests__/ssr.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@solidjs/testing-library'
+import { QueryClient, QueryClientProvider, useQuery } from '..'
+import type * as SolidWeb from 'solid-js/web'
+import type { UseQueryResult } from '..'
+
+// Force the server code path: on the server `useBaseQuery` enables
+// `experimental_prefetchInRender` and resolves the resource with a
+// serializable `hydratableObserverResult()`.
+vi.mock('solid-js/web', async (importOriginal) => {
+  const mod = await importOriginal<typeof SolidWeb>()
+  return { ...mod, isServer: true }
+})
+
+describe('useQuery on the server', () => {
+  it('resolves a disabled query without leaking the prefetch promise (#10907)', async () => {
+    const client = new QueryClient()
+    let state: UseQueryResult<string> | undefined
+
+    function Page() {
+      const query = useQuery(() => ({
+        queryKey: ['disabled-ssr'],
+        queryFn: () => Promise.resolve('data'),
+        enabled: false,
+      }))
+      state = query
+      return <div>data: {String(query.data)}</div>
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={client}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    await waitFor(() => rendered.getByText('data: undefined'))
+
+    // The resolved result is serialized into the SSR payload, so it must not
+    // carry functions or promises. The `experimental_prefetchInRender`
+    // promise of a disabled query never settles, which would hang
+    // `renderToStringAsync` while the serializer awaits it.
+    expect(state!.refetch).toBeUndefined()
+    expect(state!.promise).toBeUndefined()
+  })
+})

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -79,6 +79,10 @@ const hydratableObserverResult = <
     // During SSR, functions cannot be serialized, so we need to remove them
     // This is safe because we will add these functions back when the query is hydrated
     refetch: undefined,
+    // The `experimental_prefetchInRender` promise cannot be serialized either.
+    // For a disabled query it never settles, which would hang stream/async
+    // SSR while the serializer awaits it (#10907).
+    promise: undefined,
   }
 
   // If the query is an infinite query, we need to remove additional properties


### PR DESCRIPTION
## 🎯 Changes

Resolves #10907

A `useQuery` with `enabled: false` hangs `renderToStringAsync` (and SolidStart's async/stream SSR) as soon as the query is rendered.

**Root cause:** on the server, `useBaseQuery` forces `experimental_prefetchInRender = true`, so every observer result carries a `.promise`. `hydratableObserverResult()` strips `refetch` because functions can't be serialized, but it predates `experimental_prefetchInRender` and doesn't strip `promise`. The promise therefore ends up in the resolved resource value, and Solid's SSR serializer (seroval) awaits embedded promises — for a disabled query that promise never settles, so serialization (and the render) hangs forever.

I verified this mechanism empirically against the published `@tanstack/solid-query@5.101.0` build using the standalone repro from #10907: the resource fetcher actually resolves immediately (`isLoading` is `false` for a disabled query) — the hang happens afterwards, during serialization of the resolved value. Stripping `promise` from `hydratableObserverResult()` makes `renderToStringAsync` settle with the expected markup (`data=undefined`) and a clean hydration script.

**Fix:** strip `promise` from the hydratable result alongside `refetch`. The client rebuilds the result (including its own `promise`) from the hydrated query state, so nothing is lost.

Also adds the first SSR-path test for solid-query (`isServer` mocked to `true`), asserting the resolved result of a disabled query carries neither `refetch` nor `promise` — it fails without the fix.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`. (solid-query package: 320 tests + typecheck pass, eslint clean)

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented server-side rendering from hanging by ensuring non-serializable promise-like values aren’t included in SSR hydration data for disabled queries.

* **Tests**
  * Added server-side tests verifying disabled and enabled queries render expected data and that non-serializable fields are excluded from serialized query state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->