### PR TITLE
test(vue-query/useMutation): replace 'vi.waitFor' with 'vi.advanceTimersByTimeAsync' in async 'mutateAsync' tests

### DIFF
--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -356,9 +356,11 @@ describe('useMutation', () => {
         mutationFn: (params: string) => sleep(10).then(() => params),
       })
 
-      await vi.waitFor(() =>
-        expect(mutation.mutateAsync(result)).resolves.toBe(result),
-      )
+      const promise = mutation.mutateAsync(result)
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      await expect(promise).resolves.toBe(result)
 
       expect(mutation).toMatchObject({
         isIdle: { value: false },
@@ -376,9 +378,10 @@ describe('useMutation', () => {
           sleep(10).then(() => Promise.reject(new Error('Some error'))),
       })
 
-      await vi.waitFor(() =>
+      await Promise.all([
         expect(mutation.mutateAsync()).rejects.toThrow('Some error'),
-      )
+        vi.advanceTimersByTimeAsync(10),
+      ])
 
       expect(mutation).toMatchObject({
         isIdle: { value: false },


### PR DESCRIPTION
## 🎯 Changes

The `async` block in `useMutation.test.ts` was the only place still using `vi.waitFor` to await `mutateAsync`, even though the suite runs under fake timers and every other test drives time with `vi.advanceTimersByTimeAsync`. This replaces it so the async tests follow the same explicit fake-timer pattern as the rest of the file.

- `should resolve properly`: hold the `mutateAsync` promise, advance the timer, then `await expect(promise).resolves.toBe(result)`.
- `should throw on error`: `await Promise.all([expect(mutation.mutateAsync()).rejects.toThrow('Some error'), vi.advanceTimersByTimeAsync(10)])`. The rejection assertion is attached before the timer is advanced (the reject fires inside the `advanceTimersByTimeAsync` call), so the rejection is handled at the moment it occurs — avoiding an unhandled rejection while still satisfying `vitest/valid-expect`.

No behavior change to the assertions themselves; the subsequent `toMatchObject` state checks are unchanged.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes. This release includes internal test infrastructure improvements to ensure more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->