### PR TITLE
fix(release): avoid pre dist tag for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
           BRANCH="${GITHUB_REF_NAME}"
           if [[ "$BRANCH" == *-pre ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
-            echo "tag=pre" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" == *-maint ]]; then
             echo "tag=maint" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" =~ ^v[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- stop setting an explicit npm dist-tag for *-pre release branches
- allow Changesets pre mode to use its configured prerelease tag during publish

## Testing
- pnpm exec prettier --check .github/workflows/release.yml
- git diff --check -- .github/workflows/release.yml