### PR TITLE
test(preact-query-devtools): extract shared test setup into 'beforeEach'

### DIFF
--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtools.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/preact'
 import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
 import { TanstackQueryDevtools } from '@tanstack/query-devtools'
+import type { PreactQueryDevtools as PreactQueryDevtoolsComponent } from '../PreactQueryDevtools'
 
 const mountMock = vi.fn()
 const unmountMock = vi.fn()
@@ -26,22 +27,22 @@ vi.mock('@tanstack/query-devtools', () => ({
 }))
 
 describe('PreactQueryDevtools', () => {
-  beforeEach(() => {
+  let PreactQueryDevtools: typeof PreactQueryDevtoolsComponent
+  let queryClient: QueryClient
+
+  beforeEach(async () => {
     vi.clearAllMocks()
+    ;({ PreactQueryDevtools } = await import('../PreactQueryDevtools'))
+    queryClient = new QueryClient()
   })
 
-  it('should throw an error if no query client has been set', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-
+  it('should throw an error if no query client has been set', () => {
     expect(() => render(<PreactQueryDevtools />)).toThrow(
       'No QueryClient set, use QueryClientProvider to set one',
     )
   })
 
-  it('should not throw an error if query client is provided via context', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should not throw an error if query client is provided via context', () => {
     expect(() =>
       render(
         <QueryClientProvider client={queryClient}>
@@ -52,20 +53,14 @@ describe('PreactQueryDevtools', () => {
     expect(mountMock).toHaveBeenCalled()
   })
 
-  it('should not throw an error if query client is provided via props', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should not throw an error if query client is provided via props', () => {
     expect(() =>
       render(<PreactQueryDevtools client={queryClient} />),
     ).not.toThrow()
     expect(mountMock).toHaveBeenCalled()
   })
 
-  it('should forward "buttonPosition" to the devtools instance', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward "buttonPosition" to the devtools instance', () => {
     render(
       <PreactQueryDevtools client={queryClient} buttonPosition="top-left" />,
     )
@@ -73,36 +68,25 @@ describe('PreactQueryDevtools', () => {
     expect(setButtonPositionMock).toHaveBeenCalledWith('top-left')
   })
 
-  it('should forward "position" to the devtools instance', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward "position" to the devtools instance', () => {
     render(<PreactQueryDevtools client={queryClient} position="left" />)
 
     expect(setPositionMock).toHaveBeenCalledWith('left')
   })
 
-  it('should forward "initialIsOpen" to the devtools instance', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward "initialIsOpen" to the devtools instance', () => {
     render(<PreactQueryDevtools client={queryClient} initialIsOpen={true} />)
 
     expect(setInitialIsOpenMock).toHaveBeenCalledWith(true)
   })
 
-  it('should default "initialIsOpen" to "false" when the prop is omitted', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should default "initialIsOpen" to "false" when the prop is omitted', () => {
     render(<PreactQueryDevtools client={queryClient} />)
 
     expect(setInitialIsOpenMock).toHaveBeenCalledWith(false)
   })
 
-  it('should forward "errorTypes" to the devtools instance', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
+  it('should forward "errorTypes" to the devtools instance', () => {
     const errorTypes = [
       { name: 'Network', initializer: () => new Error('Network') },
     ]
@@ -112,37 +96,25 @@ describe('PreactQueryDevtools', () => {
     expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
   })
 
-  it('should default "errorTypes" to an empty array when the prop is omitted', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should default "errorTypes" to an empty array when the prop is omitted', () => {
     render(<PreactQueryDevtools client={queryClient} />)
 
     expect(setErrorTypesMock).toHaveBeenCalledWith([])
   })
 
-  it('should forward "theme" to the devtools instance', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward "theme" to the devtools instance', () => {
     render(<PreactQueryDevtools client={queryClient} theme="dark" />)
 
     expect(setThemeMock).toHaveBeenCalledWith('dark')
   })
 
-  it('should forward the resolved "QueryClient" via "setClient"', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward the resolved "QueryClient" via "setClient"', () => {
     render(<PreactQueryDevtools client={queryClient} />)
 
     expect(setClientMock).toHaveBeenCalledWith(queryClient)
   })
 
-  it('should forward "styleNonce" to the devtools constructor', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward "styleNonce" to the devtools constructor', () => {
     render(<PreactQueryDevtools client={queryClient} styleNonce="abc" />)
 
     expect(TanstackQueryDevtools).toHaveBeenCalledWith(
@@ -150,9 +122,7 @@ describe('PreactQueryDevtools', () => {
     )
   })
 
-  it('should forward "shadowDOMTarget" to the devtools constructor', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
+  it('should forward "shadowDOMTarget" to the devtools constructor', () => {
     const shadowDOMTarget = document
       .createElement('div')
       .attachShadow({ mode: 'open' })
@@ -169,10 +139,7 @@ describe('PreactQueryDevtools', () => {
     )
   })
 
-  it('should forward "hideDisabledQueries" to the devtools constructor', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward "hideDisabledQueries" to the devtools constructor', () => {
     render(
       <PreactQueryDevtools client={queryClient} hideDisabledQueries={true} />,
     )
@@ -182,10 +149,7 @@ describe('PreactQueryDevtools', () => {
     )
   })
 
-  it('should forward a "buttonPosition" change to the devtools instance after mount', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward a "buttonPosition" change to the devtools instance after mount', () => {
     const { rerender } = render(
       <PreactQueryDevtools
         client={queryClient}
@@ -201,10 +165,7 @@ describe('PreactQueryDevtools', () => {
     expect(setButtonPositionMock).toHaveBeenCalledWith('top-left')
   })
 
-  it('should forward a "position" change to the devtools instance after mount', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward a "position" change to the devtools instance after mount', () => {
     const { rerender } = render(
       <PreactQueryDevtools client={queryClient} position="bottom" />,
     )
@@ -215,10 +176,7 @@ describe('PreactQueryDevtools', () => {
     expect(setPositionMock).toHaveBeenCalledWith('top')
   })
 
-  it('should forward an "initialIsOpen" change to the devtools instance after mount', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward an "initialIsOpen" change to the devtools instance after mount', () => {
     const { rerender } = render(
       <PreactQueryDevtools client={queryClient} initialIsOpen={false} />,
     )
@@ -229,10 +187,7 @@ describe('PreactQueryDevtools', () => {
     expect(setInitialIsOpenMock).toHaveBeenCalledWith(true)
   })
 
-  it('should forward an "errorTypes" change to the devtools instance after mount', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward an "errorTypes" change to the devtools instance after mount', () => {
     const { rerender } = render(
       <PreactQueryDevtools client={queryClient} errorTypes={[]} />,
     )
@@ -248,10 +203,7 @@ describe('PreactQueryDevtools', () => {
     expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
   })
 
-  it('should forward a "theme" change to the devtools instance after mount', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should forward a "theme" change to the devtools instance after mount', () => {
     const { rerender } = render(
       <PreactQueryDevtools client={queryClient} theme="light" />,
     )
@@ -262,10 +214,7 @@ describe('PreactQueryDevtools', () => {
     expect(setThemeMock).toHaveBeenCalledWith('dark')
   })
 
-  it('should call "unmount" on the devtools instance when the component unmounts', async () => {
-    const { PreactQueryDevtools } = await import('../PreactQueryDevtools')
-    const queryClient = new QueryClient()
-
+  it('should call "unmount" on the devtools instance when the component unmounts', () => {
     const { unmount } = render(<PreactQueryDevtools client={queryClient} />)
     unmount()
 
@@ -277,8 +226,8 @@ describe('PreactQueryDevtools', () => {
     vi.resetModules()
 
     try {
-      const { PreactQueryDevtools } = await import('..')
-      expect(PreactQueryDevtools({})).toBeNull()
+      const { PreactQueryDevtools: ProductionDevtools } = await import('..')
+      expect(ProductionDevtools({})).toBeNull()
     } finally {
       vi.unstubAllEnvs()
       vi.resetModules()

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -30,9 +30,8 @@ describe('PreactQueryDevtoolsPanel', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    ;({ PreactQueryDevtoolsPanel } = await import(
-      '../PreactQueryDevtoolsPanel'
-    ))
+    ;({ PreactQueryDevtoolsPanel } =
+      await import('../PreactQueryDevtoolsPanel'))
     queryClient = new QueryClient()
   })
 

--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/preact'
 import { QueryClient, QueryClientProvider } from '@tanstack/preact-query'
 import { TanstackQueryDevtoolsPanel } from '@tanstack/query-devtools'
+import type { PreactQueryDevtoolsPanel as PreactQueryDevtoolsPanelComponent } from '../PreactQueryDevtoolsPanel'
 
 const mountMock = vi.fn()
 const unmountMock = vi.fn()
@@ -24,24 +25,24 @@ vi.mock('@tanstack/query-devtools', () => ({
 }))
 
 describe('PreactQueryDevtoolsPanel', () => {
-  beforeEach(() => {
+  let PreactQueryDevtoolsPanel: typeof PreactQueryDevtoolsPanelComponent
+  let queryClient: QueryClient
+
+  beforeEach(async () => {
     vi.clearAllMocks()
+    ;({ PreactQueryDevtoolsPanel } = await import(
+      '../PreactQueryDevtoolsPanel'
+    ))
+    queryClient = new QueryClient()
   })
 
-  it('should throw an error if no query client has been set', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-
+  it('should throw an error if no query client has been set', () => {
     expect(() => render(<PreactQueryDevtoolsPanel />)).toThrow(
       'No QueryClient set, use QueryClientProvider to set one',
     )
   })
 
-  it('should not throw an error if query client is provided via context', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should not throw an error if query client is provided via context', () => {
     expect(() =>
       render(
         <QueryClientProvider client={queryClient}>
@@ -52,21 +53,14 @@ describe('PreactQueryDevtoolsPanel', () => {
     expect(mountMock).toHaveBeenCalled()
   })
 
-  it('should not throw an error if query client is provided via props', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should not throw an error if query client is provided via props', () => {
     expect(() =>
       render(<PreactQueryDevtoolsPanel client={queryClient} />),
     ).not.toThrow()
     expect(mountMock).toHaveBeenCalled()
   })
 
-  it('should forward "onClose" to the devtools instance', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
+  it('should forward "onClose" to the devtools instance', () => {
     const onClose = vi.fn()
 
     render(<PreactQueryDevtoolsPanel client={queryClient} onClose={onClose} />)
@@ -74,20 +68,13 @@ describe('PreactQueryDevtoolsPanel', () => {
     expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
   })
 
-  it('should default "onClose" to a no-op function when the prop is omitted', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should default "onClose" to a no-op function when the prop is omitted', () => {
     render(<PreactQueryDevtoolsPanel client={queryClient} />)
 
     expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
   })
 
-  it('should forward "errorTypes" to the devtools instance', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
+  it('should forward "errorTypes" to the devtools instance', () => {
     const errorTypes = [
       { name: 'Network', initializer: () => new Error('Network') },
     ]
@@ -99,41 +86,25 @@ describe('PreactQueryDevtoolsPanel', () => {
     expect(setErrorTypesMock).toHaveBeenCalledWith(errorTypes)
   })
 
-  it('should default "errorTypes" to an empty array when the prop is omitted', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should default "errorTypes" to an empty array when the prop is omitted', () => {
     render(<PreactQueryDevtoolsPanel client={queryClient} />)
 
     expect(setErrorTypesMock).toHaveBeenCalledWith([])
   })
 
-  it('should forward "theme" to the devtools instance', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should forward "theme" to the devtools instance', () => {
     render(<PreactQueryDevtoolsPanel client={queryClient} theme="dark" />)
 
     expect(setThemeMock).toHaveBeenCalledWith('dark')
   })
 
-  it('should forward the resolved "QueryClient" via "setClient"', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should forward the resolved "QueryClient" via "setClient"', () => {
     render(<PreactQueryDevtoolsPanel client={queryClient} />)
 
     expect(setClientMock).toHaveBeenCalledWith(queryClient)
   })
 
-  it('should forward "styleNonce" to the devtools constructor', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should forward "styleNonce" to the devtools constructor', () => {
     render(<PreactQueryDevtoolsPanel client={queryClient} styleNonce="abc" />)
 
     expect(TanstackQueryDevtoolsPanel).toHaveBeenCalledWith(
@@ -141,10 +112,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     )
   })
 
-  it('should forward "shadowDOMTarget" to the devtools constructor', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
+  it('should forward "shadowDOMTarget" to the devtools constructor', () => {
     const shadowDOMTarget = document
       .createElement('div')
       .attachShadow({ mode: 'open' })
@@ -161,11 +129,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     )
   })
 
-  it('should forward "hideDisabledQueries" to the devtools constructor', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should forward "hideDisabledQueries" to the devtools constructor', () => {
     render(
       <PreactQueryDevtoolsPanel
         client={queryClient}
@@ -178,11 +142,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     )
   })
 
-  it('should preserve the default container height when "style" omits "height"', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should preserve the default container height when "style" omits "height"', () => {
     const { container } = render(
       <PreactQueryDevtoolsPanel
         client={queryClient}
@@ -196,11 +156,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     })
   })
 
-  it('should let "style" override the default container height on the rendered element', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should let "style" override the default container height on the rendered element', () => {
     const { container } = render(
       <PreactQueryDevtoolsPanel
         client={queryClient}
@@ -214,11 +170,7 @@ describe('PreactQueryDevtoolsPanel', () => {
     })
   })
 
-  it('should call "unmount" on the devtools instance when the component unmounts', async () => {
-    const { PreactQueryDevtoolsPanel } =
-      await import('../PreactQueryDevtoolsPanel')
-    const queryClient = new QueryClient()
-
+  it('should call "unmount" on the devtools instance when the component unmounts', () => {
     const { unmount } = render(
       <PreactQueryDevtoolsPanel client={queryClient} />,
     )
@@ -232,8 +184,9 @@ describe('PreactQueryDevtoolsPanel', () => {
     vi.resetModules()
 
     try {
-      const { PreactQueryDevtoolsPanel } = await import('..')
-      expect(PreactQueryDevtoolsPanel({})).toBeNull()
+      const { PreactQueryDevtoolsPanel: ProductionDevtoolsPanel } =
+        await import('..')
+      expect(ProductionDevtoolsPanel({})).toBeNull()
     } finally {
       vi.unstubAllEnvs()
       vi.resetModules()


### PR DESCRIPTION
## 🎯 Changes

Removes the boilerplate repeated in every test of `PreactQueryDevtools` and `PreactQueryDevtoolsPanel` by hoisting the shared setup into `beforeEach`:

- The dynamic `await import(...)` of the component and `const queryClient = new QueryClient()` were duplicated in each test. They now live in a single `beforeEach`, exposed via `let` bindings.
- Test callbacks that no longer `await` anything drop their needless `async`.
- The production (`return null`) test keeps its own `import('..')` after `vi.resetModules()` and renames the binding to `ProductionDevtools`/`ProductionDevtoolsPanel` to avoid shadowing.

No test behavior changes; all existing assertions are preserved.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded and streamlined devtools test coverage to better verify prop handling, default values, rendering behavior, and lifecycle cleanup.
  * Added checks for both prop-based and resolved client usage, plus production-mode behavior.
  * Improved confidence that settings like position, theme, height, and constructor options are passed through correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->