### PR TITLE
fix(scripts): sort 'readFile' before 'readdir' in 'generate-docs' to satisfy 'sort-imports'

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'


### PR DESCRIPTION
## 🎯 Changes

`scripts/generate-docs.ts` violated the `sort-imports` rule from `@tanstack/eslint-config` (configured with `ignoreCase: false`). With case-sensitive sorting, `readFile` (uppercase `F`) must come before `readdir` (lowercase `d`):

```
1:26  error  Member 'readFile' of the import declaration should be sorted alphabetically  sort-imports
```

This file lives in the root `scripts/` directory, which is outside the per-package nx `test:eslint` targets, so the error was not caught in CI.

- Reorder the `node:fs/promises` named imports so `readFile` precedes `readdir`.

`eslint scripts/generate-docs.ts` now passes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build script dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->