### PR TITLE
test(solid-query-persist-client/PersistQueryClientProvider): use 'toStrictEqual' to assert the exact state shape

### DIFF
--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -114,19 +114,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toEqual({
+    expect(states[0]).toStrictEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toEqual({
+    expect(states[1]).toStrictEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toEqual({
+    expect(states[2]).toStrictEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'fetched',
@@ -198,19 +198,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toEqual({
+    expect(states[0]).toStrictEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toEqual({
+    expect(states[1]).toStrictEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toEqual({
+    expect(states[2]).toStrictEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'fetched',
@@ -282,19 +282,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toEqual({
+    expect(states[0]).toStrictEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'initial',
     })
 
-    expect(states[1]).toEqual({
+    expect(states[1]).toStrictEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toEqual({
+    expect(states[2]).toStrictEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'fetched',
@@ -371,13 +371,13 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(2)
 
-    expect(states[0]).toEqual({
+    expect(states[0]).toStrictEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toEqual({
+    expect(states[1]).toStrictEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'hydrated',
@@ -580,19 +580,19 @@ describe('PersistQueryClientProvider', () => {
 
     expect(states).toHaveLength(3)
 
-    expect(states[0]).toEqual({
+    expect(states[0]).toStrictEqual({
       status: 'pending',
       fetchStatus: 'idle',
       data: undefined,
     })
 
-    expect(states[1]).toEqual({
+    expect(states[1]).toStrictEqual({
       status: 'success',
       fetchStatus: 'fetching',
       data: 'hydrated',
     })
 
-    expect(states[2]).toEqual({
+    expect(states[2]).toStrictEqual({
       status: 'success',
       fetchStatus: 'idle',
       data: 'queryFn2',


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11044. The `states` assertions check the pending state as `{ status: 'pending', fetchStatus: 'idle', data: undefined }`. With `toEqual`, a missing `data` key is treated the same as `data: undefined`, so a regression where the pending state stops including the `data` property would go unnoticed. `toStrictEqual` requires the `data` key to be explicitly present, which is the actual intent here.

All `states` assertions in the file are switched together to keep the matcher consistent within the same state-transition sequence.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test assertions for query state transitions during cache restoration, fetching, and persistence flows.
  * Improved validation of status, fetch status, and returned data across multiple client scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->