### PR TITLE
docs(*): fix 'homogenous', 'stoage', 'supressed', 'compoennts' spelling typos

### DIFF
--- a/docs/framework/react/plugins/createPersister.md
+++ b/docs/framework/react/plugins/createPersister.md
@@ -106,7 +106,7 @@ If `query` is `expired`, `busted` or `malformed` it would be removed from the st
 
 ### `persisterGc(): Promise<void>`
 
-This function can be used to sporadically clean up stoage from `expired`, `busted` or `malformed` entries.
+This function can be used to sporadically clean up storage from `expired`, `busted` or `malformed` entries.
 
 For this function to work, your storage must expose `entries` method that would return a `key-value tuple array`.  
 For example `Object.entries(localStorage)` for `localStorage` or `entries` from `idb-keyval`.

--- a/docs/framework/vue/plugins/createPersister.md
+++ b/docs/framework/vue/plugins/createPersister.md
@@ -103,7 +103,7 @@ If `query` is `expired`, `busted` or `malformed` it would be removed from the st
 
 ### `persisterGc(): Promise<void>`
 
-This function can be used to sporadically clean up stoage from `expired`, `busted` or `malformed` entries.
+This function can be used to sporadically clean up storage from `expired`, `busted` or `malformed` entries.
 
 For this function to work, your storage must expose `entries` method that would return a `key-value tuple array`.  
 For example `Object.entries(localStorage)` for `localStorage` or `entries` from `idb-keyval`.

--- a/examples/angular/pagination/src/app/components/example.component.html
+++ b/examples/angular/pagination/src/app/components/example.component.html
@@ -2,7 +2,7 @@
   <p>
     In this example, each page of data remains visible as the next page is
     fetched. The buttons and capability to proceed to the next page are also
-    supressed until the next page cursor is known. Each page is cached as a
+    suppressed until the next page cursor is known. Each page is cached as a
     normal query too, so when going to previous pages, you'll see them
     instantaneously while they are also refetched invisibly in the background.
   </p>

--- a/examples/react/pagination/src/pages/index.tsx
+++ b/examples/react/pagination/src/pages/index.tsx
@@ -54,7 +54,7 @@ function Example() {
       <p>
         In this example, each page of data remains visible as the next page is
         fetched. The buttons and capability to proceed to the next page are also
-        supressed until the next page cursor is known. Each page is cached as a
+        suppressed until the next page cursor is known. Each page is cached as a
         normal query too, so when going to previous pages, you'll see them
         instantaneously while they are also refetched invisibly in the
         background.

--- a/examples/solid/solid-start-streaming/src/routes/with-error.tsx
+++ b/examples/solid/solid-start-streaming/src/routes/with-error.tsx
@@ -13,7 +13,7 @@ export default function Streamed() {
         <p>
           For more control over error handling, try leveraging the `Switch`
           component and watching the reactive `query.isError` property. See
-          `compoennts/query-boundary.tsx` for one possible approach.
+          `components/query-boundary.tsx` for one possible approach.
         </p>
       </div>
 

--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -159,7 +159,7 @@ export type QueriesOptions<
           >
         : ReadonlyArray<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 QueryObserverOptionsForCreateQueries<

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -162,7 +162,7 @@ export type QueriesOptions<
           >
         : ReadonlyArray<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 UseQueryOptionsForUseQueries<

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -125,7 +125,7 @@ export type SuspenseQueriesOptions<
           >
         : Array<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 UseSuspenseQueryOptions<

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -162,7 +162,7 @@ export type QueriesOptions<
           >
         : ReadonlyArray<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 UseQueryOptionsForUseQueries<

--- a/packages/react-query/src/useSuspenseQueries.ts
+++ b/packages/react-query/src/useSuspenseQueries.ts
@@ -125,7 +125,7 @@ export type SuspenseQueriesOptions<
           >
         : Array<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 UseSuspenseQueryOptions<

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -142,7 +142,7 @@ type QueriesOptions<
           >
         : ReadonlyArray<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 UseQueryOptionsForUseQueries<

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -144,7 +144,7 @@ export type QueriesOptions<
           >
         : ReadonlyArray<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 CreateQueryOptionsForCreateQueries<

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -185,7 +185,7 @@ export type UseQueriesOptions<
           >
         : ReadonlyArray<unknown> extends T
           ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
+          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogeneous type!
             // use this to infer the param types in the case of Array.map() argument
             T extends Array<
                 UseQueryOptionsForUseQueries<


### PR DESCRIPTION
Fixes several spelling errors found with codespell:

- `packages/react-query/src/useQueries.ts:165`: `homogenous` -> `homogeneous`
- `packages/react-query/src/useSuspenseQueries.ts:128`: `homogenous` -> `homogeneous`
- `packages/preact-query/src/useQueries.ts:165`: `homogenous` -> `homogeneous`
- `packages/preact-query/src/useSuspenseQueries.ts:128`: `homogenous` -> `homogeneous`
- `packages/vue-query/src/useQueries.ts:188`: `homogenous` -> `homogeneous`
- `packages/solid-query/src/useQueries.ts:145`: `homogenous` -> `homogeneous`
- `packages/svelte-query/src/createQueries.svelte.ts:147`: `homogenous` -> `homogeneous`
- `packages/angular-query-experimental/src/inject-queries.ts:162`: `homogenous` -> `homogeneous`
- `docs/framework/react/plugins/createPersister.md:109`: `stoage` -> `storage`
- `docs/framework/vue/plugins/createPersister.md:106`: `stoage` -> `storage`
- `examples/react/pagination/src/pages/index.tsx:57`: `supressed` -> `suppressed`
- `examples/angular/pagination/src/app/components/example.component.html:5`: `supressed` -> `suppressed`
- `examples/solid/solid-start-streaming/src/routes/with-error.tsx:16`: `compoennts` -> `components`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected typos and clarified wording across framework docs, including persister garbage-collection descriptions.
  * Updated explanatory text in pagination and other examples for clearer, corrected rendering.
  * Refreshed TypeScript guidance comments across multiple query packages (e.g., “homogenous” → “homogeneous”) with no behavioral changes.

* **Bug Fixes**
  * Fixed an incorrect path reference in the streaming error-handling example to prevent the example from referencing the wrong component location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
