### PR TITLE
chore: add npm bugs metadata to all published packages

### DIFF
--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -110,5 +110,8 @@
   "publishConfig": {
     "directory": "dist",
     "linkDirectory": false
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -75,5 +75,8 @@
     "typescript": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/lit-query/package.json
+++ b/packages/lit-query/package.json
@@ -71,5 +71,8 @@
     "@eslint/js": "^9.36.0",
     "globals": "^17.4.0",
     "typescript-eslint": "^8.54.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/preact-query-devtools/package.json
+++ b/packages/preact-query-devtools/package.json
@@ -93,5 +93,8 @@
   "peerDependencies": {
     "@tanstack/preact-query": "workspace:^",
     "preact": "^10.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/preact-query-persist-client/package.json
+++ b/packages/preact-query-persist-client/package.json
@@ -73,5 +73,8 @@
   "peerDependencies": {
     "@tanstack/preact-query": "workspace:^",
     "preact": "^10.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/preact-query/package.json
+++ b/packages/preact-query/package.json
@@ -80,5 +80,8 @@
   },
   "peerDependencies": {
     "preact": "^10.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/query-async-storage-persister/package.json
+++ b/packages/query-async-storage-persister/package.json
@@ -64,5 +64,8 @@
   "devDependencies": {
     "@tanstack/query-test-utils": "workspace:*",
     "npm-run-all2": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -64,5 +64,8 @@
     "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react": "^4.3.4",
     "npm-run-all2": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -60,5 +60,8 @@
   "devDependencies": {
     "@tanstack/query-test-utils": "workspace:*",
     "npm-run-all2": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/query-devtools/package.json
+++ b/packages/query-devtools/package.json
@@ -78,5 +78,8 @@
     "superjson": "^2.2.2",
     "tsup-preset-solid": "^2.2.0",
     "vite-plugin-solid": "^2.11.6"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/query-persist-client-core/package.json
+++ b/packages/query-persist-client-core/package.json
@@ -63,5 +63,8 @@
   "devDependencies": {
     "@tanstack/query-test-utils": "workspace:*",
     "npm-run-all2": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/query-sync-storage-persister/package.json
+++ b/packages/query-sync-storage-persister/package.json
@@ -64,5 +64,8 @@
   "devDependencies": {
     "@tanstack/query-test-utils": "workspace:*",
     "npm-run-all2": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/react-query-devtools/package.json
+++ b/packages/react-query-devtools/package.json
@@ -91,5 +91,8 @@
   "peerDependencies": {
     "@tanstack/react-query": "workspace:^",
     "react": "^18 || ^19"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/react-query-next-experimental/package.json
+++ b/packages/react-query-next-experimental/package.json
@@ -66,5 +66,8 @@
     "@tanstack/react-query": "workspace:^",
     "next": "^13 || ^14 || ^15 || ^16",
     "react": "^18 || ^19"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/react-query-persist-client/package.json
+++ b/packages/react-query-persist-client/package.json
@@ -72,5 +72,8 @@
   "peerDependencies": {
     "@tanstack/react-query": "workspace:^",
     "react": "^18 || ^19"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -82,5 +82,8 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/solid-query-devtools/package.json
+++ b/packages/solid-query-devtools/package.json
@@ -75,5 +75,8 @@
   "peerDependencies": {
     "@tanstack/solid-query": "workspace:^",
     "solid-js": "^1.6.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/solid-query-persist-client/package.json
+++ b/packages/solid-query-persist-client/package.json
@@ -77,5 +77,8 @@
   "peerDependencies": {
     "@tanstack/solid-query": "workspace:^",
     "solid-js": "^1.6.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -77,5 +77,8 @@
   },
   "peerDependencies": {
     "solid-js": "^1.6.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/svelte-query-devtools/package.json
+++ b/packages/svelte-query-devtools/package.json
@@ -65,5 +65,8 @@
   "peerDependencies": {
     "@tanstack/svelte-query": "workspace:^",
     "svelte": "^5.25.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/svelte-query-persist-client/package.json
+++ b/packages/svelte-query-persist-client/package.json
@@ -66,5 +66,8 @@
   "peerDependencies": {
     "@tanstack/svelte-query": "workspace:^",
     "svelte": "^5.25.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/svelte-query/package.json
+++ b/packages/svelte-query/package.json
@@ -64,5 +64,8 @@
   },
   "peerDependencies": {
     "svelte": "^5.25.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/vue-query-devtools/package.json
+++ b/packages/vue-query-devtools/package.json
@@ -66,5 +66,8 @@
   "peerDependencies": {
     "@tanstack/vue-query": "workspace:^",
     "vue": "^3.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }

--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -82,5 +82,8 @@
     "@vue/composition-api": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }


### PR DESCRIPTION
## Summary

All `@tanstack/query-*` packages (24 published packages) are missing the `bugs` field in their npm metadata. This PR adds `bugs.url` pointing to the GitHub issue tracker.

## Changes

Added to each published package's `package.json`:
```json
"bugs": {
  "url": "https://github.com/TanStack/query/issues"
}
```

## Verification

```sh
npm view @tanstack/react-query bugs  # currently empty
npm view @tanstack/query-core bugs    # currently empty
npm view @tanstack/vue-query bugs     # currently empty
```

No runtime code, dependencies, tests, or build configuration are changed. This is a metadata-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized bug report URL references to all TanStack Query packages, making it easier for users to discover the GitHub issue tracker and report problems. Package configuration metadata was updated across all packages to ensure consistency and proper validation throughout the suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->