### PR TITLE
fix(query-sync-storage-persister): recover from throttle errors instead of permanently disabling persistence

### DIFF
--- a/.changeset/sync-storage-persister-throttle-error-recovery.md
+++ b/.changeset/sync-storage-persister-throttle-error-recovery.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-sync-storage-persister': patch
+---
+
+fix(query-sync-storage-persister): recover from errors thrown while persisting instead of permanently disabling future persist attempts

--- a/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
+++ b/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
@@ -189,4 +189,50 @@ describe('create persister', () => {
     const restoredClient = await persister.restoreClient()
     expect(restoredClient).toEqual(undefined)
   })
+
+  it('should keep persisting on subsequent calls even if the retry handler throws', async () => {
+    const queryCache = new QueryCache()
+    const mutationCache = new MutationCache()
+    const queryClient = new QueryClient({ queryCache, mutationCache })
+
+    let setItemCalls = 0
+    const storage = {
+      getItem: () => null,
+      setItem: () => {
+        setItemCalls++
+        throw new Error('storage always fails')
+      },
+      removeItem: () => {},
+    } as any as Storage
+
+    const persister = createSyncStoragePersister({
+      throttleTime: 10,
+      storage,
+      retry: () => {
+        throw new Error('retry handler bug')
+      },
+    })
+
+    await queryClient.prefetchQuery({
+      queryKey: ['A'],
+      queryFn: () => Promise.resolve('A'),
+    })
+
+    const persistClient = {
+      buster: '',
+      timestamp: Date.now(),
+      clientState: dehydrate(queryClient),
+    }
+
+    // First attempt: `setItem` fails, and the `retry` handler throws while
+    // trying to recover. This must not leave the persister permanently stuck.
+    persister.persistClient(persistClient)
+    await sleep(20)
+    expect(setItemCalls).toBe(1)
+
+    // A later persist call should still be attempted, not silently dropped.
+    persister.persistClient(persistClient)
+    await sleep(20)
+    expect(setItemCalls).toBe(2)
+  })
 })

--- a/packages/query-sync-storage-persister/src/index.ts
+++ b/packages/query-sync-storage-persister/src/index.ts
@@ -108,8 +108,15 @@ function throttle<TArgs extends Array<any>>(
     params = args
     if (timer === null) {
       timer = timeoutManager.setTimeout(() => {
-        func(...params)
-        timer = null
+        try {
+          func(...params)
+        } catch {
+          // Prevent an error thrown by `func` (e.g. a `retry` handler) from
+          // leaving `timer` stuck, which would silently disable all future
+          // persist attempts for the rest of the session.
+        } finally {
+          timer = null
+        }
       }, wait)
     }
   }


### PR DESCRIPTION
## 🎯 Changes

`createSyncStoragePersister`'s internal `throttle()` helper does not guard against the wrapped `persistClient` callback throwing:

```js
timer = timeoutManager.setTimeout(() => {
  func(...params)
  timer = null   // never reached if func throws
}, wait)
```

If `func` throws — which happens whenever the `retry` option (including the built-in `removeOldestQuery`, which does `[...persistedClient.clientState.mutations]` and throws on malformed/undefined `clientState`) throws while trying to recover from a failed `storage.setItem` — `timer` is left non-null forever. Every subsequent `persistClient()` call then sees `timer !== null` and silently no-ops, permanently disabling persistence for the rest of the page session with no error surfaced anywhere.

The async counterpart (`@tanstack/query-async-storage-persister`'s `asyncThrottle`) already guards against this with a `try/catch` — this brings the sync version in line.

- Wrapped the timer callback in `try/catch/finally` so `timer` is always reset, and the thrown error doesn't escape as an unhandled exception either (verified: without the `catch`, the error propagates out of the `setTimeout` callback and shows up as an unhandled rejection/exception).
- Added a regression test (`storageIsFull.test.ts`) that reproduces the stuck state.
- Added a changeset (patch).

### Testing notes

I wasn't able to run `nx`-based commands (`pnpm run test:pr` / `nx run @tanstack/query-sync-storage-persister:test:lib`) in my local environment — this repo's config files rely on symlinks (per the note in CONTRIBUTING.md about symlink support), and on my Windows checkout they materialized as plain text files instead of real symlinks, which breaks the `tsc --build` step nx depends on for this package's dependency graph. This is an environment limitation, unrelated to the change itself.

As a substitute, I verified the fix by running the package's tests directly with `vitest run` inside `packages/query-sync-storage-persister`:
- With the fix: all tests pass, no unhandled errors, exit code 0.
- With only the `src/index.ts` fix reverted (test kept): the new test fails exactly as expected (stuck timer / unhandled exception), confirming the test actually catches the regression.

I'd appreciate it if a maintainer (or CI) could confirm with the full `nx` pipeline on a symlink-capable environment.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (see "Testing notes" above — ran the package's vitest suite directly instead, due to a local symlink/environment limitation)

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).