### PR TITLE
test({vue,angular}-query): pin the reactive refetch call with 'toHaveBeenNthCalledWith'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -436,7 +436,7 @@ describe('injectQuery', () => {
 
     expect(spy).toHaveBeenCalledTimes(2)
     // should call queryFn with context containing the new queryKey
-    expect(spy).toHaveBeenCalledWith({
+    expect(spy).toHaveBeenNthCalledWith(2, {
       client: queryClient,
       meta: undefined,
       queryKey: key2,
@@ -528,7 +528,8 @@ describe('injectQuery', () => {
 
     void query.refetch().then(() => {
       expect(fetchFn).toHaveBeenCalledTimes(1)
-      expect(fetchFn).toHaveBeenCalledWith(
+      expect(fetchFn).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
           queryKey: [...key, 'key11'],
         }),
@@ -541,7 +542,8 @@ describe('injectQuery', () => {
 
     void query.refetch().then(() => {
       expect(fetchFn).toHaveBeenCalledTimes(2)
-      expect(fetchFn).toHaveBeenCalledWith(
+      expect(fetchFn).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({
           queryKey: [...key, 'key12'],
         }),

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -332,7 +332,8 @@ describe('useQuery', () => {
     expect(fetchFn).not.toHaveBeenCalled()
     await query.refetch()
     expect(fetchFn).toHaveBeenCalledTimes(1)
-    expect(fetchFn).toHaveBeenCalledWith(
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         queryKey: [...key, 'key11'],
       }),
@@ -341,7 +342,8 @@ describe('useQuery', () => {
     keyRef.value = 'key12'
     await query.refetch()
     expect(fetchFn).toHaveBeenCalledTimes(2)
-    expect(fetchFn).toHaveBeenCalledWith(
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         queryKey: [...key, 'key12'],
       }),


### PR DESCRIPTION
## 🎯 Changes

These tests change a reactive query key and refetch, so `queryFn`/`fetchFn` fires twice — first with the old key, then with the new key. The calls were asserted with order-agnostic `toHaveBeenCalledWith`, which passes as long as *some* call carried a given key, regardless of order. That leaves the sequence unverified: an assertion for the new key could be satisfied by the wrong call.

Switching to `toHaveBeenNthCalledWith(n, ...)` pins each assertion to a specific call, so the first call is verified to use the old key and the second (the refetch after the key changed) is verified to use the new key.

- `vue-query/useQuery` — `keyRef` changed then `refetch()`; both calls pinned by order
- `angular-query-experimental/inject-query` — key signal changed then re-run; both the refetch case and the options-signal-change case pinned by order (the inline comment already states the intent is "the new queryKey")

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved accuracy for query refetching tests after reactive query key updates.
  * Tests now assert the exact \`fetchFn\`/\`queryFn\` arguments by invocation order (first vs. second call), ensuring the correct query key is used on each refetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->