### PR TITLE
test(query-core/queryObserver): add test for pending state with a synchronous queryFn

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -42,6 +42,34 @@ describe('queryObserver', () => {
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
 
+  it('should go through a pending state even when the queryFn returns synchronously', async () => {
+    const key = queryKey()
+    const queryFn = vi
+      .fn<(...args: Array<unknown>) => string>()
+      .mockReturnValue('data')
+    const observer = new QueryObserver(queryClient, { queryKey: key, queryFn })
+    const unsubscribe = observer.subscribe(() => undefined)
+
+    // A synchronous return value is still wrapped in a promise, so the query
+    // goes through a fetching state before it resolves.
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(observer.getCurrentResult()).toMatchObject({
+      status: 'pending',
+      fetchStatus: 'fetching',
+      data: undefined,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(observer.getCurrentResult()).toMatchObject({
+      status: 'success',
+      fetchStatus: 'idle',
+      data: 'data',
+    })
+
+    unsubscribe()
+  })
+
   it('should be able to read latest data after subscribing', () => {
     const key = queryKey()
     queryClient.setQueryData(key, 'data')


### PR DESCRIPTION
## 🎯 Changes

Add a unit test in `queryObserver.test.tsx` verifying that a synchronous `queryFn` still goes through a fetching state before it resolves.

`QueryFunction` is typed as `(...) => T | Promise<T>`, so a synchronous return value is supported. Since the return value is still wrapped in a promise, the query goes through `status: 'pending'` / `fetchStatus: 'fetching'` for one microtask before resolving to `success`. This synchronous path was not directly covered by an existing test.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for query observer behavior when a query resolves synchronously, confirming it still goes through a loading state before switching to success.
  * Verified the expected status and data updates after timer progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->