### PR TITLE
test(query-devtools/PiPContext): assert exact spy arguments instead of 'objectContaining'/'stringContaining'

### DIFF
--- a/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
+++ b/packages/query-devtools/src/__tests__/contexts/PiPContext.test.tsx
@@ -367,7 +367,7 @@ describe('PiPContext', () => {
         })
 
         expect(consoleError).toHaveBeenCalledWith(
-          expect.stringContaining('Failed to open popup'),
+          'Failed to open popup. Please allow popups for this site to view the devtools in picture-in-picture mode.',
         )
         expect(localStorage.getItem('TanstackQueryDevtools.pip_open')).toBe(
           'false',
@@ -428,10 +428,11 @@ describe('PiPContext', () => {
           disabled: true,
         })
 
-        expect(observeSpy).toHaveBeenCalledWith(
-          gooberStyle,
-          expect.objectContaining({ childList: true, subtree: true }),
-        )
+        expect(observeSpy).toHaveBeenCalledWith(gooberStyle, {
+          childList: true,
+          subtree: true,
+          characterDataOldValue: true,
+        })
       } finally {
         gooberStyle.remove()
       }


### PR DESCRIPTION
## 🎯 Changes

Two assertions in `PiPContext.test.tsx` matched spy arguments partially, so they skipped fields the source actually passes. Both are now pinned to the exact value.

- **`should observe the parent "#_goober" style...`** — `observe` was checked with `expect.objectContaining({ childList: true, subtree: true })`, which ignores extra keys and silently skipped `characterDataOldValue`. Now asserts the full options object:

  ```ts
  observer.observe(gooberStyles, {
    childList: true,
    subtree: true,
    characterDataOldValue: true,
  })
  ```

- **`should reset "pip_open"/"open" and log when "window.open" returns null on auto-open`** — `console.error` was checked with `expect.stringContaining('Failed to open popup')`, matching only a prefix. The source logs a fixed `PipOpenError` message, so the assertion now pins the full string.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened assertions for the PiP auto-open failure scenario to expect the exact `console.error` message when popup opening returns `null`.
  * Strengthened MutationObserver-related coverage to verify observation options fully include `childList`, `subtree`, and `characterDataOldValue: true`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->