### PR TITLE
test(react-query-devtools/ReactQueryDevtools): add tests for forwarding option changes after mount

### DIFF
--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
@@ -182,6 +182,81 @@ describe('ReactQueryDevtools', () => {
     )
   })
 
+  it('should forward a "buttonPosition" change to the devtools instance after mount', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <ReactQueryDevtools client={queryClient} buttonPosition="bottom-right" />,
+    )
+    setButtonPositionMock.mockClear()
+
+    rerender(
+      <ReactQueryDevtools client={queryClient} buttonPosition="top-left" />,
+    )
+
+    expect(setButtonPositionMock).toHaveBeenCalledWith('top-left')
+  })
+
+  it('should forward a "position" change to the devtools instance after mount', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <ReactQueryDevtools client={queryClient} position="bottom" />,
+    )
+    setPositionMock.mockClear()
+
+    rerender(<ReactQueryDevtools client={queryClient} position="top" />)
+
+    expect(setPositionMock).toHaveBeenCalledWith('top')
+  })
+
+  it('should forward an "initialIsOpen" change to the devtools instance after mount', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <ReactQueryDevtools client={queryClient} initialIsOpen={false} />,
+    )
+    setInitialIsOpenMock.mockClear()
+
+    rerender(<ReactQueryDevtools client={queryClient} initialIsOpen={true} />)
+
+    expect(setInitialIsOpenMock).toHaveBeenCalledWith(true)
+  })
+
+  it('should forward an "errorTypes" change to the devtools instance after mount', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <ReactQueryDevtools client={queryClient} errorTypes={[]} />,
+    )
+    setErrorTypesMock.mockClear()
+
+    const errorTypes = [
+      { name: 'Network', initializer: () => new Error('Network') },
+    ]
+    rerender(<ReactQueryDevtools client={queryClient} errorTypes={errorTypes} />)
+
+    expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
+  })
+
+  it('should forward a "theme" change to the devtools instance after mount', async () => {
+    const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <ReactQueryDevtools client={queryClient} theme="light" />,
+    )
+    setThemeMock.mockClear()
+
+    rerender(<ReactQueryDevtools client={queryClient} theme="dark" />)
+
+    expect(setThemeMock).toHaveBeenCalledWith('dark')
+  })
+
   it('should call "unmount" on the devtools instance when the component unmounts', async () => {
     const { ReactQueryDevtools } = await import('../ReactQueryDevtools')
     const queryClient = new QueryClient()

--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtools.test.tsx
@@ -238,7 +238,9 @@ describe('ReactQueryDevtools', () => {
     const errorTypes = [
       { name: 'Network', initializer: () => new Error('Network') },
     ]
-    rerender(<ReactQueryDevtools client={queryClient} errorTypes={errorTypes} />)
+    rerender(
+      <ReactQueryDevtools client={queryClient} errorTypes={errorTypes} />,
+    )
 
     expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
   })


### PR DESCRIPTION
## 🎯 Changes

Adds regression tests verifying that `ReactQueryDevtools` forwards option changes to the underlying devtools instance **after mount**, not just on the initial render.

The existing tests only cover the initial forwarding of options. Each option is wired through its own `useEffect` with a dependency array (e.g. `[position, devtools]`), so if a dependency is accidentally dropped, the option would silently stop being re-forwarded on update — a case the initial-render tests cannot catch.

The new tests use `rerender` to change each prop after mount and assert the corresponding setter is called again:

- `buttonPosition`
- `position`
- `initialIsOpen`
- `errorTypes`
- `theme`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify devtools settings update correctly when component props change after initial render.
  * Confirmed updated values are forwarded on rerender for button position, panel position, open state, error display, and theme.
  * Kept existing mount and unmount behavior checks intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->