### PR TITLE
test(query-core/hydration): assert the exact infinite query result with 'toEqual'

### DIFF
--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -1419,10 +1419,10 @@ describe('dehydration and rehydration', () => {
     hydrate(hydrationClient, dehydrated)
 
     const hydratedQuery = hydrationCache.find({ queryKey: key })
-    expect(hydratedQuery?.state.data).toBeDefined()
-    expect(hydratedQuery?.state.data).toHaveProperty('pages')
-    expect(hydratedQuery?.state.data).toHaveProperty('pageParams')
-    expect((hydratedQuery?.state.data as any).pages).toHaveLength(1)
+    expect(hydratedQuery?.state.data).toEqual({
+      pages: [{ items: ['page-0'], nextCursor: 1 }],
+      pageParams: [0],
+    })
   })
 
   it('should attach infiniteQueryBehavior during hydration', async () => {
@@ -1548,11 +1548,10 @@ describe('dehydration and rehydration', () => {
     await vi.advanceTimersByTimeAsync(10)
     const result = await resultPromise
 
-    expect(result).toHaveProperty('pages')
-    expect(result).toHaveProperty('pageParams')
-    expect(Array.isArray(result.pages)).toBe(true)
-    expect(result.pages).toHaveLength(1)
-    expect(result.pages[0]).toHaveProperty('items')
+    expect(result).toEqual({
+      pages: [{ items: ['page-0'], next: 1 }],
+      pageParams: [0],
+    })
   })
 
   it('should retain infinite query type after subsequent setOptions calls', async () => {
@@ -1632,10 +1631,13 @@ describe('dehydration and rehydration', () => {
     await vi.advanceTimersByTimeAsync(20)
     const result = await resultPromise
 
-    expect(result.pages).toHaveLength(2)
-    expect(result.pageParams).toHaveLength(2)
-    expect(result.pages[0]).toHaveProperty('items')
-    expect(result.pages[1]).toHaveProperty('items')
+    expect(result).toEqual({
+      pages: [
+        { items: ['item-0'], next: 1 },
+        { items: ['item-1'], next: 2 },
+      ],
+      pageParams: [0, 1],
+    })
   })
 
   // Companion to the test above: when the query already exists in the cache


### PR DESCRIPTION
## 🎯 Changes

These infinite-query hydration tests only checked the *shape* of the result via several loose assertions (`toHaveProperty`, `toHaveLength`, `Array.isArray`), never the actual contents. Since the result type is exactly `InfiniteData = { pages, pageParams }` (no hidden/non-deterministic fields) and the queryFn returns deterministic values, these are collapsed into a single exact `toEqual` that also verifies the page contents (`items`, `next`/`nextCursor`) and `pageParams` values. This also removes an `as any` cast.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened hydration and refetch test assertions for infinite queries.
  * Added exact validation of page contents, ordering, and page parameters to improve regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->