### PR TITLE
chore: update pnpm to 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/query.git"
   },
-  "packageManager": "pnpm@11.1.0",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=11.9.0"
   },
   "type": "module",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 cleanupUnusedCatalogs: true
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,15 @@
 cleanupUnusedCatalogs: true
+minimumReleaseAge: 1
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true
 trustPolicy: 'no-downgrade'
 trustPolicyExclude:
   - 'vite@6.4.1'
+  - 'semver@5.7.2'
+  - 'semver@6.3.1'
+  - 'ua-parser-js@1.0.41'
+  - 'undici-types@6.21.0'
 
 packages:
   - 'packages/*'
@@ -64,4 +69,3 @@ allowBuilds:
 
   # nextJs
   sharp: false # not directly required for build
-

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,11 +5,11 @@ preferWorkspacePackages: true
 blockExoticSubdeps: true
 trustPolicy: 'no-downgrade'
 trustPolicyExclude:
-  - 'vite@6.4.1'
-  - 'semver@5.7.2'
-  - 'semver@6.3.1'
-  - 'ua-parser-js@1.0.41'
-  - 'undici-types@6.21.0'
+  - 'vite@6.4.1' # Socket score 94/100; popular and healthy.
+  - 'semver@5.7.2' # Socket score 100/100; popular and healthy.
+  - 'semver@6.3.1' # Socket score 100/100; popular and healthy.
+  - 'ua-parser-js@1.0.41' # Socket score 100/100; popular and healthy.
+  - 'undici-types@6.21.0' # Socket score 100/100; popular and healthy.
 
 packages:
   - 'packages/*'


### PR DESCRIPTION
## Summary
- update packageManager and pnpm engine floor to 11.9.0
- add minimumReleaseAge: 1
- add exact trust-policy exclusions verified against Socket.dev package pages

## Verification
- pnpm install --lockfile-only --ignore-scripts
- pnpm install --frozen-lockfile --ignore-scripts --trust-lockfile=false
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager requirement to a newer pnpm version.
  * Tightened workspace dependency trust policy settings by increasing the minimum release age and expanding the trusted-build exclusion list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->