### PR TITLE
test(svelte-query/utils): add tests for 'watchChanges' first-run skip, array sources, and cleanup

### DIFF
--- a/packages/svelte-query/tests/utils.svelte.test.ts
+++ b/packages/svelte-query/tests/utils.svelte.test.ts
@@ -1,0 +1,79 @@
+import { flushSync } from 'svelte'
+import { describe, expect, it, vi } from 'vitest'
+import { watchChanges } from '../src/utils.svelte.js'
+import { ref, withEffectRoot } from './utils.svelte.js'
+
+describe('watchChanges', () => {
+  it(
+    'should skip the first run and only call the effect on subsequent changes',
+    withEffectRoot(() => {
+      const source = ref(0)
+      const effect = vi.fn()
+
+      watchChanges(() => source.value, 'pre', effect)
+
+      // first run only records previousValues, effect is not called
+      flushSync()
+      expect(effect).not.toHaveBeenCalled()
+
+      source.value = 1
+      flushSync()
+      expect(effect).toHaveBeenCalledExactlyOnceWith(1, 0)
+    }),
+  )
+
+  it(
+    'should run with the "post" flush timing',
+    withEffectRoot(() => {
+      const source = ref(0)
+      const effect = vi.fn()
+
+      watchChanges(() => source.value, 'post', effect)
+
+      flushSync()
+      expect(effect).not.toHaveBeenCalled()
+
+      source.value = 1
+      flushSync()
+      expect(effect).toHaveBeenCalledExactlyOnceWith(1, 0)
+    }),
+  )
+
+  it(
+    'should track an array of sources and pass arrays of values',
+    withEffectRoot(() => {
+      const a = ref(1)
+      const b = ref(2)
+      const effect = vi.fn()
+
+      watchChanges([() => a.value, () => b.value], 'pre', effect)
+
+      flushSync()
+      expect(effect).not.toHaveBeenCalled()
+
+      a.value = 10
+      flushSync()
+      expect(effect).toHaveBeenCalledExactlyOnceWith([10, 2], [1, 2])
+    }),
+  )
+
+  it(
+    'should run the returned cleanup before the next effect run',
+    withEffectRoot(() => {
+      const source = ref(0)
+      const cleanup = vi.fn()
+      const effect = vi.fn(() => cleanup)
+
+      watchChanges(() => source.value, 'pre', effect)
+
+      flushSync()
+      source.value = 1
+      flushSync()
+      expect(cleanup).not.toHaveBeenCalled()
+
+      source.value = 2
+      flushSync()
+      expect(cleanup).toHaveBeenCalledOnce()
+    }),
+  )
+})


### PR DESCRIPTION
## 🎯 Changes

Add unit tests for the `watchChanges` utility in `packages/svelte-query/src/utils.svelte.ts`, which previously had no direct test coverage.

The added tests cover:

- Skipping the first run and only invoking the effect on subsequent changes
- The `'post'` flush timing
- Tracking an array of sources and passing arrays of current/previous values
- Running the returned cleanup before the next effect run

These bring the `'post'` flush branch and the array-sources branch under coverage.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for change detection behavior, including flush timing variants and cleanup function execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->