### PR TITLE
docs: add Deno to installation instructions

### DIFF
--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -31,6 +31,12 @@ or
 bun add @tanstack/react-query
 ```
 
+or
+
+```bash
+deno add @tanstack/react-query
+```
+
 [//]: # 'Compatibility'
 
 React Query is compatible with React v18+ and works with ReactDOM and React Native.


### PR DESCRIPTION
## 🎯 Changes

👋 Bartek from the Deno team here. This adds a Deno install command to the React Query installation docs (`docs/framework/react/installation.md`), alongside the existing npm / pnpm / yarn / bun blocks. Since Deno is a drop-in replacement for npm these days, `deno add @tanstack/react-query` works as a drop-in.

## ✅ Checklist

- [x] I have followed the steps in the Contributing guide.
- [ ] I have tested this code locally with `pnpm run test:pr` (N/A — docs-only content change)

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React Query installation guide to include Deno package installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->