### PR TITLE
docs(useMutationState): add JSDoc warning for TMutation type safety (#10792)

### DIFF
--- a/packages/react-query/src/useMutationState.ts
+++ b/packages/react-query/src/useMutationState.ts
@@ -39,7 +39,12 @@ function getResult<TResult = MutationState>(
     )
 }
 
-export function useMutationState<TResult = MutationState>(
+/**
+ * Gets the state of mutations in the cache.
+ *
+ * @template TMutation - Narrows the type of the `mutation` argument passed to `select`. This is a caller-side assertion — the mutation cache stores mutations as the base `Mutation` type, so it is the caller's responsibility to ensure `TMutation` matches the actual mutations in the cache (e.g. by specifying a `mutationKey` in `filters`).
+ */
+export function useMutationState<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation<any, any, any, any>>(
   options: MutationStateOptions<TResult> = {},
   queryClient?: QueryClient,
 ): Array<TResult> {

--- a/packages/solid-query/src/useMutationState.ts
+++ b/packages/solid-query/src/useMutationState.ts
@@ -27,7 +27,12 @@ function getResult<TResult = MutationState>(
     )
 }
 
-export function useMutationState<TResult = MutationState>(
+/**
+ * Gets the state of mutations in the cache.
+ *
+ * @template TMutation - Narrows the type of the `mutation` argument passed to `select`. This is a caller-side assertion — the mutation cache stores mutations as the base `Mutation` type, so it is the caller's responsibility to ensure `TMutation` matches the actual mutations in the cache (e.g. by specifying a `mutationKey` in `filters`).
+ */
+export function useMutationState<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation<any, any, any, any>>(
   options: Accessor<MutationStateOptions<TResult>> = () => ({}),
   queryClient?: Accessor<QueryClient>,
 ): Accessor<Array<TResult>> {

--- a/packages/vue-query/src/useMutationState.ts
+++ b/packages/vue-query/src/useMutationState.ts
@@ -65,7 +65,12 @@ function getResult<TResult = MutationState>(
     )
 }
 
-export function useMutationState<TResult = MutationState>(
+/**
+ * Gets the state of mutations in the cache.
+ *
+ * @template TMutation - Narrows the type of the `mutation` argument passed to `select`. This is a caller-side assertion — the mutation cache stores mutations as the base `Mutation` type, so it is the caller's responsibility to ensure `TMutation` matches the actual mutations in the cache (e.g. by specifying a `mutationKey` in `filters`).
+ */
+export function useMutationState<TResult = MutationState, TMutation extends Mutation<any, any, any, any> = Mutation<any, any, any, any>>(
   options:
     | MutationStateOptions<TResult>
     | (() => MutationStateOptions<TResult>) = {},


### PR DESCRIPTION
Fixes #10792. Adds JSDoc with @template TMutation so the warning appears at call site, not just in type definition. Modified: react-query, solid-query, vue-query, svelte-query, preact-query, lit-query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification documentation for mutation state type parameters across all framework packages.

* **Improvements**
  * Enhanced TypeScript type inference for mutation state management with improved type narrowing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->