### PR TITLE
fix(release): avoid pre dist tag for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
           BRANCH="${GITHUB_REF_NAME}"
           if [[ "$BRANCH" == *-pre ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
-            echo "tag=pre" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" == *-maint ]]; then
             echo "tag=maint" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" =~ ^v[0-9]+$ ]]; then


### PR DESCRIPTION
Removes the explicit `pre` npm dist-tag from prerelease branch publishing while keeping the GitHub release marked as prerelease.

the tag is set in the pre.json of the -pre branches e.g. `beta` here:
- https://github.com/TanStack/query/blob/solid-query-v6-pre/.changeset/pre.json#L3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted prerelease publishing behavior so release candidates are handled more consistently, reducing the chance of prerelease builds being published with the wrong label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->