### PR TITLE
Query mutation options in core

### DIFF
--- a/.changeset/quiet-cooks-sparkle.md
+++ b/.changeset/quiet-cooks-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': minor
+---
+
+Add framework-agnostic `queryOptions` and `mutationOptions` helpers.

--- a/packages/angular-query-experimental/src/__tests__/mutation-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/mutation-options.test-d.ts
@@ -1,12 +1,16 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
-import { QueryClient } from '@tanstack/query-core'
+import {
+  QueryClient,
+  mutationOptions as coreMutationOptions,
+} from '@tanstack/query-core'
 import {
   injectIsMutating,
   injectMutation,
   injectMutationState,
   mutationOptions,
 } from '..'
+import type { Signal } from '@angular/core'
 import type {
   DefaultError,
   MutationFunctionContext,
@@ -172,6 +176,20 @@ describe('mutationOptions', () => {
           },
         }),
     )
+  })
+
+  it('should infer types when core mutationOptions are used with injectMutation', () => {
+    const mutation = injectMutation(() =>
+      coreMutationOptions({
+        mutationFn: (input: { id: string }) => Promise.resolve(input.id),
+      }),
+    )
+
+    expectTypeOf(mutation.data).toEqualTypeOf<Signal<string | undefined>>()
+    expectTypeOf(mutation.variables).toEqualTypeOf<
+      Signal<{ id: string } | undefined>
+    >()
+    expectTypeOf(mutation.mutate).toBeCallableWith({ id: '1' })
   })
 
   it('should infer types when used with injectIsMutating', () => {

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -1,11 +1,18 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
-import { QueryClient, dataTagSymbol, injectQuery, queryOptions } from '..'
+import {
+  QueryClient,
+  queryOptions as coreQueryOptions,
+  dataTagSymbol,
+} from '@tanstack/query-core'
+import { injectQuery, queryOptions } from '..'
 import type { Signal } from '@angular/core'
 
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
-    expectTypeOf(queryOptions).parameter(0).not.toHaveProperty('stallTime')
+    expectTypeOf(queryOptions)
+      .parameter(0)
+      .not.toHaveProperty('stallTime')
   })
 
   it('should infer types for callbacks', () => {
@@ -34,9 +41,9 @@ describe('queryOptions', () => {
           !id
             ? undefined
             : {
-                id,
-                title: 'Initial Data',
-              },
+              id,
+              title: 'Initial Data',
+            },
       })
 
     expectTypeOf(options(null).initialData).returns.toEqualTypeOf<
@@ -54,6 +61,19 @@ it('should work when passed to injectQuery', () => {
 
   const { data } = injectQuery(() => options)
   expectTypeOf(data).toEqualTypeOf<Signal<number | undefined>>()
+})
+
+it('should work when core queryOptions are passed to injectQuery', () => {
+  const key = queryKey()
+  const options = coreQueryOptions({
+    queryKey: key,
+    queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+  })
+
+  const { data } = injectQuery(() => options)
+  expectTypeOf(data).toEqualTypeOf<
+    Signal<{ id: string; title: string } | undefined>
+  >()
 })
 
 it('should work when passed to fetchQuery', () => {

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -2,6 +2,7 @@ import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import {
   QueryClient,
+  queryOptions as coreQueryOptions,
   dataTagSymbol,
   injectQuery,
   queryOptions,
@@ -67,6 +68,19 @@ it('should work when passed to injectQuery', () => {
 
   const { data } = injectQuery(() => options)
   expectTypeOf(data).toEqualTypeOf<Signal<number | undefined>>()
+})
+
+it('should work when core queryOptions are passed to injectQuery', () => {
+  const key = queryKey()
+  const options = coreQueryOptions({
+    queryKey: key,
+    queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+  })
+
+  const { data } = injectQuery(() => options)
+  expectTypeOf(data).toEqualTypeOf<
+    Signal<{ id: string; title: string } | undefined>
+  >()
 })
 
 it('should work when passed to fetchQuery', () => {

--- a/packages/lit-query/src/tests/type-inference.test.ts
+++ b/packages/lit-query/src/tests/type-inference.test.ts
@@ -1,6 +1,8 @@
 import {
   dataTagSymbol,
+  mutationOptions as coreMutationOptions,
   QueryClient,
+  queryOptions as coreQueryOptions,
   type DefinedQueryObserverResult,
   type QueryObserverResult,
 } from '@tanstack/query-core'
@@ -161,6 +163,18 @@ describe('type inference', () => {
       { id: number; name: string } | undefined
     >()
 
+    const coreQuery = createQueryController(
+      host,
+      () => coreQueryOptions({
+        queryKey: ['type-inference', 'core-query'] as const,
+        queryFn: async () => ({ id: '1', title: 'Do Laundry' }),
+      }),
+      client,
+    )
+    expectTypeOf(coreQuery().data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
+
     const mutation = createMutationController(
       host,
       mutationOptions({
@@ -171,6 +185,18 @@ describe('type inference', () => {
     expectTypeOf(mutation().data).toEqualTypeOf<string | undefined>()
     expectTypeOf(mutation().variables).toEqualTypeOf<
       { id: number } | undefined
+    >()
+
+    const coreMutation = createMutationController(
+      host,
+      () => coreMutationOptions({
+        mutationFn: async (input: { id: string }) => input.id,
+      }),
+      client,
+    )
+    expectTypeOf(coreMutation().data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(coreMutation().variables).toEqualTypeOf<
+      { id: string } | undefined
     >()
 
     const queryOpts = queryOptions({

--- a/packages/lit-query/src/tests/type-inference.test.ts
+++ b/packages/lit-query/src/tests/type-inference.test.ts
@@ -1,7 +1,9 @@
 import {
   dataTagErrorSymbol,
   dataTagSymbol,
+  mutationOptions as coreMutationOptions,
   QueryClient,
+  queryOptions as coreQueryOptions,
   type DefinedQueryObserverResult,
   type InfiniteData,
   type QueryObserverResult,
@@ -163,6 +165,18 @@ describe('type inference', () => {
       { id: number; name: string } | undefined
     >()
 
+    const coreQuery = createQueryController(
+      host,
+      () => coreQueryOptions({
+        queryKey: ['type-inference', 'core-query'] as const,
+        queryFn: async () => ({ id: '1', title: 'Do Laundry' }),
+      }),
+      client,
+    )
+    expectTypeOf(coreQuery().data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
+
     const mutation = createMutationController(
       host,
       mutationOptions({
@@ -173,6 +187,18 @@ describe('type inference', () => {
     expectTypeOf(mutation().data).toEqualTypeOf<string | undefined>()
     expectTypeOf(mutation().variables).toEqualTypeOf<
       { id: number } | undefined
+    >()
+
+    const coreMutation = createMutationController(
+      host,
+      () => coreMutationOptions({
+        mutationFn: async (input: { id: string }) => input.id,
+      }),
+      client,
+    )
+    expectTypeOf(coreMutation().data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(coreMutation().variables).toEqualTypeOf<
+      { id: string } | undefined
     >()
 
     const queryOpts = queryOptions({

--- a/packages/preact-query/src/__tests__/mutationOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/mutationOptions.test-d.tsx
@@ -1,4 +1,7 @@
-import { QueryClient } from '@tanstack/query-core'
+import {
+  QueryClient,
+  mutationOptions as coreMutationOptions,
+} from '@tanstack/query-core'
 import type {
   DefaultError,
   MutationFunctionContext,
@@ -160,6 +163,20 @@ describe('mutationOptions', () => {
         },
       }),
     )
+  })
+
+  it('should infer types when core mutationOptions are used with useMutation', () => {
+    const mutation = useMutation(
+      coreMutationOptions({
+        mutationFn: (input: { id: string }) => Promise.resolve(input.id),
+      }),
+    )
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.variables).toEqualTypeOf<
+      { id: string } | undefined
+    >()
+    expectTypeOf(mutation.mutate).toBeCallableWith({ id: '1' })
   })
 
   it('should infer types when used with useIsMutating', () => {

--- a/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
@@ -2,6 +2,7 @@ import {
   QueriesObserver,
   QueryClient,
   dataTagSymbol,
+  queryOptions as coreQueryOptions,
   skipToken,
 } from '@tanstack/query-core'
 import type {
@@ -47,6 +48,17 @@ describe('queryOptions', () => {
 
     const { data } = useQuery(options)
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+  it('should work when core queryOptions are passed to useQuery', () => {
+    const options = coreQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+    })
+
+    const { data } = useQuery(options)
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
   })
   it('should work when passed to useSuspenseQuery', () => {
     const options = queryOptions({

--- a/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
@@ -2,6 +2,7 @@ import {
   QueriesObserver,
   QueryClient,
   dataTagSymbol,
+  queryOptions as coreQueryOptions,
   skipToken,
 } from '@tanstack/query-core'
 import type {
@@ -54,6 +55,17 @@ describe('queryOptions', () => {
 
     const { data } = useQuery(options)
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+  it('should work when core queryOptions are passed to useQuery', () => {
+    const options = coreQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+    })
+
+    const { data } = useQuery(options)
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
   })
   it('should work when passed to useSuspenseQuery', () => {
     const options = queryOptions({

--- a/packages/query-core/src/__tests__/mutationOptions.test-d.tsx
+++ b/packages/query-core/src/__tests__/mutationOptions.test-d.tsx
@@ -1,0 +1,47 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { mutationOptions } from '../mutationOptions'
+import type { CoreMutationOptions } from '../index'
+
+describe('mutationOptions', () => {
+  it('should infer mutation data and variables', () => {
+    const options = mutationOptions({
+      mutationFn: (variables: { id: string }) => Promise.resolve(variables.id),
+      onSuccess: (data, variables) => {
+        expectTypeOf(data).toEqualTypeOf<string>()
+        expectTypeOf(variables).toEqualTypeOf<{ id: string }>()
+      },
+    })
+
+    expectTypeOf(options.mutationFn)
+      .parameter(0)
+      .toEqualTypeOf<{ id: string }>()
+    type MutationFn = NonNullable<typeof options.mutationFn>
+    expectTypeOf<Awaited<ReturnType<MutationFn>>>().toEqualTypeOf<string>()
+    expectTypeOf(options).not.toHaveProperty('mutationKey')
+  })
+
+  it('should preserve a required mutationKey', () => {
+    const options = mutationOptions({
+      mutationKey: ['key'],
+      mutationFn: (variables: { id: string }) => Promise.resolve(variables.id),
+    })
+
+    expectTypeOf(options.mutationKey).toEqualTypeOf<ReadonlyArray<unknown>>()
+  })
+
+  it('should export the reusable mutation options type', () => {
+    expectTypeOf<
+      CoreMutationOptions<string, Error, { id: string }>
+    >().toHaveProperty('mutationFn')
+  })
+
+  it('should not allow _defaulted', () => {
+    expectTypeOf(mutationOptions).parameter(0).not.toHaveProperty('_defaulted')
+
+    mutationOptions({
+      mutationFn: () => Promise.resolve(5),
+      // @ts-expect-error _defaulted is an internal option
+      _defaulted: true,
+    })
+  })
+})

--- a/packages/query-core/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryOptions.test-d.tsx
@@ -1,0 +1,102 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { dataTagErrorSymbol, dataTagSymbol } from '../types'
+import { skipToken } from '../utils'
+import { QueryClient } from '../queryClient'
+import { queryOptions } from '../queryOptions'
+
+describe('queryOptions', () => {
+  it('should infer query data from queryFn', () => {
+    const options = queryOptions({
+      queryKey: ['key'],
+      queryFn: () => Promise.resolve(5),
+    })
+    type QueryFn = Exclude<typeof options.queryFn, typeof skipToken | undefined>
+
+    expectTypeOf<Awaited<ReturnType<QueryFn>>>().toEqualTypeOf<number>()
+    expectTypeOf(options.queryKey[dataTagSymbol]).toEqualTypeOf<number>()
+    expectTypeOf(options.queryKey[dataTagErrorSymbol]).toEqualTypeOf<Error>()
+  })
+
+  it('should tag queryKey with the query data type', () => {
+    const options = queryOptions({
+      queryKey: ['key'],
+      queryFn: () => Promise.resolve(5),
+    })
+    const queryClient = new QueryClient()
+    const data = queryClient.getQueryData(options.queryKey)
+
+    expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+
+  it('should type check values passed to setQueryData from the tagged queryKey', () => {
+    const options = queryOptions({
+      queryKey: ['todo'],
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+    })
+    const queryClient = new QueryClient()
+
+    queryClient.setQueryData(options.queryKey, {
+      id: '1',
+      title: 'Wash dishes',
+    })
+
+    queryClient.setQueryData(options.queryKey, (prev) => {
+      expectTypeOf(prev).toEqualTypeOf<
+        { id: string; title: string } | undefined
+      >()
+      return prev
+    })
+
+    // @ts-expect-error title should be a string
+    queryClient.setQueryData(options.queryKey, { id: '1', title: 1 })
+
+    // @ts-expect-error title is required
+    queryClient.setQueryData(options.queryKey, { id: '1' })
+  })
+
+  it('should allow initialData without a queryFn', () => {
+    const options = queryOptions({
+      queryKey: ['key'],
+      initialData: 1,
+    })
+    const queryClient = new QueryClient()
+    const data = queryClient.getQueryData(options.queryKey)
+
+    expectTypeOf(options.queryKey[dataTagSymbol]).toEqualTypeOf<number>()
+    expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+
+  it('should infer data when initialData is undefined', () => {
+    const options = queryOptions({
+      queryKey: ['key'],
+      queryFn: () => Promise.resolve(5),
+      initialData: undefined,
+    })
+
+    expectTypeOf(options.initialData).toEqualTypeOf<undefined>()
+    expectTypeOf(options.queryKey[dataTagSymbol]).toEqualTypeOf<number>()
+    expectTypeOf(options.queryKey[dataTagErrorSymbol]).toEqualTypeOf<Error>()
+  })
+
+  it('should infer a callable queryFn without skipToken', () => {
+    const options = queryOptions({
+      queryKey: ['key'],
+      queryFn: () => Promise.resolve(5),
+      enabled: false,
+    })
+    type QueryFn = Exclude<typeof options.queryFn, undefined>
+
+    expectTypeOf<QueryFn>().not.toEqualTypeOf<typeof skipToken>()
+    expectTypeOf<Awaited<ReturnType<QueryFn>>>().toEqualTypeOf<number>()
+    expectTypeOf(options.queryKey[dataTagSymbol]).toEqualTypeOf<number>()
+  })
+
+  it('should allow skipToken', () => {
+    const options = queryOptions({
+      queryKey: ['key'],
+      queryFn: skipToken,
+    })
+
+    expectTypeOf(options.queryKey[dataTagSymbol]).toEqualTypeOf<unknown>()
+  })
+})

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -41,6 +41,10 @@ export {
 export type { MutationFilters, QueryFilters, SkipToken, Updater } from './utils'
 
 export { streamedQuery as experimental_streamedQuery } from './streamedQuery'
+export { queryOptions } from './queryOptions'
+export type { CoreQueryOptions } from './queryOptions'
+export { mutationOptions } from './mutationOptions'
+export type { CoreMutationOptions } from './mutationOptions'
 
 // Types
 export type {

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -42,6 +42,10 @@ export {
 export type { MutationFilters, QueryFilters, SkipToken, Updater } from './utils'
 
 export { streamedQuery as experimental_streamedQuery } from './streamedQuery'
+export { queryOptions } from './queryOptions'
+export type { CoreQueryOptions } from './queryOptions'
+export { mutationOptions } from './mutationOptions'
+export type { CoreMutationOptions } from './mutationOptions'
 
 // Types
 export type {

--- a/packages/query-core/src/mutationOptions.ts
+++ b/packages/query-core/src/mutationOptions.ts
@@ -1,0 +1,57 @@
+import type {
+  DefaultError,
+  MutationObserverOptions,
+  OmitKeyof,
+  WithRequired,
+} from './types'
+
+export type CoreMutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TOnMutateResult = unknown,
+> = OmitKeyof<
+  MutationObserverOptions<TData, TError, TVariables, TOnMutateResult>,
+  '_defaulted'
+>
+
+export function mutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TOnMutateResult = unknown,
+>(
+  options: WithRequired<
+    CoreMutationOptions<TData, TError, TVariables, TOnMutateResult>,
+    'mutationKey'
+  >,
+): WithRequired<
+  CoreMutationOptions<TData, TError, TVariables, TOnMutateResult>,
+  'mutationKey'
+>
+
+export function mutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TOnMutateResult = unknown,
+>(
+  options: Omit<
+    CoreMutationOptions<TData, TError, TVariables, TOnMutateResult>,
+    'mutationKey'
+  >,
+): Omit<
+  CoreMutationOptions<TData, TError, TVariables, TOnMutateResult>,
+  'mutationKey'
+>
+
+export function mutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TOnMutateResult = unknown,
+>(
+  options: CoreMutationOptions<TData, TError, TVariables, TOnMutateResult>,
+): CoreMutationOptions<TData, TError, TVariables, TOnMutateResult> {
+  return options
+}

--- a/packages/query-core/src/queryOptions.ts
+++ b/packages/query-core/src/queryOptions.ts
@@ -1,0 +1,113 @@
+import type {
+  DataTag,
+  DefaultError,
+  InitialDataFunction,
+  NonUndefinedGuard,
+  OmitKeyof,
+  QueryFunction,
+  QueryKey,
+  QueryObserverOptions,
+} from './types'
+import type { SkipToken } from './utils'
+
+export type UndefinedInitialDataOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = QueryObserverOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryFnData,
+  TQueryKey
+> & {
+  initialData?:
+    | undefined
+    | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
+    | NonUndefinedGuard<TQueryFnData>
+}
+
+export type UnusedSkipTokenOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = OmitKeyof<
+  QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
+  'queryFn' | 'initialData'
+> & {
+  queryFn?: Exclude<
+    QueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey
+    >['queryFn'],
+    SkipToken | undefined
+  >
+  initialData?: undefined
+}
+
+export type DefinedInitialDataOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = Omit<
+  QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
+  'queryFn'
+> & {
+  initialData:
+    | NonUndefinedGuard<TQueryFnData>
+    | (() => NonUndefinedGuard<TQueryFnData>)
+  queryFn?: QueryFunction<TQueryFnData, TQueryKey>
+}
+
+export type CoreQueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> =
+  | DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
+  | UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
+  | UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey>
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
+}
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey>,
+): UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
+}
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
+}
+
+export function queryOptions(options: unknown) {
+  return options
+}

--- a/packages/react-query/src/__tests__/mutationOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/mutationOptions.test-d.tsx
@@ -1,5 +1,8 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
-import { QueryClient } from '@tanstack/query-core'
+import {
+  QueryClient,
+  mutationOptions as coreMutationOptions,
+} from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { useIsMutating, useMutation, useMutationState } from '..'
 import { mutationOptions } from '../mutationOptions'
@@ -159,6 +162,20 @@ describe('mutationOptions', () => {
         },
       }),
     )
+  })
+
+  it('should infer types when core mutationOptions are used with useMutation', () => {
+    const mutation = useMutation(
+      coreMutationOptions({
+        mutationFn: (input: { id: string }) => Promise.resolve(input.id),
+      }),
+    )
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.variables).toEqualTypeOf<
+      { id: string } | undefined
+    >()
+    expectTypeOf(mutation.mutate).toBeCallableWith({ id: '1' })
   })
 
   it('should infer types when used with useIsMutating', () => {

--- a/packages/react-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.test-d.tsx
@@ -2,6 +2,7 @@ import { assertType, describe, expectTypeOf, it } from 'vitest'
 import {
   QueriesObserver,
   QueryClient,
+  queryOptions as coreQueryOptions,
   dataTagSymbol,
   skipToken,
 } from '@tanstack/query-core'
@@ -47,6 +48,17 @@ describe('queryOptions', () => {
 
     const { data } = useQuery(options)
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+  it('should work when core queryOptions are passed to useQuery', () => {
+    const options = coreQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+    })
+
+    const { data } = useQuery(options)
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
   })
   it('should work when passed to useSuspenseQuery', () => {
     const options = queryOptions({

--- a/packages/react-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.test-d.tsx
@@ -2,6 +2,7 @@ import { assertType, describe, expectTypeOf, it } from 'vitest'
 import {
   QueriesObserver,
   QueryClient,
+  queryOptions as coreQueryOptions,
   dataTagSymbol,
   skipToken,
 } from '@tanstack/query-core'
@@ -54,6 +55,17 @@ describe('queryOptions', () => {
 
     const { data } = useQuery(options)
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+  it('should work when core queryOptions are passed to useQuery', () => {
+    const options = coreQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+    })
+
+    const { data } = useQuery(options)
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
   })
   it('should work when passed to useSuspenseQuery', () => {
     const options = queryOptions({

--- a/packages/solid-query/src/__tests__/mutationOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/mutationOptions.test-d.tsx
@@ -1,5 +1,8 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
-import { QueryClient } from '@tanstack/query-core'
+import {
+  QueryClient,
+  mutationOptions as coreMutationOptions,
+} from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { useIsMutating, useMutation, useMutationState } from '..'
 import { mutationOptions } from '../mutationOptions'
@@ -156,6 +159,20 @@ describe('mutationOptions', () => {
         },
       }),
     )
+  })
+
+  it('should infer types when core mutationOptions are used with useMutation', () => {
+    const mutation = useMutation(() =>
+      coreMutationOptions({
+        mutationFn: (input: { id: string }) => Promise.resolve(input.id),
+      }),
+    )
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.variables).toEqualTypeOf<
+      { id: string } | undefined
+    >()
+    expectTypeOf(mutation.mutate).toBeCallableWith({ id: '1' })
   })
 
   it('should infer types when used with useIsMutating', () => {

--- a/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
@@ -1,6 +1,7 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import {
   QueryClient,
+  queryOptions as coreQueryOptions,
   dataTagErrorSymbol,
   dataTagSymbol,
   skipToken,
@@ -38,6 +39,17 @@ describe('queryOptions', () => {
 
     const { data } = useQuery(() => options)
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+  it('should work when core queryOptions are passed to useQuery', () => {
+    const options = coreQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+    })
+
+    const { data } = useQuery(() => options)
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
   })
   it('should work when passed to fetchQuery', async () => {
     const options = queryOptions({

--- a/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
@@ -1,6 +1,7 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import {
   QueryClient,
+  queryOptions as coreQueryOptions,
   dataTagErrorSymbol,
   dataTagSymbol,
   skipToken,
@@ -83,6 +84,17 @@ describe('queryOptions', () => {
 
     const data = await new QueryClient().query(options)
     expectTypeOf(data).toEqualTypeOf<unknown>()
+  })
+  it('should work when core queryOptions are passed to useQuery', () => {
+    const options = coreQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+    })
+
+    const { data } = useQuery(() => options)
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
   })
   it('should work when passed to fetchQuery', async () => {
     const options = queryOptions({

--- a/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
+import { queryOptions as coreQueryOptions } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { createQuery, queryOptions } from '../../src/index.js'
 
@@ -26,6 +27,19 @@ describe('createQuery', () => {
         const { data } = createQuery(() => options)
 
         expectTypeOf(data).toEqualTypeOf<{ wow: boolean }>()
+      })
+
+      it('TData should be inferred when passed through core queryOptions', () => {
+        const key = queryKey()
+        const options = coreQueryOptions({
+          queryKey: key,
+          queryFn: () => ({ id: '1', title: 'Do Laundry' }),
+        })
+        const { data } = createQuery(() => options)
+
+        expectTypeOf(data).toEqualTypeOf<
+          { id: string; title: string } | undefined
+        >()
       })
 
       it('TData should have undefined in the union when initialData is NOT provided', () => {

--- a/packages/svelte-query/tests/mutationOptions/mutationOptions.test-d.ts
+++ b/packages/svelte-query/tests/mutationOptions/mutationOptions.test-d.ts
@@ -1,5 +1,8 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
-import { QueryClient } from '@tanstack/query-core'
+import {
+  QueryClient,
+  mutationOptions as coreMutationOptions,
+} from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import {
   createMutation,
@@ -182,6 +185,20 @@ describe('mutationOptions', () => {
         },
       }),
     )
+  })
+
+  it('should work when core mutationOptions are used with createMutation', () => {
+    const mutation = createMutation(() =>
+      coreMutationOptions({
+        mutationFn: (input: { id: string }) => Promise.resolve(input.id),
+      }),
+    )
+
+    expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.variables).toEqualTypeOf<
+      { id: string } | undefined
+    >()
+    expectTypeOf(mutation.mutate).toBeCallableWith({ id: '1' })
   })
 
   it('should work when used with useIsMutating', () => {

--- a/packages/vue-query/src/__tests__/mutationOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test-d.ts
@@ -1,5 +1,8 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
-import { QueryClient } from '@tanstack/query-core'
+import {
+  QueryClient,
+  mutationOptions as coreMutationOptions,
+} from '@tanstack/query-core'
 import { useMutation } from '../useMutation'
 import { useIsMutating, useMutationState } from '../useMutationState'
 import { mutationOptions } from '../mutationOptions'
@@ -161,6 +164,19 @@ describe('mutationOptions', () => {
         },
       }),
     )
+  })
+
+  it('should work when core mutationOptions are used with useMutation', () => {
+    const mutation = useMutation(
+      () => coreMutationOptions({
+        mutationFn: (input: { id: string }) => Promise.resolve(input.id),
+      }),
+    )
+
+    expectTypeOf(mutation.data.value).toEqualTypeOf<string | undefined>()
+    expectTypeOf(mutation.variables.value).toEqualTypeOf<
+      { id: string } | undefined
+    >()
   })
 
   it('should work when used with useIsMutating', () => {

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -1,6 +1,9 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { computed, reactive, ref } from 'vue-demi'
-import { dataTagSymbol } from '@tanstack/query-core'
+import {
+  queryOptions as coreQueryOptions,
+  dataTagSymbol,
+} from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { queryOptions } from '../queryOptions'
@@ -38,6 +41,37 @@ describe('queryOptions', () => {
 
     const { data } = reactive(useQuery(options))
     expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
+  it('should work when core queryOptions are returned from a useQuery getter', () => {
+    const key = queryKey()
+
+    const { data } = reactive(
+      useQuery(() =>
+        coreQueryOptions({
+          queryKey: key,
+          queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+          staleTime: (query) => (query.state.data ? 1000 : 0),
+        }),
+      ),
+    )
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
+  })
+  it('should not support passing core queryOptions directly to useQuery', () => {
+    const key = queryKey()
+    const options = coreQueryOptions({
+      queryKey: key,
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+      staleTime: (query) => (query.state.data ? 1000 : 0),
+    })
+    expectTypeOf(options.queryKey[dataTagSymbol]).toEqualTypeOf<{
+      id: string
+      title: string
+    }>()
+
+    // @ts-expect-error core queryOptions must be wrapped in a getter
+    useQuery(options)
   })
   it('should tag the queryKey with the result type of the QueryFn', () => {
     const key = queryKey()

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -1,6 +1,9 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { computed, reactive, ref } from 'vue-demi'
-import { dataTagSymbol } from '@tanstack/query-core'
+import {
+  queryOptions as coreQueryOptions,
+  dataTagSymbol,
+} from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { queryOptions } from '../queryOptions'
@@ -68,6 +71,37 @@ describe('queryOptions', () => {
 
     const data = await new QueryClient().query(options)
     expectTypeOf(data).toEqualTypeOf<string>()
+  })
+  it('should work when core queryOptions are returned from a useQuery getter', () => {
+    const key = queryKey()
+
+    const { data } = reactive(
+      useQuery(() =>
+        coreQueryOptions({
+          queryKey: key,
+          queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+          staleTime: (query) => (query.state.data ? 1000 : 0),
+        }),
+      ),
+    )
+    expectTypeOf(data).toEqualTypeOf<
+      { id: string; title: string } | undefined
+    >()
+  })
+  it('should not support passing core queryOptions directly to useQuery', () => {
+    const key = queryKey()
+    const options = coreQueryOptions({
+      queryKey: key,
+      queryFn: () => Promise.resolve({ id: '1', title: 'Do Laundry' }),
+      staleTime: (query) => (query.state.data ? 1000 : 0),
+    })
+    expectTypeOf(options.queryKey[dataTagSymbol]).toEqualTypeOf<{
+      id: string
+      title: string
+    }>()
+
+    // @ts-expect-error core queryOptions must be wrapped in a getter
+    useQuery(options)
   })
   it('should tag the queryKey with the result type of the QueryFn', () => {
     const key = queryKey()

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -6,7 +6,10 @@ import {
   reactive,
   ref,
 } from 'vue-demi'
-import { QueryObserver } from '@tanstack/query-core'
+import {
+  QueryObserver,
+  queryOptions as coreQueryOptions,
+} from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useQuery } from '../useQuery'
 import { useBaseQuery } from '../useBaseQuery'
@@ -91,6 +94,42 @@ describe('useQuery', () => {
     expect(query).toMatchObject({
       status: { value: 'success' },
       data: { value: 'result021' },
+      isPending: { value: false },
+      isFetching: { value: false },
+      isFetched: { value: true },
+      isSuccess: { value: true },
+    })
+  })
+
+  it('should work with core queryOptions getter and be reactive', async () => {
+    const key = queryKey()
+    const keyRef = ref('core-key-1')
+    const resultRef = ref('core-result-1')
+    const query = useQuery(() =>
+      coreQueryOptions({
+        queryKey: [...key, keyRef.value],
+        queryFn: () => sleep(0).then(() => resultRef.value),
+      }),
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'core-result-1' },
+      isPending: { value: false },
+      isFetching: { value: false },
+      isFetched: { value: true },
+      isSuccess: { value: true },
+    })
+
+    resultRef.value = 'core-result-2'
+    keyRef.value = 'core-key-2'
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'core-result-2' },
       isPending: { value: false },
       isFetching: { value: false },
       isFetched: { value: true },

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -6,7 +6,11 @@ import {
   reactive,
   ref,
 } from 'vue-demi'
-import { QueryObserver, experimental_streamedQuery } from '@tanstack/query-core'
+import {
+  QueryObserver,
+  queryOptions as coreQueryOptions,
+  experimental_streamedQuery,
+} from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useQuery } from '../useQuery'
 import { useBaseQuery } from '../useBaseQuery'
@@ -92,6 +96,42 @@ describe('useQuery', () => {
     expect(query).toMatchObject({
       status: { value: 'success' },
       data: { value: 'result021' },
+      isPending: { value: false },
+      isFetching: { value: false },
+      isFetched: { value: true },
+      isSuccess: { value: true },
+    })
+  })
+
+  it('should work with core queryOptions getter and be reactive', async () => {
+    const key = queryKey()
+    const keyRef = ref('core-key-1')
+    const resultRef = ref('core-result-1')
+    const query = useQuery(() =>
+      coreQueryOptions({
+        queryKey: [...key, keyRef.value],
+        queryFn: () => sleep(0).then(() => resultRef.value),
+      }),
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'core-result-1' },
+      isPending: { value: false },
+      isFetching: { value: false },
+      isFetched: { value: true },
+      isSuccess: { value: true },
+    })
+
+    resultRef.value = 'core-result-2'
+    keyRef.value = 'core-key-2'
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'core-result-2' },
       isPending: { value: false },
       isFetching: { value: false },
       isFetched: { value: true },

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -14,6 +14,7 @@ import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref, updateState } from './utils'
 import type { Ref } from 'vue-demi'
 import type {
+  CoreQueryOptions,
   DefaultedQueryObserverOptions,
   QueryKey,
   QueryObserver,
@@ -59,16 +60,18 @@ export function useBaseQuery<
   TPageParam,
 >(
   Observer: typeof QueryObserver,
-  options: MaybeRefOrGetter<
-    UseQueryOptionsGeneric<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryData,
-      TQueryKey,
-      TPageParam
-    >
-  >,
+  options:
+    | MaybeRefOrGetter<
+        UseQueryOptionsGeneric<
+          TQueryFnData,
+          TError,
+          TData,
+          TQueryData,
+          TQueryKey,
+          TPageParam
+        >
+      >
+    | (() => CoreQueryOptions<TQueryFnData, TError, TData, TQueryKey>),
   queryClient?: QueryClient,
 ): UseBaseQueryReturnType<TData, TError> {
   if (process.env.NODE_ENV === 'development') {
@@ -82,10 +85,8 @@ export function useBaseQuery<
   const client = queryClient || useQueryClient()
 
   const defaultedOptions = computed(() => {
-    let resolvedOptions = options
-    if (typeof resolvedOptions === 'function') {
-      resolvedOptions = resolvedOptions()
-    }
+    const resolvedOptions =
+      typeof options === 'function' ? options() : options
     const clonedOptions = cloneDeepUnref(resolvedOptions as any)
 
     if (typeof clonedOptions.enabled === 'function') {

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -1,6 +1,7 @@
 import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
 import type {
+  CoreQueryOptions,
   DefaultError,
   DefinedQueryObserverResult,
   InitialDataFunction,
@@ -88,6 +89,37 @@ export type UseQueryDefinedReturnType<TData, TError> = UseBaseQueryReturnType<
   DefinedQueryObserverResult<TData, TError>
 >
 
+type DefinedCoreQueryOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryKey extends QueryKey,
+> = CoreQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  initialData:
+    | NonUndefinedGuard<TQueryFnData>
+    | (() => NonUndefinedGuard<TQueryFnData>)
+}
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: () => DefinedCoreQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
+): UseQueryDefinedReturnType<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: () => CoreQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError>
+
 export function useQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -126,9 +158,11 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: MaybeRefOrGetter<
-    UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
-  >,
+  options:
+    | MaybeRefOrGetter<
+        UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
+      >
+    | (() => CoreQueryOptions<TQueryFnData, TError, TData, TQueryKey>),
   queryClient?: QueryClient,
 ):
   | UseQueryReturnType<TData, TError>

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -1,6 +1,7 @@
 import { QueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
 import type {
+  CoreQueryOptions,
   DefaultError,
   DefinedQueryObserverResult,
   InitialDataFunction,
@@ -98,6 +99,37 @@ export type UseQueryDefinedReturnType<TData, TError> = UseBaseQueryReturnType<
   DefinedQueryObserverResult<TData, TError>
 >
 
+type DefinedCoreQueryOptions<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryKey extends QueryKey,
+> = CoreQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  initialData:
+    | NonUndefinedGuard<TQueryFnData>
+    | (() => NonUndefinedGuard<TQueryFnData>)
+}
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: () => DefinedCoreQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
+): UseQueryDefinedReturnType<TData, TError>
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: () => CoreQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  queryClient?: QueryClient,
+): UseQueryReturnType<TData, TError>
+
 export function useQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -136,9 +168,11 @@ export function useQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: MaybeRefOrGetter<
-    UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
-  >,
+  options:
+    | MaybeRefOrGetter<
+        UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
+      >
+    | (() => CoreQueryOptions<TQueryFnData, TError, TData, TQueryKey>),
   queryClient?: QueryClient,
 ):
   | UseQueryReturnType<TData, TError>


### PR DESCRIPTION
## 🎯 Changes

Adds `queryOptions` and `mutationOptions` to the core library.

This was requested at https://github.com/TanStack/query/discussions/10735 and https://github.com/TanStack/query/discussions/9258 discussions. Having those function in core is useful for defining shared query options for a framework agnostic layer, or for server side usage. Specially for using query keys for type-safe interactions with the core imperative API.

Most of the frameworks accept the shared interface from core without changes. The exception is Vue, that require a small change in the interface since `MaybeRefOrGetter`wasn't compatible. I added runtime test for Vue to demonstrate that it works with the core query options, with the same shape of `() => coreOptions` as Solid/Angular/Lit/Svelte.

About docs: There is a lot of outdated docs, so I excluded the doc generation in the PR. I didn't add docs mentioning that core has this new functions.

Pending questions:

- Is `CoreQueryOptions` and `CoreMutationOptions` ok names for the interface the new `queryOptions` and `mutationOptions` requires? The core library already has `QueryOptions` and `MutationOptions`. The new `CoreQueryOptions` and `CoreMutationOptions` are the equivalent of `QueryOptions` and `MutationOptions` exported by each individual adapter. The new types can't replace the base options alredy defined in core.
- Should `CoreQueryOptions` and `CoreMutationOptions`  be excluded from the re-export from core? How? Each adapter exports `queryOptions` and `mutationOptions`, so a consumer can't import the implementation defined in core if the consumer hasn't installed `@tanstack/query-core` directly, but they can consume `CoreQueryOptions` and `CoreMutationOptions`.
- I'm not happy on how the `useQuery` interface of Vue had to be extended, there is probably something that can be done there to simplify the types.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added framework-agnostic `queryOptions` and `mutationOptions` helpers for reusable query and mutation configurations.
  * Improved type inference when sharing these options across supported frameworks, including query data, mutation data, variables, and mutation inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->