### PR TITLE
docs(svelte): replace deprecated isLoading with isPending in overview

### DIFF
--- a/docs/framework/svelte/overview.md
+++ b/docs/framework/svelte/overview.md
@@ -37,7 +37,7 @@ Then call any function (e.g. createQuery) from any component:
 </script>
 
 <div>
-  {#if query.isLoading}
+  {#if query.isPending}
     <p>Loading...</p>
   {:else if query.isError}
     <p>Error: {query.error.message}</p>


### PR DESCRIPTION
`isLoading` is a deprecated alias for `isPending && isFetching` and is scheduled for removal in the next major version. The overview example shows a standard (always-enabled) query, so `isPending` is the correct flag. All other framework overview docs (React, Vue, Angular, Lit, Preact) already use `isPending`.

Note: `isLoading` is intentionally retained in disabling-queries guides where it is the right flag for disabled/lazy queries.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Svelte overview example to use the latest loading-state check in its conditional rendering snippet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->