### PR TITLE
test(angular-query-experimental): replace deprecated 'toBeCalledWith' with 'toHaveBeenCalledWith'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -436,7 +436,7 @@ describe('injectQuery', () => {
 
     expect(spy).toHaveBeenCalledTimes(2)
     // should call queryFn with context containing the new queryKey
-    expect(spy).toBeCalledWith({
+    expect(spy).toHaveBeenCalledWith({
       client: queryClient,
       meta: undefined,
       queryKey: key2,


### PR DESCRIPTION
## 🎯 Changes

Replace the deprecated assertion alias `toBeCalledWith` with its recommended counterpart `toHaveBeenCalledWith` in the angular-query-experimental test suite.

The alias is flagged `@deprecated` by `@vitest/expect`'s type definitions, which point to the replacement used here:
- `toBeCalledWith` → `toHaveBeenCalledWith`

Affected file:
- `inject-query.test.ts`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).