### PR TITLE
test(query-core/queryClient): add test for invalidated 'fetchQuery' resolving consistently

### DIFF
--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1370,6 +1370,37 @@ describe('queryClient', () => {
   })
 
   describe('invalidateQueries', () => {
+    it.each([true, false])(
+      'should resolve an invalidated imperative fetch when observer active is %s',
+      async (observerActive) => {
+        const key = queryKey()
+        const queryFn = vi.fn(() => sleep(50).then(() => 'updated'))
+        queryClient.setQueryData(key, 'initial')
+
+        const observer = new QueryObserver(queryClient, {
+          queryKey: key,
+          queryFn,
+          staleTime: Infinity,
+          enabled: observerActive,
+        })
+        const unsubscribe = observer.subscribe(() => undefined)
+
+        const promise = queryClient.fetchQuery({
+          queryKey: key,
+          queryFn,
+          staleTime: 0,
+        })
+
+        await vi.advanceTimersByTimeAsync(10)
+        void queryClient.invalidateQueries({ queryKey: key })
+        await vi.advanceTimersByTimeAsync(50)
+
+        await expect(promise).resolves.toBe('updated')
+        expect(queryFn).toHaveBeenCalledTimes(observerActive ? 2 : 1)
+        unsubscribe()
+      },
+    )
+
     it('should refetch active queries by default', async () => {
       const key1 = queryKey()
       const key2 = queryKey()


### PR DESCRIPTION
## Summary

- add regression coverage for stale `fetchQuery` calls invalidated after fetching starts
- exercise the scenario with both an active and inactive observer
- assert that both paths resolve with fresh data while preserving their distinct refetch counts

## Context

Issue #8060 reported that `invalidateQueries` could make an imperative `fetchQuery` reject with a silent `CancelledError` only when an unrelated active observer existed.

The cancellation changes merged in #9293 now intentionally make a silently cancelled fetch follow the replacement fetch promise. On current `main`, the active-observer path starts a replacement fetch while the inactive path keeps its original fetch, but both consistently resolve with the updated data. This test locks that behavior against the original reproduction conditions.

## Validation

- `pnpm --filter @tanstack/query-core test:lib --run src/__tests__/queryClient.test.tsx` (109 tests)
- `pnpm --filter @tanstack/query-core test:lib --run` (548 tests)
- `pnpm --filter @tanstack/query-core test:eslint` (0 errors; one pre-existing cspell warning)
- `pnpm --filter @tanstack/query-core test:types:tscurrent`
- `pnpm prettier --write packages/query-core/src/__tests__/queryClient.test.tsx`

The full legacy TypeScript matrix could not run locally because Corepack attempted to execute its cached `pnpm.cjs` directly and returned `EACCES`; the current TypeScript build and Vitest type checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query invalidation behavior while fetches are in progress.
  * Ensured pending fetch requests resolve with updated data whether or not an active observer is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->