### PR TITLE
fix(query-core): guard against undefined pages in hasNextPage/hasPreviousPage

### DIFF
--- a/.changeset/guard-infinite-undefined-pages.md
+++ b/.changeset/guard-infinite-undefined-pages.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/query-core': patch
+---
+
+fix(query-core): guard against malformed `InfiniteData` whose `pages` is `undefined`
+
+`hasNextPage`/`hasPreviousPage` only checked for a missing `data`, so a malformed
+`InfiniteData` (where `data.pages` is `undefined`) reaching `getNextPageParam`
+threw `TypeError: Cannot read properties of undefined (reading 'length')`. This
+can happen at runtime via SSR hydration or an external `setQueryData`. Guard
+`pages` before reading `.length` so these helpers return `false`/`undefined`
+instead of crashing.

--- a/packages/query-core/src/__tests__/infiniteQueryBehavior.test.tsx
+++ b/packages/query-core/src/__tests__/infiniteQueryBehavior.test.tsx
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { CancelledError, InfiniteQueryObserver, QueryClient } from '..'
-import { infiniteQueryBehavior } from '../infiniteQueryBehavior'
+import {
+  hasNextPage,
+  hasPreviousPage,
+  infiniteQueryBehavior,
+} from '../infiniteQueryBehavior'
 import type { InfiniteData, InfiniteQueryObserverResult, QueryCache } from '..'
 
 describe('InfiniteQueryBehavior', () => {
@@ -529,5 +533,18 @@ describe('InfiniteQueryBehavior', () => {
     expect(persisterSpy).toHaveBeenCalledTimes(1)
 
     unsubscribe()
+  })
+
+  it('should not throw when data has no pages array (malformed InfiniteData)', () => {
+    const options = {
+      initialPageParam: 1,
+      getNextPageParam: () => 1,
+      getPreviousPageParam: () => 1,
+    }
+    const malformed = {} as InfiniteData<unknown>
+
+    // Should return false instead of throwing on `pages.length`.
+    expect(hasNextPage(options, malformed)).toBe(false)
+    expect(hasPreviousPage(options, malformed)).toBe(false)
   })
 })

--- a/packages/query-core/src/infiniteQueryBehavior.ts
+++ b/packages/query-core/src/infiniteQueryBehavior.ts
@@ -131,26 +131,30 @@ export function infiniteQueryBehavior<TQueryFnData, TError, TData, TPageParam>(
 
 function getNextPageParam(
   options: InfiniteQueryPageParamsOptions<any>,
-  { pages, pageParams }: InfiniteData<unknown>,
+  { pages, pageParams }: Partial<InfiniteData<unknown>>,
 ): unknown | undefined {
+  // `pages` can be undefined at runtime (hydration, `setQueryData`).
+  if (!pages?.length) return undefined
   const lastIndex = pages.length - 1
-  return pages.length > 0
-    ? options.getNextPageParam(
-        pages[lastIndex],
-        pages,
-        pageParams[lastIndex],
-        pageParams,
-      )
-    : undefined
+  return options.getNextPageParam(
+    pages[lastIndex],
+    pages,
+    pageParams?.[lastIndex],
+    pageParams ?? [],
+  )
 }
 
 function getPreviousPageParam(
   options: InfiniteQueryPageParamsOptions<any>,
-  { pages, pageParams }: InfiniteData<unknown>,
+  { pages, pageParams }: Partial<InfiniteData<unknown>>,
 ): unknown | undefined {
-  return pages.length > 0
-    ? options.getPreviousPageParam?.(pages[0], pages, pageParams[0], pageParams)
-    : undefined
+  if (!pages?.length) return undefined
+  return options.getPreviousPageParam?.(
+    pages[0],
+    pages,
+    pageParams?.[0],
+    pageParams ?? [],
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

`hasNextPage` / `hasPreviousPage` crash with `TypeError: Cannot read properties of undefined (reading 'length')` when `state.data` is a malformed `InfiniteData` whose `pages` is `undefined`.

The `InfiniteData` interface declares `pages: Array<TData>` as required, which is true for data produced by `infiniteQueryBehavior`'s own fetch. But `state.data` can also be populated from outside that path — SSR hydration, a manual `setQueryData`, or a persisted/restored cache — where the object may not honor the type. When such data reaches `getNextPageParam`, the unconditional `pages.length` throws.

Notably, `onFetch` in the same file already anticipates this:

```ts
const oldPages = context.state.data?.pages || []
const oldPageParams = context.state.data?.pageParams || []
```

`getNextPageParam` / `getPreviousPageParam` / `hasNextPage` / `hasPreviousPage` simply didn't get the same defensive treatment. This PR makes them consistent.

## Crash

```
TypeError: Cannot read properties of undefined (reading 'length')
  at getNextPageParam (infiniteQueryBehavior.ts) — const lastIndex = pages.length - 1
  at hasNextPage (infiniteQueryBehavior.ts)
  at InfiniteQueryObserver.createResult
  at InfiniteQueryObserver.updateResult
  ...
```

Seen in production on a TanStack Start (SSR) app across multiple infinite queries; intermittent, tied to hydration timing.

## Change

- Type the `data` argument of `getNextPageParam` / `getPreviousPageParam` as `Partial<InfiniteData<unknown>>` to reflect that it can be malformed at runtime (no `as` casts).
- Guard `if (!pages?.length) return undefined` before indexing.
- When `pages` is a valid non-empty array the behavior is unchanged — `pageParams ?? []` is a no-op on well-formed data, since `pages` and `pageParams` are always written together.

The result: a malformed `pages` now yields "no next/previous page" instead of throwing, so `hasNextPage` / `hasPreviousPage` return `false`.

## Test

Added a regression test asserting `hasNextPage` / `hasPreviousPage` return `false` (instead of throwing) for malformed `InfiniteData`. It fails without this change.

## Changeset

Included as a `patch` for `@tanstack/query-core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infinite query handling when stored data is incomplete or missing page information.
  * Prevented errors in “next” and “previous” page checks when page data is undefined, returning a safe result instead.
  * Added coverage for malformed infinite query data to ensure these checks behave reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->