### PR TITLE
test(query-core/{hydration,queriesObserver}): remove unnecessary 'async' from tests without 'await'

### DIFF
--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -1643,7 +1643,7 @@ describe('dehydration and rehydration', () => {
   // synchronous thenable resolution must also produce status: 'success'.
   // Previously the if (query) branch would spread status: 'pending' from the
   // server state without correcting it for the resolved data.
-  it('should set status to success when rehydrating an existing pending query with a synchronously resolved promise', async () => {
+  it('should set status to success when rehydrating an existing pending query with a synchronously resolved promise', () => {
     const key = queryKey()
     // --- server ---
 
@@ -1811,7 +1811,7 @@ describe('dehydration and rehydration', () => {
     serverQueryClient.clear()
   })
 
-  it('should set dataUpdatedAt when hydrating a resolved streamed query into a new cache entry', async () => {
+  it('should set dataUpdatedAt when hydrating a resolved streamed query into a new cache entry', () => {
     const key = queryKey()
 
     // --- server ---
@@ -1856,7 +1856,7 @@ describe('dehydration and rehydration', () => {
     serverQueryClient.clear()
   })
 
-  it('should set dataUpdatedAt when hydrating a resolved streamed query into an existing cache entry', async () => {
+  it('should set dataUpdatedAt when hydrating a resolved streamed query into an existing cache entry', () => {
     const key = queryKey()
 
     // --- server ---

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -473,7 +473,7 @@ describe('queriesObserver', () => {
     expect(newCombined.count).toBe(2)
   })
 
-  it('should skip combine notifications while suspense queries have no data', async () => {
+  it('should skip combine notifications while suspense queries have no data', () => {
     const key = queryKey()
     const combine = vi.fn((results: Array<QueryObserverResult>) =>
       results.map((result) => result.data),
@@ -506,7 +506,7 @@ describe('queriesObserver', () => {
     unsubscribe()
   })
 
-  it('should skip combine notifications after suspense is enabled without structural changes', async () => {
+  it('should skip combine notifications after suspense is enabled without structural changes', () => {
     const key = queryKey()
     const combine = vi.fn((results: Array<QueryObserverResult>) =>
       results.map((result) => result.data),


### PR DESCRIPTION
## 🎯 Changes

Removes the `async` keyword from `it` callbacks that contain no `await` in their body, in two `query-core` test files:

- `hydration.test.tsx` (3 tests): rehydrating an existing pending query with a synchronously resolved promise, and setting `dataUpdatedAt` when hydrating a resolved streamed query into a new / existing cache entry.
- `queriesObserver.test.tsx` (2 tests): skipping combine notifications while suspense queries have no data, and after suspense is enabled without structural changes.

These callbacks were marked `async` but never awaited anything, so the marker is unnecessary.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated hydration and query observer tests to use synchronous execution where appropriate.
  * Improved coverage for hydration state updates and suspense-related notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->