### PR TITLE
test({react,preact}-query-devtools): assert the forwarded 'onClose' callback in the panel instead of 'expect.any(Function)'

### DIFF
--- a/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
+++ b/packages/preact-query-devtools/src/__tests__/PreactQueryDevtoolsPanel.test.tsx
@@ -64,13 +64,15 @@ describe('PreactQueryDevtoolsPanel', () => {
 
     render(<PreactQueryDevtoolsPanel client={queryClient} onClose={onClose} />)
 
-    expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
+    expect(setOnCloseMock).toHaveBeenCalledWith(onClose)
   })
 
   it('should default "onClose" to a no-op function when the prop is omitted', () => {
     render(<PreactQueryDevtoolsPanel client={queryClient} />)
 
-    expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
+    const forwarded = setOnCloseMock.mock.calls[0]?.[0]
+    expect(forwarded).toBeInstanceOf(Function)
+    expect(forwarded()).toBeUndefined()
   })
 
   it('should forward "errorTypes" to the devtools instance', () => {

--- a/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
+++ b/packages/react-query-devtools/src/__tests__/ReactQueryDevtoolsPanel.test.tsx
@@ -63,13 +63,15 @@ describe('ReactQueryDevtoolsPanel', () => {
 
     render(<ReactQueryDevtoolsPanel client={queryClient} onClose={onClose} />)
 
-    expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
+    expect(setOnCloseMock).toHaveBeenCalledWith(onClose)
   })
 
   it('should default "onClose" to a no-op function when the prop is omitted', () => {
     render(<ReactQueryDevtoolsPanel client={queryClient} />)
 
-    expect(setOnCloseMock).toHaveBeenCalledWith(expect.any(Function))
+    const forwarded = setOnCloseMock.mock.calls[0]?.[0]
+    expect(forwarded).toBeInstanceOf(Function)
+    expect(forwarded()).toBeUndefined()
   })
 
   it('should forward "errorTypes" to the devtools instance', () => {


### PR DESCRIPTION
## 🎯 Changes

The panel's `onClose` tests both asserted `expect.any(Function)`, so the "forward" and "default" cases were indistinguishable and could not catch a regression in the `props.onClose ?? (() => {})` defaulting logic (any function satisfies the assertion).

- **Forward test**: now asserts the exact `onClose` callback is forwarded (`toHaveBeenCalledWith(onClose)`) instead of any function.
- **Default test**: now captures the forwarded argument and verifies it is a callable no-op (invoking it does not throw and returns `undefined`) instead of any function.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage for devtools panel close behavior.
  * Verified the close callback is passed through exactly as expected.
  * Added checks that the default close callback is a function and safely returns no value when called.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->