### PR TITLE
test(svelte-query/containers): add test for deleting a non-existent property

### DIFF
--- a/packages/svelte-query/tests/containers.svelte.test.ts
+++ b/packages/svelte-query/tests/containers.svelte.test.ts
@@ -198,6 +198,13 @@ describe('createRawRef', () => {
     expect(ref).toEqual([7, 8, 9])
   })
 
+  it('should return `false` when deleting a property that does not exist', () => {
+    const [ref] = createRawRef<Record<string, number>>({ a: 1, b: 2 })
+
+    expect(Reflect.deleteProperty(ref, 'c')).toBe(false)
+    expect(ref).toEqual({ a: 1, b: 2 })
+  })
+
   it('should behave like a regular object when not using `update`', () => {
     const [ref] = createRawRef<Record<string, unknown>>({ a: 1, b: 2 })
 


### PR DESCRIPTION
## 🎯 Changes

Add a unit test for `createRawRef` in `packages/svelte-query/src/containers.svelte.ts` covering the `deleteProperty` trap when the property does not exist.

This complements the existing `deleteProperty` coverage (deleting an existing key) by asserting that deleting a non-existent property returns `false` and leaves the reference unchanged, matching the file's per-trap test pattern (`has`, `ownKeys`, `getOwnPropertyDescriptor`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for deleting a non-existent property from a reference, confirming the delete operation fails gracefully and leaves the reference unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->