### PR TITLE
docs(angular): fix malformed QueryClient reference link in provideQueryClient docs

### DIFF
--- a/docs/framework/angular/reference/functions/provideQueryClient.md
+++ b/docs/framework/angular/reference/functions/provideQueryClient.md
@@ -12,7 +12,7 @@ function provideQueryClient(queryClient): Provider;
 Defined in: [providers.ts:14](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/providers.ts#L14)
 
 Usually [provideTanStackQuery](provideTanStackQuery.md) is used once to set up TanStack Query and the
-[https://tanstack.com/query/latest/docs/reference/QueryClient\|QueryClient](https://tanstack.com/query/latest/docs/reference/QueryClient|QueryClient)
+[QueryClient](https://tanstack.com/query/latest/docs/reference/QueryClient)
 for the entire application. Internally it calls `provideQueryClient`.
 You can use `provideQueryClient` to provide a different `QueryClient` instance for a part
 of the application or for unit testing purposes.


### PR DESCRIPTION
The auto-generated link in `docs/framework/angular/reference/functions/provideQueryClient.md` had a `|` pipe inside the URL (`https://tanstack.com/query/latest/docs/reference/QueryClient|QueryClient`), which tanstack.com returns HTTP 500 for. The link text was the URL itself rather than `QueryClient`. Replaced with the canonical link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `provideQueryClient` reference page to improve the wording and formatting of a `QueryClient` link in the description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->