### PR TITLE
test({react,preact}-query/useMutation): split 'should pass meta to mutation' into separate success and error tests

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -1486,8 +1486,7 @@ describe('useMutation', () => {
     expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
   })
 
-  it('should pass meta to mutation', async () => {
-    const errorMock = vi.fn()
+  it('should pass meta to mutation on success', async () => {
     const successMock = vi.fn()
 
     const queryClientMutationMeta = new QueryClient({
@@ -1495,33 +1494,21 @@ describe('useMutation', () => {
         onSuccess: (_, __, ___, mutation) => {
           successMock(mutation.meta?.metaSuccessMessage)
         },
-        onError: (_, __, ___, mutation) => {
-          errorMock(mutation.meta?.metaErrorMessage)
-        },
       }),
     })
 
     const metaSuccessMessage = 'mutation succeeded'
-    const metaErrorMessage = 'mutation failed'
 
     function Page() {
       const { mutate: succeed, isSuccess } = useMutation({
         mutationFn: () => Promise.resolve(''),
         meta: { metaSuccessMessage },
       })
-      const { mutate: error, isError } = useMutation({
-        mutationFn: () => {
-          return Promise.reject(new Error(''))
-        },
-        meta: { metaErrorMessage },
-      })
 
       return (
         <div>
           <button onClick={() => succeed()}>succeed</button>
-          <button onClick={() => error()}>error</button>
           {isSuccess && <div>successTest</div>}
-          {isError && <div>errorTest</div>}
         </div>
       )
     }
@@ -1532,14 +1519,53 @@ describe('useMutation', () => {
     )
 
     fireEvent.click(getByText('succeed'))
-    fireEvent.click(getByText('error'))
 
     await vi.advanceTimersByTimeAsync(0)
     expect(queryByText('successTest')).not.toBeNull()
-    expect(queryByText('errorTest')).not.toBeNull()
 
     expect(successMock).toHaveBeenCalledTimes(1)
     expect(successMock).toHaveBeenCalledWith(metaSuccessMessage)
+  })
+
+  it('should pass meta to mutation on error', async () => {
+    const errorMock = vi.fn()
+
+    const queryClientMutationMeta = new QueryClient({
+      mutationCache: new MutationCache({
+        onError: (_, __, ___, mutation) => {
+          errorMock(mutation.meta?.metaErrorMessage)
+        },
+      }),
+    })
+
+    const metaErrorMessage = 'mutation failed'
+
+    function Page() {
+      const { mutate: error, isError } = useMutation({
+        mutationFn: () => {
+          return Promise.reject(new Error(''))
+        },
+        meta: { metaErrorMessage },
+      })
+
+      return (
+        <div>
+          <button onClick={() => error()}>error</button>
+          {isError && <div>errorTest</div>}
+        </div>
+      )
+    }
+
+    const { getByText, queryByText } = renderWithClient(
+      queryClientMutationMeta,
+      <Page />,
+    )
+
+    fireEvent.click(getByText('error'))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryByText('errorTest')).not.toBeNull()
+
     expect(errorMock).toHaveBeenCalledTimes(1)
     expect(errorMock).toHaveBeenCalledWith(metaErrorMessage)
   })

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1485,8 +1485,7 @@ describe('useMutation', () => {
     expect(rendered.getByText('error: Expected mock error')).toBeInTheDocument()
   })
 
-  it('should pass meta to mutation', async () => {
-    const errorMock = vi.fn()
+  it('should pass meta to mutation on success', async () => {
     const successMock = vi.fn()
 
     const queryClientMutationMeta = new QueryClient({
@@ -1494,33 +1493,21 @@ describe('useMutation', () => {
         onSuccess: (_, __, ___, mutation) => {
           successMock(mutation.meta?.metaSuccessMessage)
         },
-        onError: (_, __, ___, mutation) => {
-          errorMock(mutation.meta?.metaErrorMessage)
-        },
       }),
     })
 
     const metaSuccessMessage = 'mutation succeeded'
-    const metaErrorMessage = 'mutation failed'
 
     function Page() {
       const { mutate: succeed, isSuccess } = useMutation({
         mutationFn: () => Promise.resolve(''),
         meta: { metaSuccessMessage },
       })
-      const { mutate: error, isError } = useMutation({
-        mutationFn: () => {
-          return Promise.reject(new Error(''))
-        },
-        meta: { metaErrorMessage },
-      })
 
       return (
         <div>
           <button onClick={() => succeed()}>succeed</button>
-          <button onClick={() => error()}>error</button>
           {isSuccess && <div>successTest</div>}
-          {isError && <div>errorTest</div>}
         </div>
       )
     }
@@ -1531,14 +1518,53 @@ describe('useMutation', () => {
     )
 
     fireEvent.click(getByText('succeed'))
-    fireEvent.click(getByText('error'))
 
     await vi.advanceTimersByTimeAsync(0)
     expect(queryByText('successTest')).not.toBeNull()
-    expect(queryByText('errorTest')).not.toBeNull()
 
     expect(successMock).toHaveBeenCalledTimes(1)
     expect(successMock).toHaveBeenCalledWith(metaSuccessMessage)
+  })
+
+  it('should pass meta to mutation on error', async () => {
+    const errorMock = vi.fn()
+
+    const queryClientMutationMeta = new QueryClient({
+      mutationCache: new MutationCache({
+        onError: (_, __, ___, mutation) => {
+          errorMock(mutation.meta?.metaErrorMessage)
+        },
+      }),
+    })
+
+    const metaErrorMessage = 'mutation failed'
+
+    function Page() {
+      const { mutate: error, isError } = useMutation({
+        mutationFn: () => {
+          return Promise.reject(new Error(''))
+        },
+        meta: { metaErrorMessage },
+      })
+
+      return (
+        <div>
+          <button onClick={() => error()}>error</button>
+          {isError && <div>errorTest</div>}
+        </div>
+      )
+    }
+
+    const { getByText, queryByText } = renderWithClient(
+      queryClientMutationMeta,
+      <Page />,
+    )
+
+    fireEvent.click(getByText('error'))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryByText('errorTest')).not.toBeNull()
+
     expect(errorMock).toHaveBeenCalledTimes(1)
     expect(errorMock).toHaveBeenCalledWith(metaErrorMessage)
   })


### PR DESCRIPTION
## 🎯 Changes

The `should pass meta to mutation` test bundled two independent scenarios into one block: it set up two separate `useMutation` calls (one resolving, one rejecting) in a single component and asserted both the success-meta and error-meta paths together. These are unrelated behaviors, so each is split into its own focused test.

- Split into `should pass meta to mutation on success` (only the resolving mutation + `onSuccess` cache callback) and `should pass meta to mutation on error` (only the rejecting mutation + `onError` cache callback).
- Applied identically to `react-query` and `preact-query`, whose `useMutation` tests are kept in sync.

No assertions are lost — each new test keeps the exact expectations for its path. Both packages' `useMutation` suites pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved mutation test suite by refactoring into separate, focused test cases. Enhanced coverage by splitting a combined test into two dedicated scenarios for success and error flows, each specifically verifying that `meta` parameters are correctly passed to the corresponding mutation callbacks. Improved test clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->