### PR TITLE
fix(solid-query): avoid stale-notification resuspend

### DIFF
--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -167,6 +167,67 @@ describe("useQuery's in Suspense mode", () => {
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
 
+  it('should not re-suspend a cache-warm query when it only becomes stale', async () => {
+    const key = queryKey()
+    queryClient.setQueryData(key, 'cached')
+
+    const fallbackMounts: number[] = []
+    const removals: number[] = []
+
+    function Fallback() {
+      fallbackMounts.push(Date.now())
+      return <div data-testid="fallback">loading</div>
+    }
+
+    function Page() {
+      const state = useQuery(() => ({
+        queryKey: key,
+        queryFn: () => Promise.resolve('fresh'),
+        staleTime: 1000,
+      }))
+
+      return (
+        <div data-testid="root">
+          <span>{state.data}</span>
+          <input data-testid="input" />
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback={<Fallback />}>
+        <Page />
+      </Suspense>
+    ))
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const root = rendered.getByTestId('root')
+    const baselineFallbackMounts = fallbackMounts.length
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        removals.push(record.removedNodes.length)
+      }
+    })
+    observer.observe(root.parentElement!, { childList: true })
+
+    const input = rendered.getByTestId('input') as HTMLInputElement
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    await vi.advanceTimersByTimeAsync(1001)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(rendered.queryByTestId('fallback')).toBeNull()
+    expect(document.activeElement).toBe(input)
+    expect(removals.reduce((sum, count) => sum + count, 0)).toBe(0)
+    expect(fallbackMounts.length).toBe(baselineFallbackMounts)
+
+    observer.disconnect()
+  })
+
   it('should remove query instance when component unmounted', async () => {
     const key = queryKey()
 

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -182,9 +182,16 @@ export function useBaseQuery<
     return obs.subscribe((result) => {
       observerResult = result
       queueMicrotask(() => {
-        if (unsubscribe) {
-          refetch()
+        if (!unsubscribe) {
+          return
         }
+
+        if (resolver || result.isLoading || result.isError) {
+          refetch()
+          return
+        }
+
+        setStateWithReconciliation(result)
       })
     })
   }


### PR DESCRIPTION
## Summary
- stop cycling the Solid resource for already-settled observer notifications in `useBaseQuery`
- keep Suspense/error semantics for genuine loading and error transitions by still using `refetch()` when the resource must re-enter those states
- add a cache-warm staleTime regression test that proves a stale-only notification no longer re-suspends the subtree and drops input focus

Closes #11024.

## Testing
- `cd packages/solid-query && pnpm exec vitest run src/__tests__/suspense.test.tsx --environment jsdom`
- `pnpm --filter @tanstack/solid-query test:types:tscurrent`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query behavior so cached results don’t re-trigger loading states when they become stale.
  * Preserved focus and prevented unnecessary UI remounts during stale transitions.
  * Reduced the chance of updates running after a view has already unsubscribed.

* **Tests**
  * Added coverage for stale cached queries in Suspense, including focus stability and DOM preservation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->