### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,5 +85,8 @@
     "typescript60": "npm:typescript@6.0.1-rc",
     "vite": "^6.4.1",
     "vitest": "^4.0.18"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to point to the project's issue tracker for bug reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->