### PR TITLE
test(preact-query-devtools/PreactQueryDevtools): add tests for forwarding option changes after mount

### DIFF
--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -182,6 +182,83 @@ describe('PreactQueryDevtools', () => {
     )
   })
 
+  it('should forward a "buttonPosition" change to the devtools instance after mount', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <PreactQueryDevtools client={queryClient} buttonPosition="bottom-right" />,
+    )
+    setButtonPositionMock.mockClear()
+
+    rerender(
+      <PreactQueryDevtools client={queryClient} buttonPosition="top-left" />,
+    )
+
+    expect(setButtonPositionMock).toHaveBeenCalledWith('top-left')
+  })
+
+  it('should forward a "position" change to the devtools instance after mount', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <PreactQueryDevtools client={queryClient} position="bottom" />,
+    )
+    setPositionMock.mockClear()
+
+    rerender(<PreactQueryDevtools client={queryClient} position="top" />)
+
+    expect(setPositionMock).toHaveBeenCalledWith('top')
+  })
+
+  it('should forward an "initialIsOpen" change to the devtools instance after mount', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <PreactQueryDevtools client={queryClient} initialIsOpen={false} />,
+    )
+    setInitialIsOpenMock.mockClear()
+
+    rerender(<PreactQueryDevtools client={queryClient} initialIsOpen={true} />)
+
+    expect(setInitialIsOpenMock).toHaveBeenCalledWith(true)
+  })
+
+  it('should forward an "errorTypes" change to the devtools instance after mount', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <PreactQueryDevtools client={queryClient} errorTypes={[]} />,
+    )
+    setErrorTypesMock.mockClear()
+
+    const errorTypes = [
+      { name: 'Network', initializer: () => new Error('Network') },
+    ]
+    rerender(
+      <PreactQueryDevtools client={queryClient} errorTypes={errorTypes} />,
+    )
+
+    expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
+  })
+
+  it('should forward a "theme" change to the devtools instance after mount', async () => {
+    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
+    const queryClient = new QueryClient()
+
+    const { rerender } = render(
+      <PreactQueryDevtools client={queryClient} theme="light" />,
+    )
+    setThemeMock.mockClear()
+
+    rerender(<PreactQueryDevtools client={queryClient} theme="dark" />)
+
+    expect(setThemeMock).toHaveBeenCalledWith('dark')
+  })
+
   it('should call "unmount" on the devtools instance when the component unmounts', async () => {
     const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
     const queryClient = new QueryClient()

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -187,7 +187,10 @@ describe('PreactQueryDevtools', () => {
     const queryClient = new QueryClient()
 
     const { rerender } = render(
-      <PreactQueryDevtools client={queryClient} buttonPosition="bottom-right" />,
+      <PreactQueryDevtools
+        client={queryClient}
+        buttonPosition="bottom-right"
+      />,
     )
     setButtonPositionMock.mockClear()
 


### PR DESCRIPTION
## 🎯 Changes

Adds regression tests verifying that `PreactQueryDevtools` forwards option changes to the underlying devtools instance **after mount**, not just on the initial render.

The existing tests only cover the initial forwarding of options. Each option is wired through its own `useEffect` with a dependency array (e.g. `[position, devtools]`), so if a dependency is accidentally dropped, the option would silently stop being re-forwarded on update — a case the initial-render tests cannot catch.

The new tests use `rerender` to change each prop after mount and assert the corresponding setter is called again:

- `buttonPosition`
- `position`
- `initialIsOpen`
- `errorTypes`
- `theme`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for updating devtools props after mount.
  * Verified that changes to button position, panel position, open state, error types, and theme are passed through correctly when the component is re-rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->