### PR TITLE
test(solid-query-devtools/devtools): add tests for forwarding option changes after mount

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createSignal } from 'solid-js'
 import { render } from '@solidjs/testing-library'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
 import { TanstackQueryDevtools } from '@tanstack/query-devtools'
 import SolidQueryDevtools from '../devtools'
+import type {
+  DevtoolsButtonPosition,
+  DevtoolsErrorType,
+  DevtoolsPosition,
+  Theme,
+} from '@tanstack/query-devtools'
 
 describe('SolidQueryDevtools', () => {
   afterEach(() => {
@@ -138,6 +145,100 @@ describe('SolidQueryDevtools', () => {
     render(() => <SolidQueryDevtools client={queryClient} />)
 
     expect(setClient).toHaveBeenCalledWith(queryClient)
+  })
+
+  it('should forward a "buttonPosition" change to the devtools instance after mount', () => {
+    const setButtonPosition = vi.spyOn(
+      TanstackQueryDevtools.prototype,
+      'setButtonPosition',
+    )
+    const queryClient = new QueryClient()
+    const [buttonPosition, setButtonPositionSignal] = createSignal<
+      DevtoolsButtonPosition
+    >('bottom-right')
+
+    render(() => (
+      <SolidQueryDevtools
+        client={queryClient}
+        buttonPosition={buttonPosition()}
+      />
+    ))
+    setButtonPosition.mockClear()
+
+    setButtonPositionSignal('top-left')
+
+    expect(setButtonPosition).toHaveBeenCalledWith('top-left')
+  })
+
+  it('should forward a "position" change to the devtools instance after mount', () => {
+    const setPosition = vi.spyOn(TanstackQueryDevtools.prototype, 'setPosition')
+    const queryClient = new QueryClient()
+    const [position, setPositionSignal] = createSignal<DevtoolsPosition>(
+      'bottom',
+    )
+
+    render(() => (
+      <SolidQueryDevtools client={queryClient} position={position()} />
+    ))
+    setPosition.mockClear()
+
+    setPositionSignal('top')
+
+    expect(setPosition).toHaveBeenCalledWith('top')
+  })
+
+  it('should forward an "initialIsOpen" change to the devtools instance after mount', () => {
+    const setInitialIsOpen = vi.spyOn(
+      TanstackQueryDevtools.prototype,
+      'setInitialIsOpen',
+    )
+    const queryClient = new QueryClient()
+    const [initialIsOpen, setInitialIsOpenSignal] = createSignal(false)
+
+    render(() => (
+      <SolidQueryDevtools client={queryClient} initialIsOpen={initialIsOpen()} />
+    ))
+    setInitialIsOpen.mockClear()
+
+    setInitialIsOpenSignal(true)
+
+    expect(setInitialIsOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('should forward an "errorTypes" change to the devtools instance after mount', () => {
+    const setErrorTypes = vi.spyOn(
+      TanstackQueryDevtools.prototype,
+      'setErrorTypes',
+    )
+    const queryClient = new QueryClient()
+    const [errorTypes, setErrorTypesSignal] = createSignal<
+      Array<DevtoolsErrorType>
+    >([])
+
+    render(() => (
+      <SolidQueryDevtools client={queryClient} errorTypes={errorTypes()} />
+    ))
+    setErrorTypes.mockClear()
+
+    const nextErrorTypes = [
+      { name: 'Network', initializer: () => new Error('Network') },
+    ]
+    setErrorTypesSignal(nextErrorTypes)
+
+    expect(setErrorTypes).toHaveBeenCalledWith(nextErrorTypes)
+  })
+
+  it('should forward a "theme" change to the devtools instance after mount', () => {
+    const setTheme = vi.spyOn(TanstackQueryDevtools.prototype, 'setTheme')
+    const queryClient = new QueryClient()
+    const [theme, setThemeSignal] = createSignal<Theme>('light')
+
+    render(() => <SolidQueryDevtools client={queryClient} theme={theme()} />)
+    setTheme.mockClear()
+
+    setThemeSignal('dark')
+
+    expect(setTheme).toHaveBeenCalledWith('dark')
   })
 
   it('should call "unmount" on the devtools instance when the component unmounts', () => {

--- a/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtools.test.tsx
@@ -153,9 +153,8 @@ describe('SolidQueryDevtools', () => {
       'setButtonPosition',
     )
     const queryClient = new QueryClient()
-    const [buttonPosition, setButtonPositionSignal] = createSignal<
-      DevtoolsButtonPosition
-    >('bottom-right')
+    const [buttonPosition, setButtonPositionSignal] =
+      createSignal<DevtoolsButtonPosition>('bottom-right')
 
     render(() => (
       <SolidQueryDevtools
@@ -173,9 +172,8 @@ describe('SolidQueryDevtools', () => {
   it('should forward a "position" change to the devtools instance after mount', () => {
     const setPosition = vi.spyOn(TanstackQueryDevtools.prototype, 'setPosition')
     const queryClient = new QueryClient()
-    const [position, setPositionSignal] = createSignal<DevtoolsPosition>(
-      'bottom',
-    )
+    const [position, setPositionSignal] =
+      createSignal<DevtoolsPosition>('bottom')
 
     render(() => (
       <SolidQueryDevtools client={queryClient} position={position()} />
@@ -196,7 +194,10 @@ describe('SolidQueryDevtools', () => {
     const [initialIsOpen, setInitialIsOpenSignal] = createSignal(false)
 
     render(() => (
-      <SolidQueryDevtools client={queryClient} initialIsOpen={initialIsOpen()} />
+      <SolidQueryDevtools
+        client={queryClient}
+        initialIsOpen={initialIsOpen()}
+      />
     ))
     setInitialIsOpen.mockClear()
 


### PR DESCRIPTION
## 🎯 Changes

Adds regression tests verifying that `SolidQueryDevtools` forwards option changes to the underlying devtools instance **after mount**, not just on the initial render.

The existing tests only cover the initial forwarding of options. Each option is wired through its own `createEffect` that reads the reactive `props`, so if a value is read outside the effect (breaking reactivity), the option would silently stop being re-forwarded on update — a case the initial-render tests cannot catch.

Since Solid components run once and update via signals (there is no `rerender`), the new tests drive each prop with a `createSignal` and update it after mount, asserting the corresponding setter is called again:

- `buttonPosition`
- `position`
- `initialIsOpen`
- `errorTypes`
- `theme`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for devtools to verify that runtime prop updates are forwarded correctly after mount.
  * Added checks for changes to position, button position, open state, error types, and theme.
  * Improved confidence that interactive settings stay in sync when updated dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->