### PR TITLE
test(query-async-storage-persister): replace deprecated 'toBeCalledTimes' with 'toHaveBeenCalledTimes'

### DIFF
--- a/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
+++ b/packages/query-async-storage-persister/src/__tests__/asyncThrottle.test.ts
@@ -36,7 +36,7 @@ describe('asyncThrottle', () => {
     await vi.advanceTimersToNextTimerAsync()
     await vi.advanceTimersByTimeAsync(interval)
 
-    expect(mockFunc).toBeCalledTimes(2)
+    expect(mockFunc).toHaveBeenCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(3)
     expect(execTimeStamps.length).toBe(2)
     expect(execTimeStamps[1]! - execTimeStamps[0]!).toBeGreaterThanOrEqual(
@@ -68,7 +68,7 @@ describe('asyncThrottle', () => {
     await vi.advanceTimersToNextTimerAsync()
     await vi.advanceTimersByTimeAsync(interval)
 
-    expect(mockFunc).toBeCalledTimes(2)
+    expect(mockFunc).toHaveBeenCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(4)
     expect(execTimeStamps.length).toBe(2)
     expect(execTimeStamps[1]! - execTimeStamps[0]!).toBeGreaterThanOrEqual(
@@ -98,7 +98,7 @@ describe('asyncThrottle', () => {
     await vi.advanceTimersByTimeAsync(interval + 10)
     await vi.advanceTimersByTimeAsync(interval + 10)
 
-    expect(mockFunc).toBeCalledTimes(2)
+    expect(mockFunc).toHaveBeenCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(3)
     expect(execTimeStamps.length).toBe(2)
     expect(execTimeStamps[1]! - execTimeStamps[0]!).toBeGreaterThanOrEqual(
@@ -126,7 +126,7 @@ describe('asyncThrottle', () => {
     new Promise((resolve) => testFunc(2, resolve))
     await vi.advanceTimersByTimeAsync(interval)
 
-    expect(mockFunc).toBeCalledTimes(2)
+    expect(mockFunc).toHaveBeenCalledTimes(2)
     expect(mockFunc.mock.calls[1]?.[0]).toBe(2)
   })
 


### PR DESCRIPTION
## 🎯 Changes

Replace the deprecated assertion alias `toBeCalledTimes` with its recommended counterpart `toHaveBeenCalledTimes` in the query-async-storage-persister test suite.

The alias is flagged `@deprecated` by `@vitest/expect`'s type definitions, which point to the replacement used here:
- `toBeCalledTimes` → `toHaveBeenCalledTimes`

Affected file:
- `asyncThrottle.test.ts`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).