### PR TITLE
Fix Markdown comment syntax in docs source files

### DIFF
--- a/docs/framework/angular/guides/query-cancellation.md
+++ b/docs/framework/angular/guides/query-cancellation.md
@@ -29,7 +29,7 @@ postQuery = injectQuery(() => ({
 
 ## Using `fetch`
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```ts
 query = injectQuery(() => ({
@@ -54,11 +54,11 @@ query = injectQuery(() => ({
 }))
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ## Using `axios`
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```ts
 import axios from 'axios'
@@ -73,13 +73,13 @@ const query = injectQuery(() => ({
 }))
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## Manual Cancellation
 
 You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries({ queryKey })`, which will cancel the query and revert it back to its previous state. If you have consumed the `signal` passed to the query function, TanStack Query will additionally also cancel the Promise.
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ```angular-ts
 @Component({
@@ -102,4 +102,4 @@ export class TodosComponent {
 }
 ```
 
-[//]: # 'Example7'
+[//]: # (Example7)

--- a/docs/framework/angular/overview.md
+++ b/docs/framework/angular/overview.md
@@ -52,7 +52,7 @@ On a more technical note, TanStack Query will likely:
 - Have a direct impact on your end-users by making your application feel faster and more responsive than ever before.
 - Potentially help you save on bandwidth and increase memory performance
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ## Enough talk, show me some code already!
 

--- a/docs/framework/angular/quick-start.md
+++ b/docs/framework/angular/quick-start.md
@@ -5,7 +5,7 @@ title: Quick Start
 
 > IMPORTANT: This library is currently in an experimental stage. This means that breaking changes will happen in minor AND patch releases. Upgrade carefully. If you use this in production while in experimental stage, please lock your version to a patch-level version to avoid unexpected breaking changes.
 
-[//]: # 'Example'
+[//]: # (Example)
 
 If you're looking for a fully functioning example, please have a look at our [basic codesandbox example](./examples/basic)
 
@@ -114,4 +114,4 @@ interface Todo {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)

--- a/docs/framework/react/graphql.md
+++ b/docs/framework/react/graphql.md
@@ -7,7 +7,7 @@ Because React Query's fetching mechanisms are agnostically built on Promises, yo
 
 > Keep in mind that React Query does not support normalized caching. While a vast majority of users do not actually need a normalized cache or even benefit from it as much as they believe they do, there may be very rare circumstances that may warrant it so be sure to check with us first to make sure it's truly something you need!
 
-[//]: # 'Codegen'
+[//]: # (Codegen)
 
 ## Type-Safety and Code Generation
 
@@ -52,4 +52,4 @@ _You can find a [complete example in the repo](https://github.com/dotansimha/gra
 
 Get started with the [dedicated guide on GraphQL Code Generator documentation](https://www.the-guild.dev/graphql/codegen/docs/guides/react-vue).
 
-[//]: # 'Codegen'
+[//]: # (Codegen)

--- a/docs/framework/react/guides/advanced-ssr.md
+++ b/docs/framework/react/guides/advanced-ssr.md
@@ -641,10 +641,10 @@ Server Components and streaming are still fairly new concepts and we are still f
 
 Similarly, it would be impossible to teach all the intricacies of this new paradigm all in one guide, on the first try. If you are missing some piece of information here or have suggestions on how to improve this content, also get in touch, or even better, click the "Edit on GitHub" button below and help us out.
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further reading
 
 To understand if your application can benefit from React Query when also using Server Components, see the article [You Might Not Need React Query](https://tkdodo.eu/blog/you-might-not-need-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/background-fetching-indicators.md
+++ b/docs/framework/react/guides/background-fetching-indicators.md
@@ -5,7 +5,7 @@ title: Background Fetching Indicators
 
 A query's `status === 'pending'` state is sufficient enough to show the initial hard-loading state for a query, but sometimes you may want to display an additional indicator that a query is refetching in the background. To do this, queries also supply you with an `isFetching` boolean that you can use to show that it's in a fetching state, regardless of the state of the `status` variable:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 function Todos() {
@@ -37,13 +37,13 @@ function Todos() {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ## Displaying Global Background Fetching Loading State
 
 In addition to individual query loading states, if you would like to show a global loading indicator when **any** queries are fetching (including in the background), you can use the `useIsFetching` hook:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 import { useIsFetching } from '@tanstack/react-query'
@@ -57,4 +57,4 @@ function GlobalLoadingIndicator() {
 }
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)

--- a/docs/framework/react/guides/default-query-function.md
+++ b/docs/framework/react/guides/default-query-function.md
@@ -5,7 +5,7 @@ title: Default Query Function
 
 If you find yourself wishing for whatever reason that you could just share the same query function for your entire app and just use query keys to identify what it should fetch, you can do that by providing a **default query function** to TanStack Query:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 // Define a default query function that will receive the query key
@@ -51,6 +51,6 @@ function Post({ postId }) {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 If you ever want to override the default queryFn, you can just provide your own like you normally would.

--- a/docs/framework/react/guides/dependent-queries.md
+++ b/docs/framework/react/guides/dependent-queries.md
@@ -7,7 +7,7 @@ title: Dependent Queries
 
 Dependent (or serial) queries depend on previous ones to finish before they can execute. To achieve this, it's as easy as using the `enabled` option to tell a query when it is ready to run:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 // Get the user
@@ -31,7 +31,7 @@ const {
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 The `projects` query will start in:
 
@@ -61,7 +61,7 @@ fetchStatus: 'idle'
 
 Dynamic parallel query - `useQueries` can depend on a previous query also, here's how to achieve this:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 // Get the users ids
@@ -84,7 +84,7 @@ const usersMessages = useQueries({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 **Note** that `useQueries` return an **array of query results**
 

--- a/docs/framework/react/guides/disabling-queries.md
+++ b/docs/framework/react/guides/disabling-queries.md
@@ -16,7 +16,7 @@ When `enabled` is `false`:
 
 > TypeScript users may prefer to use [skipToken](#typesafe-disabling-of-queries-using-skiptoken) as an alternative to `enabled = false`.
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 function Todos() {
@@ -50,7 +50,7 @@ function Todos() {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 Permanently disabling a query opts out of many great features that TanStack Query has to offer (like background refetches), and it's also not the idiomatic way. It takes you from the declarative approach (defining dependencies when your query should run) into an imperative mode (fetch whenever I click here). It is also not possible to pass parameters to `refetch`. Oftentimes, all you want is a lazy query that defers the initial fetch:
 
@@ -58,7 +58,7 @@ Permanently disabling a query opts out of many great features that TanStack Quer
 
 The enabled option can not only be used to permanently disable a query, but also to enable / disable it at a later time. A good example would be a filter form where you only want to fire off the first request once the user has entered a filter value:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 function Todos() {
@@ -81,7 +81,7 @@ function Todos() {
 }
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ### isLoading (Previously: `isInitialLoading`)
 
@@ -99,7 +99,7 @@ If you are using TypeScript, you can use the `skipToken` to disable a query. Thi
 
 > **IMPORTANT**: `refetch` from `useQuery` will not work with `skipToken`. Calling `refetch()` on a query that uses `skipToken` will result in a `Missing queryFn` error because there is no valid query function to execute. If you need to manually trigger queries, consider using `enabled: false` instead, which allows `refetch()` to work properly. Other than this limitation, `skipToken` works the same as `enabled: false`.
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 import { skipToken, useQuery } from '@tanstack/react-query'
@@ -123,4 +123,4 @@ function Todos() {
 }
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)

--- a/docs/framework/react/guides/important-defaults.md
+++ b/docs/framework/react/guides/important-defaults.md
@@ -34,15 +34,15 @@ Out of the box, TanStack Query is configured with **aggressive but sane** defaul
 
   > To change this, you can alter the default `retry` and `retryDelay` options for queries to something other than `3` and the default exponential backoff function.
 
-[//]: # 'StructuralSharing'
+[//]: # (StructuralSharing)
 
 - Query results by default are **structurally shared to detect if data has actually changed** and if not, **the data reference remains unchanged** to better help with value stabilization with regards to useMemo and useCallback. If this concept sounds foreign, then don't worry about it! 99.9% of the time you will not need to disable this and it makes your app more performant at zero cost to you.
 
-[//]: # 'StructuralSharing'
+[//]: # (StructuralSharing)
 
 > Structural sharing only works with JSON-compatible values, any other value types will always be considered as changed. If you are seeing performance issues because of large responses for example, you can disable this feature with the `config.structuralSharing` flag. If you are dealing with non-JSON compatible values in your query responses and still want to detect if data has changed or not, you can provide your own custom function as `config.structuralSharing` to compute a value from the old and new responses, retaining references as required.
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further Reading
 
@@ -52,4 +52,4 @@ Have a look at the following articles from our [Community Resources](../../../co
 - [React Query as a State Manager](https://tkdodo.eu/blog/react-query-as-a-state-manager)
 - [Thinking in React Query](https://tkdodo.eu/blog/thinking-in-react-query)
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/infinite-queries.md
+++ b/docs/framework/react/guides/infinite-queries.md
@@ -40,7 +40,7 @@ With this information, we can create a "Load More" UI by:
 - Returning the information for the next query in `getNextPageParam`
 - Calling `fetchNextPage` function
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 import { useInfiniteQuery } from '@tanstack/react-query'
@@ -97,7 +97,7 @@ function Projects() {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 It's essential to understand that calling `fetchNextPage` while an ongoing fetch is in progress runs the risk of overwriting data refreshes happening in the background. This situation becomes particularly critical when rendering a list and triggering `fetchNextPage` simultaneously.
 
@@ -107,13 +107,13 @@ If you intend to enable simultaneous fetching, you can utilize the `{ cancelRefe
 
 To ensure a seamless querying process without conflicts, it's highly recommended to verify that the query is not in an `isFetching` state, especially if the user won't directly control that call.
 
-[//]: # 'Example1'
+[//]: # (Example1)
 
 ```jsx
 <List onEndReached={() => hasNextPage && !isFetching && fetchNextPage()} />
 ```
 
-[//]: # 'Example1'
+[//]: # (Example1)
 
 ## What happens when an infinite query needs to be refetched?
 
@@ -123,7 +123,7 @@ When an infinite query becomes `stale` and needs to be refetched, each group is 
 
 Bi-directional lists can be implemented by using the `getPreviousPageParam`, `fetchPreviousPage`, `hasPreviousPage` and `isFetchingPreviousPage` properties and functions.
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 useInfiniteQuery({
@@ -135,13 +135,13 @@ useInfiniteQuery({
 })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## What if I want to show the pages in reversed order?
 
 Sometimes you may want to show the pages in reversed order. If this is case, you can use the `select` option:
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 useInfiniteQuery({
@@ -154,13 +154,13 @@ useInfiniteQuery({
 })
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ## What if I want to manually update the infinite query?
 
 ### Manually removing first page:
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ```tsx
 queryClient.setQueryData(['projects'], (data) => ({
@@ -169,11 +169,11 @@ queryClient.setQueryData(['projects'], (data) => ({
 }))
 ```
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ### Manually removing a single value from an individual page:
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ```tsx
 const newPagesArray =
@@ -187,11 +187,11 @@ queryClient.setQueryData(['projects'], (data) => ({
 }))
 ```
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ### Keep only the first page:
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ```tsx
 queryClient.setQueryData(['projects'], (data) => ({
@@ -200,7 +200,7 @@ queryClient.setQueryData(['projects'], (data) => ({
 }))
 ```
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 Make sure to always keep the same data structure of pages and pageParams!
 
@@ -215,7 +215,7 @@ The solution is to use a "Limited Infinite Query". This is made possible by usin
 
 In the following example only 3 pages are kept in the query data pages array. If a refetch is needed, only 3 pages will be refetched sequentially.
 
-[//]: # 'Example8'
+[//]: # (Example8)
 
 ```tsx
 useInfiniteQuery({
@@ -228,13 +228,13 @@ useInfiniteQuery({
 })
 ```
 
-[//]: # 'Example8'
+[//]: # (Example8)
 
 ## What if my API doesn't return a cursor?
 
 If your API doesn't return a cursor, you can use the `pageParam` as a cursor. Because `getNextPageParam` and `getPreviousPageParam` also get the `pageParam`of the current page, you can use it to calculate the next / previous page param.
 
-[//]: # 'Example9'
+[//]: # (Example9)
 
 ```tsx
 return useInfiniteQuery({
@@ -256,11 +256,11 @@ return useInfiniteQuery({
 })
 ```
 
-[//]: # 'Example9'
-[//]: # 'Materials'
+[//]: # (Example9)
+[//]: # (Materials)
 
 ## Further reading
 
 To get a better understanding of how Infinite Queries work under the hood, see the article [How Infinite Queries work](https://tkdodo.eu/blog/how-infinite-queries-work).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/initial-query-data.md
+++ b/docs/framework/react/guides/initial-query-data.md
@@ -17,7 +17,7 @@ There may be times when you already have the initial data for a query available 
 
 > IMPORTANT: `initialData` is persisted to the cache, so it is not recommended to provide placeholder, partial or incomplete data to this option and instead use `placeholderData`
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 const result = useQuery({
@@ -27,7 +27,7 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ### `staleTime` and `initialDataUpdatedAt`
 
@@ -35,7 +35,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
 - If you configure your query observer with `initialData`, and no `staleTime` (the default `staleTime: 0`), the query will immediately refetch when it mounts:
 
-  [//]: # 'Example2'
+  [//]: # (Example2)
 
   ```tsx
   // Will show initialTodos immediately, but also immediately refetch todos after mount
@@ -46,11 +46,11 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
   })
   ```
 
-  [//]: # 'Example2'
+  [//]: # (Example2)
 
 - If you configure your query observer with `initialData` and a `staleTime` of `1000` ms, the data will be considered fresh for that same amount of time, as if it was just fetched from your query function.
 
-  [//]: # 'Example3'
+  [//]: # (Example3)
 
   ```tsx
   // Show initialTodos immediately, but won't refetch until another interaction event is encountered after 1000 ms
@@ -62,11 +62,11 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
   })
   ```
 
-  [//]: # 'Example3'
+  [//]: # (Example3)
 
 - So what if your `initialData` isn't totally fresh? That leaves us with the last configuration that is actually the most accurate and uses an option called `initialDataUpdatedAt`. This option allows you to pass a numeric JS timestamp in milliseconds of when the initialData itself was last updated, e.g. what `Date.now()` provides. Take note that if you have a unix timestamp, you'll need to convert it to a JS timestamp by multiplying it by `1000`.
 
-  [//]: # 'Example4'
+  [//]: # (Example4)
 
   ```tsx
   // Show initialTodos immediately, but won't refetch until another interaction event is encountered after 1000 ms
@@ -80,7 +80,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
   })
   ```
 
-  [//]: # 'Example4'
+  [//]: # (Example4)
 
   This option allows the staleTime to be used for its original purpose, determining how fresh the data needs to be, while also allowing the data to be refetched on mount if the `initialData` is older than the `staleTime`. In the example above, our data needs to be fresh within 1 minute, and we can hint to the query when the initialData was last updated so the query can decide for itself whether the data needs to be refetched again or not.
 
@@ -90,7 +90,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
 
 If the process for accessing a query's initial data is intensive or just not something you want to perform on every render, you can pass a function as the `initialData` value. This function will be executed only once when the query is initialized, saving you precious memory and/or CPU:
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ```tsx
 const result = useQuery({
@@ -100,13 +100,13 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ### Initial Data from Cache
 
 In some circumstances, you may be able to provide the initial data for a query from the cached result of another. A good example of this would be searching the cached data from a todos list query for an individual todo item, then using that as the initial data for your individual todo query:
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ```tsx
 const result = useQuery({
@@ -119,13 +119,13 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ### Initial Data from the cache with `initialDataUpdatedAt`
 
 Getting initial data from the cache means the source query you're using to look up the initial data from is likely old. Instead of using an artificial `staleTime` to keep your query from refetching immediately, it's suggested that you pass the source query's `dataUpdatedAt` to `initialDataUpdatedAt`. This provides the query instance with all the information it needs to determine if and when the query needs to be refetched, regardless of initial data being provided.
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ```tsx
 const result = useQuery({
@@ -138,13 +138,13 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ### Conditional Initial Data from Cache
 
 If the source query you're using to look up the initial data from is old, you may not want to use the cached data at all and just fetch from the server. To make this decision easier, you can use the `queryClient.getQueryState` method instead to get more information about the source query, including a `state.dataUpdatedAt` timestamp you can use to decide if the query is "fresh" enough for your needs:
 
-[//]: # 'Example8'
+[//]: # (Example8)
 
 ```tsx
 const result = useQuery({
@@ -165,11 +165,11 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example8'
-[//]: # 'Materials'
+[//]: # (Example8)
+[//]: # (Materials)
 
 ## Further reading
 
 For a comparison between `Initial Data` and `Placeholder Data`, see the [article by TkDodo](https://tkdodo.eu/blog/placeholder-and-initial-data-in-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/invalidations-from-mutations.md
+++ b/docs/framework/react/guides/invalidations-from-mutations.md
@@ -7,17 +7,17 @@ Invalidating queries is only half the battle. Knowing **when** to invalidate the
 
 For example, assume we have a mutation to post a new todo:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 const mutation = useMutation({ mutationFn: postTodo })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 When a successful `postTodo` mutation happens, we likely want all `todos` queries to get invalidated and possibly refetched to show the new todo item. To do this, you can use `useMutation`'s `onSuccess` options and the `client`'s `invalidateQueries` function:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -40,18 +40,18 @@ const mutation = useMutation({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 Returning a Promise on `onSuccess` makes sure the data is updated before the mutation is entirely complete (i.e., isPending is true until onSuccess is fulfilled)
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 You can wire up your invalidations to happen using any of the callbacks available in the [`useMutation` hook](./mutations.md)
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further reading
 
 For a technique to automatically invalidate Queries after Mutations, have a look at [TkDodo's article on Automatic Query Invalidation after Mutations](https://tkdodo.eu/blog/automatic-query-invalidation-after-mutations).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/migrating-to-v5.md
+++ b/docs/framework/react/guides/migrating-to-v5.md
@@ -371,7 +371,7 @@ To understand the reasoning behind this change checkout the [v5 roadmap discussi
 
 because it also hashes mutation keys and can be used inside the `predicate` functions of `useIsMutating` and `useMutationState`, which gets mutations passed.
 
-[//]: # 'FrameworkSpecificBreakingChanges'
+[//]: # (FrameworkSpecificBreakingChanges)
 
 ### The minimum required React version is now 18.0
 
@@ -447,7 +447,7 @@ queryClient.setQueryDefaults(['todo', 'detail'], {
 
 Note that in this specific example, `retry: true` was added to the `['todo', 'detail']` registration to counteract it now inheriting `retry: false` from the more general registration. The specific changes needed to maintain exact behavior will vary depending on your defaults.
 
-[//]: # 'FrameworkSpecificBreakingChanges'
+[//]: # (FrameworkSpecificBreakingChanges)
 
 ## New Features 🚀
 
@@ -504,7 +504,7 @@ See the [useQueries docs](../reference/useQueries.md#combine) for more details.
 
 See the [experimental_createPersister docs](../plugins/createPersister.md) for more details.
 
-[//]: # 'FrameworkSpecificNewFeatures'
+[//]: # (FrameworkSpecificNewFeatures)
 
 ### Typesafe way to create Query Options
 
@@ -526,4 +526,4 @@ The experimental `suspense: boolean` flag on the query hooks has been removed.
 
 You can read more about them in the [suspense docs](./suspense.md).
 
-[//]: # 'FrameworkSpecificNewFeatures'
+[//]: # (FrameworkSpecificNewFeatures)

--- a/docs/framework/react/guides/mutations.md
+++ b/docs/framework/react/guides/mutations.md
@@ -7,7 +7,7 @@ Unlike queries, mutations are typically used to create/update/delete data or per
 
 Here's an example of a mutation that adds a new todo to the server:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 function App() {
@@ -43,7 +43,7 @@ function App() {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 A mutation can only be in one of the following states at any given moment:
 
@@ -61,12 +61,12 @@ In the example above, you also saw that you can pass variables to your mutations
 
 Even with just variables, mutations aren't all that special, but when used with the `onSuccess` option, the [Query Client's `invalidateQueries` method](../../../reference/QueryClient.md#queryclientinvalidatequeries) and the [Query Client's `setQueryData` method](../../../reference/QueryClient.md#queryclientsetquerydata), mutations become a very powerful tool.
 
-[//]: # 'Info1'
+[//]: # (Info1)
 
 > IMPORTANT: The `mutate` function is an asynchronous function, which means you cannot use it directly in an event callback in **React 16 and earlier**. If you need to access the event in `onSubmit` you need to wrap `mutate` in another function. This is due to [React event pooling](https://reactjs.org/docs/legacy-event-pooling.html).
 
-[//]: # 'Info1'
-[//]: # 'Example2'
+[//]: # (Info1)
+[//]: # (Example2)
 
 ```tsx
 // This will not work in React 16 and earlier
@@ -97,13 +97,13 @@ const CreateTodo = () => {
 }
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ## Resetting Mutation State
 
 It's sometimes the case that you need to clear the `error` or `data` of a mutation request. To do this, you can use the `reset` function to handle this:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 const CreateTodo = () => {
@@ -132,13 +132,13 @@ const CreateTodo = () => {
 }
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## Mutation Side Effects
 
 `useMutation` comes with some helper options that allow quick and easy side-effects at any stage during the mutation lifecycle. These come in handy for both [invalidating and refetching queries after mutations](./invalidations-from-mutations.md) and even [optimistic updates](./optimistic-updates.md)
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 useMutation({
@@ -162,11 +162,11 @@ useMutation({
 })
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 When returning a promise in any of the callback functions it will first be awaited before the next callback is called:
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ```tsx
 useMutation({
@@ -180,11 +180,11 @@ useMutation({
 })
 ```
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 You might find that you want to **trigger additional callbacks** beyond the ones defined on `useMutation` when calling `mutate`. This can be used to trigger component-specific side effects. To do that, you can provide any of the same callback options to the `mutate` function after your mutation variable. Supported options include: `onSuccess`, `onError` and `onSettled`. Please keep in mind that those additional callbacks won't run if your component unmounts _before_ the mutation finishes.
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ```tsx
 useMutation({
@@ -213,7 +213,7 @@ mutate(todo, {
 })
 ```
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ### Consecutive mutations
 
@@ -221,7 +221,7 @@ There is a slight difference in handling `onSuccess`, `onError` and `onSettled` 
 
 > Be aware that most likely, `mutationFn` passed to `useMutation` is asynchronous. In that case, the order in which mutations are fulfilled may differ from the order of `mutate` function calls.
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ```tsx
 useMutation({
@@ -242,13 +242,13 @@ todos.forEach((todo) => {
 })
 ```
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ## Promises
 
 Use `mutateAsync` instead of `mutate` to get a promise which will resolve on success or throw on an error. This can for example be used to compose side effects.
 
-[//]: # 'Example8'
+[//]: # (Example8)
 
 ```tsx
 const mutation = useMutation({ mutationFn: addTodo })
@@ -263,13 +263,13 @@ try {
 }
 ```
 
-[//]: # 'Example8'
+[//]: # (Example8)
 
 ## Retry
 
 By default, TanStack Query will not retry a mutation on error, but it is possible with the `retry` option:
 
-[//]: # 'Example9'
+[//]: # (Example9)
 
 ```tsx
 const mutation = useMutation({
@@ -278,7 +278,7 @@ const mutation = useMutation({
 })
 ```
 
-[//]: # 'Example9'
+[//]: # (Example9)
 
 If mutations fail because the device is offline, they will be retried in the same order when the device reconnects.
 
@@ -286,7 +286,7 @@ If mutations fail because the device is offline, they will be retried in the sam
 
 Mutations can be persisted to storage if needed and resumed at a later point. This can be done with the hydration functions:
 
-[//]: # 'Example10'
+[//]: # (Example10)
 
 ```tsx
 const queryClient = new QueryClient()
@@ -339,18 +339,18 @@ hydrate(queryClient, state)
 queryClient.resumePausedMutations()
 ```
 
-[//]: # 'Example10'
-[//]: # 'PersistOfflineIntro'
+[//]: # (Example10)
+[//]: # (PersistOfflineIntro)
 
 ### Persisting Offline mutations
 
 If you persist offline mutations with the [persistQueryClient plugin](../plugins/persistQueryClient.md), mutations cannot be resumed when the page is reloaded unless you provide a default mutation function.
 
-[//]: # 'PersistOfflineIntro'
+[//]: # (PersistOfflineIntro)
 
 This is a technical limitation. When persisting to an external storage, only the state of mutations is persisted, as functions cannot be serialized. After hydration, the component that triggers the mutation might not be mounted, so calling `resumePausedMutations` might yield an error: `No mutationFn found`.
 
-[//]: # 'Example11'
+[//]: # (Example11)
 
 ```tsx
 const persister = createSyncStoragePersister({
@@ -387,18 +387,18 @@ export default function App() {
 }
 ```
 
-[//]: # 'Example11'
-[//]: # 'OfflineExampleLink'
+[//]: # (Example11)
+[//]: # (OfflineExampleLink)
 
 We also have an extensive [offline example](../examples/offline) that covers both queries and mutations.
 
-[//]: # 'OfflineExampleLink'
+[//]: # (OfflineExampleLink)
 
 ## Mutation Scopes
 
 Per default, all mutations run in parallel - even if you invoke `.mutate()` of the same mutation multiple times. Mutations can be given a `scope` with an `id` to avoid that. All mutations with the same `scope.id` will run in serial, which means when they are triggered, they will start in `isPaused: true` state if there is already a mutation for that scope in progress. They will be put into a queue and will automatically resume once their time in the queue has come.
 
-[//]: # 'ExampleScopes'
+[//]: # (ExampleScopes)
 
 ```tsx
 const mutation = useMutation({
@@ -409,11 +409,11 @@ const mutation = useMutation({
 })
 ```
 
-[//]: # 'ExampleScopes'
-[//]: # 'Materials'
+[//]: # (ExampleScopes)
+[//]: # (Materials)
 
 ## Further reading
 
 For more information about mutations, have a look at [TkDodo's article on Mastering Mutations in React Query](https://tkdodo.eu/blog/mastering-mutations-in-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/optimistic-updates.md
+++ b/docs/framework/react/guides/optimistic-updates.md
@@ -9,7 +9,7 @@ React Query provides two ways to optimistically update your UI before a mutation
 
 This is the simpler variant, as it doesn't interact with the cache directly.
 
-[//]: # 'ExampleUI1'
+[//]: # (ExampleUI1)
 
 ```tsx
 const addTodoMutation = useMutation({
@@ -22,11 +22,11 @@ const addTodoMutation = useMutation({
 const { isPending, submittedAt, variables, mutate, isError } = addTodoMutation
 ```
 
-[//]: # 'ExampleUI1'
+[//]: # (ExampleUI1)
 
 you will then have access to `addTodoMutation.variables`, which contain the added todo. In your UI list, where the query is rendered, you can append another item to the list while the mutation `isPending`:
 
-[//]: # 'ExampleUI2'
+[//]: # (ExampleUI2)
 
 ```tsx
 <ul>
@@ -37,13 +37,13 @@ you will then have access to `addTodoMutation.variables`, which contain the adde
 </ul>
 ```
 
-[//]: # 'ExampleUI2'
+[//]: # (ExampleUI2)
 
 We're rendering a temporary item with a different `opacity` as long as the mutation is pending. Once it completes, the item will automatically no longer be rendered. Given that the refetch succeeded, we should see the item as a "normal item" in our list.
 
 If the mutation errors, the item will also disappear. But we could continue to show it, if we want, by checking for the `isError` state of the mutation. `variables` are _not_ cleared when the mutation errors, so we can still access them, maybe even show a retry button:
 
-[//]: # 'ExampleUI3'
+[//]: # (ExampleUI3)
 
 ```tsx
 {
@@ -56,13 +56,13 @@ If the mutation errors, the item will also disappear. But we could continue to s
 }
 ```
 
-[//]: # 'ExampleUI3'
+[//]: # (ExampleUI3)
 
 ### If the mutation and the query don't live in the same component
 
 This approach works very well if the mutation and the query live in the same component. However, you also get access to all mutations in other components via the dedicated `useMutationState` hook. It is best combined with a `mutationKey`:
 
-[//]: # 'ExampleUI4'
+[//]: # (ExampleUI4)
 
 ```tsx
 // somewhere in your app
@@ -79,7 +79,7 @@ const variables = useMutationState<string>({
 })
 ```
 
-[//]: # 'ExampleUI4'
+[//]: # (ExampleUI4)
 
 `variables` will be an `Array`, because there might be multiple mutations running at the same time. If we need a unique key for the items, we can also select `mutation.state.submittedAt`. This will even make displaying concurrent optimistic updates a breeze.
 
@@ -91,7 +91,7 @@ To do this, `useMutation`'s `onMutate` handler option allows you to return a val
 
 ### Updating a list of todos when adding a new todo
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 const queryClient = useQueryClient()
@@ -124,11 +124,11 @@ useMutation({
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ### Updating a single todo
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 useMutation({
@@ -161,11 +161,11 @@ useMutation({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 You can also use the `onSettled` function in place of the separate `onError` and `onSuccess` handlers if you wish:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 useMutation({
@@ -179,7 +179,7 @@ useMutation({
 })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## When to use what
 
@@ -187,10 +187,10 @@ If you only have one place where the optimistic result should be shown, using `v
 
 However, if you have multiple places on the screen that would require to know about the update, manipulating the cache directly will take care of this for you automatically.
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further reading
 
 Have a look at the guide by TkDodo on [Concurrent Optimistic Updates](https://tkdodo.eu/blog/concurrent-optimistic-updates-in-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/paginated-queries.md
+++ b/docs/framework/react/guides/paginated-queries.md
@@ -5,7 +5,7 @@ title: Paginated / Lagged Queries
 
 Rendering paginated data is a very common UI pattern and in TanStack Query, it "just works" by including the page information in the query key:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 const result = useQuery({
@@ -14,7 +14,7 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 However, if you run this simple example, you might notice something strange:
 
@@ -30,7 +30,7 @@ Consider the following example where we would ideally want to increment a pageIn
 - When the new data arrives, the previous `data` is seamlessly swapped to show the new data.
 - `isPlaceholderData` is made available to know what data the query is currently providing you
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
@@ -86,7 +86,7 @@ function Todos() {
 }
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ## Lagging Infinite Query results with `placeholderData`
 

--- a/docs/framework/react/guides/parallel-queries.md
+++ b/docs/framework/react/guides/parallel-queries.md
@@ -9,7 +9,7 @@ title: Parallel Queries
 
 When the number of parallel queries does not change, there is **no extra effort** to use parallel queries. Just use any number of TanStack Query's `useQuery` and `useInfiniteQuery` hooks side-by-side!
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 function App () {
@@ -21,26 +21,26 @@ function App () {
 }
 ```
 
-[//]: # 'Example'
-[//]: # 'Info'
+[//]: # (Example)
+[//]: # (Info)
 
 > When using React Query in suspense mode, this pattern of parallelism does not work, since the first query would throw a promise internally and would suspend the component before the other queries run. To get around this, you'll either need to use the `useSuspenseQueries` hook (which is suggested) or orchestrate your own parallelism with separate components for each `useSuspenseQuery` instance.
 
-[//]: # 'Info'
+[//]: # (Info)
 
 ## Dynamic Parallel Queries with `useQueries`
 
-[//]: # 'DynamicParallelIntro'
+[//]: # (DynamicParallelIntro)
 
 If the number of queries you need to execute is changing from render to render, you cannot use manual querying since that would violate the rules of hooks. Instead, TanStack Query provides a `useQueries` hook, which you can use to dynamically execute as many queries in parallel as you'd like.
 
-[//]: # 'DynamicParallelIntro'
-[//]: # 'DynamicParallelDescription'
+[//]: # (DynamicParallelIntro)
+[//]: # (DynamicParallelDescription)
 
 `useQueries` accepts an **options object** with a **queries key** whose value is an **array of query objects**. It returns an **array of query results**:
 
-[//]: # 'DynamicParallelDescription'
-[//]: # 'Example2'
+[//]: # (DynamicParallelDescription)
+[//]: # (Example2)
 
 ```tsx
 function App({ users }) {
@@ -55,9 +55,9 @@ function App({ users }) {
 }
 ```
 
-[//]: # 'Example2'
-[//]: # 'TypeScriptSelect'
+[//]: # (Example2)
+[//]: # (TypeScriptSelect)
 
 > When using TypeScript, an inline `select` written on a query object passed to `useQueries` can't infer its `data` argument from that same object's `queryFn` — it falls back to `unknown`. Annotate the `select` parameter explicitly, or define the query with the [`queryOptions`](../reference/queryOptions.md) helper, to keep type inference. See [this known limitation](https://github.com/TanStack/query/issues/6556).
 
-[//]: # 'TypeScriptSelect'
+[//]: # (TypeScriptSelect)

--- a/docs/framework/react/guides/placeholder-query-data.md
+++ b/docs/framework/react/guides/placeholder-query-data.md
@@ -20,7 +20,7 @@ When we use `placeholderData`, our Query will not be in a `pending` state - it w
 
 ## Placeholder Data as a Value
 
-[//]: # 'ExampleValue'
+[//]: # (ExampleValue)
 
 ```tsx
 function Todos() {
@@ -32,8 +32,8 @@ function Todos() {
 }
 ```
 
-[//]: # 'ExampleValue'
-[//]: # 'Memoization'
+[//]: # (ExampleValue)
+[//]: # (Memoization)
 
 ### Placeholder Data Memoization
 
@@ -50,13 +50,13 @@ function Todos() {
 }
 ```
 
-[//]: # 'Memoization'
+[//]: # (Memoization)
 
 ## Placeholder Data as a Function
 
 `placeholderData` can also be a function, where you can get access to the data and Query meta information of a "previous" successful Query. This is useful for situations where you want to use the data from one query as the placeholder data for another query. When the QueryKey changes, e.g. from `['todos', 1]` to `['todos', 2]`, we can keep displaying "old" data instead of having to show a loading spinner while data is _transitioning_ from one Query to the next. For more information, see [Paginated Queries](./paginated-queries.md).
 
-[//]: # 'ExampleFunction'
+[//]: # (ExampleFunction)
 
 ```tsx
 const result = useQuery({
@@ -66,13 +66,13 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'ExampleFunction'
+[//]: # (ExampleFunction)
 
 ### Placeholder Data from Cache
 
 In some circumstances, you may be able to provide the placeholder data for a query from the cached result of another. A good example of this would be searching the cached data from a blog post list query for a preview version of the post, then using that as the placeholder data for your individual post query:
 
-[//]: # 'ExampleCache'
+[//]: # (ExampleCache)
 
 ```tsx
 function BlogPost({ blogPostId }) {
@@ -91,11 +91,11 @@ function BlogPost({ blogPostId }) {
 }
 ```
 
-[//]: # 'ExampleCache'
-[//]: # 'Materials'
+[//]: # (ExampleCache)
+[//]: # (Materials)
 
 ## Further reading
 
 For a comparison between `Placeholder Data` and `Initial Data`, see the [article by TkDodo](https://tkdodo.eu/blog/placeholder-and-initial-data-in-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/polling.md
+++ b/docs/framework/react/guides/polling.md
@@ -5,7 +5,7 @@ title: Polling
 
 `refetchInterval` makes a query refetch on a timer. Set it to a number in milliseconds and the query runs every N ms while there's at least one active observer:
 
-[//]: # 'Example1'
+[//]: # (Example1)
 
 ```tsx
 useQuery({
@@ -15,7 +15,7 @@ useQuery({
 })
 ```
 
-[//]: # 'Example1'
+[//]: # (Example1)
 
 Polling is independent of `staleTime`. A query can be fresh and still poll on schedule; see [Important Defaults](./important-defaults.md) for how `staleTime` interacts with other refetch behaviors. `refetchInterval` fires on its own clock regardless of freshness.
 
@@ -23,7 +23,7 @@ Polling is independent of `staleTime`. A query can be fresh and still poll on sc
 
 Pass a function instead of a number to compute the interval from the current query. The function receives the `Query` object and should return a number in ms or `false` to stop polling:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 useQuery({
@@ -37,7 +37,7 @@ useQuery({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 Returning `false` clears the interval timer. If the query result changes so the function would return a positive number again, polling resumes automatically.
 
@@ -45,7 +45,7 @@ Returning `false` clears the interval timer. If the query result changes so the 
 
 By default, polling pauses when the browser tab loses focus. For dashboards or any interface where data needs to stay current even while the user is in another tab, disable that behavior:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 useQuery({
@@ -56,13 +56,13 @@ useQuery({
 })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## Pausing polling
 
 Pass a function to `refetchInterval` and close over component state to control when polling runs:
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 useQuery({
@@ -75,13 +75,13 @@ useQuery({
 })
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ## Polling with offline support
 
 TanStack Query detects connectivity by listening to the browser's `online` and `offline` events. In environments where those events don't fire reliably (Electron, some embedded WebViews), set `networkMode: 'always'` to skip the connectivity check:
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ```tsx
 useQuery({
@@ -92,7 +92,7 @@ useQuery({
 })
 ```
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 For more on network modes, see [Network Mode](./network-mode.md).
 
@@ -100,10 +100,10 @@ For more on network modes, see [Network Mode](./network-mode.md).
 
 Each `QueryObserver` (each component using `useQuery` with `refetchInterval`) runs its own timer. Two components subscribed to the same key with `refetchInterval: 5000` each fire their timer every 5 seconds. What gets deduplicated is concurrent in-flight fetches: if two timers fire at the same time, only one network request goes out. The timers are observer-level; the deduplication is query-level.
 
-[//]: # 'ReactNative'
+[//]: # (ReactNative)
 
 ## Non-browser environments
 
 For non-browser runtimes like React Native, the standard `online`/`offline` and focus events aren't available. The [React Native guide](../react-native.md) covers how to connect `focusManager` and `onlineManager` to native app state APIs.
 
-[//]: # 'ReactNative'
+[//]: # (ReactNative)

--- a/docs/framework/react/guides/prefetching.md
+++ b/docs/framework/react/guides/prefetching.md
@@ -31,7 +31,7 @@ Before jumping into the different specific prefetch patterns, let's look at the 
 
 This is how you use `prefetchQuery`:
 
-[//]: # 'ExamplePrefetchQuery'
+[//]: # (ExamplePrefetchQuery)
 
 ```tsx
 const prefetchTodos = async () => {
@@ -43,11 +43,11 @@ const prefetchTodos = async () => {
 }
 ```
 
-[//]: # 'ExamplePrefetchQuery'
+[//]: # (ExamplePrefetchQuery)
 
 Infinite Queries can be prefetched like regular Queries. Per default, only the first page of the Query will be prefetched and will be stored under the given QueryKey. If you want to prefetch more than one page, you can use the `pages` option, in which case you also have to provide a `getNextPageParam` function:
 
-[//]: # 'ExamplePrefetchInfiniteQuery'
+[//]: # (ExamplePrefetchInfiniteQuery)
 
 ```tsx
 const prefetchProjects = async () => {
@@ -62,7 +62,7 @@ const prefetchProjects = async () => {
 }
 ```
 
-[//]: # 'ExamplePrefetchInfiniteQuery'
+[//]: # (ExamplePrefetchInfiniteQuery)
 
 Next, let's look at how you can use these and other ways to prefetch in different situations.
 
@@ -70,7 +70,7 @@ Next, let's look at how you can use these and other ways to prefetch in differen
 
 A straightforward form of prefetching is doing it when the user interacts with something. In this example we'll use `queryClient.prefetchQuery` to start a prefetch on `onMouseEnter` or `onFocus`.
 
-[//]: # 'ExampleEventHandler'
+[//]: # (ExampleEventHandler)
 
 ```tsx
 function ShowDetailsButton() {
@@ -94,13 +94,13 @@ function ShowDetailsButton() {
 }
 ```
 
-[//]: # 'ExampleEventHandler'
+[//]: # (ExampleEventHandler)
 
 ## Prefetch in components
 
 Prefetching during the component lifecycle is useful when we know some child or descendant will need a particular piece of data, but we can't render that until some other query has finished loading. Let's borrow an example from the Request Waterfall guide to explain:
 
-[//]: # 'ExampleComponent'
+[//]: # (ExampleComponent)
 
 ```tsx
 function Article({ id }) {
@@ -132,7 +132,7 @@ function Comments({ id }) {
 }
 ```
 
-[//]: # 'ExampleComponent'
+[//]: # (ExampleComponent)
 
 This results in a request waterfall looking like this:
 
@@ -145,7 +145,7 @@ As mentioned in that guide, one way to flatten this waterfall and improve perfor
 
 In that case, we can instead prefetch the query in the parent. The simplest way to do this is to use a query but ignore the result:
 
-[//]: # 'ExampleParentComponent'
+[//]: # (ExampleParentComponent)
 
 ```tsx
 function Article({ id }) {
@@ -185,7 +185,7 @@ function Comments({ id }) {
 }
 ```
 
-[//]: # 'ExampleParentComponent'
+[//]: # (ExampleParentComponent)
 
 This starts fetching `'article-comments'` immediately and flattens the waterfall:
 
@@ -194,7 +194,7 @@ This starts fetching `'article-comments'` immediately and flattens the waterfall
 1. |> getArticleCommentsById()
 ```
 
-[//]: # 'Suspense'
+[//]: # (Suspense)
 
 If you want to prefetch together with Suspense, you will have to do things a bit differently. You can't use `useSuspenseQueries` to prefetch, since the prefetch would block the component from rendering. You also can not use `useQuery` for the prefetch, because that wouldn't start the prefetch until after suspenseful query had resolved. For this scenario, you can use the [`usePrefetchQuery`](../reference/usePrefetchQuery.md) or the [`usePrefetchInfiniteQuery`](../reference/usePrefetchInfiniteQuery.md) hooks available in the library.
 
@@ -263,13 +263,13 @@ To recap, if you want to prefetch a query during the component lifecycle, there 
 
 Let's look at a slightly more advanced case next.
 
-[//]: # 'Suspense'
+[//]: # (Suspense)
 
 ### Dependent Queries & Code Splitting
 
 Sometimes we want to prefetch conditionally, based on the result of another fetch. Consider this example borrowed from the [Performance & Request Waterfalls guide](./request-waterfalls.md):
 
-[//]: # 'ExampleConditionally1'
+[//]: # (ExampleConditionally1)
 
 ```tsx
 // This lazy loads the GraphFeedItem component, meaning
@@ -310,7 +310,7 @@ function GraphFeedItem({ feedItem }) {
 }
 ```
 
-[//]: # 'ExampleConditionally1'
+[//]: # (ExampleConditionally1)
 
 As noted over in that guide, this example leads to the following double request waterfall:
 
@@ -322,7 +322,7 @@ As noted over in that guide, this example leads to the following double request 
 
 If we can not restructure our API so `getFeed()` also returns the `getGraphDataById()` data when necessary, there is no way to get rid of the `getFeed->getGraphDataById` waterfall, but by leveraging conditional prefetching, we can at least load the code and data in parallel. Just like described above, there are multiple ways to do this, but for this example, we'll do it in the query function:
 
-[//]: # 'ExampleConditionally2'
+[//]: # (ExampleConditionally2)
 
 ```tsx
 function Feed() {
@@ -349,7 +349,7 @@ function Feed() {
 }
 ```
 
-[//]: # 'ExampleConditionally2'
+[//]: # (ExampleConditionally2)
 
 This would load the code and data in parallel:
 
@@ -361,7 +361,7 @@ This would load the code and data in parallel:
 
 There is a tradeoff however, in that the code for `getGraphDataById` is now included in the parent bundle instead of in `JS for <GraphFeedItem>` so you'll need to determine what's the best performance tradeoff on a case by case basis. If `GraphFeedItem` are likely, it's probably worth to include the code in the parent. If they are exceedingly rare, it's probably not.
 
-[//]: # 'Router'
+[//]: # (Router)
 
 ## Router Integration
 
@@ -414,20 +414,20 @@ const articleRoute = new Route({
 
 Integration with other routers is also possible, see the [react-router](../examples/react-router) for another demonstration.
 
-[//]: # 'Router'
+[//]: # (Router)
 
 ## Manually Priming a Query
 
 If you already have the data for your query synchronously available, you don't need to prefetch it. You can just use the [Query Client's `setQueryData` method](../../../reference/QueryClient.md#queryclientsetquerydata) to directly add or update a query's cached result by key.
 
-[//]: # 'ExampleManualPriming'
+[//]: # (ExampleManualPriming)
 
 ```tsx
 queryClient.setQueryData(['todos'], todos)
 ```
 
-[//]: # 'ExampleManualPriming'
-[//]: # 'Materials'
+[//]: # (ExampleManualPriming)
+[//]: # (Materials)
 
 ## Further reading
 
@@ -435,4 +435,4 @@ For a deep-dive on how to get data into your Query Cache before you fetch, see t
 
 Integrating with Server Side routers and frameworks is very similar to what we just saw, with the addition that the data has to be passed from the server to the client to be hydrated into the cache there. To learn how, continue on to the [Server Rendering & Hydration guide](./ssr.md).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/queries.md
+++ b/docs/framework/react/guides/queries.md
@@ -7,18 +7,18 @@ title: Queries
 
 A query is a declarative dependency on an asynchronous source of data that is tied to a **unique key**. A query can be used with any Promise based method (including GET and POST methods) to fetch data from a server. If your method modifies data on the server, we recommend using [Mutations](./mutations.md) instead.
 
-[//]: # 'SubscribeDescription'
+[//]: # (SubscribeDescription)
 
 To subscribe to a query in your components or custom hooks, call the `useQuery` hook with at least:
 
-[//]: # 'SubscribeDescription'
+[//]: # (SubscribeDescription)
 
 - A **unique key for the query**
 - A function that returns a promise that:
   - Resolves the data, or
   - Throws an error
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 import { useQuery } from '@tanstack/react-query'
@@ -28,19 +28,19 @@ function App() {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 The **unique key** you provide is used internally for refetching, caching, and sharing your queries throughout your application.
 
 The query result returned by `useQuery` contains all of the information about the query that you'll need for templating and any other usage of the data:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 const result = useQuery({ queryKey: ['todos'], queryFn: fetchTodoList })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 The `result` object contains a few very important states you'll need to be aware of to be productive. A query can only be in one of the following states at any given moment:
 
@@ -56,7 +56,7 @@ Beyond those primary states, more information is available depending on the stat
 
 For **most** queries, it's usually sufficient to check for the `isPending` state, then the `isError` state, then finally, assume that the data is available and render the successful state:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 function Todos() {
@@ -84,11 +84,11 @@ function Todos() {
 }
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 If booleans aren't your thing, you can always use the `status` state as well:
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 function Todos() {
@@ -116,7 +116,7 @@ function Todos() {
 }
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 TypeScript will also narrow the type of `data` correctly if you've checked for `pending` and `error` before accessing it.
 
@@ -140,10 +140,10 @@ So keep in mind that a query can be in `pending` state without actually fetching
 - The `status` gives information about the `data`: Do we have any or not?
 - The `fetchStatus` gives information about the `queryFn`: Is it running or not?
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further Reading
 
 For an alternative way of performing status checks, have a look at [this article by TkDodo](https://tkdodo.eu/blog/status-checks-in-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/query-cancellation.md
+++ b/docs/framework/react/guides/query-cancellation.md
@@ -15,7 +15,7 @@ However, if you consume the `AbortSignal`, the Promise will be cancelled (e.g. a
 
 ## Using `fetch`
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 const query = useQuery({
@@ -40,11 +40,11 @@ const query = useQuery({
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ## Using `axios` [v0.22.0+](https://github.com/axios/axios/releases/tag/v0.22.0)
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 import axios from 'axios'
@@ -59,11 +59,11 @@ const query = useQuery({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ### Using `axios` with version lower than v0.22.0
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 import axios from 'axios'
@@ -90,11 +90,11 @@ const query = useQuery({
 })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## Using `XMLHttpRequest`
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 const query = useQuery({
@@ -116,13 +116,13 @@ const query = useQuery({
 })
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ## Using `graphql-request`
 
 An `AbortSignal` can be set in the client `request` method.
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ```tsx
 const client = new GraphQLClient(endpoint)
@@ -135,13 +135,13 @@ const query = useQuery({
 })
 ```
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ## Using `graphql-request` with version lower than v4.0.0
 
 An `AbortSignal` can be set in the `GraphQLClient` constructor.
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ```tsx
 const query = useQuery({
@@ -155,13 +155,13 @@ const query = useQuery({
 })
 ```
 
-[//]: # 'Example6'
+[//]: # (Example6)
 
 ## Manual Cancellation
 
 You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries({ queryKey })`, which will cancel the query and revert it back to its previous state. If you have consumed the `signal` passed to the query function, TanStack Query will additionally also cancel the Promise.
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ```tsx
 const query = useQuery({
@@ -186,7 +186,7 @@ return (
 )
 ```
 
-[//]: # 'Example7'
+[//]: # (Example7)
 
 ## `Cancel Options`
 
@@ -208,8 +208,8 @@ A cancel options object supports the following properties:
 
 ## Limitations
 
-[//]: # 'Limitations'
+[//]: # (Limitations)
 
 Cancellation does not work when working with `Suspense` hooks: `useSuspenseQuery`, `useSuspenseQueries` and `useSuspenseInfiniteQuery`.
 
-[//]: # 'Limitations'
+[//]: # (Limitations)

--- a/docs/framework/react/guides/query-functions.md
+++ b/docs/framework/react/guides/query-functions.md
@@ -9,7 +9,7 @@ On success, the resolved value may be anything **except `undefined`**. Queries t
 
 All of the following are valid query function configurations:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 useQuery({ queryKey: ['todos'], queryFn: fetchAllTodos })
@@ -27,13 +27,13 @@ useQuery({
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ## Handling and Throwing Errors
 
 For TanStack Query to determine a query has errored, the query function **must throw** or return a **rejected Promise**. Any error that is thrown in the query function will be persisted on the `error` state of the query.
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 const { error } = useQuery({
@@ -51,13 +51,13 @@ const { error } = useQuery({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ## Usage with `fetch` and other clients that do not throw by default
 
 While most utilities like `axios` or `graphql-request` automatically throw errors for unsuccessful HTTP calls, some utilities like `fetch` do not throw errors by default. If that's the case, you'll need to throw them on your own. Here is a simple way to do that with the popular `fetch` API:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 useQuery({
@@ -72,13 +72,13 @@ useQuery({
 })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## Query Function Variables
 
 Query keys are not just for uniquely identifying the data you are fetching, but are also conveniently passed into your query function as part of the QueryFunctionContext. While not always necessary, this makes it possible to extract your query functions if needed:
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 function Todos({ status, page }) {
@@ -95,7 +95,7 @@ function fetchTodoList({ queryKey }) {
 }
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ### QueryFunctionContext
 

--- a/docs/framework/react/guides/query-invalidation.md
+++ b/docs/framework/react/guides/query-invalidation.md
@@ -5,7 +5,7 @@ title: Query Invalidation
 
 Waiting for queries to become stale before they are fetched again doesn't always work, especially when you know for a fact that a query's data is out of date because of something the user has done. For that purpose, the `QueryClient` has an `invalidateQueries` method that lets you intelligently mark queries as stale and potentially refetch them too!
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 // Invalidate every query in the cache
@@ -14,7 +14,7 @@ queryClient.invalidateQueries()
 queryClient.invalidateQueries({ queryKey: ['todos'] })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 > Note: Where other libraries that use normalized caches would attempt to update local queries with the new data either imperatively or via schema inference, TanStack Query gives you the tools to avoid the manual labor that comes with maintaining normalized caches and instead prescribes **targeted invalidation, background-refetching and ultimately atomic updates**.
 
@@ -29,7 +29,7 @@ When using APIs like `invalidateQueries` and `removeQueries` (and others that su
 
 In this example, we can use the `todos` prefix to invalidate any queries that start with `todos` in their query key:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -50,11 +50,11 @@ const todoListQuery = useQuery({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 You can even invalidate queries with specific variables by passing a more specific query key to the `invalidateQueries` method:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 queryClient.invalidateQueries({
@@ -74,11 +74,11 @@ const todoListQuery = useQuery({
 })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 The `invalidateQueries` API is very flexible, so even if you want to **only** invalidate `todos` queries that don't have any more variables or subkeys, you can pass an `exact: true` option to the `invalidateQueries` method:
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 queryClient.invalidateQueries({
@@ -99,11 +99,11 @@ const todoListQuery = useQuery({
 })
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 If you find yourself wanting **even more** granularity, you can pass a predicate function to the `invalidateQueries` method. This function will receive each `Query` instance from the query cache and allow you to return `true` or `false` for whether you want to invalidate that query:
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ```tsx
 queryClient.invalidateQueries({
@@ -130,4 +130,4 @@ const todoListQuery = useQuery({
 })
 ```
 
-[//]: # 'Example5'
+[//]: # (Example5)

--- a/docs/framework/react/guides/query-keys.md
+++ b/docs/framework/react/guides/query-keys.md
@@ -12,7 +12,7 @@ The simplest form of a key is an array with constants values. This format is use
 - Generic List/Index resources
 - Non-hierarchical resources
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 // A list of todos
@@ -22,7 +22,7 @@ useQuery({ queryKey: ['todos'], ... })
 useQuery({ queryKey: ['something', 'special'], ... })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ## Array Keys with variables
 
@@ -33,7 +33,7 @@ When a query needs more information to uniquely describe its data, you can use a
 - Queries with additional parameters
   - It's common to pass an object of additional options
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 // An individual todo
@@ -46,13 +46,13 @@ useQuery({ queryKey: ['todo', 5, { preview: true }], ...})
 useQuery({ queryKey: ['todos', { type: 'done' }], ... })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ## Query Keys are hashed deterministically!
 
 This means that no matter the order of keys in objects, all of the following queries are considered equal:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 useQuery({ queryKey: ['todos', { status, page }], ... })
@@ -60,11 +60,11 @@ useQuery({ queryKey: ['todos', { page, status }], ...})
 useQuery({ queryKey: ['todos', { page, status, other: undefined }], ... })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 The following query keys, however, are not equal. Array item order matters!
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 useQuery({ queryKey: ['todos', status, page], ... })
@@ -72,13 +72,13 @@ useQuery({ queryKey: ['todos', page, status], ...})
 useQuery({ queryKey: ['todos', undefined, page, status], ...})
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ## If your query function depends on a variable, include it in your query key
 
 Since query keys uniquely describe the data they are fetching, they should include any variables you use in your query function that **change**. For example:
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 ```tsx
 function Todos({ todoId }) {
@@ -89,15 +89,15 @@ function Todos({ todoId }) {
 }
 ```
 
-[//]: # 'Example5'
+[//]: # (Example5)
 
 Note that query keys act as dependencies for your query functions. Adding dependent variables to your query key will ensure that queries are cached independently, and that any time a variable changes, _queries will be refetched automatically_ (depending on your `staleTime` settings). See the [exhaustive-deps](../../../eslint/exhaustive-deps.md) section for more information and examples.
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further reading
 
 For tips on organizing Query Keys in larger applications, have a look at [Effective React Query Keys](https://tkdodo.eu/blog/effective-react-query-keys) and check the [Query Key Factory Package](https://github.com/lukemorales/query-key-factory) from
 the [Community Resources](../../../community-resources).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/guides/query-options.md
+++ b/docs/framework/react/guides/query-options.md
@@ -5,7 +5,7 @@ title: Query Options
 
 One of the best ways to share `queryKey` and `queryFn` between multiple places, yet keep them co-located to one another, is to use the `queryOptions` helper. At runtime, this helper just returns whatever you pass into it, but it has a lot of advantages when using it [with TypeScript](../typescript.md#typing-query-options). You can define all possible options for a query in one place, and you'll also get type inference and type safety for all of them.
 
-[//]: # 'Example1'
+[//]: # (Example1)
 
 ```ts
 import { queryOptions } from '@tanstack/react-query'
@@ -29,16 +29,16 @@ queryClient.prefetchQuery(groupOptions(23))
 queryClient.setQueryData(groupOptions(42).queryKey, newGroups)
 ```
 
-[//]: # 'Example1'
+[//]: # (Example1)
 
 For Infinite Queries, a separate [`infiniteQueryOptions`](../reference/infiniteQueryOptions.md) helper is available.
 
-[//]: # 'SelectDescription'
+[//]: # (SelectDescription)
 
 You can still override some options at the component level. A very common and useful pattern is to create per-component [`select`](./render-optimizations.md#select) functions:
 
-[//]: # 'SelectDescription'
-[//]: # 'Example2'
+[//]: # (SelectDescription)
+[//]: # (Example2)
 
 ```ts
 // Type inference still works, so query.data will be the return type of select instead of queryFn
@@ -49,4 +49,4 @@ const query = useQuery({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)

--- a/docs/framework/react/guides/query-retries.md
+++ b/docs/framework/react/guides/query-retries.md
@@ -12,12 +12,12 @@ You can configure retries both on a global level and an individual query level.
 - Setting `retry = true` will infinitely retry failing requests.
 - Setting `retry = (failureCount, error) => ...` allows for custom logic based on why the request failed. Note that `failureCount` starts at `0` for the first retry attempt.
 
-[//]: # 'Info'
+[//]: # (Info)
 
 > On the server, retries default to `0` to make server rendering as fast as possible.
 
-[//]: # 'Info'
-[//]: # 'Example'
+[//]: # (Info)
+[//]: # (Example)
 
 ```tsx
 import { useQuery } from '@tanstack/react-query'
@@ -30,7 +30,7 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 > Info: Contents of the `error` property will be part of `failureReason` response property of `useQuery` until the last retry attempt. So in above example any error contents will be part of `failureReason` property for first 9 retry attempts (Overall 10 attempts) and finally they will be part of `error` after last attempt if error persists after all retry attempts.
 
@@ -40,7 +40,7 @@ By default, retries in TanStack Query do not happen immediately after a request 
 
 The default `retryDelay` is set to double (starting at `1000`ms) with each attempt, but not exceed 30 seconds:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 // Configure for all queries
@@ -63,11 +63,11 @@ function App() {
 }
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 Though it is not recommended, you can obviously override the `retryDelay` function/integer in both the Provider and individual query options. If set to an integer instead of a function the delay will always be the same amount of time:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 const result = useQuery({
@@ -77,7 +77,7 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ## Background Retry Behavior
 
@@ -85,7 +85,7 @@ When using `refetchInterval` with `refetchIntervalInBackground: true`, retries w
 
 If you need continuous retries in the background, consider disabling retries and implementing a custom refetch strategy:
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 const result = useQuery({
@@ -100,6 +100,6 @@ const result = useQuery({
 })
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 This approach lets you control retry timing manually while keeping refetches active in the background.

--- a/docs/framework/react/guides/request-waterfalls.md
+++ b/docs/framework/react/guides/request-waterfalls.md
@@ -11,11 +11,11 @@ The [Prefetching & Router Integration guide](./prefetching.md) builds on this an
 
 The [Server Rendering & Hydration guide](./ssr.md) teaches you how to prefetch data on the server and pass that data down to the client so you don't have to fetch it again.
 
-[//]: # 'AdvancedSSRLink'
+[//]: # (AdvancedSSRLink)
 
 The [Advanced Server Rendering guide](./advanced-ssr.md) further teaches you how to apply these patterns to Server Components and Streaming Server Rendering.
 
-[//]: # 'AdvancedSSRLink'
+[//]: # (AdvancedSSRLink)
 
 ## What is a Request Waterfall?
 
@@ -71,7 +71,7 @@ With this as a basis, let's look at a few different patterns that can lead to Re
 
 When a single component first fetches one query, and then another, that's a request waterfall. This can happen when the second query is a [Dependent Query](./dependent-queries.md), that is, it depends on data from the first query when fetching:
 
-[//]: # 'DependentExample'
+[//]: # (DependentExample)
 
 ```tsx
 // Get the user
@@ -95,16 +95,16 @@ const {
 })
 ```
 
-[//]: # 'DependentExample'
+[//]: # (DependentExample)
 
 While not always feasible, for optimal performance it's better to restructure your API so you can fetch both of these in a single query. In the example above, instead of first fetching `getUserByEmail` to be able to `getProjectsByUser`, introducing a new `getProjectsByUserEmail` query would flatten the waterfall.
 
-[//]: # 'ServerComponentsNote1'
+[//]: # (ServerComponentsNote1)
 
 > Another way to mitigate dependent queries without restructuring your API is to move the waterfall to the server where latency is lower. This is the idea behind Server Components which are covered in the [Advanced Server Rendering guide](./advanced-ssr.md).
 
-[//]: # 'ServerComponentsNote1'
-[//]: # 'SuspenseSerial'
+[//]: # (ServerComponentsNote1)
+[//]: # (SuspenseSerial)
 
 Another example of serial queries is when you use React Query with Suspense:
 
@@ -135,21 +135,21 @@ const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
 })
 ```
 
-[//]: # 'SuspenseSerial'
+[//]: # (SuspenseSerial)
 
 ### Nested Component Waterfalls
 
-[//]: # 'NestedIntro'
+[//]: # (NestedIntro)
 
 Nested Component Waterfalls is when both a parent and a child component contains queries, and the parent does not render the child until its query is done. This can happen both with `useQuery` and `useSuspenseQuery`.
 
-[//]: # 'NestedIntro'
+[//]: # (NestedIntro)
 
 If the child renders conditionally based on the data in the parent, or if the child relies on some part of the result being passed down as a prop from the parent to make its query, we have a _dependent_ nested component waterfall.
 
 Let's first look at an example where the child is **not** dependent on the parent.
 
-[//]: # 'NestedExample'
+[//]: # (NestedExample)
 
 ```tsx
 function Article({ id }) {
@@ -182,11 +182,11 @@ function Comments({ id }) {
 }
 ```
 
-[//]: # 'NestedExample'
+[//]: # (NestedExample)
 
 Note that while `<Comments>` takes a prop `id` from the parent, that id is already available when the `<Article>` renders so there is no reason we could not fetch the comments at the same time as the article. In real world applications, the child might be nested far below the parent and these kinds of waterfalls are often trickier to spot and fix, but for our example, one way to flatten the waterfall would be to hoist the comments query to the parent instead:
 
-[//]: # 'NestedHoistedExample'
+[//]: # (NestedHoistedExample)
 
 ```tsx
 function Article({ id }) {
@@ -218,18 +218,18 @@ function Article({ id }) {
 }
 ```
 
-[//]: # 'NestedHoistedExample'
-[//]: # 'NestedHoistedOutro'
+[//]: # (NestedHoistedExample)
+[//]: # (NestedHoistedOutro)
 
 The two queries will now fetch in parallel. Note that if you are using suspense, you'd want to combine these two queries into a single `useSuspenseQueries` instead.
 
-[//]: # 'NestedHoistedOutro'
+[//]: # (NestedHoistedOutro)
 
 Another way to flatten this waterfall would be to prefetch the comments in the `<Article>` component, or prefetch both of these queries at the router level on page load or page navigation, read more about this in the [Prefetching & Router Integration guide](./prefetching.md).
 
 Next, let's look at a _Dependent Nested Component Waterfall_.
 
-[//]: # 'DependentNestedExample'
+[//]: # (DependentNestedExample)
 
 ```tsx
 function Feed() {
@@ -265,7 +265,7 @@ function GraphFeedItem({ feedItem }) {
 }
 ```
 
-[//]: # 'DependentNestedExample'
+[//]: # (DependentNestedExample)
 
 The second query `getGraphDataById` is dependent on its parent in two different ways. First of all, it doesn't ever happen unless the `feedItem` is a graph, and second, it needs an `id` from the parent.
 
@@ -274,11 +274,11 @@ The second query `getGraphDataById` is dependent on its parent in two different 
 2.   |> getGraphDataById()
 ```
 
-[//]: # 'ServerComponentsNote2'
+[//]: # (ServerComponentsNote2)
 
 In this example, we can't trivially flatten the waterfall by just hoisting the query to the parent, or even adding prefetching. Just like the dependent query example at the beginning of this guide, one option is to refactor our API to include the graph data in the `getFeed` query. Another more advanced solution is to leverage Server Components to move the waterfall to the server where latency is lower (read more about this in the [Advanced Server Rendering guide](./advanced-ssr.md)) but note that this can be a very big architectural change.
 
-[//]: # 'ServerComponentsNote2'
+[//]: # (ServerComponentsNote2)
 
 You can have good performance even with a few query waterfalls here and there, just know they are a common performance concern and be mindful about them. An especially insidious version is when Code Splitting is involved, let's take a look at this next.
 
@@ -288,7 +288,7 @@ Splitting an applications JS-code into smaller chunks and only loading the neces
 
 Consider this a slightly modified version of the Feed example.
 
-[//]: # 'LazyExample'
+[//]: # (LazyExample)
 
 ```tsx
 // This lazy loads the GraphFeedItem component, meaning
@@ -329,7 +329,7 @@ function GraphFeedItem({ feedItem }) {
 }
 ```
 
-[//]: # 'LazyExample'
+[//]: # (LazyExample)
 
 This example has a double waterfall, looking like this:
 
@@ -361,7 +361,7 @@ In the code split case, it might actually help to hoist the `getGraphDataById` q
 
 This is very much a tradeoff however. You are now including the data fetching code for `getGraphDataById` in the same bundle as `<Feed>`, so evaluate what is best for your case. Read more about how to do this in the [Prefetching & Router Integration guide](./prefetching.md).
 
-[//]: # 'ServerComponentsNote3'
+[//]: # (ServerComponentsNote3)
 
 > The tradeoff between:
 >
@@ -370,7 +370,7 @@ This is very much a tradeoff however. You are now including the data fetching co
 >
 > is not great and has been one of the motivations for Server Components. With Server Components, it's possible to avoid both, read more about how this applies to React Query in the [Advanced Server Rendering guide](./advanced-ssr.md).
 
-[//]: # 'ServerComponentsNote3'
+[//]: # (ServerComponentsNote3)
 
 ## Summary and takeaways
 

--- a/docs/framework/react/guides/updates-from-mutation-responses.md
+++ b/docs/framework/react/guides/updates-from-mutation-responses.md
@@ -5,7 +5,7 @@ title: Updates from Mutation Responses
 
 When dealing with mutations that **update** objects on the server, it's common for the new object to be automatically returned in the response of the mutation. Instead of refetching any queries for that item and wasting a network call for data we already have, we can take advantage of the object returned by the mutation function and update the existing query with the new data immediately using the [Query Client's `setQueryData`](../../../reference/QueryClient.md#queryclientsetquerydata) method:
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 const queryClient = useQueryClient()
@@ -30,12 +30,12 @@ const { status, data, error } = useQuery({
 })
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 You might want to tie the `onSuccess` logic into a reusable mutation, for that you can
 create a custom hook like this:
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 const useMutateTodo = () => {
@@ -51,13 +51,13 @@ const useMutateTodo = () => {
 }
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ## Immutability
 
 Updates via `setQueryData` must be performed in an _immutable_ way. **DO NOT** attempt to write directly to the cache by mutating data (that you retrieved from the cache) in place. It might work at first but can lead to subtle bugs along the way.
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 queryClient.setQueryData(['posts', { id }], (oldData) => {
@@ -81,4 +81,4 @@ queryClient.setQueryData(
 )
 ```
 
-[//]: # 'Example3'
+[//]: # (Example3)

--- a/docs/framework/react/guides/window-focus-refetching.md
+++ b/docs/framework/react/guides/window-focus-refetching.md
@@ -7,7 +7,7 @@ If a user leaves your application and returns and the query data is stale, **Tan
 
 #### Disabling Globally
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ```tsx
 //
@@ -24,11 +24,11 @@ function App() {
 }
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 #### Disabling Per-Query
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ```tsx
 useQuery({
@@ -38,13 +38,13 @@ useQuery({
 })
 ```
 
-[//]: # 'Example2'
+[//]: # (Example2)
 
 ## Custom Window Focus Event
 
 In rare circumstances, you may want to manage your own window focus events that trigger TanStack Query to revalidate. To do this, TanStack Query provides a `focusManager.setEventListener` function that supplies you the callback that should be fired when the window is focused and allows you to set up your own events. When calling `focusManager.setEventListener`, the previously set handler is removed (which in most cases will be the default handler) and your new handler is used instead. For example, this is the default handler:
 
-[//]: # 'Example3'
+[//]: # (Example3)
 
 ```tsx
 focusManager.setEventListener((handleFocus) => {
@@ -62,8 +62,8 @@ focusManager.setEventListener((handleFocus) => {
 })
 ```
 
-[//]: # 'Example3'
-[//]: # 'ReactNative'
+[//]: # (Example3)
+[//]: # (ReactNative)
 
 ## Managing Focus in React Native
 
@@ -86,11 +86,11 @@ useEffect(() => {
 }, [])
 ```
 
-[//]: # 'ReactNative'
+[//]: # (ReactNative)
 
 ## Managing focus state
 
-[//]: # 'Example4'
+[//]: # (Example4)
 
 ```tsx
 import { focusManager } from '@tanstack/react-query'
@@ -102,4 +102,4 @@ focusManager.setFocused(true)
 focusManager.setFocused(undefined)
 ```
 
-[//]: # 'Example4'
+[//]: # (Example4)

--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -37,19 +37,19 @@ or
 deno add @tanstack/react-query
 ```
 
-[//]: # 'Compatibility'
+[//]: # (Compatibility)
 
 React Query is compatible with React v18+ and works with ReactDOM and React Native.
 
 > Wanna give it a spin before you download? Try out the [simple](./examples/simple) or [basic](./examples/basic) examples!
 
-[//]: # 'Compatibility'
+[//]: # (Compatibility)
 
 ### CDN
 
 If you're not using a module bundler or package manager, you can also use this library via an ESM-compatible CDN such as [ESM.sh](https://esm.sh/). Simply add a `<script type="module">` tag to the bottom of your HTML file:
 
-[//]: # 'CDNExample'
+[//]: # (CDNExample)
 
 ```html
 <script type="module">
@@ -61,7 +61,7 @@ If you're not using a module bundler or package manager, you can also use this l
 
 > You can find instructions on how to use React without JSX [here](https://react.dev/reference/react/createElement#creating-an-element-without-jsx).
 
-[//]: # 'CDNExample'
+[//]: # (CDNExample)
 
 ### Requirements
 

--- a/docs/framework/react/overview.md
+++ b/docs/framework/react/overview.md
@@ -40,7 +40,7 @@ On a more technical note, TanStack Query will likely:
 - Have a direct impact on your end-users by making your application feel faster and more responsive than ever before
 - Potentially help you save on bandwidth and increase memory performance
 
-[//]: # 'Example'
+[//]: # (Example)
 
 ## Enough talk, show me some code already!
 
@@ -90,8 +90,8 @@ function Example() {
 }
 ```
 
-[//]: # 'Example'
-[//]: # 'Materials'
+[//]: # (Example)
+[//]: # (Materials)
 
 ## You talked me into it, so what now?
 
@@ -99,4 +99,4 @@ function Example() {
 - Learn TanStack Query at your own pace with our amazingly thorough [Walkthrough Guide](./installation.md) and [API Reference](./reference/useQuery.md)
 - See the Article [Why You Want React Query](https://tkdodo.eu/blog/why-you-want-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -9,7 +9,7 @@ This code snippet very briefly illustrates the 3 core concepts of React Query:
 - [Mutations](./guides/mutations.md)
 - [Query Invalidation](./guides/query-invalidation.md)
 
-[//]: # 'Example'
+[//]: # (Example)
 
 If you're looking for a fully functioning example, please have a look at our [simple StackBlitz example](./examples/simple)
 
@@ -76,6 +76,6 @@ function Todos() {
 render(<App />, document.getElementById('root'))
 ```
 
-[//]: # 'Example'
+[//]: # (Example)
 
 These three concepts make up most of the core functionality of React Query. The next sections of the documentation will go over each of these core concepts in great detail.

--- a/docs/framework/react/reference/hydration.md
+++ b/docs/framework/react/reference/hydration.md
@@ -98,7 +98,7 @@ hydrate(queryClient, dehydratedState, options)
 
 If the queries you're trying to hydrate already exist in the queryCache, `hydrate` will only overwrite them if the data is newer than the data present in the cache. Otherwise, it will **not** get applied.
 
-[//]: # 'HydrationBoundary'
+[//]: # (HydrationBoundary)
 
 ## `HydrationBoundary`
 
@@ -125,4 +125,4 @@ function App() {
   - `queryClient?: QueryClient`
     - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
-[//]: # 'HydrationBoundary'
+[//]: # (HydrationBoundary)

--- a/docs/framework/react/reference/queryOptions.md
+++ b/docs/framework/react/reference/queryOptions.md
@@ -23,10 +23,10 @@ You can generally pass everything to `queryOptions` that you can also pass to [`
   - When set to `true`, queries will be prefetched during render, which can be useful for certain optimization scenarios
   - Needs to be turned on for the experimental `useQuery().promise` functionality
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further reading
 
 To learn more about `QueryOptions`, have a look at [this article by TkDodo The Query Options API](https://tkdodo.eu/blog/the-query-options-api).
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/react/typescript.md
+++ b/docs/framework/react/typescript.md
@@ -16,7 +16,7 @@ Things to keep in mind:
 
 Types in React Query generally flow through very well so that you don't have to provide type annotations for yourself
 
-[//]: # 'TypeInference1'
+[//]: # (TypeInference1)
 
 ```tsx
 const { data } = useQuery({
@@ -28,8 +28,8 @@ const { data } = useQuery({
 
 [typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVwM4FMCKz1QJ5wC+cAZlBCHAORToCGAxjALQCOO+VAsAFC8MQAdqnhIAJnRh0icALwoM2XHgAUAbSqDkIAEa4qAXQA0cFQEo5APjgAFciGAYAdLVQQANgDd0KgKxmzXgB6ILgw8IA9AH5eIA)
 
-[//]: # 'TypeInference1'
-[//]: # 'TypeInference2'
+[//]: # (TypeInference1)
+[//]: # (TypeInference2)
 
 ```tsx
 const { data } = useQuery({
@@ -42,11 +42,11 @@ const { data } = useQuery({
 
 [typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVwM4FMCKz1QJ5wC+cAZlBCHAORToCGAxjALQCOO+VAsAFC8MQAdqnhIAJnRh0icALwoM2XHgAUAbSox0IqgF0ANHBUBKOQD44ABXIhgGAHS1UEADYA3dCoCsxw0gwu6EwAXHASUuZhknT2MBAAyjBQwIIA5iaExrwA9Nlw+QUAegD8vEA)
 
-[//]: # 'TypeInference2'
+[//]: # (TypeInference2)
 
 This works best if your `queryFn` has a well-defined returned type. Keep in mind that most data fetching libraries return `any` per default, so make sure to extract it to a properly typed function:
 
-[//]: # 'TypeInference3'
+[//]: # (TypeInference3)
 
 ```tsx
 const fetchGroups = (): Promise<Group[]> =>
@@ -58,13 +58,13 @@ const { data } = useQuery({ queryKey: ['groups'], queryFn: fetchGroups })
 
 [typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVwM4FMCKz1QJ5wC+cAZlBCHAORToCGAxjALQCOO+VAsAFCiSw4dAB7AIqUuUpURY1Nx68YeMOjgBxcsjBwAvIjjAAJgC44AO2QgARriK9eDCOdTwS6GAwAWmiNon6ABQAlGYAClLAGAA8vtoA2gC6AHx6qbLiAHQA5h6BVAD02Vpg8sGZMF7o5oG0qJAuarqpdQ0YmUZ0MHTBDjxOLvBInd1EeigY2Lh4gfFUxX6lVIkANKQe3nGlvTwFBXAHhwB6APxwA65wI3RmW0lwAD4o5kboJMDm6Ea8QA)
 
-[//]: # 'TypeInference3'
+[//]: # (TypeInference3)
 
 ## Type Narrowing
 
 React Query uses a [discriminated union type](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions) for the query result, discriminated by the `status` field and the derived status boolean flags. This will allow you to check for e.g. `success` status to make `data` defined:
 
-[//]: # 'TypeNarrowing'
+[//]: # (TypeNarrowing)
 
 ```tsx
 const { data, isSuccess } = useQuery({
@@ -80,13 +80,13 @@ if (isSuccess) {
 
 [typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVwM4FMCKz1QJ5wC+cAZlBCHAORToCGAxjALQCOO+VAsAFC8MQAdqnhIAJnRh0ANHGCoAysgYN0qVETgBeFBmy48ACgDaVGGphUAurMMBKbQD44ABXIh56AHS1UEADYAbuiGAKx2dry8wCRwhvJKKmqoDgi8cBlwElK8APS5GQB6APy8hLxAA)
 
-[//]: # 'TypeNarrowing'
+[//]: # (TypeNarrowing)
 
 ## Typing the error field
 
 The type for error defaults to `Error`, because that is what most users expect.
 
-[//]: # 'TypingError'
+[//]: # (TypingError)
 
 ```tsx
 const { error } = useQuery({ queryKey: ['groups'], queryFn: fetchGroups })
@@ -95,22 +95,22 @@ const { error } = useQuery({ queryKey: ['groups'], queryFn: fetchGroups })
 
 [typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVwM4FMCKz1QJ5wC+cAZlBCHAOQACMAhgHaoMDGA1gPRTr2swBaAI458VALAAoUJFhx6AD2ARUpcpSqLlqCZKkw8YdHADi5ZGDgBeRHGAATAFxxGyEACNcRKVNYRm8CToMKwAFmYQFqo2ABQAlM4ACurAGAA8ERYA2gC6AHzWBVoqAHQA5sExVJxl5mA6cSUwoeiMMTyokMzGVgUdXRgl9vQMcT6SfgG2uORQRNYoGNi4eDFZVLWR9VQ5ADSkwWGZ9WOSnJxwl1cAegD8QA)
 
-[//]: # 'TypingError'
+[//]: # (TypingError)
 
 If you want to throw a custom error, or something that isn't an `Error` at all, you can specify the type of the error field:
 
-[//]: # 'TypingError2'
+[//]: # (TypingError2)
 
 ```tsx
 const { error } = useQuery<Group[], string>(['groups'], fetchGroups)
 //      ^? const error: string | null
 ```
 
-[//]: # 'TypingError2'
+[//]: # (TypingError2)
 
 However, this has the drawback that type inference for all other generics of `useQuery` will not work anymore. It is generally not considered a good practice to throw something that isn't an `Error`, so if you have a subclass like `AxiosError` you can use _type narrowing_ to make the error field more specific:
 
-[//]: # 'TypingError3'
+[//]: # (TypingError3)
 
 ```tsx
 import axios from 'axios'
@@ -126,13 +126,13 @@ if (axios.isAxiosError(error)) {
 
 [typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVwM4FMCKz1QJ5wC+cAZlBCHAOQACMAhgHaoMDGA1gPRTr2swBaAI458VALAAoUJFhx6AD2ARUpcpSqLlqCZKkw8YdHADi5ZGDgBeRHGAATAFxxGyEACNcRKVNYRm8CToMKwAFmYQFqo2ABQAlM4ACurAGAA8ERYA2gC6AHzWBVoqAHQA5sExVJxl5mA6cSUwoeiMMTyokMzGVgUdXRgl9vQMcT6SfgG2uORQRNYoGNi4eDFIIisA0uh4zllUtZH1VDkANHAb+ABijM5BIeF1qoRjkpyccJ9fAHoA-OPAEhwGLFVAlVIAQSUKgAolBZjEZtA4nFEFJPkioOi4O84H8pIQgA)
 
-[//]: # 'TypingError3'
+[//]: # (TypingError3)
 
 ### Registering a global Error
 
 TanStack Query v5 allows for a way to set a global Error type for everything, without having to specify generics on call-sides, by amending the `Register` interface. This will make sure inference still works, but the error field will be of the specified type. If you want to enforce that call-sides must do explicit type-narrowing, set `defaultError` to `unknown`:
 
-[//]: # 'RegisterErrorType'
+[//]: # (RegisterErrorType)
 
 ```tsx
 import '@tanstack/react-query'
@@ -148,8 +148,8 @@ const { error } = useQuery({ queryKey: ['groups'], queryFn: fetchGroups })
 //      ^? const error: unknown | null
 ```
 
-[//]: # 'RegisterErrorType'
-[//]: # 'TypingMeta'
+[//]: # (RegisterErrorType)
+[//]: # (TypingMeta)
 
 ## Typing meta
 
@@ -172,8 +172,8 @@ declare module '@tanstack/react-query' {
 }
 ```
 
-[//]: # 'TypingMeta'
-[//]: # 'TypingQueryAndMutationKeys'
+[//]: # (TypingMeta)
+[//]: # (TypingQueryAndMutationKeys)
 
 ## Typing query and mutation keys
 
@@ -194,8 +194,8 @@ declare module '@tanstack/react-query' {
 }
 ```
 
-[//]: # 'TypingQueryAndMutationKeys'
-[//]: # 'TypingQueryOptions'
+[//]: # (TypingQueryAndMutationKeys)
+[//]: # (TypingQueryOptions)
 
 ## Typing Query Options
 
@@ -264,17 +264,17 @@ useIsMutating(groupMutationOptions())
 queryClient.isMutating(groupMutationOptions())
 ```
 
-[//]: # 'TypingQueryOptions'
+[//]: # (TypingQueryOptions)
 
 ## Typesafe disabling of queries using `skipToken`
 
 If you are using TypeScript, you can use the `skipToken` to disable a query. This is useful when you want to disable a query based on a condition, but you still want to keep the query to be type safe.
 Read more about it in the [Disabling Queries](./guides/disabling-queries.md) guide.
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further Reading
 
 For tips and tricks around type inference, see the article [React Query and TypeScript](https://tkdodo.eu/blog/react-query-and-type-script). To find out how to get the best possible type-safety, you can read [Type-safe React Query](https://tkdodo.eu/blog/type-safe-react-query). [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) outlines how type inference works with the `queryOptions` helper function.
 
-[//]: # 'Materials'
+[//]: # (Materials)

--- a/docs/framework/solid/typescript.md
+++ b/docs/framework/solid/typescript.md
@@ -129,7 +129,7 @@ if (axios.isAxiosError(query.error)) {
 
 [typescript playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgYygUwIYzQRQK5pQCecAvnAGZQQhwDkAAjBgHYDOzyA1gPRsQAbYABMAtAEcCxOgFgAUKEiw4GAB7AIbStVp01GtrLnyYRMGjgBxanjBwAvIjgiAXHBZ4QAI0Jl585Ah2eAo0GGQAC2sIWy1HAAoASjcABR1gNjQAHmjbAG0AXQA+BxL9TQA6AHMw+LoeKpswQ0SKmAi0Fnj0Nkh2C3sSnr7MiuEsDET-OUDguElCEkdUTGx8Rfik0rh4hHk4A-mpIgBpNCI3PLpGmOa6AoAaOH3DheIAMRY3UPCoprYHvJSIkpsY5G8iBVCNQoPIeDxDnAAHoAfmmwAoO3KbAqGQAgupNABRKAw+IQqGk6AgxAvA4U6HQOlweGI1FA+RAA)
 
-[//]: # 'RegisterErrorType'
+[//]: # (RegisterErrorType)
 
 ```tsx
 import '@tanstack/solid-query'
@@ -150,7 +150,7 @@ query.error
 //    ^? (property) error: unknown | null
 ```
 
-[//]: # 'RegisterErrorType'
+[//]: # (RegisterErrorType)
 
 ## Registering global `Meta`
 

--- a/docs/framework/vue/guides/prefetching.md
+++ b/docs/framework/vue/guides/prefetching.md
@@ -5,7 +5,7 @@ title: Prefetching
 
 If you're lucky enough, you may know enough about what your users will do to be able to prefetch the data they need before it's needed! If this is the case, you can use the `prefetchQuery` method to prefetch the results of a query to be placed into the cache:
 
-[//]: # 'ExamplePrefetching'
+[//]: # (ExamplePrefetching)
 
 ```tsx
 const prefetchTodos = async () => {
@@ -17,7 +17,7 @@ const prefetchTodos = async () => {
 }
 ```
 
-[//]: # 'ExamplePrefetching'
+[//]: # (ExamplePrefetching)
 
 - If **fresh** data for this query is already in the cache, the data will not be fetched
 - If a `staleTime` is passed eg. `prefetchQuery({ queryKey: ['todos'], queryFn: fn, staleTime: 5000 })` and the data is older than the specified `staleTime`, the query will be fetched
@@ -27,7 +27,7 @@ const prefetchTodos = async () => {
 
 Infinite Queries can be prefetched like regular Queries. Per default, only the first page of the Query will be prefetched and will be stored under the given QueryKey. If you want to prefetch more than one page, you can use the `pages` option, in which case you also have to provide a `getNextPageParam` function:
 
-[//]: # 'ExampleInfiniteQuery'
+[//]: # (ExampleInfiniteQuery)
 
 ```tsx
 const prefetchProjects = async () => {
@@ -42,6 +42,6 @@ const prefetchProjects = async () => {
 }
 ```
 
-[//]: # 'ExampleInfiniteQuery'
+[//]: # (ExampleInfiniteQuery)
 
 The above code will try to prefetch 3 pages in order, and `getNextPageParam` will be executed for each page to determine the next page to prefetch. If `getNextPageParam` returns `undefined`, the prefetching will stop.

--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -114,10 +114,10 @@ The `clear` method can be used to clear the cache entirely and start fresh.
 queryCache.clear()
 ```
 
-[//]: # 'Materials'
+[//]: # (Materials)
 
 ## Further reading
 
 To get a better understanding how the QueryCache works internally, have a look at [the Inside React Query article by TkDodo](https://tkdodo.eu/blog/inside-react-query).
 
-[//]: # 'Materials'
+[//]: # (Materials)


### PR DESCRIPTION
## 🎯 Changes

Fixes visible `[//]: # 'Example'` markers appearing literally in the
rendered documentation (e.g. on the Queries guide page).

The intended Markdown "hidden comment" syntax requires parentheses, not
quotes:

    [//]: # (comment)

The docs were using single quotes instead:

    [//]: # 'comment'

This is not recognized as a hidden link-reference by Markdown parsers, so
the marker renders visibly on the page instead of being hidden.

**Root cause:** most framework-specific docs (Vue, Angular, Solid, Svelte)
are generated from the `react/` source files via `scripts/generate-docs.ts`.
The malformed syntax originated in the `react/` source and was propagated
to every generated file.

**Fix:** updated the syntax only in the 38 source files that do not have a
`ref:` frontmatter field (i.e. the files that are not auto-generated).
Running `pnpm generate-docs` will propagate this fix to the remaining
generated files automatically.

Confirmed no project code references the old pattern:

    grep -r "\[//\]: #" --include="*.js" --include="*.ts" --include="*.mjs" .

(no matches found)

Note: was unable to run `pnpm run test:pr` locally due to unstable network
conditions while installing dependencies. Verified the change manually via
`sed` dry-runs and `git diff --stat` (38 files changed, 1:1 line
replacement, no unintended additions/removals).

## ✅ Checklist
- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact
- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized documentation markers and section boundaries across many framework guides for more consistent rendering.
  * Added or expanded guidance in a few guides, including mutations, prefetching, query retries, and parallel queries.
  * Clarified several best practices and behaviors around mutation handling, background retries, optimistic updates, and query prefetching.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->