### PR TITLE
fix(vue-query): align queryOptions with useQuery

### DIFF
--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { computed, reactive, ref } from 'vue-demi'
-import { dataTagSymbol } from '@tanstack/query-core'
+import { dataTagSymbol, skipToken } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { queryOptions } from '../queryOptions'
@@ -11,9 +11,9 @@ describe('queryOptions', () => {
     const key = queryKey()
     assertType(
       queryOptions({
-        // @ts-expect-error this is a good error, because stallTime does not exist!
         queryKey: key,
         queryFn: () => Promise.resolve(5),
+        // @ts-expect-error this is a good error, because stallTime does not exist!
         stallTime: 1000,
       }),
     )
@@ -231,27 +231,45 @@ describe('queryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<number>()
   })
 
-  it('should allow accessing queryFn and other properties on the returned options object', () => {
+  it('should keep the tagged queryKey accessible and be spreadable into useQuery', () => {
     const options = queryOptions({
       queryKey: queryKey(),
-      queryFn: () => Promise.resolve([]),
+      queryFn: () => Promise.resolve(5),
     })
 
-    expectTypeOf(options.queryFn).not.toBeUndefined()
     expectTypeOf(options.queryKey).not.toBeUndefined()
-    expectTypeOf(options.staleTime).not.toBeUndefined()
+
+    const { data } = reactive(
+      useQuery({
+        ...options,
+        select: (d) => d.toString(),
+      }),
+    )
+    expectTypeOf(data).toEqualTypeOf<string | undefined>()
   })
 
-  it('should allow accessing queryFn and other properties on the returned options when used with getter', () => {
+  it('should allow a getter returning options to be passed to useQuery', () => {
     const options = queryOptions(() => ({
       queryKey: queryKey(),
-      queryFn: () => Promise.resolve([]),
+      queryFn: () => Promise.resolve(5),
     }))
 
-    const resolvedGetter = options()
+    const { data } = reactive(useQuery(options))
+    expectTypeOf(data).toEqualTypeOf<number | undefined>()
+  })
 
-    expectTypeOf(resolvedGetter.queryFn).not.toBeUndefined()
-    expectTypeOf(resolvedGetter.queryKey).not.toBeUndefined()
+  it('should allow a computed queryFn returning skipToken, matching useQuery', () => {
+    const enabled = ref(false)
+
+    const options = queryOptions({
+      queryKey: queryKey(),
+      queryFn: computed(() =>
+        enabled.value ? () => Promise.resolve(5) : skipToken,
+      ),
+    })
+
+    const { data } = reactive(useQuery(options))
+    expectTypeOf(data).toEqualTypeOf<number | undefined>()
   })
 
   it('should allow computed ref as enabled property', () => {
@@ -322,14 +340,15 @@ describe('queryOptions', () => {
     expectTypeOf(options.queryKey).not.toBeUndefined()
   })
 
-  it('should allow getter function as queryKey', () => {
+  it('should not allow a per-field getter as queryKey, matching useQuery (use computed/ref, or a getter for the whole options)', () => {
     const id = ref<string | null>('1')
 
-    const options = queryOptions({
-      queryKey: () => ['foo', id.value] as const,
-      queryFn: () => Promise.resolve({ id: '1' }),
-    })
-
-    expectTypeOf(options.queryKey).not.toBeUndefined()
+    assertType(
+      queryOptions({
+        // @ts-expect-error queryKey must be a plain key / ref / computed, not a per-field getter
+        queryKey: () => ['foo', id.value] as const,
+        queryFn: () => Promise.resolve({ id: '1' }),
+      }),
+    )
   })
 })

--- a/packages/vue-query/src/__tests__/queryOptions.test.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import { queryOptions } from '../queryOptions'
-import type { QueryOptions } from '../queryOptions'
+import type { UseQueryOptions } from '../queryOptions'
 
 describe('queryOptions', () => {
   it('should return the object received as a parameter without any modification.', () => {
-    const object: QueryOptions = {
+    const object: UseQueryOptions = {
       queryKey: queryKey(),
       queryFn: () => Promise.resolve(5),
     } as const

--- a/packages/vue-query/src/__tests__/useQueries.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test-d.ts
@@ -4,7 +4,7 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { skipToken, useQueries } from '..'
 import { queryOptions } from '../queryOptions'
 import type { OmitKeyof, QueryObserverResult } from '..'
-import type { UseQueryOptions } from '../useQuery'
+import type { UseQueryOptions } from '../queryOptions'
 
 describe('UseQueries config object overload', () => {
   it('TData should always be defined when initialData is provided as an object', () => {

--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -6,7 +6,6 @@ export { VueQueryPlugin } from './vueQueryPlugin'
 export { QueryClient } from './queryClient'
 export { QueryCache } from './queryCache'
 export { queryOptions } from './queryOptions'
-export { type QueryOptions } from './queryOptions'
 export { infiniteQueryOptions } from './infiniteQueryOptions'
 export type {
   DefinedInitialDataInfiniteOptions,
@@ -26,17 +25,14 @@ export { VUE_QUERY_CLIENT } from './utils'
 
 export type { UsePrefetchQueryOptions } from './usePrefetchQuery'
 export type { UsePrefetchInfiniteQueryOptions } from './usePrefetchInfiniteQuery'
+export type { UseQueryReturnType, UseQueryDefinedReturnType } from './useQuery'
 export type {
   UseQueryOptions,
-  UseQueryReturnType,
-  UseQueryDefinedReturnType,
   UndefinedInitialQueryOptions,
   DefinedInitialQueryOptions,
-} from './useQuery'
-export type {
-  UseInfiniteQueryOptions,
-  UseInfiniteQueryReturnType,
-} from './useInfiniteQuery'
+} from './queryOptions'
+export type { UseInfiniteQueryReturnType } from './useInfiniteQuery'
+export type { UseInfiniteQueryOptions } from './infiniteQueryOptions'
 export type { UseMutationOptions, UseMutationReturnType } from './useMutation'
 export type { MutationOptions } from './types'
 export type { UseQueriesOptions, UseQueriesResults } from './useQueries'

--- a/packages/vue-query/src/infiniteQueryOptions.ts
+++ b/packages/vue-query/src/infiniteQueryOptions.ts
@@ -2,10 +2,54 @@ import type {
   DataTag,
   DefaultError,
   InfiniteData,
+  InfiniteQueryObserverOptions,
   NonUndefinedGuard,
   QueryKey,
 } from '@tanstack/query-core'
-import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
+
+import type {
+  DeepUnwrapRef,
+  MaybeRef,
+  MaybeRefDeep,
+  MaybeRefOrGetter,
+  ShallowOption,
+} from './types'
+
+export type UseInfiniteQueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+> = MaybeRef<
+  {
+    [Property in keyof InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryKey,
+      TPageParam
+    >]: Property extends 'enabled'
+      ? MaybeRefOrGetter<
+          InfiniteQueryObserverOptions<
+            TQueryFnData,
+            TError,
+            TData,
+            DeepUnwrapRef<TQueryKey>,
+            TPageParam
+          >[Property]
+        >
+      : MaybeRefDeep<
+          InfiniteQueryObserverOptions<
+            TQueryFnData,
+            TError,
+            TData,
+            DeepUnwrapRef<TQueryKey>,
+            TPageParam
+          >[Property]
+        >
+  } & ShallowOption
+>
 
 export type UndefinedInitialDataInfiniteOptions<
   TQueryFnData,

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -3,7 +3,7 @@ import { QueryClient as QC } from '@tanstack/query-core'
 import { cloneDeepUnref } from './utils'
 import { QueryCache } from './queryCache'
 import { MutationCache } from './mutationCache'
-import type { UseQueryOptions } from './useQuery'
+import type { UseQueryOptions } from './queryOptions'
 import type { Ref } from 'vue-demi'
 import type { MaybeRefDeep, NoUnknown, QueryClientConfig } from './types'
 import type {

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -1,4 +1,3 @@
-import type { DeepUnwrapRef, MaybeRefOrGetter, ShallowOption } from './types'
 import type {
   DataTag,
   DefaultError,
@@ -9,45 +8,55 @@ import type {
   QueryObserverOptions,
 } from '@tanstack/query-core'
 
-export type QueryOptions<
+import type {
+  DeepUnwrapRef,
+  MaybeRef,
+  MaybeRefDeep,
+  MaybeRefOrGetter,
+  ShallowOption,
+} from './types'
+
+export type UseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = {
-  [Property in keyof QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  >]: Property extends 'enabled'
-    ?
-        | MaybeRefOrGetter<boolean | undefined>
-        | (() => QueryBooleanOption<
+> = MaybeRef<
+  {
+    [Property in keyof QueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >]: Property extends 'enabled'
+      ?
+          | MaybeRefOrGetter<boolean | undefined>
+          | (() => QueryBooleanOption<
+              TQueryFnData,
+              TError,
+              TQueryData,
+              DeepUnwrapRef<TQueryKey>
+            >)
+      : MaybeRefDeep<
+          QueryObserverOptions<
             TQueryFnData,
             TError,
+            TData,
             TQueryData,
             DeepUnwrapRef<TQueryKey>
-          >)
-    : Property extends 'queryKey'
-      ? MaybeRefOrGetter<TQueryKey>
-      : QueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          DeepUnwrapRef<TQueryKey>
-        >[Property]
-} & ShallowOption
+          >[Property]
+        >
+  } & ShallowOption
+>
 
 export type UndefinedInitialQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
   initialData?:
     | undefined
     | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
@@ -59,7 +68,7 @@ export type DefinedInitialQueryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
   initialData:
     | NonUndefinedGuard<TQueryFnData>
     | (() => NonUndefinedGuard<TQueryFnData>)
@@ -82,22 +91,6 @@ export function queryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: () => DefinedInitialQueryOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryKey
-  >,
-): () => DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
-
-export function queryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
   options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
@@ -109,17 +102,11 @@ export function queryOptions<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
-  options: () => UndefinedInitialQueryOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryKey
+  options: MaybeRefOrGetter<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
   >,
-): () => UndefinedInitialQueryOptions<
-  TQueryFnData,
-  TError,
-  TData,
-  TQueryKey
+): MaybeRefOrGetter<
+  UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>
 > & {
   queryKey: DataTag<TQueryKey, TQueryFnData, TError>
 }

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -20,9 +20,9 @@ import type {
   QueryObserverResult,
 } from '@tanstack/query-core'
 import type { QueryClient } from './queryClient'
-import type { UseQueryOptions } from './useQuery'
-import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
 import type { MaybeRefOrGetter } from './types'
+import type { UseQueryOptions } from './queryOptions'
+import type { UseInfiniteQueryOptions } from './infiniteQueryOptions'
 
 export type UseBaseQueryReturnType<
   TData,

--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -1,64 +1,22 @@
 import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
-import type {
-  DefinedInitialDataInfiniteOptions,
-  UndefinedInitialDataInfiniteOptions,
-} from './infiniteQueryOptions'
+
 import type {
   DefaultError,
   InfiniteData,
-  InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
   QueryKey,
   QueryObserver,
 } from '@tanstack/query-core'
 
-import type { UseBaseQueryReturnType } from './useBaseQuery'
-
-import type {
-  DeepUnwrapRef,
-  MaybeRef,
-  MaybeRefDeep,
-  MaybeRefOrGetter,
-  ShallowOption,
-} from './types'
+import type { MaybeRefOrGetter } from './types'
 import type { QueryClient } from './queryClient'
-
-export type UseInfiniteQueryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-  TPageParam = unknown,
-> = MaybeRef<
-  {
-    [Property in keyof InfiniteQueryObserverOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryKey,
-      TPageParam
-    >]: Property extends 'enabled'
-      ? MaybeRefOrGetter<
-          InfiniteQueryObserverOptions<
-            TQueryFnData,
-            TError,
-            TData,
-            DeepUnwrapRef<TQueryKey>,
-            TPageParam
-          >[Property]
-        >
-      : MaybeRefDeep<
-          InfiniteQueryObserverOptions<
-            TQueryFnData,
-            TError,
-            TData,
-            DeepUnwrapRef<TQueryKey>,
-            TPageParam
-          >[Property]
-        >
-  } & ShallowOption
->
+import type { UseBaseQueryReturnType } from './useBaseQuery'
+import type {
+  DefinedInitialDataInfiniteOptions,
+  UndefinedInitialDataInfiniteOptions,
+  UseInfiniteQueryOptions,
+} from './infiniteQueryOptions'
 
 export type UseInfiniteQueryReturnType<TData, TError> = UseBaseQueryReturnType<
   TData,

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -22,9 +22,9 @@ import type {
   QueryObserverResult,
   ThrowOnError,
 } from '@tanstack/query-core'
-import type { UseQueryOptions } from './useQuery'
 import type { QueryClient } from './queryClient'
 import type { DeepUnwrapRef, MaybeRefDeep, ShallowOption } from './types'
+import type { UseQueryOptions } from './queryOptions'
 
 // This defines the `UseQueryOptions` that are accepted in `QueriesOptions` & `GetOptions`.
 // `placeholderData` function does not have a parameter

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -3,79 +3,16 @@ import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
-  InitialDataFunction,
-  NonUndefinedGuard,
-  QueryBooleanOption,
   QueryKey,
-  QueryObserverOptions,
 } from '@tanstack/query-core'
 import type { UseBaseQueryReturnType } from './useBaseQuery'
-import type {
-  DeepUnwrapRef,
-  MaybeRef,
-  MaybeRefDeep,
-  MaybeRefOrGetter,
-  ShallowOption,
-} from './types'
+import type { MaybeRefOrGetter } from './types'
 import type { QueryClient } from './queryClient'
-
-export type UseQueryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = MaybeRef<
-  {
-    [Property in keyof QueryObserverOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryData,
-      TQueryKey
-    >]: Property extends 'enabled'
-      ?
-          | MaybeRefOrGetter<boolean | undefined>
-          | (() => QueryBooleanOption<
-              TQueryFnData,
-              TError,
-              TQueryData,
-              DeepUnwrapRef<TQueryKey>
-            >)
-      : MaybeRefDeep<
-          QueryObserverOptions<
-            TQueryFnData,
-            TError,
-            TData,
-            TQueryData,
-            DeepUnwrapRef<TQueryKey>
-          >[Property]
-        >
-  } & ShallowOption
->
-
-export type UndefinedInitialQueryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData?:
-    | undefined
-    | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
-    | NonUndefinedGuard<TQueryFnData>
-}
-
-export type DefinedInitialQueryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData:
-    | NonUndefinedGuard<TQueryFnData>
-    | (() => NonUndefinedGuard<TQueryFnData>)
-}
+import type {
+  DefinedInitialQueryOptions,
+  UndefinedInitialQueryOptions,
+  UseQueryOptions,
+} from './queryOptions'
 
 export type UseQueryReturnType<TData, TError> = UseBaseQueryReturnType<
   TData,


### PR DESCRIPTION
## 🎯 Changes

### queryOptions rejects some reactive options that useQuery accepts

I ran into this while using `queryOptions` in a Vue app. It rejects options that `useQuery` accepts without any problem. The case that actually blocked me was a reactive `queryFn` that returns `skipToken`, so the query stays idle until there's an input:

```ts
function pokemonOptions(name: MaybeRefOrGetter<string | null>) {
  return queryOptions({
    queryKey: computed(() => ['pokemon', toValue(name)]),
    queryFn: computed(() => {
      const current = toValue(name)
      if (!current) {
        return skipToken
      }
      return () => fetchPokemon(current)
    }),
  })
}
```

If I pass that same object straight to `useQuery` it type-checks. Through `queryOptions` it errors. So I can't move the options into a shared helper without the types getting in the way.

Reproduction: https://codesandbox.io/p/devbox/2yzjz5

The reason is that `queryOptions` and `useQuery` were built on two different option types. `queryOptions` only treated `queryKey` and `enabled` as reactive and required every other field (including `queryFn`) to be a plain non-reactive value, while `useQuery` treats every field as reactive, which is what makes a `computed` `queryFn` work.

This aligns `queryOptions` and `infiniteQueryOptions` with the option types `useQuery` and `useInfiniteQuery` already use, so if `useQuery` accepts it, `queryOptions` accepts it too.

### Breaking change
The `QueryOptions` type is no longer exported, since it no longer exists. Use `UseQueryOptions` instead.

---

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript support for query options, including better handling of getters, reactive values, and `skipToken`.
  * Expanded typing coverage for query and infinite query helpers to match real usage more closely.

* **Bug Fixes**
  * Fixed an incorrect type-check expectation around unsupported option properties.
  * Tightened `queryKey` validation so invalid getter-based key shapes are now rejected consistently.

* **Refactor**
  * Reorganized internal type exports to better separate query options from return types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->