### PR TITLE
test(preact-query): replace deprecated 'toBeCalledTimes' with 'toHaveBeenCalledTimes'

### DIFF
--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -976,7 +976,7 @@ describe('useInfiniteQuery', () => {
     await vi.advanceTimersByTimeAsync(160)
 
     const expectedCallCount = 3
-    expect(fetchPage).toBeCalledTimes(expectedCallCount)
+    expect(fetchPage).toHaveBeenCalledTimes(expectedCallCount)
     expect(onAborts).toHaveLength(expectedCallCount)
     expect(abortListeners).toHaveLength(expectedCallCount)
 
@@ -1051,7 +1051,7 @@ describe('useInfiniteQuery', () => {
     await vi.advanceTimersByTimeAsync(160)
 
     const expectedCallCount = 2
-    expect(fetchPage).toBeCalledTimes(expectedCallCount)
+    expect(fetchPage).toHaveBeenCalledTimes(expectedCallCount)
     expect(onAborts).toHaveLength(expectedCallCount)
     expect(abortListeners).toHaveLength(expectedCallCount)
 

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -4954,17 +4954,17 @@ describe('useQuery', () => {
     // // render error state component
     await vi.advanceTimersByTimeAsync(11)
     rendered.getByText('error')
-    expect(queryFn).toBeCalledTimes(1)
+    expect(queryFn).toHaveBeenCalledTimes(1)
 
     // change to enabled to false
     fireEvent.click(rendered.getByLabelText('retry'))
     await vi.advanceTimersByTimeAsync(11)
     rendered.getByText('error')
-    expect(queryFn).toBeCalledTimes(1)
+    expect(queryFn).toHaveBeenCalledTimes(1)
 
     // // change to enabled to true
     fireEvent.click(rendered.getByLabelText('retry'))
-    expect(queryFn).toBeCalledTimes(2)
+    expect(queryFn).toHaveBeenCalledTimes(2)
   })
 
   it('should refetch when query key changed when previous status is error', async () => {


### PR DESCRIPTION
## 🎯 Changes

Replace the deprecated assertion alias `toBeCalledTimes` with its recommended counterpart `toHaveBeenCalledTimes` across the preact-query test suite.

The alias is flagged `@deprecated` by `@vitest/expect`'s type definitions, which point to the replacement used here:
- `toBeCalledTimes` → `toHaveBeenCalledTimes`

Affected files:
- `useQuery.test.tsx`
- `useInfiniteQuery.test.tsx`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use correct testing framework matchers for validating function call counts, improving test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->