### PR TITLE
fix: add bugs metadata to packages/solid-query/package.json

### DIFF
--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -77,5 +77,8 @@
   },
   "peerDependencies": {
     "solid-js": "^1.6.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -64,5 +64,8 @@
   },
   "peerDependencies": {
     "svelte": "^5.25.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }


### PR DESCRIPTION
## Summary
The published npm package `@tanstack/solid-query@5.101.0` is missing the `bugs` field in its `package.json` metadata.

## Fix
Added the `bugs` field to `packages/solid-query/package.json`:
```json
"bugs": {
  "url": "https://github.com/TanStack/query/issues"
}
```

## Verification
- `npm view @tanstack/solid-query bugs --json` returns nothing
- No dependencies, runtime code, or build configuration affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include GitHub issues URL for bug reporting in Solid Query and Svelte Query packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->