### PR TITLE
test({react,preact}-query/useMutation): split 'should handle conditional logic based on mutate success or failure' into separate success and error tests

### DIFF
--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -1980,7 +1980,7 @@ describe('useMutation', () => {
     ).toBeInTheDocument()
   })
 
-  it('should handle conditional logic based on mutate success or failure', async () => {
+  it('should set success message from mutate callbacks when mutation succeeds', async () => {
     function Page() {
       const [message, setMessage] = useState<string>('idle')
 
@@ -2007,6 +2007,38 @@ describe('useMutation', () => {
           >
             submit
           </button>
+          <div>message: {message}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('message: success: submitted successfully'),
+    ).toBeInTheDocument()
+  })
+
+  it('should set error message from mutate callbacks when mutation fails', async () => {
+    function Page() {
+      const [message, setMessage] = useState<string>('idle')
+
+      const { mutate } = useMutation({
+        mutationFn: async (shouldFail: boolean) => {
+          await sleep(10)
+          if (shouldFail) {
+            throw new Error('submission failed')
+          }
+          return 'submitted successfully'
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
           <button
             onClick={() =>
               mutate(true, {
@@ -2023,13 +2055,6 @@ describe('useMutation', () => {
     }
 
     const rendered = renderWithClient(queryClient, <Page />)
-
-    fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
-    await vi.advanceTimersByTimeAsync(11)
-
-    expect(
-      rendered.getByText('message: success: submitted successfully'),
-    ).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /submit fail/i }))
     await vi.advanceTimersByTimeAsync(11)

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1979,7 +1979,7 @@ describe('useMutation', () => {
     ).toBeInTheDocument()
   })
 
-  it('should handle conditional logic based on mutate success or failure', async () => {
+  it('should set success message from mutate callbacks when mutation succeeds', async () => {
     function Page() {
       const [message, setMessage] = React.useState<string>('idle')
 
@@ -2006,6 +2006,38 @@ describe('useMutation', () => {
           >
             submit
           </button>
+          <div>message: {message}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('message: success: submitted successfully'),
+    ).toBeInTheDocument()
+  })
+
+  it('should set error message from mutate callbacks when mutation fails', async () => {
+    function Page() {
+      const [message, setMessage] = React.useState<string>('idle')
+
+      const { mutate } = useMutation({
+        mutationFn: async (shouldFail: boolean) => {
+          await sleep(10)
+          if (shouldFail) {
+            throw new Error('submission failed')
+          }
+          return 'submitted successfully'
+        },
+        retry: false,
+      })
+
+      return (
+        <div>
           <button
             onClick={() =>
               mutate(true, {
@@ -2022,13 +2054,6 @@ describe('useMutation', () => {
     }
 
     const rendered = renderWithClient(queryClient, <Page />)
-
-    fireEvent.click(rendered.getByRole('button', { name: /^submit$/i }))
-    await vi.advanceTimersByTimeAsync(11)
-
-    expect(
-      rendered.getByText('message: success: submitted successfully'),
-    ).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: /submit fail/i }))
     await vi.advanceTimersByTimeAsync(11)


### PR DESCRIPTION
## 🎯 Changes

The `should handle conditional logic based on mutate success or failure` test bundled two independent scenarios into one block: a single component rendered both a `submit` button (mutates with `shouldFail: false`) and a `submit fail` button (mutates with `shouldFail: true`), then asserted the success path and the error path sequentially. These are unrelated outcomes, so each is split into its own focused test.

- Split into `should set success message from mutate callbacks when mutation succeeds` (only the `submit` button + success assertion) and `should set error message from mutate callbacks when mutation fails` (only the `submit fail` button + error assertion).
- Applied identically to `react-query` and `preact-query`, whose `useMutation` tests are kept in sync.

No assertions are lost — each new test keeps the exact expectation for its path. Both packages' `useMutation` suites pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored mutation test coverage to separately verify success and failure callback handlers in both Preact Query and React Query libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->