### PR TITLE
fix(react-query): preserve narrowing with NoInfer

### DIFF
--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -293,6 +293,25 @@ describe('useQuery', () => {
         void result
       })
 
+      // eslint-disable-next-line vitest/expect-expect
+      it('should preserve discriminated-union narrowing while keeping the reverse-inference guard', () => {
+        type Result =
+          | { type: 'first'; first: string }
+          | { type: 'second'; second: string }
+
+        const query = useQuery({
+          queryKey: queryKey(),
+          queryFn: (): Result => ({ type: 'first', first: 'a' }),
+        })
+
+        const second = query.data?.type === 'first' ? undefined : query.data
+
+        expectTypeOf(second).toEqualTypeOf<
+          | { type: 'second'; second: string }
+          | undefined
+        >()
+      })
+
       it('data should not have undefined when initialData is provided', () => {
         const { data } = useQuery({
           queryKey: queryKey(),

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -7,6 +7,8 @@ import type {
   UseQueryOptions,
   UseQueryResult,
 } from './types'
+
+type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never
 import type {
   DefinedInitialDataOptions,
   UndefinedInitialDataOptions,
@@ -20,7 +22,7 @@ export function useQuery<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): DefinedUseQueryResult<NoInfer<TData>, TError>
+): DefinedUseQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -30,7 +32,7 @@ export function useQuery<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<NoInfer<TData>, TError>
+): UseQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -40,7 +42,7 @@ export function useQuery<
 >(
   options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<NoInfer<TData>, TError>
+): UseQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useQuery(options: UseQueryOptions, queryClient?: QueryClient) {
   return useBaseQuery(options, QueryObserver, queryClient)


### PR DESCRIPTION
## 🎯 Changes

- wrap the `useQuery` return-type `NoInfer` fence in a distributive helper
- preserve the reverse-inference guard that rejects incorrect contextual `UseQueryResult` annotations
- restore discriminated-union narrowing on `query.data`
- add focused dts coverage for the narrowing regression reported in `#11018`

Closes #11018

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- Additional local validation: `pnpm --filter @tanstack/react-query test:types:tscurrent`

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
- This PR changes published React Query types. I have not added a changeset in this contribution.
