### PR TITLE
fix(vue-query): preserve useQuery inference for spread queryOptions o…

### DIFF
--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { computed, reactive, ref } from 'vue-demi'
+import { computed, reactive, ref, type MaybeRefOrGetter, toValue } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { queryOptions, useQuery } from '..'
 import type { OmitKeyof, UseQueryOptions } from '..'
@@ -61,6 +61,28 @@ describe('useQuery', () => {
       )
 
       expectTypeOf(query.data).toEqualTypeOf<boolean | undefined>()
+    })
+
+    it('should allow spreading queryOptions with a non-data-shaping override like enabled', () => {
+      const fooQueryOptions = (id: MaybeRefOrGetter<string | null>) =>
+        queryOptions({
+          queryKey: computed(() => ['foo', toValue(id)] as const),
+          queryFn: async () => {
+            const v = toValue(id)
+            return v ? { id: v } : null
+          },
+        })
+
+      const direct = reactive(useQuery(fooQueryOptions('1')))
+      expectTypeOf(direct.data).toEqualTypeOf<{ id: string } | null | undefined>()
+
+      const spread = reactive(
+        useQuery({
+          ...fooQueryOptions('1'),
+          enabled: () => true,
+        }),
+      )
+      expectTypeOf(spread.data).toEqualTypeOf<{ id: string } | null | undefined>()
     })
 
     it('TData should always be defined when initialData is provided as a function which ALWAYS returns the data', () => {

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -42,15 +42,17 @@ export type UseQueryOptions<
               TQueryData,
               DeepUnwrapRef<TQueryKey>
             >)
-      : MaybeRefDeep<
-          QueryObserverOptions<
-            TQueryFnData,
-            TError,
-            TData,
-            TQueryData,
-            DeepUnwrapRef<TQueryKey>
-          >[Property]
-        >
+      : Property extends 'queryKey'
+        ? MaybeRefOrGetter<TQueryKey>
+        : MaybeRefDeep<
+            QueryObserverOptions<
+              TQueryFnData,
+              TError,
+              TData,
+              TQueryData,
+              DeepUnwrapRef<TQueryKey>
+            >[Property]
+          >
   } & ShallowOption
 >
 


### PR DESCRIPTION


## 🎯 Changes

Fixes a type inference bug in `useQuery` when spreading `queryOptions()` and overriding non-data-shaping options like `enabled`.

**Root cause:** In `UseQueryOptions`, `queryKey` was typed through the generic `MaybeRefDeep<...>` path (same as other options). When using the spread + override pattern, `TQueryKey` was not preserved correctly and generics widened to `unknown`.

**Fix:** Add a dedicated branch for `queryKey`, typing it as `MaybeRefOrGetter<TQueryKey>` (similar to the existing `enabled` branch). Both patterns now infer the same `data` type:

```ts
// direct
useQuery(fooQueryOptions('1'))

// spread + enabled override
useQuery({ ...fooQueryOptions('1'), enabled: () => true })
```

## ✅ Checklist

- [✅] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [✅] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced type-checking for query options spreading behavior.

* **Refactor**
  * Improved type definition formatting for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->