### PR TITLE
test({react,preact}-query/usePrefetchQuery): inline the shared 'Suspended' component into each test

### DIFF
--- a/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -11,7 +11,6 @@ import {
   useQueryErrorResetBoundary,
   useSuspenseQuery,
 } from '..'
-import type { UseSuspenseQueryOptions } from '..'
 import { ErrorBoundary } from './ErrorBoundary'
 import { renderWithClient } from './utils'
 
@@ -35,20 +34,6 @@ describe('usePrefetchQuery', () => {
     vi.useRealTimers()
   })
 
-  function Suspended<TData = unknown>(props: {
-    queryOpts: UseSuspenseQueryOptions<TData, Error, TData, Array<string>>
-    children?: VNode
-  }) {
-    const state = useSuspenseQuery(props.queryOpts)
-
-    return (
-      <div>
-        <div>data: {String(state.data)}</div>
-        {props.children}
-      </div>
-    )
-  }
-
   it('should prefetch query if query state does not exist', async () => {
     const queryOpts = {
       queryKey: queryKey(),
@@ -60,12 +45,17 @@ describe('usePrefetchQuery', () => {
       queryFn: generateQueryFn('useSuspenseQuery'),
     }
 
+    function Page() {
+      const state = useSuspenseQuery(componentQueryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(queryOpts)
 
       return (
         <Suspense fallback="Loading...">
-          <Suspended queryOpts={componentQueryOpts} />
+          <Page />
         </Suspense>
       )
     }
@@ -85,12 +75,17 @@ describe('usePrefetchQuery', () => {
       queryFn: generateQueryFn('The usePrefetchQuery hook is smart!'),
     }
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(queryOpts)
 
       return (
         <Suspense fallback="Loading...">
-          <Suspended queryOpts={queryOpts} />
+          <Page />
         </Suspense>
       )
     }
@@ -123,13 +118,18 @@ describe('usePrefetchQuery', () => {
       throw new Error('Oops! Server error!')
     })
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(queryOpts)
 
       return (
         <ErrorBoundary fallbackRender={() => <div>Oops!</div>}>
           <Suspense fallback="Loading...">
-            <Suspended queryOpts={queryOpts} />
+            <Page />
           </Suspense>
         </ErrorBoundary>
       )
@@ -160,11 +160,16 @@ describe('usePrefetchQuery', () => {
       return <>{children}</>
     }
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       return (
         <Suspense fallback={<></>}>
           <Prefetch>
-            <Suspended queryOpts={queryOpts} />
+            <Page />
           </Prefetch>
         </Suspense>
       )
@@ -192,6 +197,11 @@ describe('usePrefetchQuery', () => {
       throw new Error('Oops! Server error!')
     })
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       const { reset } = useQueryErrorResetBoundary()
       usePrefetchQuery(queryOpts)
@@ -207,7 +217,7 @@ describe('usePrefetchQuery', () => {
           )}
         >
           <Suspense fallback="Loading...">
-            <Suspended queryOpts={queryOpts} />
+            <Page />
           </Suspense>
         </ErrorBoundary>
       )
@@ -247,6 +257,31 @@ describe('usePrefetchQuery', () => {
 
     const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)
 
+    function FirstQuery({ children }: { children?: VNode }) {
+      const state = useSuspenseQuery(firstQueryOpts)
+      return (
+        <div>
+          <div>data: {String(state.data)}</div>
+          {children}
+        </div>
+      )
+    }
+
+    function SecondQuery({ children }: { children?: VNode }) {
+      const state = useSuspenseQuery(secondQueryOpts)
+      return (
+        <div>
+          <div>data: {String(state.data)}</div>
+          {children}
+        </div>
+      )
+    }
+
+    function ThirdQuery() {
+      const state = useSuspenseQuery(thirdQueryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(firstQueryOpts)
       usePrefetchQuery(secondQueryOpts)
@@ -254,11 +289,11 @@ describe('usePrefetchQuery', () => {
 
       return (
         <Suspense fallback={<Fallback />}>
-          <Suspended queryOpts={firstQueryOpts}>
-            <Suspended queryOpts={secondQueryOpts}>
-              <Suspended queryOpts={thirdQueryOpts} />
-            </Suspended>
-          </Suspended>
+          <FirstQuery>
+            <SecondQuery>
+              <ThirdQuery />
+            </SecondQuery>
+          </FirstQuery>
         </Suspense>
       )
     }

--- a/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -12,8 +12,6 @@ import {
 } from '..'
 import { renderWithClient } from './utils'
 
-import type { UseSuspenseQueryOptions } from '..'
-
 const generateQueryFn = (data: string) =>
   vi
     .fn<(...args: Array<any>) => Promise<string>>()
@@ -34,20 +32,6 @@ describe('usePrefetchQuery', () => {
     vi.useRealTimers()
   })
 
-  function Suspended<TData = unknown>(props: {
-    queryOpts: UseSuspenseQueryOptions<TData, Error, TData, Array<string>>
-    children?: React.ReactNode
-  }) {
-    const state = useSuspenseQuery(props.queryOpts)
-
-    return (
-      <div>
-        <div>data: {String(state.data)}</div>
-        {props.children}
-      </div>
-    )
-  }
-
   it('should prefetch query if query state does not exist', async () => {
     const queryOpts = {
       queryKey: queryKey(),
@@ -59,12 +43,17 @@ describe('usePrefetchQuery', () => {
       queryFn: generateQueryFn('useSuspenseQuery'),
     }
 
+    function Page() {
+      const state = useSuspenseQuery(componentQueryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(queryOpts)
 
       return (
         <React.Suspense fallback="Loading...">
-          <Suspended queryOpts={componentQueryOpts} />
+          <Page />
         </React.Suspense>
       )
     }
@@ -84,12 +73,17 @@ describe('usePrefetchQuery', () => {
       queryFn: generateQueryFn('The usePrefetchQuery hook is smart!'),
     }
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(queryOpts)
 
       return (
         <React.Suspense fallback="Loading...">
-          <Suspended queryOpts={queryOpts} />
+          <Page />
         </React.Suspense>
       )
     }
@@ -122,13 +116,18 @@ describe('usePrefetchQuery', () => {
       throw new Error('Oops! Server error!')
     })
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(queryOpts)
 
       return (
         <ErrorBoundary fallbackRender={() => <div>Oops!</div>}>
           <React.Suspense fallback="Loading...">
-            <Suspended queryOpts={queryOpts} />
+            <Page />
           </React.Suspense>
         </ErrorBoundary>
       )
@@ -159,11 +158,16 @@ describe('usePrefetchQuery', () => {
       return <>{children}</>
     }
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       return (
         <React.Suspense>
           <Prefetch>
-            <Suspended queryOpts={queryOpts} />
+            <Page />
           </Prefetch>
         </React.Suspense>
       )
@@ -191,6 +195,11 @@ describe('usePrefetchQuery', () => {
       throw new Error('Oops! Server error!')
     })
 
+    function Page() {
+      const state = useSuspenseQuery(queryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       const { reset } = useQueryErrorResetBoundary()
       usePrefetchQuery(queryOpts)
@@ -206,7 +215,7 @@ describe('usePrefetchQuery', () => {
           )}
         >
           <React.Suspense fallback="Loading...">
-            <Suspended queryOpts={queryOpts} />
+            <Page />
           </React.Suspense>
         </ErrorBoundary>
       )
@@ -246,6 +255,31 @@ describe('usePrefetchQuery', () => {
 
     const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)
 
+    function FirstQuery({ children }: { children?: React.ReactNode }) {
+      const state = useSuspenseQuery(firstQueryOpts)
+      return (
+        <div>
+          <div>data: {String(state.data)}</div>
+          {children}
+        </div>
+      )
+    }
+
+    function SecondQuery({ children }: { children?: React.ReactNode }) {
+      const state = useSuspenseQuery(secondQueryOpts)
+      return (
+        <div>
+          <div>data: {String(state.data)}</div>
+          {children}
+        </div>
+      )
+    }
+
+    function ThirdQuery() {
+      const state = useSuspenseQuery(thirdQueryOpts)
+      return <div>data: {String(state.data)}</div>
+    }
+
     function App() {
       usePrefetchQuery(firstQueryOpts)
       usePrefetchQuery(secondQueryOpts)
@@ -253,11 +287,11 @@ describe('usePrefetchQuery', () => {
 
       return (
         <React.Suspense fallback={<Fallback />}>
-          <Suspended queryOpts={firstQueryOpts}>
-            <Suspended queryOpts={secondQueryOpts}>
-              <Suspended queryOpts={thirdQueryOpts} />
-            </Suspended>
-          </Suspended>
+          <FirstQuery>
+            <SecondQuery>
+              <ThirdQuery />
+            </SecondQuery>
+          </FirstQuery>
         </React.Suspense>
       )
     }


### PR DESCRIPTION
## 🎯 Changes

Inlines the `describe`-level shared `Suspended` component into each `it` block as a local `Page` component, so each test reads as self-contained (the hook call it exercises is visible in the test itself rather than in a shared helper). The `should not create a suspense waterfall if prefetch is fired` test, which nests three differently-parameterized instances, is split into three standalone local components (`FirstQuery`/`SecondQuery`/`ThirdQuery`) instead of one generic component taking a `queryOpts` prop. Applies to both `react-query` and `preact-query`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded and clarified `usePrefetchQuery` coverage across React and Preact.
  * Improved validation for prefetching, existing query state, error recovery, failed requests, and Suspense behavior.
  * Added clearer coverage ensuring prefetching prevents unnecessary Suspense waterfalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->