### PR TITLE
test(lit-query): replace deprecated 'toThrowError' with 'toThrow'

### DIFF
--- a/packages/lit-query/src/tests/context-provider.test.ts
+++ b/packages/lit-query/src/tests/context-provider.test.ts
@@ -46,7 +46,7 @@ describe('QueryClientProvider/context', () => {
     provider.remove()
     await Promise.resolve()
 
-    expect(() => useQueryClient()).toThrowError(/No QueryClient available/)
+    expect(() => useQueryClient()).toThrow(/No QueryClient available/)
   })
 
   it('prefers an explicit client in resolveQueryClient', () => {
@@ -76,7 +76,7 @@ describe('QueryClientProvider/context', () => {
     providerA.remove()
     await Promise.resolve()
 
-    expect(() => useQueryClient()).toThrowError(/No QueryClient available/)
+    expect(() => useQueryClient()).toThrow(/No QueryClient available/)
   })
 
   it('throws when multiple different providers make global lookup ambiguous', async () => {
@@ -93,10 +93,8 @@ describe('QueryClientProvider/context', () => {
     await providerB.updateComplete
 
     expect(getDefaultQueryClient()).toBeUndefined()
-    expect(() => useQueryClient()).toThrowError(
-      /Multiple QueryClients are mounted/,
-    )
-    expect(() => resolveQueryClient()).toThrowError(
+    expect(() => useQueryClient()).toThrow(/Multiple QueryClients are mounted/)
+    expect(() => resolveQueryClient()).toThrow(
       /Multiple QueryClients are mounted/,
     )
 
@@ -112,7 +110,7 @@ describe('QueryClientProvider/context', () => {
 
   it('requires an explicit client before connect', () => {
     const provider = document.createElement(tagName) as QueryClientProvider
-    expect(() => provider.connectedCallback()).toThrowError(
+    expect(() => provider.connectedCallback()).toThrow(
       /No QueryClient available/,
     )
   })
@@ -195,7 +193,7 @@ describe('QueryClientProvider/context', () => {
     )
     expect(unmount).toHaveBeenCalledTimes(1)
     expect(getDefaultQueryClient()).toBeUndefined()
-    expect(() => useQueryClient()).toThrowError(/No QueryClient available/)
+    expect(() => useQueryClient()).toThrow(/No QueryClient available/)
     await waitForMissingQueryClient(() => consumer.query())
     await expect(consumer.query.refetch()).rejects.toThrow(
       /No QueryClient available/,

--- a/packages/lit-query/src/tests/mutation-controller.test.ts
+++ b/packages/lit-query/src/tests/mutation-controller.test.ts
@@ -42,7 +42,7 @@ describe('createMutationController', () => {
     ) as ContextMutationHostElement
 
     expect(consumer.mutation().isIdle).toBe(true)
-    expect(() => consumer.mutation.mutate(1)).toThrowError(
+    expect(() => consumer.mutation.mutate(1)).toThrow(
       /No QueryClient available/,
     )
     await expect(consumer.mutation.mutateAsync(1)).rejects.toThrow(


### PR DESCRIPTION
## 🎯 Changes

Replace the deprecated assertion alias `toThrowError` with its recommended counterpart `toThrow` across the lit-query test suite.

The alias is flagged `@deprecated` by `@vitest/expect`'s type definitions, which point to the replacement used here:
- `toThrowError` → `toThrow`

Affected files:
- `context-provider.test.ts`
- `mutation-controller.test.ts`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Updated test assertions for query client context provider validation to align with current testing framework standards
  - Updated mutation controller validation tests to use consistent assertion methods
  - No changes to expected behavior or validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->