### PR TITLE
docs: add StitchAPI to community resources

### DIFF
--- a/docs/community-resources.md
+++ b/docs/community-resources.md
@@ -188,7 +188,7 @@ others:
     {
       title: 'StitchAPI',
       url: 'https://stitchapi.dev',
-      description: 'Typed, validated, streaming-first API toolkit; its stitchQueryOptions helper turns any endpoint into TanStack Query options across React, Vue, Svelte, Solid, and Angular.',
+      description: 'Gives TanStack Query a typed, validated, streaming-first queryFn: stitchQueryOptions supplies the fetcher, so Query keeps owning caching and revalidation. Bindings for React, Vue, Svelte, Solid, and Angular.',
     },
     {
       title: 'Tanstack Query Visualizer',

--- a/docs/community-resources.md
+++ b/docs/community-resources.md
@@ -186,6 +186,11 @@ others:
       description: 'VS Code extension for TanStack Query (React Query): visualize query keys, cache invalidation/refetch flows, and file impact graph',
     },
     {
+      title: 'StitchAPI',
+      url: 'https://stitchapi.dev',
+      description: 'Typed, validated, streaming-first API toolkit; its stitchQueryOptions helper turns any endpoint into TanStack Query options across React, Vue, Svelte, Solid, and Angular.',
+    },
+    {
       title: 'Tanstack Query Visualizer',
       url: 'https://tanstack-query-visualizer.sofi.coop/',
       description: 'An interactive sandbox that visualizes the relationship between mutations and query keys.',


### PR DESCRIPTION
## 🎯 Changes

Adds StitchAPI to the **Community Resources** list (`others`). StitchAPI isn't a data-fetching library that competes with TanStack Query — it fills the `queryFn`. Its `stitchQueryOptions` helper supplies a typed, validated, streaming-first fetcher, so TanStack Query keeps owning caching, revalidation, and everything else; StitchAPI just makes the request typed and validated end to end. Matching bindings for React, Vue, Svelte, Solid, and Angular.

- Site/docs: https://stitchapi.dev
- Source: https://github.com/rejifald/StitchAPI

Inserted alphabetically in the `others` section, following the existing entry format.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community resource entry for StitchAPI, including its website and a short description of its typed, validated, streaming-first toolkit.
  * Highlighted support for generating TanStack Query options through a helper available across multiple frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->