### PR TITLE
docs(react): add holistic useQuery and useMutation lifecycle example

### DIFF
--- a/docs/framework/react/guides/mutations.md
+++ b/docs/framework/react/guides/mutations.md
@@ -10,34 +10,45 @@ Here's an example of a mutation that adds a new todo to the server:
 [//]: # 'Example'
 
 ```tsx
-function App() {
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+
+function TodoApp() {
+  const queryClient = useQueryClient()
+
+  // 1. Fetch the existing todos list
+  const { data: todos, isLoading } = useQuery({
+    queryKey: ['todos'],
+    queryFn: () => axios.get('/todos').then((res) => res.data),
+  })
+
+  // 2. Create the mutation and invalidate the list on success
   const mutation = useMutation({
-    mutationFn: (newTodo) => {
-      return axios.post('/todos', newTodo)
+    mutationFn: (newTodo) => axios.post('/todos', newTodo),
+    onSuccess: () => {
+      // This forces useQuery to refetch and pull the updated list automatically
+      queryClient.invalidateQueries({ queryKey: ['todos'] })
     },
   })
 
+  if (isLoading) return 'Loading todos...'
+
   return (
     <div>
-      {mutation.isPending ? (
-        'Adding todo...'
-      ) : (
-        <>
-          {mutation.isError ? (
-            <div>An error occurred: {mutation.error.message}</div>
-          ) : null}
+      <ul>
+        {todos?.map((todo) => (
+          <li key={todo.id}>{todo.title}</li>
+        ))}
+      </ul>
 
-          {mutation.isSuccess ? <div>Todo added!</div> : null}
-
-          <button
-            onClick={() => {
-              mutation.mutate({ id: new Date(), title: 'Do Laundry' })
-            }}
-          >
-            Create Todo
-          </button>
-        </>
-      )}
+      <button
+        disabled={mutation.isPending}
+        onClick={() => {
+          mutation.mutate({ title: 'Do Laundry' })
+        }}
+      >
+        {mutation.isPending ? 'Adding...' : 'Create Todo'}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## 🎯 Changes

The primary `useMutation` example in the React mutations guide introduces the hook in isolation without demonstrating how to synchronize the state with `useQuery`. 

This creates friction for developers learning the library, as they immediately need to know how to refresh a list after a mutation. I replaced the isolated `axios.post` snippet with a holistic `TodoApp` example that demonstrates the complete, real-world lifecycle: fetching data with `useQuery`, mutating it, and automatically triggering a refetch via `queryClient.invalidateQueries`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`. *(N/A - Docs only change)*

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “add a new todo” example to show a more complete data flow, including loading existing items, creating a new todo, and refreshing the list after saving.
  * The example UI now includes a loading state, displays current todos, and disables the create button while the request is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->