### PR TITLE
docs: add missing bugs metadata to @tanstack/query-core

### DIFF
--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -60,5 +60,8 @@
   "devDependencies": {
     "@tanstack/query-test-utils": "workspace:*",
     "npm-run-all2": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/query/issues"
   }
 }


### PR DESCRIPTION
This PR fixes the following issue reported in charles-microbounties:
- Issue #1193: @tanstack/query-core lacks bugs metadata

Changes:
- Added 'bugs': { 'url': 'https://github.com/TanStack/query/issues' } to packages/query-core/package.json.

Verified with publint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration with improved metadata references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->