### PR TITLE
chore(knip): update '$schema' to 'knip@6' to match the installed major version

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignore": ["scripts/*.{j,t}s", "**/root.*.config.*", "**/ts-fixture/file.ts"],
   "ignoreDependencies": [
     "@types/react",


### PR DESCRIPTION
## 🎯 Changes

The root `knip.json` `$schema` still pointed at `knip@5`, while the repo has been on knip `6.x` for a while (`"knip": "^6.0.2"` in the root `package.json`, resolving to `6.1.1`). This bumps the schema URL to `knip@6` so editor validation/autocomplete matches the installed major version.

- Update `$schema` from `https://unpkg.com/knip@5/schema.json` to `https://unpkg.com/knip@6/schema.json`.

No config keys are changed and `knip --treat-config-hints-as-errors` still passes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration schema to version 6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->