### PR TITLE
test(vue-query/{usePrefetchQuery,usePrefetchInfiniteQuery}): assert exact prefetch options instead of 'objectContaining'

### DIFF
--- a/packages/vue-query/src/__tests__/usePrefetchInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/usePrefetchInfiniteQuery.test.ts
@@ -19,9 +19,9 @@ describe('usePrefetchInfiniteQuery', () => {
       queryClient,
       'prefetchInfiniteQuery',
     )
-    const queryFn = vi.fn(() =>
-      Promise.resolve({ data: 'prefetched', currentPage: 1 }),
-    )
+    const queryFn = () =>
+      Promise.resolve({ data: 'prefetched', currentPage: 1 })
+    const getNextPageParam = () => undefined
 
     const key = queryKey()
 
@@ -30,7 +30,7 @@ describe('usePrefetchInfiniteQuery', () => {
         queryKey: key,
         queryFn,
         initialPageParam: 1,
-        getNextPageParam: () => undefined,
+        getNextPageParam,
       },
       queryClient,
     )
@@ -40,7 +40,7 @@ describe('usePrefetchInfiniteQuery', () => {
       queryKey: key,
       queryFn,
       initialPageParam: 1,
-      getNextPageParam: expect.any(Function),
+      getNextPageParam,
     })
   })
 
@@ -50,9 +50,8 @@ describe('usePrefetchInfiniteQuery', () => {
       queryClient,
       'prefetchInfiniteQuery',
     )
-    const queryFn = vi.fn(() =>
-      Promise.resolve({ data: 'prefetched', currentPage: 1 }),
-    )
+    const queryFn = () =>
+      Promise.resolve({ data: 'prefetched', currentPage: 1 })
 
     const key = queryKey()
     queryClient.setQueryData(key, {
@@ -81,22 +80,26 @@ describe('usePrefetchInfiniteQuery', () => {
     )
     const nestedRef = ref('value')
     const key = queryKey()
+    const queryFn = () =>
+      Promise.resolve({ data: 'prefetched', currentPage: 1 })
+    const getNextPageParam = () => undefined
 
     usePrefetchInfiniteQuery(
       {
         queryKey: [...key, nestedRef],
-        queryFn: () => Promise.resolve({ data: 'prefetched', currentPage: 1 }),
+        queryFn,
         initialPageParam: 1,
-        getNextPageParam: () => undefined,
+        getNextPageParam,
       },
       queryClient,
     )
 
-    expect(prefetchInfiniteQuerySpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queryKey: [...key, 'value'],
-      }),
-    )
+    expect(prefetchInfiniteQuerySpy).toHaveBeenCalledWith({
+      queryKey: [...key, 'value'],
+      queryFn,
+      initialPageParam: 1,
+      getNextPageParam,
+    })
   })
 
   it('should prefetch infinite query again when query key changes reactively', async () => {
@@ -107,33 +110,37 @@ describe('usePrefetchInfiniteQuery', () => {
     )
     const keyRef = ref('first')
     const key = queryKey()
+    const queryFn = () =>
+      Promise.resolve({ data: keyRef.value, currentPage: 1 })
+    const getNextPageParam = () => undefined
 
     usePrefetchInfiniteQuery(
       () => ({
         queryKey: [...key, keyRef.value],
-        queryFn: () => Promise.resolve({ data: keyRef.value, currentPage: 1 }),
+        queryFn,
         initialPageParam: 1,
-        getNextPageParam: () => undefined,
+        getNextPageParam,
       }),
       queryClient,
     )
 
-    expect(prefetchInfiniteQuerySpy).toHaveBeenCalledTimes(1)
-    expect(prefetchInfiniteQuerySpy).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        queryKey: [...key, 'first'],
-      }),
-    )
+    expect(prefetchInfiniteQuerySpy).toHaveBeenNthCalledWith(1, {
+      queryKey: [...key, 'first'],
+      queryFn,
+      initialPageParam: 1,
+      getNextPageParam,
+    })
 
     keyRef.value = 'second'
     await nextTick()
 
     expect(prefetchInfiniteQuerySpy).toHaveBeenCalledTimes(2)
-    expect(prefetchInfiniteQuerySpy).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        queryKey: [...key, 'second'],
-      }),
-    )
+    expect(prefetchInfiniteQuerySpy).toHaveBeenNthCalledWith(2, {
+      queryKey: [...key, 'second'],
+      queryFn,
+      initialPageParam: 1,
+      getNextPageParam,
+    })
   })
 
   it('should warn when used outside of setup function in development mode', () => {

--- a/packages/vue-query/src/__tests__/usePrefetchQuery.test.ts
+++ b/packages/vue-query/src/__tests__/usePrefetchQuery.test.ts
@@ -16,7 +16,7 @@ describe('usePrefetchQuery', () => {
   it('should prefetch query if query state does not exist', () => {
     const queryClient = new QueryClient()
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
-    const queryFn = vi.fn(() => Promise.resolve('prefetched'))
+    const queryFn = () => Promise.resolve('prefetched')
     const key = queryKey()
 
     usePrefetchQuery(
@@ -37,7 +37,7 @@ describe('usePrefetchQuery', () => {
   it('should not prefetch query if query state exists', () => {
     const queryClient = new QueryClient()
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
-    const queryFn = vi.fn(() => Promise.resolve('prefetched'))
+    const queryFn = () => Promise.resolve('prefetched')
     const key = queryKey()
     queryClient.setQueryData(key, 'existing')
 
@@ -57,20 +57,20 @@ describe('usePrefetchQuery', () => {
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
     const nestedRef = ref('value')
     const key = queryKey()
+    const queryFn = () => Promise.resolve('prefetched')
 
     usePrefetchQuery(
       {
         queryKey: [...key, nestedRef],
-        queryFn: () => Promise.resolve('prefetched'),
+        queryFn,
       },
       queryClient,
     )
 
-    expect(prefetchQuerySpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queryKey: [...key, 'value'],
-      }),
-    )
+    expect(prefetchQuerySpy).toHaveBeenCalledWith({
+      queryKey: [...key, 'value'],
+      queryFn,
+    })
   })
 
   it('should prefetch again when query key changes reactively', async () => {
@@ -78,28 +78,28 @@ describe('usePrefetchQuery', () => {
     const prefetchQuerySpy = vi.spyOn(queryClient, 'prefetchQuery')
     const keyRef = ref('first')
     const key = queryKey()
+    const queryFn = () => Promise.resolve(keyRef.value)
 
     usePrefetchQuery(
       () => ({
         queryKey: [...key, keyRef.value],
-        queryFn: () => Promise.resolve(keyRef.value),
+        queryFn,
       }),
       queryClient,
     )
 
-    expect(prefetchQuerySpy).toHaveBeenCalledTimes(1)
-    expect(prefetchQuerySpy).toHaveBeenLastCalledWith({
+    expect(prefetchQuerySpy).toHaveBeenNthCalledWith(1, {
       queryKey: [...key, 'first'],
-      queryFn: expect.any(Function),
+      queryFn,
     })
 
     keyRef.value = 'second'
     await nextTick()
 
     expect(prefetchQuerySpy).toHaveBeenCalledTimes(2)
-    expect(prefetchQuerySpy).toHaveBeenLastCalledWith({
+    expect(prefetchQuerySpy).toHaveBeenNthCalledWith(2, {
       queryKey: [...key, 'second'],
-      queryFn: expect.any(Function),
+      queryFn,
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

The `usePrefetchQuery` / `usePrefetchInfiniteQuery` tests spy on `queryClient.prefetchQuery` / `prefetchInfiniteQuery` and check the forwarded options. They matched only `queryKey` via `expect.objectContaining(...)`, leaving the rest of the forwarded options (`queryFn`, `initialPageParam`, `getNextPageParam`) unverified. Since `cloneDeepUnref` preserves function references, the full options object can be asserted exactly.

- **`objectContaining({ queryKey })` → exact object** — asserts the whole forwarded options, so extra/missing keys are caught.
- **`expect.any(Function)` → reference** — inline `queryFn` / `getNextPageParam` are extracted to consts and asserted by reference, so the test verifies the exact function is forwarded, not just "some function". A sibling test already used this reference-matching style.
- **`toHaveBeenLastCalledWith` → `toHaveBeenNthCalledWith(n, ...)`** in the reactive-key-change tests, pinning each call to its position (first call = old key, second = new key). The redundant `toHaveBeenCalledTimes(1)` before the first `Nth(1)` is dropped, while the `toHaveBeenCalledTimes(2)` guarding the total call count is kept.
- **`queryFn` unwrapped from `vi.fn(...)` to a plain function** — these tests never use its mock features, so the wrapper was noise; `getNextPageParam` was already plain.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for query and infinite-query prefetching.
  * Improved precision in assertions for prefetch call options, including exact query function references and unwrapped reactive query-key values.
  * Updated expectations to verify correct behavior across initial and reactive query-key changes (including “do not prefetch when state exists” scenarios).
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->