### PR TITLE
test(solid-query/useMutation): split 'should pass meta to mutation' into separate success and error tests

### DIFF
--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -1244,8 +1244,7 @@ describe('useMutation', () => {
     consoleMock.mockRestore()
   })
 
-  it('should pass meta to mutation', async () => {
-    const errorMock = vi.fn()
+  it('should pass meta to mutation on success', async () => {
     const successMock = vi.fn()
 
     const queryClientMutationMeta = new QueryClient({
@@ -1253,33 +1252,21 @@ describe('useMutation', () => {
         onSuccess: (_, __, ___, mutation) => {
           successMock(mutation.meta?.metaSuccessMessage)
         },
-        onError: (_, __, ___, mutation) => {
-          errorMock(mutation.meta?.metaErrorMessage)
-        },
       }),
     })
 
     const metaSuccessMessage = 'mutation succeeded'
-    const metaErrorMessage = 'mutation failed'
 
     function Page() {
       const mutationSucceed = useMutation(() => ({
         mutationFn: () => Promise.resolve(''),
         meta: { metaSuccessMessage },
       }))
-      const mutationError = useMutation(() => ({
-        mutationFn: () => {
-          throw new Error('')
-        },
-        meta: { metaErrorMessage },
-      }))
 
       return (
         <div>
           <button onClick={() => mutationSucceed.mutate()}>succeed</button>
-          <button onClick={() => mutationError.mutate()}>error</button>
           {mutationSucceed.isSuccess && <div>successTest</div>}
-          {mutationError.isError && <div>errorTest</div>}
         </div>
       )
     }
@@ -1291,13 +1278,51 @@ describe('useMutation', () => {
     ))
 
     fireEvent.click(rendered.getByText('succeed'))
-    fireEvent.click(rendered.getByText('error'))
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.queryByText('successTest')).not.toBeNull()
-    expect(rendered.queryByText('errorTest')).not.toBeNull()
 
     expect(successMock).toHaveBeenCalledTimes(1)
     expect(successMock).toHaveBeenCalledWith(metaSuccessMessage)
+  })
+
+  it('should pass meta to mutation on error', async () => {
+    const errorMock = vi.fn()
+
+    const queryClientMutationMeta = new QueryClient({
+      mutationCache: new MutationCache({
+        onError: (_, __, ___, mutation) => {
+          errorMock(mutation.meta?.metaErrorMessage)
+        },
+      }),
+    })
+
+    const metaErrorMessage = 'mutation failed'
+
+    function Page() {
+      const mutationError = useMutation(() => ({
+        mutationFn: () => {
+          throw new Error('')
+        },
+        meta: { metaErrorMessage },
+      }))
+
+      return (
+        <div>
+          <button onClick={() => mutationError.mutate()}>error</button>
+          {mutationError.isError && <div>errorTest</div>}
+        </div>
+      )
+    }
+
+    const rendered = render(() => (
+      <QueryClientProvider client={queryClientMutationMeta}>
+        <Page />
+      </QueryClientProvider>
+    ))
+
+    fireEvent.click(rendered.getByText('error'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.queryByText('errorTest')).not.toBeNull()
 
     expect(errorMock).toHaveBeenCalledTimes(1)
     expect(errorMock).toHaveBeenCalledWith(metaErrorMessage)


### PR DESCRIPTION
## 🎯 Changes

The `should pass meta to mutation` test bundled two independent scenarios into one block: it set up two separate `useMutation` calls (one resolving, one throwing) in a single component and asserted both the success-meta and error-meta paths together. These are unrelated behaviors, so each is split into its own focused test.

- Split into `should pass meta to mutation on success` (only the resolving mutation + `onSuccess` cache callback) and `should pass meta to mutation on error` (only the throwing mutation + `onError` cache callback).
- Mirrors the same split already applied to `react-query` and `preact-query`.

No assertions are lost — each new test keeps the exact expectations for its path. The `useMutation` suite passes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for mutation meta values by splitting previously combined test cases into isolated scenarios for `onSuccess` and `onError` callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->