### PR TITLE
test(*): assert exact values instead of loose matchers

### DIFF
--- a/packages/lit-query/src/tests/infinite-and-options.test.ts
+++ b/packages/lit-query/src/tests/infinite-and-options.test.ts
@@ -364,7 +364,7 @@ describe('createInfiniteQueryController', () => {
 
     const nextPageResult = await infinite.fetchNextPage()
     expect(nextPageResult.isFetchNextPageError).toBe(true)
-    expect(nextPageResult.error).toBeInstanceOf(Error)
+    expect(nextPageResult.error).toEqual(new Error('next-page-failed'))
     await waitFor(() => infinite().isFetchNextPageError)
     expect(infinite().data?.pages).toEqual([0])
   })

--- a/packages/lit-query/src/tests/mutation-controller.test.ts
+++ b/packages/lit-query/src/tests/mutation-controller.test.ts
@@ -164,7 +164,7 @@ describe('createMutationController', () => {
     await waitFor(() => mutation().isPending)
     await expect(errorPromise).rejects.toThrow('negative-not-allowed')
     await waitFor(() => mutation().isError)
-    expect(mutation().error).toBeInstanceOf(Error)
+    expect(mutation().error).toEqual(new Error('negative-not-allowed'))
   })
 
   it('M10: reset clears mutation state back to idle baseline', async () => {
@@ -188,7 +188,7 @@ describe('createMutationController', () => {
       'reset-target',
     )
     await waitFor(() => mutation().isError)
-    expect(mutation().error).toBeInstanceOf(Error)
+    expect(mutation().error).toEqual(new Error('reset-target'))
 
     mutation.reset()
     expect(mutation().isIdle).toBe(true)
@@ -221,7 +221,7 @@ describe('createMutationController', () => {
 
     expect(() => mutation.mutate(-1)).not.toThrow()
     await waitFor(() => mutation().isError)
-    expect(mutation().error).toBeInstanceOf(Error)
+    expect(mutation().error).toEqual(new Error('negative-not-allowed'))
 
     await expect(mutation.mutateAsync(-1)).rejects.toThrow(
       'negative-not-allowed',

--- a/packages/query-core/src/__tests__/timeoutManager.test.tsx
+++ b/packages/query-core/src/__tests__/timeoutManager.test.tsx
@@ -93,7 +93,7 @@ describe('timeoutManager', () => {
           expect.stringMatching(
             /\[timeoutManager\]: Switching .* might result in unexpected behavior\..*/,
           ),
-          expect.anything(),
+          { previous: customProvider, provider: customProvider2 },
         )
 
         // 3. Switching again with no intermediate calls should not warn

--- a/packages/query-devtools/src/__tests__/Explorer.test.tsx
+++ b/packages/query-devtools/src/__tests__/Explorer.test.tsx
@@ -232,7 +232,7 @@ describe('Explorer', () => {
       ).toBeInTheDocument()
       expect(consoleError).toHaveBeenCalledWith(
         'Failed to copy: ',
-        expect.any(Error),
+        new Error('denied'),
       )
     })
 

--- a/packages/vue-query/src/__tests__/useQueryClient.test.ts
+++ b/packages/vue-query/src/__tests__/useQueryClient.test.ts
@@ -34,7 +34,9 @@ describe('useQueryClient', () => {
   it('should throw an error when queryClient does not exist in the context', () => {
     injectSpy.mockReturnValueOnce(undefined)
 
-    expect(useQueryClient).toThrow()
+    expect(useQueryClient).toThrow(
+      "No 'queryClient' found in Vue context, use 'VueQueryPlugin' to properly initialize the library.",
+    )
     expect(injectSpy).toHaveBeenCalledTimes(1)
     expect(injectSpy).toHaveBeenCalledWith(VUE_QUERY_CLIENT)
   })
@@ -42,7 +44,9 @@ describe('useQueryClient', () => {
   it('should throw an error when used outside of setup function', () => {
     hasInjectionContextSpy.mockReturnValueOnce(false)
 
-    expect(useQueryClient).toThrow()
+    expect(useQueryClient).toThrow(
+      'vue-query hooks can only be used inside setup() function or functions that support injection context.',
+    )
     expect(hasInjectionContextSpy).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
## 🎯 Changes

Several tests used loose matchers that pass as long as *something* is present, without checking the actual value. Where the thrown/forwarded value is deterministic (thrown by the test itself, or a fixed source message), the assertions are tightened to the exact value.

- **`lit-query` — `infinite-and-options`, `mutation-controller`** — `toBeInstanceOf(Error)` → `toEqual(new Error('<message>'))`. Each error is thrown by the test's own `queryFn`/`mutationFn` (`next-page-failed`, `negative-not-allowed`, `reset-target`), and the sibling `rejects.toThrow('<message>')` already checks the same message, so the `error` object is now checked to match it too.
- **`query-core` — `timeoutManager`** — the second argument of the provider-switch warning was `expect.anything()` (any non-null value); it now asserts the exact `{ previous, provider }` payload the source passes.
- **`query-devtools` — `Explorer`** — the clipboard copy failure logs `console.error('Failed to copy: ', err)`; `expect.any(Error)` → the exact `new Error('denied')` the test's `writeText` mock rejects with.
- **`vue-query` — `useQueryClient`** — bare `toThrow()` → `toThrow('<message>')` for the two guards (`No 'queryClient' found ...` and `vue-query hooks can only be used inside setup() ...`), which the source throws unconditionally.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage by verifying exact error values and messages across pagination, mutations, timeout handling, clipboard failures, and Vue query-client usage.
  * Added more precise validation for timeout-provider warnings and missing query-client guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->