### PR TITLE
test(solid-query/useQuery): add type test for generic indexed-access 'TData' regression guard

### DIFF
--- a/packages/solid-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test-d.tsx
@@ -250,4 +250,52 @@ describe('useQuery', () => {
       })
     })
   })
+
+  describe('generic indexed access TData', () => {
+    // https://github.com/TanStack/query/issues/9937
+    it('should be assignable back to its source indexed type when passed to a generic function parameter', () => {
+      enum DataType {
+        Account = 'account',
+        Product = 'product',
+      }
+
+      interface Account {
+        name: string
+      }
+      interface Product {
+        code: string
+      }
+
+      type DataTypeToEntity = {
+        [DataType.Account]: Account
+        [DataType.Product]: Product
+      }
+
+      const getData = <TDataType extends DataType>(
+        _dataType: TDataType,
+      ): Promise<DataTypeToEntity[TDataType]> =>
+        Promise.resolve({} as DataTypeToEntity[TDataType])
+
+      const getLabel = <TDataType extends DataType>(
+        _dataType: TDataType,
+        _data: DataTypeToEntity[TDataType],
+      ) => 'test'
+
+      function Test<TDataType extends DataType>(props: {
+        dataType: TDataType
+      }) {
+        const { data } = useQuery(() => ({
+          queryKey: ['test'],
+          queryFn: () => getData(props.dataType),
+        }))
+
+        // Regression guard: this call must compile. With the previous
+        // hand-rolled NoInfer, `data` failed to flow back into the generic
+        // indexed-access parameter `DataTypeToEntity[TDataType]`.
+        return data ? getLabel(props.dataType, data) : null
+      }
+
+      expectTypeOf(Test).toBeFunction()
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

`react-query`'s `useQuery.test-d.tsx` has a `generic indexed access TData` type test that guards against the regression from [#9937](https://github.com/TanStack/query/issues/9937) (fixed in #10593): when `data` is passed back into a generic function parameter typed as `DataTypeToEntity[TDataType]`, it must remain assignable. `solid-query` shares the same `query-core` types but had no equivalent guard, so this ports it over.

- Add `describe('generic indexed access TData', ...)` to `useQuery.test-d.tsx`, mirroring `react-query` and using solid's `useQuery(() => ({ ... }))` accessor form.

Verified the guard is meaningful: temporarily passing a wrong value (`123`) into `getLabel` makes the type test fail (`Argument of type 'number' is not assignable to parameter of type 'DataTypeToEntity[TDataType]'`), and it passes again once restored.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added TypeScript type inference tests for generic indexed-access patterns to ensure correct type handling and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->