### PR TITLE
test(solid-query/useQueries): add test for using a provided custom 'queryClient'

### DIFF
--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -7,7 +7,7 @@ import {
   it,
   vi,
 } from 'vitest'
-import { fireEvent } from '@solidjs/testing-library'
+import { fireEvent, render } from '@solidjs/testing-library'
 import * as QueryCore from '@tanstack/query-core'
 import { createRenderEffect, createSignal } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
@@ -722,6 +722,32 @@ describe('useQueries', () => {
 
     await vi.advanceTimersByTimeAsync(20)
     QueriesObserverSpy.mockRestore()
+  })
+
+  it('should use provided custom queryClient', async () => {
+    const key = queryKey()
+    const queryFn = () => sleep(10).then(() => 'custom client')
+
+    function Page() {
+      const queries = useQueries(
+        () => ({
+          queries: [
+            {
+              queryKey: key,
+              queryFn,
+            },
+          ],
+        }),
+        () => queryClient,
+      )
+
+      return <div>data: {queries[0].data}</div>
+    }
+
+    const rendered = render(() => <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('data: custom client')).toBeInTheDocument()
   })
 
   it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {


### PR DESCRIPTION
## 🎯 Changes

`react-query`'s `useQueries` tests cover passing a custom `queryClient` as the second argument (instead of relying on `QueryClientProvider`), but `solid-query` had no equivalent. This ports that coverage.

- Add a test that calls `useQueries(() => ({ queries }), () => queryClient)` with the client passed directly as the second argument, renders without a `QueryClientProvider`, and asserts the query resolves against that client.

The test passes against the current behavior — no source changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying custom query client parameter support in the queries functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->