### PR TITLE
test(query-core): assert exact cache event payloads in subscribe callbacks

### DIFF
--- a/packages/query-core/src/__tests__/mutationCache.test.tsx
+++ b/packages/query-core/src/__tests__/mutationCache.test.tsx
@@ -503,9 +503,7 @@ describe('mutationCache', () => {
 
       expect(testCache.getAll()).toHaveLength(0)
       expect(callback).toHaveBeenCalledTimes(1)
-      expect(callback).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'removed', mutation }),
-      )
+      expect(callback).toHaveBeenCalledWith({ type: 'removed', mutation })
 
       unsubscribe()
     })

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -966,13 +966,10 @@ describe('query', () => {
     const unsubscribe = queryClient.getQueryCache().subscribe(fn)
 
     queryClient.setQueryData(key, 'data')
+    const query = queryClient.getQueryCache().find({ queryKey: key })
 
     await vi.advanceTimersByTimeAsync(10)
-    expect(fn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'removed',
-      }),
-    )
+    expect(fn).toHaveBeenLastCalledWith({ type: 'removed', query })
 
     expect(queryClient.getQueryCache().findAll()).toHaveLength(0)
 

--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -24,7 +24,7 @@ describe('queryCache', () => {
       const unsubscribe = queryCache.subscribe(subscriber)
       queryClient.setQueryData(key, 'foo')
       const query = queryCache.find({ queryKey: key })
-      expect(subscriber).toHaveBeenCalledWith({ query, type: 'added' })
+      expect(subscriber).toHaveBeenNthCalledWith(1, { query, type: 'added' })
       unsubscribe()
     })
 
@@ -37,7 +37,8 @@ describe('queryCache', () => {
         queryFn: () => sleep(100).then(() => 'data'),
       })
       await vi.advanceTimersByTimeAsync(100)
-      expect(callback).toHaveBeenCalled()
+      const query = queryCache.find({ queryKey: key })
+      expect(callback).toHaveBeenNthCalledWith(1, { query, type: 'added' })
     })
 
     it('should notify query cache when a query becomes stale', async () => {
@@ -89,7 +90,7 @@ describe('queryCache', () => {
       })
       await vi.advanceTimersByTimeAsync(100)
       const query = queryCache.find({ queryKey: key })
-      expect(callback).toHaveBeenCalledWith({ query, type: 'added' })
+      expect(callback).toHaveBeenNthCalledWith(1, { query, type: 'added' })
     })
 
     it('should notify subscribers when new query with initialData is added', async () => {
@@ -102,7 +103,8 @@ describe('queryCache', () => {
         initialData: 'initial',
       })
       await vi.advanceTimersByTimeAsync(100)
-      expect(callback).toHaveBeenCalled()
+      const query = queryCache.find({ queryKey: key })
+      expect(callback).toHaveBeenNthCalledWith(1, { query, type: 'added' })
     })
 
     it('should be able to limit cache size', async () => {

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1614,7 +1614,15 @@ describe('queryClient', () => {
 
       queryClient.resetQueries({ queryKey: key })
 
-      expect(callback).toHaveBeenCalled()
+      const query = queryCache.find({ queryKey: key })
+      expect(callback).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          type: 'updated',
+          query,
+          action: expect.objectContaining({ type: 'setState' }),
+        }),
+      )
     })
 
     it('should reset query', async () => {

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1240,10 +1240,13 @@ describe('queryObserver', () => {
     const unsubscribe = queryClient.getQueryCache().subscribe(spy)
     observer.setOptions({ queryKey: key, enabled: false, refetchInterval: 10 })
 
+    const query = queryClient.getQueryCache().find({ queryKey: key })
     expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'observerOptionsUpdated' }),
-    )
+    expect(spy).toHaveBeenCalledWith({
+      type: 'observerOptionsUpdated',
+      query,
+      observer,
+    })
 
     unsubscribe()
   })


### PR DESCRIPTION
## 🎯 Changes

`QueryCache`/`MutationCache` subscribe callbacks receive an event object whose `query`/`mutation` is an instance the library creates internally. Several tests only checked that the callback fired (`toHaveBeenCalled()`) or matched the `type` field partially (`objectContaining`), leaving the instance and the exact payload shape unverified.

Each test can recover the instance from the cache (`find({ queryKey })`, or the in-scope `mutation`/`observer`), so the assertions now pin the full event object. Where the callback fires multiple times in a known order, the assertion is also pinned to the right call (`added` is the first event, `removed` from gc is the last).

- **`queryCache` — `added` events (4 tests)** — assert `toHaveBeenNthCalledWith(1, { query, type: 'added' })`; `added` is always the first event, and the earlier `toHaveBeenCalledWith`/`toHaveBeenCalled()` did not pin the call position
- **`mutationCache` — "should still notify removal..."** — dropped `objectContaining` so `{ type: 'removed', mutation }` also asserts no extra fields (single call is already guaranteed by `toHaveBeenCalledTimes(1)`)
- **`query` — "queries should be garbage collected even if they never fetched"** — captures the query before gc removes it, then asserts `toHaveBeenLastCalledWith({ type: 'removed', query })` (gc removal is the last event)
- **`queryObserver` — "should notify cache listeners when setOptions is called"** — asserts the full `{ type: 'observerOptionsUpdated', query, observer }` (single call is already guaranteed by `toHaveBeenCalledTimes(1)`)
- **`queryClient` — "should notify listeners when a query is reset"** — `toHaveBeenCalled()` → `toHaveBeenNthCalledWith(1, objectContaining({ type: 'updated', query, action: { type: 'setState' } }))` (the `action.state` snapshot is left open, as it depends on timing)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened cache and observer notification tests to verify complete event payloads.
  * Added precise assertions for query and mutation additions, removals, updates, garbage collection, and option changes.
  * Improved validation of callback invocation order and associated query, observer, and action details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->