### PR TITLE
test(vue-query/useQueries): replace 'toMatchObject' with 'toEqual'

### DIFF
--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -264,7 +264,7 @@ describe('useQueries', () => {
     )
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(queriesResult.value).toMatchObject({
+    expect(queriesResult.value).toEqual({
       combined: true,
       res: [firstResult, secondResult],
     })


### PR DESCRIPTION
## 🎯 Changes

The `combine` function in this test returns exactly `{ combined: true, res: [...] }` — a two-field object fully owned and constructed by the test. Since `queriesResult.value` is precisely this returned object with no non-deterministic or hidden fields, the partial `toMatchObject` matcher is tightened to the exact `toEqual`, which additionally catches any unexpected extra key in the combined result.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for combined query results by requiring an exact match for the returned object shape and values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->