### PR TITLE
test(solid-query-devtools/devtoolsPanel): assert the default 'onClose' is a no-op instead of 'expect.any(Function)'

### DIFF
--- a/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
+++ b/packages/solid-query-devtools/src/__tests__/devtoolsPanel.test.tsx
@@ -58,7 +58,9 @@ describe('SolidQueryDevtoolsPanel', () => {
     )
     render(() => <SolidQueryDevtoolsPanel client={queryClient} />)
 
-    expect(setOnClose).toHaveBeenCalledWith(expect.any(Function))
+    const forwarded = setOnClose.mock.calls[0]![0]
+    expect(forwarded).toBeInstanceOf(Function)
+    expect(forwarded()).toBeUndefined()
   })
 
   it('should forward "errorTypes" to the devtools instance', () => {


### PR DESCRIPTION
## 🎯 Changes

The panel's default `onClose` test asserted `expect.any(Function)`, which passes for any function and cannot catch a regression in the `props.onClose ?? (() => {})` defaulting logic.

The test now captures the forwarded argument and verifies it is a callable no-op (invoking it does not throw and returns `undefined`) instead of any function.

The "forward" test already asserts the exact callback (`toHaveBeenCalledWith(onClose)`), so it is left as-is.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for the devtools panel’s default close handler by verifying the registered callback is a function and that it behaves as expected when invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->