### PR TITLE
test({react,preact}-query/usePrefetchQuery): assert the 'Loading...' fallback is rendered before the prefetch resolves

### DIFF
--- a/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -72,6 +72,8 @@ describe('usePrefetchQuery', () => {
 
     const rendered = renderWithClient(queryClient, <App />)
 
+    expect(rendered.getByText('Loading...')).toBeInTheDocument()
+
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('data: prefetchQuery')).toBeInTheDocument()
     expect(queryOpts.queryFn).toHaveBeenCalledTimes(1)

--- a/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -71,6 +71,8 @@ describe('usePrefetchQuery', () => {
 
     const rendered = renderWithClient(queryClient, <App />)
 
+    expect(rendered.getByText('Loading...')).toBeInTheDocument()
+
     await act(() => vi.advanceTimersByTimeAsync(10))
     expect(rendered.getByText('data: prefetchQuery')).toBeInTheDocument()
     expect(queryOpts.queryFn).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## 🎯 Changes

Adds an assertion right after the initial render that the Suspense `'Loading...'` fallback is shown while the prefetched query is still in flight, in `should prefetch query if query state does not exist` for both `react-query` and `preact-query`. The same file's `should not create a suspense waterfall if prefetch is fired` test already follows this convention (checking `fetchStatus`/fallback text before advancing timers); this test was missing it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/strengthened assertions to confirm the Suspense loading fallback (“Loading...”) appears immediately when prefetching a query without existing state.
  * Updated coverage for both React and Preact integrations to better validate prefetch behavior during the initial render.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->