### PR TITLE
ci: add dependency vulnerability scanning via CVE Lite CLI

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,35 @@
+name: Dependency Vulnerability Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+
+permissions: {}
+
+jobs:
+  scan:
+    name: CVE Lite CLI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Scan dependencies
+        run: |
+          set +e
+          npx cve-lite-cli@latest . --fail-on critical --sarif
+          echo "SCAN_EXIT=$?" >> "$GITHUB_ENV"
+      - name: Upload SARIF to Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: .
+          category: dependency-scan
+      - name: Check scan result
+        run: exit "$SCAN_EXIT"


### PR DESCRIPTION
Your current CI setup covers GitHub Actions security (zizmor) and version drift (Renovate), but there is no CVE-specific scanning pass on the lockfile.

This adds a lightweight workflow using CVE Lite CLI (an OWASP Lab Project) that:
- Scans the pnpm lockfile for known CVEs via the OSV database
- Uploads results as SARIF to GitHub Code Scanning for inline annotations
- Fails on critical severity only to start (you can tighten to `--fail-on high` once the current findings in the `examples/` and `integrations/` subdirectories are resolved)

Running the scan today finds 1 critical and 31 high severity advisories across the monorepo - most of the highs are in example lockfiles, not in the core packages. The SARIF upload puts the findings directly in the Security tab so contributors can see what they are introducing on each PR.

Let me know if you would like the threshold adjusted or the scan scoped to specific paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated dependency vulnerability scanning in the continuous integration pipeline to detect security issues on code changes and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->