### PR TITLE
fix(solid-query): drop disabled idle SSR promise

### DIFF
--- a/packages/solid-query/src/__tests__/useBaseQuery.server.test.ts
+++ b/packages/solid-query/src/__tests__/useBaseQuery.server.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('solid-js/web', () => ({
+  isServer: true,
+}))
+
+const { hydratableObserverResult } = await import('../useBaseQuery')
+
+describe('hydratableObserverResult', () => {
+  it('omits the pending promise for disabled idle queries during SSR', () => {
+    const promise = new Promise(() => {})
+    const query = {
+      state: { status: 'pending', fetchStatus: 'idle' },
+      queryKey: ['disabled'],
+      queryHash: '["disabled"]',
+      meta: undefined,
+    } as any
+    const result = {
+      status: 'pending',
+      fetchStatus: 'idle',
+      isEnabled: false,
+      data: undefined,
+      refetch: () => undefined,
+      promise,
+    } as any
+
+    const hydratable = hydratableObserverResult(query, result)
+
+    expect(hydratable.promise).toBeUndefined()
+    expect(hydratable.refetch).toBeUndefined()
+    expect(hydratable.hydrationData).toMatchObject({
+      state: query.state,
+      queryKey: query.queryKey,
+      queryHash: query.queryHash,
+    })
+  })
+
+  it('keeps the promise for active SSR queries that are still fetching', () => {
+    const promise = new Promise(() => {})
+    const query = {
+      state: { status: 'pending', fetchStatus: 'fetching' },
+      queryKey: ['active'],
+      queryHash: '["active"]',
+      meta: undefined,
+    } as any
+    const result = {
+      status: 'pending',
+      fetchStatus: 'fetching',
+      isEnabled: true,
+      data: undefined,
+      refetch: () => undefined,
+      promise,
+    } as any
+
+    const hydratable = hydratableObserverResult(query, result)
+
+    expect(hydratable.promise).toBe(promise)
+  })
+})

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -63,7 +63,7 @@ function reconcileFn<TData, TError>(
  * Solid's `onHydrated` functionality will silently "fail" (hydrate with an empty object)
  * if the resource data is not serializable.
  */
-const hydratableObserverResult = <
+export const hydratableObserverResult = <
   TQueryFnData,
   TError,
   TData,
@@ -79,6 +79,12 @@ const hydratableObserverResult = <
     // During SSR, functions cannot be serialized, so we need to remove them
     // This is safe because we will add these functions back when the query is hydrated
     refetch: undefined,
+  }
+
+  // Disabled queries expose a pending thenable during SSR even though no fetch will start.
+  // Serializing that promise keeps Solid's resource suspended forever.
+  if (result.isEnabled === false && result.fetchStatus === 'idle') {
+    delete obj.promise
   }
 
   // If the query is an infinite query, we need to remove additional properties


### PR DESCRIPTION
## 🎯 Changes

- stop serializing the pending SSR promise for disabled idle `solid-query` results
- keep the SSR promise intact for actively fetching queries
- add server-side coverage for both disabled-idle and active-fetching cases

Closes #10907

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- Additional local validation: `pnpm --filter @tanstack/solid-query exec vitest run src/__tests__/useBaseQuery.server.test.ts`

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
- This PR changes published Solid Query behavior. I have not added a changeset in this contribution.
