### PR TITLE
docs(query-react): Update links in useQuery documentation

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -67,20 +67,20 @@ const {
 - `queryKey: unknown[]`
   - **Required**
   - The query key to use for this query.
-  - The query key will be hashed into a stable hash. See [Query Keys](../../../../framework/react/guides/query-keys) for more information.
+  - The query key will be hashed into a stable hash. See [Query Keys](../../../../docs/framework/react/guides/query-keys) for more information.
   - The query will automatically update when this key changes (as long as `enabled` is not set to `false`).
 - `queryFn: (context: QueryFunctionContext) => Promise<TData>`
-  - **Required, but only if no default query function has been defined** See [Default Query Function](../../../../framework/react/guides/default-query-function) for more information.
+  - **Required, but only if no default query function has been defined** See [Default Query Function](../../../../docs/framework/react/guides/default-query-function) for more information.
   - The function that the query will use to request data.
-  - Receives a [QueryFunctionContext](../../../../framework/react/guides/query-functions#queryfunctioncontext)
+  - Receives a [QueryFunctionContext](../../../../docs/framework/react/guides/query-functions#queryfunctioncontext)
   - Must return a promise that will either resolve data or throw an error. The data cannot be `undefined`.
 - `enabled: boolean`
   - Set this to `false` to disable this query from automatically running.
-  - Can be used for [Dependent Queries](../../../../framework/react/guides/dependent-queries).
+  - Can be used for [Dependent Queries](../../../../docs/framework/react/guides/dependent-queries).
 - `networkMode: 'online' | 'always' | 'offlineFirst`
   - optional
   - defaults to `'online'`
-  - see [Network Mode](../../../../framework/react/guides/network-mode) for more information.
+  - see [Network Mode](../../../../docs/framework/react/guides/network-mode) for more information.
 - `retry: boolean | number | (failureCount: number, error: TError) => boolean`
   - If `false`, failed queries will not retry by default.
   - If `true`, failed queries will retry infinitely.
@@ -238,7 +238,7 @@ const {
   - `fetching`: Is `true` whenever the queryFn is executing, which includes initial `loading` as well as background refetches.
   - `paused`: The query wanted to fetch, but has been `paused`.
   - `idle`: The query is not fetching.
-  - see [Network Mode](../../../../framework/react/guides/network-mode) for more information.
+  - see [Network Mode](../../../../docs/framework/react/guides/network-mode) for more information.
 - `isFetching: boolean`
   - A derived boolean from the `fetchStatus` variable above, provided for convenience.
 - `isPaused: boolean`


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
The link is broken in current web.
https://tanstack.com/query/v4/docs/framework/react/reference/useQuery

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
This change is docs only.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
