### PR TITLE
test(query-core): replace deprecated 'toBeCalledWith' and 'toBeCalledTimes' with 'toHaveBeenCalledWith' and 'toHaveBeenCalledTimes'

### DIFF
--- a/packages/query-core/src/__tests__/infiniteQueryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/infiniteQueryObserver.test.tsx
@@ -70,7 +70,7 @@ describe('InfiniteQueryObserver', () => {
     expect(observerResult).toMatchObject({
       data: { pages: ['1'], pageParams: [1] },
     })
-    expect(queryFn).toBeCalledWith(expect.objectContaining({ meta }))
+    expect(queryFn).toHaveBeenCalledWith(expect.objectContaining({ meta }))
   })
 
   it('should make getNextPageParam and getPreviousPageParam receive current pageParams', async () => {
@@ -162,7 +162,7 @@ describe('InfiniteQueryObserver', () => {
     await vi.advanceTimersByTimeAsync(10)
 
     expect(observer.getCurrentResult().data?.pages).toEqual(['1', '2'])
-    expect(queryFn).toBeCalledTimes(2)
+    expect(queryFn).toHaveBeenCalledTimes(2)
     expect(observer.getCurrentResult().hasNextPage).toBe(true)
 
     next = undefined
@@ -171,7 +171,7 @@ describe('InfiniteQueryObserver', () => {
     await vi.advanceTimersByTimeAsync(10)
 
     expect(observer.getCurrentResult().data?.pages).toEqual(['1'])
-    expect(queryFn).toBeCalledTimes(3)
+    expect(queryFn).toHaveBeenCalledTimes(3)
     expect(observer.getCurrentResult().hasNextPage).toBe(false)
   })
 
@@ -194,7 +194,7 @@ describe('InfiniteQueryObserver', () => {
     await vi.advanceTimersByTimeAsync(10)
 
     expect(observer.getCurrentResult().data?.pages).toEqual(['1', '2'])
-    expect(queryFn).toBeCalledTimes(2)
+    expect(queryFn).toHaveBeenCalledTimes(2)
     expect(observer.getCurrentResult().hasNextPage).toBe(true)
 
     next = null
@@ -203,7 +203,7 @@ describe('InfiniteQueryObserver', () => {
     await vi.advanceTimersByTimeAsync(10)
 
     expect(observer.getCurrentResult().data?.pages).toEqual(['1'])
-    expect(queryFn).toBeCalledTimes(3)
+    expect(queryFn).toHaveBeenCalledTimes(3)
     expect(observer.getCurrentResult().hasNextPage).toBe(false)
   })
 

--- a/packages/query-core/src/__tests__/mutationObserver.test.tsx
+++ b/packages/query-core/src/__tests__/mutationObserver.test.tsx
@@ -31,12 +31,12 @@ describe('mutationObserver', () => {
 
     unsubscribe1()
 
-    expect(subscription1Handler).toBeCalledTimes(1)
-    expect(subscription2Handler).toBeCalledTimes(1)
+    expect(subscription1Handler).toHaveBeenCalledTimes(1)
+    expect(subscription2Handler).toHaveBeenCalledTimes(1)
 
     await vi.advanceTimersByTimeAsync(20)
-    expect(subscription1Handler).toBeCalledTimes(1)
-    expect(subscription2Handler).toBeCalledTimes(2)
+    expect(subscription1Handler).toHaveBeenCalledTimes(1)
+    expect(subscription2Handler).toHaveBeenCalledTimes(2)
 
     unsubscribe2()
   })

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -311,9 +311,9 @@ describe('queriesObserver', () => {
     await vi.advanceTimersByTimeAsync(20)
 
     // 1 call: pending
-    expect(subscription1Handler).toBeCalledTimes(1)
+    expect(subscription1Handler).toHaveBeenCalledTimes(1)
     // 1 call: success
-    expect(subscription2Handler).toBeCalledTimes(1)
+    expect(subscription2Handler).toHaveBeenCalledTimes(1)
 
     // Clean-up
     unsubscribe2()

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -738,7 +738,7 @@ describe('query', () => {
 
     await queryClient.prefetchQuery({ queryKey: key, queryFn, meta })
 
-    expect(queryFn).toBeCalledWith(
+    expect(queryFn).toHaveBeenCalledWith(
       expect.objectContaining({
         meta,
       }),


### PR DESCRIPTION
## 🎯 Changes

`toBeCalledWith` and `toBeCalledTimes` are deprecated Jest-style aliases in Vitest. This replaces the remaining usages in `query-core` tests with their canonical `toHaveBeenCalledWith` / `toHaveBeenCalledTimes` forms, matching the rest of the suite.

- `infiniteQueryObserver.test.tsx`: `toBeCalledWith` → `toHaveBeenCalledWith`, `toBeCalledTimes` → `toHaveBeenCalledTimes`
- `queriesObserver.test.tsx`: `toBeCalledTimes` → `toHaveBeenCalledTimes`
- `mutationObserver.test.tsx`: `toBeCalledTimes` → `toHaveBeenCalledTimes`
- `query.test.tsx`: `toBeCalledWith` → `toHaveBeenCalledWith`

Purely a matcher-name change; no assertion behavior is altered.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions across multiple test files for improved assertion validation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->