### PR TITLE
test(solid-query-persist-client/PersistQueryClientProvider): replace 'toMatchObject' with 'toEqual'

### DIFF
--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -114,19 +114,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toMatchObject({
+    expect(states[0]).toEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toMatchObject({
+    expect(states[1]).toEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toMatchObject({
+    expect(states[2]).toEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'fetched',
@@ -198,19 +198,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toMatchObject({
+    expect(states[0]).toEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toMatchObject({
+    expect(states[1]).toEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toMatchObject({
+    expect(states[2]).toEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'fetched',
@@ -282,19 +282,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toMatchObject({
+    expect(states[0]).toEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'initial',
     })
 
-    expect(states[1]).toMatchObject({
+    expect(states[1]).toEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toMatchObject({
+    expect(states[2]).toEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'fetched',
@@ -371,13 +371,13 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(2)
 
-    expect(states[0]).toMatchObject({
+    expect(states[0]).toEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toMatchObject({
+    expect(states[1]).toEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'hydrated',
@@ -580,19 +580,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toMatchObject({
+    expect(states[0]).toEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toMatchObject({
+    expect(states[1]).toEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toMatchObject({
+    expect(states[2]).toEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'queryFn2',


### PR DESCRIPTION
## 🎯 Changes

The `states` array in these tests is populated with hand-built literals of exactly three fields (`status`, `fetchStatus`, `data`) — its type is `Array<{ status; fetchStatus; data }>`. Since every field is asserted and no extra fields exist, the partial `toMatchObject` matcher is tightened to the exact `toEqual`, which additionally catches any unexpected extra key on the observed state.

Note: the sibling react-query persist test pushes the raw `UseQueryResult` (dozens of fields), so `toMatchObject` is correct there and is left unchanged — only this solid test builds a 3-field literal.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test assertions for persisted query state transitions.
  * Added explicit checks for query status, fetch status, and returned data across captured states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->