### PR TITLE
fix: resetQueries predicate filter no longer matches after reset

### DIFF
--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -260,13 +260,22 @@ export class QueryClient {
     const queryCache = this.#queryCache
 
     return notifyManager.batch(() => {
-      queryCache.findAll(filters).forEach((query) => {
+      const queries = queryCache.findAll(filters)
+
+      queries.forEach((query) => {
         query.reset()
       })
+
+      const queryHashes = new Set(queries.map((q) => q.queryHash))
+
+      if (!queryHashes.size) {
+        return Promise.resolve()
+      }
+
       return this.refetchQueries(
         {
           type: 'active',
-          ...filters,
+          predicate: (query) => queryHashes.has(query.queryHash),
         },
         options,
       )


### PR DESCRIPTION
When `resetQueries` is called with a predicate filter (e.g. `predicate: (query) => query.state.status === 'error'`), calling `query.reset()` changes the query state before the refetch step. The predicate would then no longer match the reset queries, causing them to never be refetched and remain stuck in `pending`.

**Fix**: Capture matching query hashes before resetting the queries, then refetch those exact queries using the captured hashes rather than re-applying the original predicate.

Closes #10705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query reset behavior so only the matching queries are refetched after a reset.
  * If no queries match the reset criteria, the operation now completes immediately without extra work.
  * This helps make query refreshes more consistent and avoids unintended refetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->