### PR TITLE
test(solid-query/useQueries): add test for not fetching during the restoring period when 'isRestoring' is true

### DIFF
--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -11,7 +11,13 @@ import { fireEvent } from '@solidjs/testing-library'
 import * as QueryCore from '@tanstack/query-core'
 import { createRenderEffect, createSignal } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueriesObserver, QueryCache, QueryClient, useQueries } from '..'
+import {
+  IsRestoringProvider,
+  QueriesObserver,
+  QueryCache,
+  QueryClient,
+  useQueries,
+} from '..'
 import { renderWithClient } from './utils'
 import type {
   QueryFunction,
@@ -716,5 +722,60 @@ describe('useQueries', () => {
 
     await vi.advanceTimersByTimeAsync(20)
     QueriesObserverSpy.mockRestore()
+  })
+
+  it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+    const queryFn1 = vi.fn(() => sleep(10).then(() => 'data1'))
+    const queryFn2 = vi.fn(() => sleep(10).then(() => 'data2'))
+
+    function Page() {
+      const results = useQueries(() => ({
+        queries: [
+          { queryKey: key1, queryFn: queryFn1 },
+          { queryKey: key2, queryFn: queryFn2 },
+        ],
+      }))
+
+      return (
+        <div>
+          <div data-testid="status1">{results[0].status}</div>
+          <div data-testid="status2">{results[1].status}</div>
+          <div data-testid="fetchStatus1">{results[0].fetchStatus}</div>
+          <div data-testid="fetchStatus2">{results[1].fetchStatus}</div>
+          <div data-testid="data1">{results[0].data ?? 'undefined'}</div>
+          <div data-testid="data2">{results[1].data ?? 'undefined'}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, () => (
+      <IsRestoringProvider value={() => true}>
+        <Page />
+      </IsRestoringProvider>
+    ))
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(rendered.getByTestId('status1')).toHaveTextContent('pending')
+    expect(rendered.getByTestId('status2')).toHaveTextContent('pending')
+    expect(rendered.getByTestId('fetchStatus1')).toHaveTextContent('idle')
+    expect(rendered.getByTestId('fetchStatus2')).toHaveTextContent('idle')
+    expect(rendered.getByTestId('data1')).toHaveTextContent('undefined')
+    expect(rendered.getByTestId('data2')).toHaveTextContent('undefined')
+    expect(queryFn1).toHaveBeenCalledTimes(0)
+    expect(queryFn2).toHaveBeenCalledTimes(0)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(rendered.getByTestId('status1')).toHaveTextContent('pending')
+    expect(rendered.getByTestId('status2')).toHaveTextContent('pending')
+    expect(rendered.getByTestId('fetchStatus1')).toHaveTextContent('idle')
+    expect(rendered.getByTestId('fetchStatus2')).toHaveTextContent('idle')
+    expect(rendered.getByTestId('data1')).toHaveTextContent('undefined')
+    expect(rendered.getByTestId('data2')).toHaveTextContent('undefined')
+    expect(queryFn1).toHaveBeenCalledTimes(0)
+    expect(queryFn2).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
## 🎯 Changes

`react-query`'s `useQueries` tests cover that queries do not fetch while `isRestoring` is `true`, but `solid-query` had no equivalent. This ports that coverage.

- Add a test that wraps `useQueries` in an `IsRestoringProvider` set to `true` and asserts that both queries stay `pending` / `idle` with no data and that their `queryFn`s are never called, even after advancing past their `sleep` duration.

The test passes against the current behavior — no source changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for query restoration scenarios, ensuring queries properly maintain pending status with idle fetch status when restoring application state, preventing unnecessary query function invocation during restoration, and validating that state remains stable and unchanged throughout the restoration process and subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->