### PR TITLE
docs(angular-query/devtools): add the 'theme' option

### DIFF
--- a/docs/framework/angular/devtools.md
+++ b/docs/framework/angular/devtools.md
@@ -137,7 +137,7 @@ export const appConfig: ApplicationConfig = {
 
 ### Options returned from the callback
 
-Of these options `loadDevtools`, `client`, `position`, `errorTypes`, `buttonPosition`, and `initialIsOpen` support reactivity through signals.
+Of these options `loadDevtools`, `client`, `position`, `errorTypes`, `buttonPosition`, `initialIsOpen`, and `theme` support reactivity through signals.
 
 - `loadDevtools?: 'auto' | boolean`
   - Defaults to `auto`: lazily loads devtools when in development mode. Skips loading in production mode.
@@ -162,3 +162,6 @@ Of these options `loadDevtools`, `client`, `position`, `errorTypes`, `buttonPosi
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
 - `hideDisabledQueries?: boolean`
   - Set this to true to hide disabled queries from the devtools panel.
+- `theme?: "light" | "dark" | "system"`
+  - Defaults to `system`.
+  - Set this to change the theme of the devtools panel.


### PR DESCRIPTION
## 🎯 Changes

Document the `theme` option for the Angular Query devtools, which is already supported by `withDevtools` but was missing from the docs.

- Add `theme` to the list of options that support reactivity through signals.
- Add a `theme?: "light" | "dark" | "system"` entry to the options list, matching the wording used in the React, Vue, Solid, and Preact devtools docs.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Angular DevTools docs to include the new `theme` option in the list of supported reactive settings.
  * Added details on the available theme values (`light`, `dark`, `system`), the default setting, and how it affects the DevTools panel appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->