### PR TITLE
test(query-core): assert exact booleans with 'toBe' instead of 'toBeTruthy'/'toBeFalsy'

### DIFF
--- a/packages/query-core/src/__tests__/focusManager.test.tsx
+++ b/packages/query-core/src/__tests__/focusManager.test.tsx
@@ -39,7 +39,7 @@ describe('focusManager', () => {
 
     vi.advanceTimersByTime(20)
     expect(count).toEqual(1)
-    expect(focusManager.isFocused()).toBeTruthy()
+    expect(focusManager.isFocused()).toBe(true)
   })
 
   it('should return true for isFocused if document is undefined', () => {
@@ -49,7 +49,7 @@ describe('focusManager', () => {
     delete globalThis.document
 
     focusManager.setFocused()
-    expect(focusManager.isFocused()).toBeTruthy()
+    expect(focusManager.isFocused()).toBe(true)
     globalThis.document = document
   })
 

--- a/packages/query-core/src/__tests__/onlineManager.test.tsx
+++ b/packages/query-core/src/__tests__/onlineManager.test.tsx
@@ -19,7 +19,7 @@ describe('onlineManager', () => {
     // Force navigator to be undefined
     // @ts-expect-error
     navigatorSpy.mockImplementation(() => undefined)
-    expect(onlineManager.isOnline()).toBeTruthy()
+    expect(onlineManager.isOnline()).toBe(true)
 
     navigatorSpy.mockRestore()
   })
@@ -28,7 +28,7 @@ describe('onlineManager', () => {
     const navigatorSpy = vi.spyOn(navigator, 'onLine', 'get')
     navigatorSpy.mockImplementation(() => true)
 
-    expect(onlineManager.isOnline()).toBeTruthy()
+    expect(onlineManager.isOnline()).toBe(true)
 
     navigatorSpy.mockRestore()
   })
@@ -48,7 +48,7 @@ describe('onlineManager', () => {
 
     vi.advanceTimersByTime(20)
     expect(count).toEqual(1)
-    expect(onlineManager.isOnline()).toBeFalsy()
+    expect(onlineManager.isOnline()).toBe(false)
   })
 
   it('setEventListener should call previous remove handler when replacing an event listener', () => {

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -807,7 +807,7 @@ describe('query', () => {
     const query = queryCache.find({ queryKey: key })!
 
     query.invalidate()
-    expect(query.state.isInvalidated).toBeTruthy()
+    expect(query.state.isInvalidated).toBe(true)
 
     const previousState = query.state
 

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1781,8 +1781,8 @@ describe('queryClient', () => {
       void observer1.mutate()
       void observer2.mutate()
 
-      expect(observer1.getCurrentResult().isPaused).toBeTruthy()
-      expect(observer2.getCurrentResult().isPaused).toBeTruthy()
+      expect(observer1.getCurrentResult().isPaused).toBe(true)
+      expect(observer2.getCurrentResult().isPaused).toBe(true)
 
       onlineManager.setOnline(true)
 
@@ -1816,8 +1816,8 @@ describe('queryClient', () => {
       void observer1.mutate()
       void observer2.mutate()
 
-      expect(observer1.getCurrentResult().isPaused).toBeTruthy()
-      expect(observer2.getCurrentResult().isPaused).toBeTruthy()
+      expect(observer1.getCurrentResult().isPaused).toBe(true)
+      expect(observer2.getCurrentResult().isPaused).toBe(true)
 
       onlineManager.setOnline(true)
 
@@ -1861,8 +1861,8 @@ describe('queryClient', () => {
       void observer1.mutate()
       void observer2.mutate()
 
-      expect(observer1.getCurrentResult().isPaused).toBeTruthy()
-      expect(observer2.getCurrentResult().isPaused).toBeTruthy()
+      expect(observer1.getCurrentResult().isPaused).toBe(true)
+      expect(observer2.getCurrentResult().isPaused).toBe(true)
 
       onlineManager.setOnline(true)
       void queryClient.resumePausedMutations()
@@ -1885,12 +1885,12 @@ describe('queryClient', () => {
 
       void observer.mutate()
 
-      expect(observer.getCurrentResult().isPaused).toBeTruthy()
+      expect(observer.getCurrentResult().isPaused).toBe(true)
 
       await queryClient.resumePausedMutations()
 
       // still paused because we are still offline
-      expect(observer.getCurrentResult().isPaused).toBeTruthy()
+      expect(observer.getCurrentResult().isPaused).toBe(true)
 
       onlineManager.setOnline(true)
 
@@ -1909,7 +1909,7 @@ describe('queryClient', () => {
 
       void observer.mutate()
 
-      expect(observer.getCurrentResult().isPaused).toBeTruthy()
+      expect(observer.getCurrentResult().isPaused).toBe(true)
 
       const state = dehydrate(queryClient)
 
@@ -2004,9 +2004,9 @@ describe('queryClient', () => {
 
       void observer3.mutate()
 
-      expect(observer.getCurrentResult().isPaused).toBeTruthy()
-      expect(observer2.getCurrentResult().isPaused).toBeTruthy()
-      expect(observer3.getCurrentResult().isPaused).toBeTruthy()
+      expect(observer.getCurrentResult().isPaused).toBe(true)
+      expect(observer2.getCurrentResult().isPaused).toBe(true)
+      expect(observer3.getCurrentResult().isPaused).toBe(true)
       onlineManager.setOnline(true)
 
       await vi.advanceTimersByTimeAsync(110)

--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -79,7 +79,7 @@ describe('core/utils', () => {
     })
 
     it('should return `true` for object with an undefined constructor', () => {
-      expect(isPlainObject(Object.create(null))).toBeTruthy()
+      expect(isPlainObject(Object.create(null))).toBe(true)
     })
 
     it('should return `false` if constructor does not have an Object-specific method', () => {
@@ -89,7 +89,7 @@ describe('core/utils', () => {
           this.abc = {}
         }
       }
-      expect(isPlainObject(new Foo())).toBeFalsy()
+      expect(isPlainObject(new Foo())).toBe(false)
     })
 
     it('should return `false` if the object has a modified prototype', () => {
@@ -102,7 +102,7 @@ describe('core/utils', () => {
         this.vertices.push(v)
       }
 
-      expect(isPlainObject(Object.create(Graph))).toBeFalsy()
+      expect(isPlainObject(Object.create(Graph))).toBe(false)
     })
 
     it('should return `false` for object with custom prototype', () => {
@@ -110,7 +110,7 @@ describe('core/utils', () => {
       const obj = Object.create(CustomProto)
       obj.b = 2
 
-      expect(isPlainObject(obj)).toBeFalsy()
+      expect(isPlainObject(obj)).toBe(false)
     })
   })
 
@@ -456,7 +456,7 @@ describe('core/utils', () => {
         mutationCache: queryClient.getMutationCache(),
         options: {},
       })
-      expect(matchMutation(filters, mutation)).toBeFalsy()
+      expect(matchMutation(filters, mutation)).toBe(false)
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

Several assertions on strictly-typed `boolean` values used the loose `toBeTruthy()`/`toBeFalsy()` matchers. Since these values are guaranteed to be `boolean` by their type signatures, this tightens them to `toBe(true)`/`toBe(false)`, which additionally catches a value being a truthy/falsy non-boolean (e.g. `1`, `''`, an object) instead of a real boolean.

Affected assertions (all return/field types are `boolean`):

- `onlineManager.isOnline()` — `isOnline(): boolean` (3)
- `focusManager.isFocused()` — `isFocused(): boolean` (2)
- `isPlainObject()` / `matchMutation()` — `boolean` return (5)
- `query.state.isInvalidated` — `isInvalidated: boolean` (1)
- observer `getCurrentResult().isPaused` — `isPaused: boolean` (12)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened boolean assertions across focus, online status, query invalidation, paused mutations, and utility behavior tests.
  * Improved test precision by requiring exact `true` or `false` results instead of truthy or falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->