### PR TITLE
fix(query-codemods): forward extra args in keep-previous-data

### DIFF
--- a/packages/query-codemods/src/v5/keep-previous-data/keep-previous-data.cjs
+++ b/packages/query-codemods/src/v5/keep-previous-data/keep-previous-data.cjs
@@ -172,7 +172,7 @@ const transformUsages = ({ jscodeshift, utils, root, filePath, config }) => {
         return jscodeshift.callExpression(node.original.callee, [
           node.arguments[0],
           transformedArgument,
-          ...node.arguments.slice(2, 0),
+          ...node.arguments.slice(2),
         ])
       }
 


### PR DESCRIPTION
## 🎯 Changes

In the `keep-previous-data` codemod, the `QueryClient`-method transformer rebuilds the call expression as `[arg0, transformedArg1, ...node.arguments.slice(2, 0)]`. The intent of the spread is to forward any arguments beyond the second, but `slice(2, 0)` **always returns `[]`** — per the spec, when `end < start` the result is empty. So the spread is a no-op that silently discards any trailing arguments.

The fix drops the erroneous `end` argument so the tail is actually forwarded:

```diff
-          ...node.arguments.slice(2, 0),
+          ...node.arguments.slice(2),
```

This matches the `...slice(2)` form already used in the `remove-overloads` transformer.

Scope note: today this codemod only transforms `setQueryDefaults`, whose public signature is 2-arg (`queryKey`, `options`), so no current input reaches a 3rd argument — this is a correctness/robustness fix that removes a dead-code no-op and guards the transformer against future config additions or hand-written input, rather than a fix for an observed broken migration.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with the package's test suite (`@tanstack/query-codemods` vitest + eslint pass).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release) — `@tanstack/query-codemods` is a private, unpublished package, so no changeset applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where an update path could drop extra arguments in certain query-related transformations, preserving the full original call details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->