### PR TITLE
test(vue-query/vueQueryPlugin): assert exact booleans with 'toBe' instead of 'toBeTruthy'/'toBeFalsy'

### DIFF
--- a/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
+++ b/packages/vue-query/src/__tests__/vueQueryPlugin.test.ts
@@ -271,11 +271,11 @@ describe('VueQueryPlugin', () => {
         ],
       })
 
-      expect(customClient.isRestoring?.value).toBeTruthy()
+      expect(customClient.isRestoring?.value).toBe(true)
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(customClient.isRestoring?.value).toBeFalsy()
+      expect(customClient.isRestoring?.value).toBe(false)
     })
 
     it('should delay useQuery subscription and not call fetcher if data is not stale', async () => {
@@ -314,14 +314,14 @@ describe('VueQueryPlugin', () => {
         customClient,
       )
 
-      expect(customClient.isRestoring?.value).toBeTruthy()
-      expect(query.isFetching.value).toBeFalsy()
+      expect(customClient.isRestoring?.value).toBe(true)
+      expect(query.isFetching.value).toBe(false)
       expect(query.data.value).toStrictEqual(undefined)
       expect(fnSpy).toHaveBeenCalledTimes(0)
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(customClient.isRestoring?.value).toBeFalsy()
+      expect(customClient.isRestoring?.value).toBe(false)
       expect(query.data.value).toStrictEqual({ foo: 'bar' })
       expect(fnSpy).toHaveBeenCalledTimes(0)
     })
@@ -378,18 +378,18 @@ describe('VueQueryPlugin', () => {
         customClient,
       )
 
-      expect(customClient.isRestoring?.value).toBeTruthy()
+      expect(customClient.isRestoring?.value).toBe(true)
 
-      expect(query.isFetching.value).toBeFalsy()
+      expect(query.isFetching.value).toBe(false)
       expect(query.data.value).toStrictEqual(undefined)
 
-      expect(queries.value[0].isFetching).toBeFalsy()
+      expect(queries.value[0].isFetching).toBe(false)
       expect(queries.value[0].data).toStrictEqual(undefined)
       expect(fnSpy).toHaveBeenCalledTimes(0)
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(customClient.isRestoring?.value).toBeFalsy()
+      expect(customClient.isRestoring?.value).toBe(false)
       expect(query.data.value).toStrictEqual({ foo1: 'bar1' })
       expect(queries.value[0].data).toStrictEqual({ foo2: 'bar2' })
       expect(fnSpy).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11043 (same change, for the vue-query package). Several assertions on strictly-typed `boolean` values used the loose `toBeTruthy()`/`toBeFalsy()` matchers. Since these values are guaranteed `boolean` by their types, this tightens them to `toBe(true)`/`toBe(false)`, which additionally catches a value being a truthy/falsy non-boolean instead of a real boolean.

Affected values (all `boolean`):

- `client.isRestoring.value` — `isRestoring: Ref<boolean>`
- `query.isFetching.value` / `queries.value[0].isFetching` — `isFetching: boolean`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for persisted query restoration.
  * Added explicit checks confirming queries remain idle and without data while restoration is in progress.
  * Verified fetchers are not called prematurely and restoration completes as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->