### PR TITLE
docs: replace deprecated isLoading with isPending in disabled queries guides

### DIFF
--- a/docs/framework/angular/guides/disabling-queries.md
+++ b/docs/framework/angular/guides/disabling-queries.md
@@ -22,14 +22,14 @@ replace: { 'useQuery': 'injectQuery' }
     } @else {
       @if (query.isError()) {
         <span>Error: {{ query.error().message }}</span>
-      } @else if (query.isLoading()) {
+      } @else if (query.isPending()) {
         <span>Loading...</span>
-      } @else if (!query.isLoading() && !query.isError()) {
+      } @else if (!query.isPending() && !query.isError()) {
         <span>Not ready ...</span>
       }
     }
 
-    <div>{{ query.isLoading() ? 'Fetching...' : '' }}</div>
+    <div>{{ query.isPending() ? 'Fetching...' : '' }}</div>
   </div>`,
 })
 export class TodosComponent {

--- a/docs/framework/react/guides/disabling-queries.md
+++ b/docs/framework/react/guides/disabling-queries.md
@@ -20,7 +20,7 @@ When `enabled` is `false`:
 
 ```tsx
 function Todos() {
-  const { isLoading, isError, data, error, refetch, isFetching } = useQuery({
+  const { isPending, isError, data, error, refetch, isFetching } = useQuery({
     queryKey: ['todos'],
     queryFn: fetchTodoList,
     enabled: false,
@@ -38,7 +38,7 @@ function Todos() {
         </ul>
       ) : isError ? (
         <span>Error: {error.message}</span>
-      ) : isLoading ? (
+      ) : isPending ? (
         <span>Loading...</span>
       ) : (
         <span>Not ready ...</span>

--- a/docs/framework/solid/guides/disabling-queries.md
+++ b/docs/framework/solid/guides/disabling-queries.md
@@ -29,7 +29,7 @@ function Todos() {
         <Match when={todosQuery.isError}>
           <span>Error: {todosQuery.error.message}</span>
         </Match>
-        <Match when={todosQuery.isLoading}>
+        <Match when={todosQuery.isPending}>
           <span>Loading...</span>
         </Match>
         <Match when={true}>

--- a/docs/framework/vue/guides/disabling-queries.md
+++ b/docs/framework/vue/guides/disabling-queries.md
@@ -10,7 +10,7 @@ ref: docs/framework/react/guides/disabling-queries.md
 <script setup>
 import { useQuery } from '@tanstack/vue-query'
 
-const { isLoading, isError, data, error, refetch, isFetching } = useQuery({
+const { isPending, isError, data, error, refetch, isFetching } = useQuery({
   queryKey: ['todos'],
   queryFn: fetchTodoList,
   enabled: false,
@@ -19,7 +19,7 @@ const { isLoading, isError, data, error, refetch, isFetching } = useQuery({
 
 <template>
   <button @click="refetch()">Fetch Todos</button>
-  <span v-if="isLoading">Loading...</span>
+  <span v-if="isPending">Loading...</span>
   <span v-else-if="isError">Error: {{ error?.message }}</span>
   <div v-else-if="data">
     <span v-if="isFetching">Fetching...</span>


### PR DESCRIPTION
Updates the `disabling-queries` guides across React, Vue, Solid, and Angular frameworks to use `isPending` instead of the deprecated `isLoading` flag, which was replaced in TanStack Query v5.

`isLoading` is still available as an alias but will be removed in the next major version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated query disabling examples across Angular, React, Solid, and Vue to use the newer pending state in loading conditions.
  * Aligned the displayed “Loading...” behavior with the updated state handling in all examples.
  * Clarified the initial disabled-query state in the React guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->