### PR TITLE
chore(changeset): split solid-query into its own fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -26,10 +26,12 @@
       "@tanstack/react-query-devtools",
       "@tanstack/react-query-next-experimental",
       "@tanstack/react-query-persist-client",
+      "@tanstack/vue-query"
+    ],
+    [
       "@tanstack/solid-query",
       "@tanstack/solid-query-devtools",
-      "@tanstack/solid-query-persist-client",
-      "@tanstack/vue-query"
+      "@tanstack/solid-query-persist-client"
     ],
     [
       "@tanstack/vue-query-devtools",


### PR DESCRIPTION
## Problem

`solid-query` is tracking the Solid 1 → 2 breaking jump and sits on a **v6 pre-release line**, while `query-core` and the other adapters are on **v5**. But `react-*`, `query-core`, `vue-query` and `solid-*` all shared a single `fixed` group in `.changeset/config.json`.

Because `fixed` releases the whole group at one version, the solid v6 beta changesets dragged **every package in that group** to `6.0.0-beta.5` — even though none of the changesets target them. That's why the release PR wanted to push a v6 beta of core / react / vue.

## Change

Carve the three solid packages into their own `fixed` group:

```diff
       "@tanstack/react-query-persist-client",
+      "@tanstack/vue-query"
+    ],
+    [
       "@tanstack/solid-query",
       "@tanstack/solid-query-devtools",
-      "@tanstack/solid-query-persist-client",
-      "@tanstack/vue-query"
+      "@tanstack/solid-query-persist-client"
     ],
```

This lets solid version independently on the v6 line. It mirrors the **existing svelte group** (already on `6.x` while core stays on `5.x`) and matches the agreed policy from Discord — *version-syncing should happen across majors only; we do not want a v6 beta of any unaffected adapter*.

## Verification

Ran `changeset version` in prerelease mode locally with this config:

| Package | Result |
|---|---|
| `solid-query`, `solid-query-devtools`, `solid-query-persist-client` | **6.0.0-beta.5** ✅ |
| `query-core`, `react-query`, `vue-query` | `5.101.0` (unchanged) ✅ |
| `svelte-query` | `6.1.34` (unchanged) ✅ |

Only the three solid packages (and their examples) bump. No core/react/vue/svelte package is touched.

## Follow-up (not in this PR)

When core/react eventually go to v6 stable, the solid (and svelte) groups should be **merged back** into the main group so the whole suite re-syncs at v6+.