### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tanstack/query-core",
   "version": "5.101.0",
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
+  },
   "description": "The framework agnostic core that powers TanStack Query",
   "author": "tannerlinsley",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/query-core/package.json`.

Fixes npm tooling unable to resolve package metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with bug reporting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->