### PR TITLE
test(query-core/utils): split 'isValidTimeout' rejection cases into separate 'it' blocks

### DIFF
--- a/packages/query-core/src/__tests__/utils.test.tsx
+++ b/packages/query-core/src/__tests__/utils.test.tsx
@@ -587,11 +587,23 @@ describe('core/utils', () => {
       expect(isValidTimeout(1_000)).toBe(true)
     })
 
-    it('should reject invalid timeout values', () => {
+    it('should reject a negative timeout value', () => {
       expect(isValidTimeout(-1)).toBe(false)
+    })
+
+    it('should reject NaN', () => {
       expect(isValidTimeout(Number.NaN)).toBe(false)
+    })
+
+    it('should reject Infinity', () => {
       expect(isValidTimeout(Number.POSITIVE_INFINITY)).toBe(false)
+    })
+
+    it('should reject a string timeout value', () => {
       expect(isValidTimeout('1000')).toBe(false)
+    })
+
+    it('should reject undefined', () => {
       expect(isValidTimeout(undefined)).toBe(false)
     })
   })


### PR DESCRIPTION
## 🎯 Changes

Splits the single `should reject invalid timeout values` test (which bundled 5 `expect` assertions for `-1`, `NaN`, `Infinity`, `'1000'`, and `undefined`) into 5 separate `it` blocks, so a failure identifies exactly which case broke instead of stopping at the first failed assertion.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded timeout validation test coverage with separate checks for negative numbers, special numeric values, text inputs, and missing values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->