### PR TITLE
fix: lit produces dist-js which needs to be a prod build output

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -69,7 +69,11 @@
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
-      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"]
+      "outputs": [
+        "{projectRoot}/build",
+        "{projectRoot}/dist",
+        "{projectRoot}/dist-cjs"
+      ]
     },
     "test:build": {
       "cache": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build artifact tracking so the build process now recognizes additional output folders, improving consistency for generated files and cached build results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->