### PR TITLE
test({react,preact}-query/useSuspenseQuery): assert the 'loading' fallback is rendered when gcTime is 0

### DIFF
--- a/packages/preact-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -788,6 +788,7 @@ describe('useSuspenseQuery', () => {
       </Suspense>,
     )
 
+    expect(rendered.getByText('loading')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('rendered')).toBeInTheDocument()
 

--- a/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -748,6 +748,7 @@ describe('useSuspenseQuery', () => {
       </React.Suspense>,
     )
 
+    expect(rendered.getByText('loading')).toBeInTheDocument()
     await act(() => vi.advanceTimersByTimeAsync(10))
     expect(rendered.getByText('rendered')).toBeInTheDocument()
 


### PR DESCRIPTION
## 🎯 Changes

Adds an assertion right after the initial render that the Suspense `'loading'` fallback is shown before advancing timers, in `should render the correct amount of times in Suspense mode when gcTime is set to 0` for both `react-query` and `preact-query`. The sibling test in the same file (`should render the correct amount of times in Suspense mode`, without `gcTime: 0`) already follows this convention; the `gcTime: 0` variant was missing it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Suspense query coverage by asserting the loading fallback is shown immediately before advancing timers to let the query resolve when garbage-collection time is set to zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->