### PR TITLE
test(solid-query): add 'renderWithClient' helper and replace inline 'QueryClientProvider' wrapping in tests

### DIFF
--- a/packages/solid-query/src/__tests__/mutationOptions.test.tsx
+++ b/packages/solid-query/src/__tests__/mutationOptions.test.tsx
@@ -1,15 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render } from '@solidjs/testing-library'
+import { fireEvent } from '@solidjs/testing-library'
 import { createEffect, createRenderEffect } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import {
-  QueryClient,
-  QueryClientProvider,
-  useIsMutating,
-  useMutation,
-  useMutationState,
-} from '..'
+import { QueryClient, useIsMutating, useMutation, useMutationState } from '..'
 import { mutationOptions } from '../mutationOptions'
+import { renderWithClient } from './utils'
 import type { MutationState } from '@tanstack/query-core'
 
 describe('mutationOptions', () => {
@@ -65,11 +60,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     expect(isMutatingArray[0]).toEqual(0)
@@ -101,11 +92,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     expect(isMutatingArray[0]).toEqual(0)
@@ -144,11 +131,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate1/i }))
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
@@ -189,11 +172,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate1/i }))
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
@@ -223,11 +202,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     const mutationCache = queryClient.getMutationCache()
     const unsubscribe = mutationCache.subscribe(() => {
@@ -263,11 +238,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     const mutationCache = queryClient.getMutationCache()
     const unsubscribe = mutationCache.subscribe(() => {
@@ -310,11 +281,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     const mutationCache = queryClient.getMutationCache()
     const unsubscribe = mutationCache.subscribe(() => {
@@ -358,11 +325,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     const mutationCache = queryClient.getMutationCache()
     const unsubscribe = mutationCache.subscribe(() => {
@@ -416,11 +379,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     expect(mutationStateArray[0]).toEqual([])
 
@@ -454,11 +413,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     expect(mutationStateArray[0]).toEqual([])
 
@@ -499,11 +454,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     expect(mutationStateArray[0]).toEqual([])
 
@@ -546,11 +497,7 @@ describe('mutationOptions', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Mutation />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Mutation />)
 
     expect(mutationStateArray[0]).toEqual([])
 

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render } from '@solidjs/testing-library'
+import { fireEvent } from '@solidjs/testing-library'
 import {
   ErrorBoundary,
   Show,
@@ -9,13 +9,8 @@ import {
   on,
 } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import {
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-  useInfiniteQuery,
-  useQuery,
-} from '..'
+import { QueryCache, QueryClient, useInfiniteQuery, useQuery } from '..'
+import { renderWithClient } from './utils'
 import type { InfiniteData, UseInfiniteQueryResult, UseQueryResult } from '..'
 
 describe("useQuery's in Suspense mode", () => {
@@ -66,12 +61,10 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback="loading">
-          <Page />
-        </Suspense>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
     ))
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
@@ -116,12 +109,10 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback="loading">
-          <Page />
-        </Suspense>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
     ))
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
@@ -164,12 +155,10 @@ describe("useQuery's in Suspense mode", () => {
       return <>rendered</>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback="loading">
-          <Page />
-        </Suspense>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
     ))
 
     expect(rendered.getByText('rendered')).toBeInTheDocument()
@@ -204,11 +193,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     expect(rendered.queryByText('rendered')).not.toBeInTheDocument()
     expect(queryCache.find({ queryKey: key })).toBeFalsy()
@@ -251,28 +236,26 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary
-          fallback={(_err, resetSolid) => (
-            <div>
-              <div>error boundary</div>
-              <button
-                onClick={() => {
-                  succeed = true
-                  resetSolid()
-                }}
-              >
-                retry
-              </button>
-            </div>
-          )}
-        >
-          <Suspense fallback="loading">
-            <Page />
-          </Suspense>
-        </ErrorBoundary>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <ErrorBoundary
+        fallback={(_err, resetSolid) => (
+          <div>
+            <div>error boundary</div>
+            <button
+              onClick={() => {
+                succeed = true
+                resetSolid()
+              }}
+            >
+              retry
+            </button>
+          </div>
+        )}
+      >
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </ErrorBoundary>
     ))
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
@@ -311,27 +294,25 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary
-          fallback={(_err, resetSolid) => (
-            <div>
-              <div>error boundary</div>
-              <button
-                onClick={() => {
-                  resetSolid()
-                }}
-              >
-                retry
-              </button>
-            </div>
-          )}
-        >
-          <Suspense fallback="loading">
-            <Page />
-          </Suspense>
-        </ErrorBoundary>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <ErrorBoundary
+        fallback={(_err, resetSolid) => (
+          <div>
+            <div>error boundary</div>
+            <button
+              onClick={() => {
+                resetSolid()
+              }}
+            >
+              retry
+            </button>
+          </div>
+        )}
+      >
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </ErrorBoundary>
     ))
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
@@ -390,11 +371,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(100)
@@ -448,11 +425,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(100)
@@ -504,11 +477,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -553,11 +522,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -604,11 +569,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -654,11 +615,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -688,12 +645,10 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback="loading">
-          <Page />
-        </Suspense>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
     ))
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
@@ -751,11 +706,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     // render suspense fallback (Loading...)
     expect(rendered.getByText('loading')).toBeInTheDocument()
@@ -816,11 +767,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     // render suspense fallback (Loading...)
     expect(rendered.getByText('loading')).toBeInTheDocument()
@@ -886,11 +833,7 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -935,12 +878,10 @@ describe("useQuery's in Suspense mode", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback="loading">
-          <Page />
-        </Suspense>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
     ))
 
     expect(rendered.getByText('loading')).toBeInTheDocument()

--- a/packages/solid-query/src/__tests__/transition.test.tsx
+++ b/packages/solid-query/src/__tests__/transition.test.tsx
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render } from '@solidjs/testing-library'
+import { fireEvent } from '@solidjs/testing-library'
 import { Show, Suspense, createSignal, startTransition } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryCache, QueryClient, QueryClientProvider, useQuery } from '..'
+import { QueryCache, QueryClient, useQuery } from '..'
+import { renderWithClient } from './utils'
 
 describe("useQuery's in Suspense mode with transitions", () => {
   let queryCache: QueryCache
@@ -52,11 +53,7 @@ describe("useQuery's in Suspense mode with transitions", () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('Show')).toBeInTheDocument()
     fireEvent.click(rendered.getByLabelText('toggle'))

--- a/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -15,12 +15,11 @@ import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   QueryCache,
   QueryClient,
-  QueryClientProvider,
   infiniteQueryOptions,
   keepPreviousData,
   useInfiniteQuery,
 } from '..'
-import { Blink, setActTimeout } from './utils'
+import { Blink, renderWithClient, setActTimeout } from './utils'
 import type {
   InfiniteData,
   QueryFunctionContext,
@@ -84,11 +83,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -200,11 +195,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(50)
 
@@ -246,11 +237,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 0-desc')).toBeInTheDocument()
@@ -333,11 +320,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -381,11 +364,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -442,11 +421,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 0')).toBeInTheDocument()
@@ -512,11 +487,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(30)
 
@@ -597,11 +568,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 10')).toBeInTheDocument()
@@ -734,11 +701,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 10')).toBeInTheDocument()
@@ -836,11 +799,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 10')).toBeInTheDocument()
@@ -940,11 +899,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 10')).toBeInTheDocument()
@@ -1040,11 +995,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(160)
 
@@ -1126,11 +1077,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(160)
 
@@ -1207,11 +1154,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(160)
 
@@ -1267,11 +1210,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(60)
 
@@ -1328,11 +1267,7 @@ describe('useInfiniteQuery', () => {
       return <>{show() ? <List /> : null}</>
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(125)
 
@@ -1385,11 +1320,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(70)
 
@@ -1470,11 +1401,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(30)
 
@@ -1528,11 +1455,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -1573,11 +1496,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -1618,11 +1537,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -1666,11 +1581,7 @@ describe('useInfiniteQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -1779,11 +1690,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('Loading...')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -1911,11 +1818,7 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('Loading...')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -1980,12 +1883,10 @@ describe('useInfiniteQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Blink duration={5}>
-          <Page />
-        </Blink>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Blink duration={5}>
+        <Page />
+      </Blink>
     ))
 
     await vi.advanceTimersByTimeAsync(5)

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -2,14 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render } from '@solidjs/testing-library'
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import {
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-  useIsFetching,
-  useQuery,
-} from '..'
-import { setActTimeout } from './utils'
+import { QueryCache, QueryClient, useIsFetching, useQuery } from '..'
+import { renderWithClient, setActTimeout } from './utils'
 
 describe('useIsFetching', () => {
   let queryCache: QueryCache
@@ -57,11 +51,7 @@ describe('useIsFetching', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('isFetching: 0')).toBeInTheDocument()
 
@@ -125,11 +115,7 @@ describe('useIsFetching', () => {
       )
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     // unlike react, Updating renderSecond wont cause a rerender for FirstQuery
     await vi.advanceTimersByTimeAsync(300)
@@ -185,11 +171,7 @@ describe('useIsFetching', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('isFetching: 0')).toBeInTheDocument()
 
@@ -220,11 +202,7 @@ describe('useIsFetching', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('isFetching: 1')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)

--- a/packages/solid-query/src/__tests__/useIsMutating.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsMutating.test.tsx
@@ -3,13 +3,8 @@ import { fireEvent, render } from '@solidjs/testing-library'
 import { Show, createEffect, createRenderEffect, createSignal } from 'solid-js'
 import * as QueryCore from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import {
-  QueryClient,
-  QueryClientProvider,
-  useIsMutating,
-  useMutation,
-} from '..'
-import { setActTimeout } from './utils'
+import { QueryClient, useIsMutating, useMutation } from '..'
+import { renderWithClient, setActTimeout } from './utils'
 
 describe('useIsMutating', () => {
   let queryClient: QueryClient
@@ -68,11 +63,7 @@ describe('useIsMutating', () => {
       )
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(150)
 
@@ -112,11 +103,7 @@ describe('useIsMutating', () => {
       return <IsMutating />
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     // Unlike React, IsMutating Wont re-render twice with mutation2
     await vi.advanceTimersByTimeAsync(100)
@@ -160,11 +147,7 @@ describe('useIsMutating', () => {
       return <IsMutating />
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     // Again, No unnecessary re-renders like React
     await vi.advanceTimersByTimeAsync(100)
@@ -257,11 +240,7 @@ describe('useIsMutating', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={spiedClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(spiedClient, () => <Page />)
 
     fireEvent.click(rendered.getByText('unmount'))
 

--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -7,14 +7,12 @@ import {
 } from 'solid-js'
 import { fireEvent, render } from '@solidjs/testing-library'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
+import { MutationCache, QueryCache, QueryClient, useMutation } from '..'
 import {
-  MutationCache,
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-  useMutation,
-} from '..'
-import { mockOnlineManagerIsOnline, setActTimeout } from './utils'
+  mockOnlineManagerIsOnline,
+  renderWithClient,
+  setActTimeout,
+} from './utils'
 import type { UseMutationResult } from '../types'
 
 describe('useMutation', () => {
@@ -49,11 +47,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByRole('heading').textContent).toBe('empty')
 
@@ -88,11 +82,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.queryByRole('heading')).toBeNull()
 
@@ -134,11 +124,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
@@ -175,11 +161,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
@@ -210,11 +192,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
@@ -248,11 +226,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
@@ -283,11 +257,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
     await vi.advanceTimersByTimeAsync(10)
@@ -320,11 +290,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -364,11 +330,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -397,11 +359,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -435,11 +393,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -468,11 +422,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -510,11 +460,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByRole('heading').textContent).toBe('0')
 
@@ -572,11 +518,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('Data')).toBeInTheDocument()
 
@@ -636,11 +578,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByRole('heading').textContent).toBe('0')
 
@@ -707,11 +645,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -760,11 +694,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -805,11 +735,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(20)
 
@@ -842,11 +768,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(20)
 
@@ -882,11 +804,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(
       rendered.getByText('error: null, status: idle, isPaused: false'),
@@ -939,11 +857,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(
       rendered.getByText('data: null, status: idle, isPaused: false'),
@@ -1005,11 +919,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     rendered.getByText('data: null, status: idle, isPaused: false')
     fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
@@ -1067,11 +977,7 @@ describe('useMutation', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(16)
 
@@ -1138,11 +1044,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
     fireEvent.click(rendered.getByText('mutate'))
     fireEvent.click(rendered.getByText('unmount'))
   })
@@ -1169,18 +1071,16 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary
-          fallback={() => (
-            <div>
-              <span>error</span>
-            </div>
-          )}
-        >
-          <Page />
-        </ErrorBoundary>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <ErrorBoundary
+        fallback={() => (
+          <div>
+            <span>error</span>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>
     ))
 
     fireEvent.click(rendered.getByText('mutate'))
@@ -1217,18 +1117,16 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary
-          fallback={() => (
-            <div>
-              <span>error boundary</span>
-            </div>
-          )}
-        >
-          <Page />
-        </ErrorBoundary>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <ErrorBoundary
+        fallback={() => (
+          <div>
+            <span>error boundary</span>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>
     ))
 
     // first error goes to component
@@ -1271,11 +1169,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClientMutationMeta}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClientMutationMeta, () => <Page />)
 
     fireEvent.click(rendered.getByText('succeed'))
     await vi.advanceTimersByTimeAsync(0)
@@ -1314,11 +1208,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClientMutationMeta}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClientMutationMeta, () => <Page />)
 
     fireEvent.click(rendered.getByText('error'))
     await vi.advanceTimersByTimeAsync(0)
@@ -1379,11 +1269,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await rendered.findByText('data: null, status: idle, isPaused: false')
 
@@ -1438,11 +1324,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await rendered.findByText('data: null, status: idle')
 
@@ -1495,11 +1377,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await rendered.findByText('status: idle')
 
@@ -1548,11 +1426,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('error: null, status: idle')).toBeInTheDocument()
@@ -1599,11 +1473,7 @@ describe('useMutation', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('error: null, status: idle')).toBeInTheDocument()
 

--- a/packages/solid-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutationState.test.tsx
@@ -1,13 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render } from '@solidjs/testing-library'
+import { fireEvent } from '@solidjs/testing-library'
 import { createEffect } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import {
-  QueryClient,
-  QueryClientProvider,
-  useMutation,
-  useMutationState,
-} from '..'
+import { QueryClient, useMutation, useMutationState } from '..'
+import { renderWithClient } from './utils'
 
 describe('useMutationState', () => {
   let queryClient: QueryClient
@@ -53,11 +49,7 @@ describe('useMutationState', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('count: 0')).toBeInTheDocument()
 
@@ -109,11 +101,7 @@ describe('useMutationState', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('data: null')).toBeInTheDocument()
 

--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -7,17 +7,12 @@ import {
   it,
   vi,
 } from 'vitest'
-import { fireEvent, render } from '@solidjs/testing-library'
+import { fireEvent } from '@solidjs/testing-library'
 import * as QueryCore from '@tanstack/query-core'
 import { createRenderEffect, createSignal } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import {
-  QueriesObserver,
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-  useQueries,
-} from '..'
+import { QueriesObserver, QueryCache, QueryClient, useQueries } from '..'
+import { renderWithClient } from './utils'
 import type {
   QueryFunction,
   QueryFunctionContext,
@@ -74,11 +69,7 @@ describe('useQueries', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(100)
     expect(rendered.getByText('data1: 1, data2: 2')).toBeInTheDocument()
@@ -716,11 +707,7 @@ describe('useQueries', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     fireEvent.click(rendered.getByText('unmount'))
 

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -28,11 +28,15 @@ import {
   IsRestoringProvider,
   QueryCache,
   QueryClient,
-  QueryClientProvider,
   keepPreviousData,
   useQuery,
 } from '..'
-import { Blink, mockOnlineManagerIsOnline, setActTimeout } from './utils'
+import {
+  Blink,
+  mockOnlineManagerIsOnline,
+  renderWithClient,
+  setActTimeout,
+} from './utils'
 import type {
   DefinedUseQueryResult,
   OmitKeyof,
@@ -233,11 +237,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('default')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -281,11 +281,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('test')).toBeInTheDocument()
@@ -378,11 +374,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(21)
     expect(rendered.getByText('Status: error')).toBeInTheDocument()
@@ -496,11 +488,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(states.length).toBe(2)
@@ -545,11 +533,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(15)
     // first refetch only, second refetch is ignored
@@ -584,11 +568,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(15)
     // first refetch (gets cancelled) and second refetch
@@ -622,11 +602,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(15)
     // first refetch will not get cancelled, second one gets skipped
@@ -649,11 +625,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -700,11 +672,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 1')).toBeInTheDocument()
@@ -757,11 +725,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -788,11 +752,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -816,11 +776,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -845,11 +801,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -874,11 +826,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -911,11 +859,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: test')).toBeInTheDocument()
@@ -947,11 +891,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -992,11 +932,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -1038,11 +974,7 @@ describe('useQuery', () => {
       )
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -1088,11 +1020,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(
@@ -1158,11 +1086,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: false')).toBeInTheDocument()
@@ -1218,11 +1142,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: set')).toBeInTheDocument()
@@ -1270,11 +1190,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 1')).toBeInTheDocument()
@@ -1344,11 +1260,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(30)
 
@@ -1390,11 +1302,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(30)
 
@@ -1433,11 +1341,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -1487,11 +1391,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(30)
 
@@ -1556,11 +1456,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(
@@ -1641,11 +1537,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(50)
 
@@ -1720,11 +1612,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 1')).toBeInTheDocument()
@@ -1792,11 +1680,7 @@ describe('useQuery', () => {
       )
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(200)
 
@@ -1861,11 +1745,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(70)
 
@@ -1899,11 +1779,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(15)
 
@@ -1950,11 +1826,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('First Data: init')).toBeInTheDocument()
     expect(rendered.getByText('Second Data: init')).toBeInTheDocument()
@@ -1973,11 +1845,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     expect(queryCache.find({ queryKey: key })!.options.retryDelay).toBe(20)
   })
@@ -1996,11 +1864,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(0)
 
@@ -2028,11 +1892,7 @@ describe('useQuery', () => {
       return <div>{state.data}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -2067,11 +1927,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     // use "act" to wait for state update and prevent console warning
 
@@ -2100,11 +1956,7 @@ describe('useQuery', () => {
       return <div>status: {status}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('status: pending')).toBeInTheDocument()
   })
@@ -2129,11 +1981,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('default')).toBeInTheDocument()
@@ -2161,11 +2009,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     window.dispatchEvent(new Event('visibilitychange'))
 
@@ -2194,11 +2038,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     window.dispatchEvent(new Event('visibilitychange'))
 
@@ -2227,11 +2067,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     window.dispatchEvent(new Event('visibilitychange'))
 
@@ -2260,11 +2096,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     window.dispatchEvent(new Event('visibilitychange'))
@@ -2297,11 +2129,7 @@ describe('useQuery', () => {
       return <div>data: {state.data}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -2354,11 +2182,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -2398,11 +2222,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -2442,11 +2262,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('error')).toBeInTheDocument()
@@ -2480,12 +2296,10 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary fallback={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <ErrorBoundary fallback={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>
     ))
 
     await vi.advanceTimersByTimeAsync(10)
@@ -2521,11 +2335,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('error boundary')).toBeInTheDocument()
@@ -2562,11 +2372,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Fallback error: Error test')).toBeInTheDocument()
@@ -2603,11 +2409,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(
@@ -2637,11 +2439,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(result?.data).toBe('data')
@@ -2667,12 +2465,10 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary fallback={() => <div>error boundary</div>}>
-          <Page />
-        </ErrorBoundary>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <ErrorBoundary fallback={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>
     ))
 
     await vi.advanceTimersByTimeAsync(10)
@@ -2701,19 +2497,17 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary
-          fallback={(error) => (
-            <div>
-              <div>error boundary</div>
-              <div>{error?.message}</div>
-            </div>
-          )}
-        >
-          <Page />
-        </ErrorBoundary>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <ErrorBoundary
+        fallback={(error) => (
+          <div>
+            <div>error boundary</div>
+            <div>{error?.message}</div>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>
     ))
 
     await vi.advanceTimersByTimeAsync(10)
@@ -2760,11 +2554,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -2830,11 +2620,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -2893,11 +2679,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: data')).toBeInTheDocument()
@@ -2939,11 +2721,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -2978,11 +2756,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(60)
 
@@ -3019,11 +2793,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(70)
 
@@ -3063,11 +2833,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3110,11 +2876,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3150,11 +2912,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('pending')).toBeInTheDocument()
@@ -3202,11 +2960,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('pending')).toBeInTheDocument()
@@ -3250,11 +3004,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('pending')).toBeInTheDocument()
@@ -3301,11 +3051,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     // The query should display the first error result
     await vi.advanceTimersByTimeAsync(11)
@@ -3373,11 +3119,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3421,11 +3163,7 @@ describe('useQuery', () => {
       )
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3489,11 +3227,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3525,11 +3259,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3566,11 +3296,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     // First attempt fails immediately
     await vi.advanceTimersByTimeAsync(10)
@@ -3628,11 +3354,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('isPrefetched')).toBeInTheDocument()
@@ -3669,11 +3391,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('FetchStatus: idle')).toBeInTheDocument()
     expect(rendered.getByText('Data: no data')).toBeInTheDocument()
@@ -3721,11 +3439,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Outer />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Outer />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('component')).toBeInTheDocument()
@@ -3785,11 +3499,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Outer />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Outer />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('component')).toBeInTheDocument()
@@ -3833,11 +3543,7 @@ describe('useQuery', () => {
       return <div>data: {result.data}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('data: initialData')).toBeInTheDocument()
 
@@ -3867,11 +3573,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3908,11 +3610,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(15)
 
@@ -3938,11 +3636,7 @@ describe('useQuery', () => {
       return <div>fetchStatus: {fetchStatus}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(queryFn).not.toHaveBeenCalled()
     expect(queryCache.find({ queryKey: key })).not.toBeUndefined()
@@ -3969,11 +3663,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('status: pending, idle')).toBeInTheDocument()
   })
@@ -3990,11 +3680,7 @@ describe('useQuery', () => {
       return <div>{query.data}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -4018,11 +3704,7 @@ describe('useQuery', () => {
       return <div>{query.data}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -4065,11 +3747,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('status pending')).toBeInTheDocument()
 
@@ -4107,11 +3785,7 @@ describe('useQuery', () => {
       return <div>count: {state.data}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     // mount
     await vi.advanceTimersByTimeAsync(10)
@@ -4150,11 +3824,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     // Initial fetch (10ms)
     await vi.advanceTimersByTimeAsync(10)
@@ -4223,11 +3893,7 @@ describe('useQuery', () => {
       return <div>count: {state.data}</div>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('count: 1')).toBeInTheDocument()
@@ -4260,11 +3926,7 @@ describe('useQuery', () => {
       return <>{JSON.stringify(result.data)}</>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('[""]')).toBeInTheDocument()
@@ -4279,11 +3941,7 @@ describe('useQuery', () => {
       return <>{JSON.stringify(result.data)}</>
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('[{"a":"a"}]')).toBeInTheDocument()
@@ -4317,11 +3975,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(queryFn).toHaveBeenCalledTimes(0)
 
@@ -4356,11 +4010,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: data')).toBeInTheDocument()
@@ -4410,11 +4060,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: data')).toBeInTheDocument()
@@ -4472,11 +4118,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: 2')).toBeInTheDocument()
@@ -4524,11 +4166,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: 2')).toBeInTheDocument()
@@ -4584,11 +4222,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('Data: selected 101')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
@@ -4634,11 +4268,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: [2,3]')).toBeInTheDocument()
@@ -4687,11 +4317,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: [2,3]')).toBeInTheDocument()
@@ -4728,12 +4354,10 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Blink duration={5}>
-          <Page />
-        </Blink>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Blink duration={5}>
+        <Page />
+      </Blink>
     ))
 
     await vi.advanceTimersByTimeAsync(10)
@@ -4771,15 +4395,13 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Blink duration={5}>
-          <Page limit={0} />
-          <Page limit={1} />
-          <Page limit={2} />
-          <Page limit={3} />
-        </Blink>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <Blink duration={5}>
+        <Page limit={0} />
+        <Page limit={1} />
+        <Page limit={2} />
+        <Page limit={3} />
+      </Blink>
     ))
 
     await vi.advanceTimersByTimeAsync(10)
@@ -4839,11 +4461,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(50)
     expect(states.length).toBe(2)
@@ -4891,11 +4509,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: 1')).toBeInTheDocument()
@@ -4970,11 +4584,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     expect(rendered.getByText('data: null')).toBeInTheDocument()
 
@@ -5037,11 +4647,7 @@ describe('useQuery', () => {
       return null
     }
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     expect(hashes).toBe(1)
   })
@@ -5090,11 +4696,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     // initial state check
     expect(rendered.getByText('status: pending')).toBeInTheDocument()
@@ -5157,11 +4759,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     // initial state check
     expect(rendered.getByText('status: pending')).toBeInTheDocument()
@@ -5216,11 +4814,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <App />)
 
     // initial state check
     expect(rendered.getByText('status: fetching')).toBeInTheDocument()
@@ -5281,11 +4875,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('error')).toBeInTheDocument()
@@ -5348,11 +4938,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       window.dispatchEvent(new Event('offline'))
 
@@ -5404,11 +4990,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       expect(
         rendered.getByText(
@@ -5478,11 +5060,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       expect(
         rendered.getByText('status: pending, fetchStatus: fetching'),
@@ -5535,11 +5113,7 @@ describe('useQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       expect(
         rendered.getByText('status: pending, fetchStatus: paused'),
@@ -5586,11 +5160,7 @@ describe('useQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       expect(
         rendered.getByText('status: success, fetchStatus: paused'),
@@ -5639,11 +5209,7 @@ describe('useQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       window.dispatchEvent(new Event('offline'))
 
@@ -5703,11 +5269,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       // First retry (online): retryDelay (10ms) + queryFn (10ms)
       await vi.advanceTimersByTimeAsync(10)
@@ -5785,11 +5347,7 @@ describe('useQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       window.dispatchEvent(new Event('offline'))
 
@@ -5850,11 +5408,7 @@ describe('useQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       expect(
         rendered.getByText('status: success, fetchStatus: paused'),
@@ -5908,11 +5462,7 @@ describe('useQuery', () => {
 
       const onlineMock = mockOnlineManagerIsOnline(false)
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       expect(
         rendered.getByText('status: pending, fetchStatus: paused'),
@@ -5975,11 +5525,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       await vi.advanceTimersByTimeAsync(10)
       expect(
@@ -6036,11 +5582,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       await vi.advanceTimersByTimeAsync(10)
       expect(
@@ -6082,11 +5624,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       await vi.advanceTimersByTimeAsync(10)
       await vi.advanceTimersByTimeAsync(10)
@@ -6135,11 +5673,7 @@ describe('useQuery', () => {
         )
       }
 
-      const rendered = render(() => (
-        <QueryClientProvider client={queryClient}>
-          <Page />
-        </QueryClientProvider>
-      ))
+      const rendered = renderWithClient(queryClient, () => <Page />)
 
       window.dispatchEvent(new Event('offline'))
 
@@ -6201,11 +5735,7 @@ describe('useQuery', () => {
     queryClient.prefetchQuery({ queryKey: key, queryFn })
     await vi.advanceTimersByTimeAsync(10)
 
-    render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    renderWithClient(queryClient, () => <Page />)
 
     expect(states).toHaveLength(1)
 
@@ -6240,11 +5770,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: data')).toBeInTheDocument()
@@ -6273,11 +5799,7 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <Page />
-      </QueryClientProvider>
-    ))
+    const rendered = renderWithClient(queryClient, () => <Page />)
 
     const fetchBtn = rendered.getByRole('button', { name: 'refetch' })
 
@@ -6314,12 +5836,10 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(() => (
-      <QueryClientProvider client={queryClient}>
-        <IsRestoringProvider value={isRestoring}>
-          <Page />
-        </IsRestoringProvider>
-      </QueryClientProvider>
+    const rendered = renderWithClient(queryClient, () => (
+      <IsRestoringProvider value={isRestoring}>
+        <Page />
+      </IsRestoringProvider>
     ))
 
     await vi.advanceTimersByTimeAsync(0)

--- a/packages/solid-query/src/__tests__/utils.tsx
+++ b/packages/solid-query/src/__tests__/utils.tsx
@@ -1,8 +1,20 @@
 import { vi } from 'vitest'
 import { Show, createEffect, createSignal, onCleanup } from 'solid-js'
 import { onlineManager } from '@tanstack/query-core'
-import type { ParentProps } from 'solid-js'
+import { render } from '@solidjs/testing-library'
+import { QueryClientProvider } from '..'
+import type { JSX, ParentProps } from 'solid-js'
 import type { MockInstance } from 'vitest'
+import type { QueryClient } from '..'
+
+export function renderWithClient(
+  client: QueryClient,
+  ui: () => JSX.Element,
+): ReturnType<typeof render> {
+  return render(() => (
+    <QueryClientProvider client={client}>{ui()}</QueryClientProvider>
+  ))
+}
 
 export function Blink(
   props: {


### PR DESCRIPTION
## 🎯 Changes

The solid-query tests wrapped almost every render in an inline `QueryClientProvider`:

```tsx
const rendered = render(() => (
  <QueryClientProvider client={queryClient}>
    <Page />
  </QueryClientProvider>
))
```

`react-query` and `preact-query` already share a `renderWithClient` helper in their test `utils.tsx` for exactly this; this adds the equivalent to solid-query and uses it across the test suite.

- Add `renderWithClient(client, ui)` to `src/__tests__/utils.tsx`. It mirrors the react/preact helper but takes a `() => JSX.Element` (matching solid's `render`), and returns the underlying `render` result unchanged (solid tests don't use `rerender`, so no wrapping is needed).
- Replace the inline `QueryClientProvider` wrapping with `renderWithClient(...)` across the test files, and drop the now-unused `QueryClientProvider` / `render` imports.
- `QueryClientProvider.test.tsx` is intentionally left untouched — it tests the provider itself (including multiple/nested providers and the missing-provider throw case).

No test behavior changes: the whole solid-query suite (21 files, 320 tests) passes with no type errors. Net ~880 fewer lines of boilerplate.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal test infrastructure and maintainability through refactored test utilities for the solid-query test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->