### PR TITLE
test(vue-query): replace deprecated 'toBeCalledWith' with 'toHaveBeenCalledWith'

### DIFF
--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -34,7 +34,7 @@ describe('useQuery', () => {
       staleTime: 1000,
     })
 
-    expect(useBaseQuery).toBeCalledWith(
+    expect(useBaseQuery).toHaveBeenCalledWith(
       QueryObserver,
       {
         queryKey: key,


### PR DESCRIPTION
## 🎯 Changes

`toBeCalledWith` is a deprecated Jest-style alias in Vitest. This replaces the remaining usage in `vue-query`'s `useQuery.test.ts` with the canonical `toHaveBeenCalledWith`.

- `useQuery.test.ts`: `expect(useBaseQuery).toBeCalledWith(...)` → `toHaveBeenCalledWith(...)`

Purely a matcher-name change; no assertion behavior is altered.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for improved reliability and consistency in mock verification.

---

**Note:** This release contains internal test improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->