### PR TITLE
fix(query-core): distinguish query keys differing only by a Date in partialMatchKey

### DIFF
--- a/.changeset/spicy-dates-match.md
+++ b/.changeset/spicy-dates-match.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/query-core': patch
+---
+
+fix(`partialMatchKey`): distinguish query keys that differ only by a `Date`
+
+Non-exact key matching (used by `invalidateQueries`, `refetchQueries`, `removeQueries`, `cancelQueries`, etc.) traversed objects structurally, so two keys differing only by a `Date` value (e.g. `['report', { from: dateA }]` vs `['report', { from: dateB }]`) were treated as equal even though `hashKey` stores them as separate queries. `partialMatchKey` now compares non-plain objects the same way `hashKey` serializes them, keeping non-exact matching consistent with cache identity.

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -166,6 +166,28 @@ describe('core/utils', () => {
       const b = [{ a: null, c: 'c', d: [{ d: 'd ' }] }]
       expect(partialMatchKey(a, b)).toEqual(false)
     })
+
+    it('should distinguish different `Date` values, consistent with `hashKey`', () => {
+      expect(partialMatchKey([new Date(0)], [new Date(1000)])).toEqual(false)
+      expect(
+        partialMatchKey(
+          ['report', { from: new Date(0) }],
+          ['report', { from: new Date(1000) }],
+        ),
+      ).toEqual(false)
+    })
+
+    it('should return `true` for equal `Date` values', () => {
+      expect(partialMatchKey([new Date(0)], [new Date(0)])).toEqual(true)
+    })
+
+    it('should match non-plain objects that hash equally (e.g. `Map`)', () => {
+      // `Map`/`Set` serialize to `{}` via `hashKey`, so they share a cache
+      // entry and must keep matching, unlike `Date`.
+      expect(
+        partialMatchKey([new Map([['a', 1]])], [new Map([['a', 2]])]),
+      ).toEqual(true)
+    })
   })
 
   describe('replaceEqualDeep', () => {

--- a/packages/query-core/src/utils.ts
+++ b/packages/query-core/src/utils.ts
@@ -256,7 +256,19 @@ export function partialMatchKey(a: any, b: any): boolean {
   }
 
   if (a && b && typeof a === 'object' && typeof b === 'object') {
-    return Object.keys(b).every((key) => partialMatchKey(a[key], b[key]))
+    // Plain objects and arrays are matched structurally. Other objects
+    // (e.g. `Date`) are compared the same way `hashKey` serializes them, so
+    // that non-exact matching stays consistent with how queries are stored.
+    if (
+      (isPlainArray(a) && isPlainArray(b)) ||
+      (isPlainObject(a) && isPlainObject(b))
+    ) {
+      return Object.keys(b).every((key) =>
+        partialMatchKey((a as any)[key], (b as any)[key]),
+      )
+    }
+
+    return hashKey([a]) === hashKey([b])
   }
 
   return false


### PR DESCRIPTION
## 🎯 Changes

Non-exact query-key matching (`partialMatchKey`) traverses objects structurally via `Object.keys(b).every(...)`. For values whose data lives in internal slots rather than own-enumerable keys, `Object.keys()` is `[]`, so the comparison is vacuously `true`. This makes two keys that differ **only** by a `Date` compare as equal — even though `hashKey` serializes Dates to distinct ISO strings and therefore stores them as **separate** cache entries.

As a result, non-exact operations (`invalidateQueries`, `refetchQueries`, `removeQueries`, `cancelQueries`, and `createPersister` matching) over-match unrelated sibling queries:

```ts
useQuery({ queryKey: ['report', { from: new Date('2020-01-01') }], queryFn }) // entry A
useQuery({ queryKey: ['report', { from: new Date('2021-06-25') }], queryFn }) // entry B (distinct hash)

// intends to invalidate only A, but invalidates BOTH A and B:
queryClient.invalidateQueries({ queryKey: ['report', { from: new Date('2020-01-01') }] })
```

### Fix
`partialMatchKey` now only traverses **plain** objects/arrays structurally; any other object (e.g. `Date`) is compared the same way `hashKey` serializes it, keeping non-exact matching consistent with cache identity:

- `Date` keys that differ are no longer matched (the bug).
- `Map`/`Set`/`RegExp` keep matching, because `hashKey` also serializes them to `{}` — they already share a cache entry, so behavior there is unchanged and consistent.

### Tests
Added regression tests to the `partialMatchKey` suite: distinct `Date` values must not match, equal `Date` values must match, and `Map` keys that hash equally keep matching.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

> Verified locally on `@tanstack/query-core`: `vitest run` → 24 files / 548 tests pass, no type errors; `eslint ./src` → no new warnings on changed files. The full `test:pr` nx pipeline was not run.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (`patch` for `@tanstack/query-core`).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-exact query key matching so keys with different `Date` values no longer incorrectly match.
  * Kept matching consistent for non-plain objects, including cases like `Map`, when their serialized values are the same.
  * Added test coverage for `Date` and other hash-equivalent object matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->