### PR TITLE
test(query-core/utils,vue-query/mutationOptions): assert reference identity with 'toBe'

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -463,7 +463,7 @@ describe('core/utils', () => {
   describe('keepPreviousData', () => {
     it('should return the parameter as is', () => {
       const x = { a: 1, b: 2 }
-      expect(keepPreviousData(x)).toEqual(x)
+      expect(keepPreviousData(x)).toBe(x)
     })
   })
 

--- a/packages/vue-query/src/__tests__/mutationOptions.test.ts
+++ b/packages/vue-query/src/__tests__/mutationOptions.test.ts
@@ -24,7 +24,7 @@ describe('mutationOptions', () => {
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the object received as a parameter without any modification (without mutationKey in mutationOptions)', () => {
@@ -32,7 +32,7 @@ describe('mutationOptions', () => {
       mutationFn: () => sleep(10).then(() => 5),
     } as const
 
-    expect(mutationOptions(object)).toStrictEqual(object)
+    expect(mutationOptions(object)).toBe(object)
   })
 
   it('should return the getter received as a parameter without any modification (with mutationKey in mutationOptions)', () => {


### PR DESCRIPTION
## 🎯 Changes

`keepPreviousData` and `mutationOptions` are pure pass-through helpers that return the exact same reference they receive (`return previousData` / `return options`). Their tests asserted the return value with `toEqual`/`toStrictEqual`, which only compares by value — so they would still pass even if the helper wrongly returned a copy (e.g. `{ ...options }`), missing the "return as is" contract. This switches them to `toBe`, which asserts reference identity — the actual contract.

- `keepPreviousData` (`query-core`) — test title is literally "should return the parameter as is"
- `mutationOptions` (`vue-query`) — aligns with the other frameworks, whose `*Options` tests already use `toBe` (#10192, #10407)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated tests to verify that returned and provided objects preserve their original references.
  * Improved coverage for data retention and mutation option handling without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->