### PR TITLE
fix(query-core): addToEnd caps result to max when items already exceeds max

### DIFF
--- a/.changeset/fix-add-to-end-max-cap.md
+++ b/.changeset/fix-add-to-end-max-cap.md
@@ -1,0 +1,12 @@
+---
+"@tanstack/query-core": patch
+---
+
+fix(query-core): addToEnd now correctly caps result length when items already exceeds max
+
+`addToEnd(items, item, max)` previously used `slice(1)` which only removed one element from
+the front of the array. When `items.length` was already greater than `max` (e.g. when
+`maxPages` is reduced at runtime), the returned array could still exceed `max`.
+
+Replaced `slice(1)` with `slice(-max)` so the result is always capped to the last `max`
+elements regardless of the input length.

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -493,6 +493,11 @@ describe('core/utils', () => {
       const max = undefined
       expect(addToEnd(items, item, max)).toEqual([1, 2, 3, 4])
     })
+    it('should not exceed max when items already exceed max', () => {
+      const items = [1, 2, 3, 4, 5]
+      const newItems = addToEnd(items, 6, 3)
+      expect(newItems).toEqual([4, 5, 6])
+    })
   })
 
   describe('addToStart', () => {

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -417,7 +417,7 @@ export function keepPreviousData<T>(
 
 export function addToEnd<T>(items: Array<T>, item: T, max = 0): Array<T> {
   const newItems = [...items, item]
-  return max && newItems.length > max ? newItems.slice(1) : newItems
+  return max && newItems.length > max ? newItems.slice(-max) : newItems
 }
 
 export function addToStart<T>(items: Array<T>, item: T, max = 0): Array<T> {


### PR DESCRIPTION
## Bug

`addToEnd(items, item, max)` uses `slice(1)` which only ever removes one element from the front. When `items.length` is already greater than `max`, the returned array still exceeds `max`.

This matters in practice for infinite queries with a dynamic `maxPages` option: if the user reduces `maxPages` between fetches (e.g. via React state), `addToEnd` receives a `pages` array that is longer than the new `max`. The result silently accumulates more pages than the configured limit.

### Before (broken)

```ts
addToEnd([1, 2, 3, 4, 5], 6, 3)
// → [2, 3, 4, 5, 6]  (length 5 — exceeds max of 3)
```

### After (fix)

```ts
addToEnd([1, 2, 3, 4, 5], 6, 3)
// → [4, 5, 6]  (length 3 — correctly capped)
```

## Fix

Replace `newItems.slice(1)` with `newItems.slice(-max)` in `addToEnd`.

All four existing `addToEnd` tests are unaffected: they all use `items.length === max`, where both expressions produce the same result.

`addToStart` has the symmetric issue (`slice(0, -1)`), but an existing test already asserts the current behavior, so that change warrants a separate discussion.

## Verification

```
npx nx run @tanstack/query-core:test:lib -- --reporter=verbose --testNamePattern="addToEnd"
```

All 5 tests pass (4 pre-existing + 1 new regression test).

> AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `addToEnd` function to correctly limit array length when items already exceed the maximum capacity, ensuring proper array truncation and maintaining size constraints.

* **Tests**
  * Added test coverage for the `addToEnd` function to verify correct behavior when handling oversized arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->