### PR TITLE
docs(CONTRIBUTING): update pnpm version from 'v10' to 'v11'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ If you have been assigned to fix an issue or develop a new feature, please follo
   pnpm install
   ```
 
-  - We use [pnpm](https://pnpm.io/) v10 for package management (run in case of pnpm-related issues).
+  - We use [pnpm](https://pnpm.io/) v11 for package management (run in case of pnpm-related issues).
 
     ```bash
     corepack enable && corepack prepare


### PR DESCRIPTION
Hi, and thank you for TanStack Query.

Tiny docs fix. `CONTRIBUTING.md` (line 28) says:

> We use [pnpm](https://pnpm.io/) v10 for package management

but the repo is pinned to pnpm v11 in `package.json`:

```json
"packageManager": "pnpm@11.9.0"
```

This bumps the doc from v10 → v11 so a new contributor installs the matching major. Nothing else changed.

For transparency: I used AI assistance to spot and draft this; I verified `CONTRIBUTING.md` and `package.json` against the current source myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to use pnpm v11.
  * Added a reference to pnpm-related issue guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->