### PR TITLE
fix(solid-query): expose deferred SSR query errors

### DIFF
--- a/.changeset/settled-ssr-state.md
+++ b/.changeset/settled-ssr-state.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Expose settled query state when rendering deferred queries during SSR.

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -375,6 +375,16 @@ export function useBaseQuery<
       target: QueryObserverResult<TData, TError>,
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
+      // The server subscriber resolves the resource without updating `state`.
+      // Read the settled resource so deferred SSR renders do not stay frozen
+      // on the initial optimistic result.
+      if (isServer) {
+        const resolved = queryResource()
+        if (resolved && prop in resolved) {
+          return Reflect.get(resolved, prop)
+        }
+      }
+
       if (prop === 'data') {
         if (state.data !== undefined) {
           return queryResource.latest?.data


### PR DESCRIPTION
## 🎯 Changes

- Read settled query properties from the Solid resource during SSR instead of the stale optimistic store.
- Allow deferred query failures to expose `status`, `isError`, and `error` without requiring an ErrorBoundary.
- Preserve the existing initial-error resolution path used by SolidStart redirects.
- Add a patch changeset for `@tanstack/solid-query`.

The server subscriber resolves `queryResource`, but it does not synchronize the proxy-backed `state`. After a deferred query failed, server renders therefore kept reading the initial pending result. Reading the resolved resource on the server keeps rendered state aligned with the serialized resource.

Closes #8300

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

`pnpm test:pr` was attempted. Affected builds and tests ran, but the command failed in unrelated package type matrices because the local Corepack cache returned `EACCES` while spawning `pnpm.cjs`.

Focused validation passed:
- `pnpm --filter @tanstack/solid-query test:eslint`
- `pnpm --filter @tanstack/solid-query test:types:tscurrent`
- `pnpm --filter @tanstack/solid-query test:lib --run` (322 tests)
- `pnpm --filter @tanstack/solid-query build`
- Manual Node SSR render: `no data:error:true:SSR Error`

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering for deferred queries by exposing settled query results once available.
  * Prevented deferred SSR output from remaining stuck on the initial optimistic state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->