### PR TITLE
test({react,preact}-query/usePrefetchInfiniteQuery): inline the shared 'Suspended' component into each test

### DIFF
--- a/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -11,7 +11,6 @@ import {
   usePrefetchInfiniteQuery,
   useSuspenseInfiniteQuery,
 } from '..'
-import type { InfiniteData, UseSuspenseInfiniteQueryOptions } from '..'
 import { renderWithClient } from './utils'
 
 const generateInfiniteQueryOptions = (
@@ -59,28 +58,6 @@ describe('usePrefetchInfiniteQuery', () => {
 
   const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)
 
-  function Suspended<T = unknown>(props: {
-    queryOpts: UseSuspenseInfiniteQueryOptions<
-      T,
-      Error,
-      InfiniteData<T>,
-      Array<string>,
-      any
-    >
-    renderPage: (page: T) => VNode
-  }) {
-    const state = useSuspenseInfiniteQuery(props.queryOpts)
-
-    return (
-      <div>
-        {state.data.pages.map((page, index) => (
-          <div key={index}>{props.renderPage(page)}</div>
-        ))}
-        <button onClick={() => state.fetchNextPage()}>Next Page</button>
-      </div>
-    )
-  }
-
   it('should prefetch an infinite query if query state does not exist', async () => {
     const data = [
       { data: 'Do you fetch on render?', currentPage: 1, totalPages: 3 },
@@ -97,15 +74,25 @@ describe('usePrefetchInfiniteQuery', () => {
       ...generateInfiniteQueryOptions(data),
     }
 
+    function Page() {
+      const state = useSuspenseInfiniteQuery(queryOpts)
+
+      return (
+        <div>
+          {state.data.pages.map((page, index) => (
+            <div key={index}>data: {page.data}</div>
+          ))}
+          <button onClick={() => state.fetchNextPage()}>Next Page</button>
+        </div>
+      )
+    }
+
     function App() {
       usePrefetchInfiniteQuery({ ...queryOpts, pages: data.length })
 
       return (
         <Suspense fallback={<Fallback />}>
-          <Suspended
-            queryOpts={queryOpts}
-            renderPage={(page) => <div>data: {page.data}</div>}
-          />
+          <Page />
         </Suspense>
       )
     }
@@ -140,15 +127,25 @@ describe('usePrefetchInfiniteQuery', () => {
     await vi.advanceTimersByTimeAsync(30)
     ;(queryOpts.queryFn as Mock).mockClear()
 
+    function Page() {
+      const state = useSuspenseInfiniteQuery(queryOpts)
+
+      return (
+        <div>
+          {state.data.pages.map((page, index) => (
+            <div key={index}>data: {page.data}</div>
+          ))}
+          <button onClick={() => state.fetchNextPage()}>Next Page</button>
+        </div>
+      )
+    }
+
     function App() {
       usePrefetchInfiniteQuery(queryOpts)
 
       return (
         <Suspense fallback={<Fallback />}>
-          <Suspended
-            queryOpts={queryOpts}
-            renderPage={(page) => <div>data: {page.data}</div>}
-          />
+          <Page />
         </Suspense>
       )
     }
@@ -179,14 +176,24 @@ describe('usePrefetchInfiniteQuery', () => {
       return <>{children}</>
     }
 
+    function Page() {
+      const state = useSuspenseInfiniteQuery(queryOpts)
+
+      return (
+        <div>
+          {state.data.pages.map((page, index) => (
+            <div key={index}>data: {page.data}</div>
+          ))}
+          <button onClick={() => state.fetchNextPage()}>Next Page</button>
+        </div>
+      )
+    }
+
     function App() {
       return (
         <Suspense fallback={<></>}>
           <Prefetch>
-            <Suspended
-              queryOpts={queryOpts}
-              renderPage={(page) => <div>data: {page.data}</div>}
-            />
+            <Page />
           </Prefetch>
         </Suspense>
       )

--- a/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -9,7 +9,6 @@ import {
   useSuspenseInfiniteQuery,
 } from '..'
 import { renderWithClient } from './utils'
-import type { InfiniteData, UseSuspenseInfiniteQueryOptions } from '..'
 import type { Mock } from 'vitest'
 
 const createFallback = () =>
@@ -57,28 +56,6 @@ describe('usePrefetchInfiniteQuery', () => {
     vi.useRealTimers()
   })
 
-  function Suspended<T = unknown>(props: {
-    queryOpts: UseSuspenseInfiniteQueryOptions<
-      T,
-      Error,
-      InfiniteData<T>,
-      Array<string>,
-      any
-    >
-    renderPage: (page: T) => React.JSX.Element
-  }) {
-    const state = useSuspenseInfiniteQuery(props.queryOpts)
-
-    return (
-      <div>
-        {state.data.pages.map((page, index) => (
-          <div key={index}>{props.renderPage(page)}</div>
-        ))}
-        <button onClick={() => state.fetchNextPage()}>Next Page</button>
-      </div>
-    )
-  }
-
   it('should prefetch an infinite query if query state does not exist', async () => {
     const Fallback = createFallback()
     const data = [
@@ -96,15 +73,25 @@ describe('usePrefetchInfiniteQuery', () => {
       ...generateInfiniteQueryOptions(data),
     }
 
+    function Page() {
+      const state = useSuspenseInfiniteQuery(queryOpts)
+
+      return (
+        <div>
+          {state.data.pages.map((page, index) => (
+            <div key={index}>data: {page.data}</div>
+          ))}
+          <button onClick={() => state.fetchNextPage()}>Next Page</button>
+        </div>
+      )
+    }
+
     function App() {
       usePrefetchInfiniteQuery({ ...queryOpts, pages: data.length })
 
       return (
         <React.Suspense fallback={<Fallback />}>
-          <Suspended
-            queryOpts={queryOpts}
-            renderPage={(page) => <div>data: {page.data}</div>}
-          />
+          <Page />
         </React.Suspense>
       )
     }
@@ -140,15 +127,25 @@ describe('usePrefetchInfiniteQuery', () => {
     await vi.advanceTimersByTimeAsync(30)
     ;(queryOpts.queryFn as Mock).mockClear()
 
+    function Page() {
+      const state = useSuspenseInfiniteQuery(queryOpts)
+
+      return (
+        <div>
+          {state.data.pages.map((page, index) => (
+            <div key={index}>data: {page.data}</div>
+          ))}
+          <button onClick={() => state.fetchNextPage()}>Next Page</button>
+        </div>
+      )
+    }
+
     function App() {
       usePrefetchInfiniteQuery(queryOpts)
 
       return (
         <React.Suspense fallback={<Fallback />}>
-          <Suspended
-            queryOpts={queryOpts}
-            renderPage={(page) => <div>data: {page.data}</div>}
-          />
+          <Page />
         </React.Suspense>
       )
     }
@@ -179,14 +176,24 @@ describe('usePrefetchInfiniteQuery', () => {
       return <>{children}</>
     }
 
+    function Page() {
+      const state = useSuspenseInfiniteQuery(queryOpts)
+
+      return (
+        <div>
+          {state.data.pages.map((page, index) => (
+            <div key={index}>data: {page.data}</div>
+          ))}
+          <button onClick={() => state.fetchNextPage()}>Next Page</button>
+        </div>
+      )
+    }
+
     function App() {
       return (
         <React.Suspense>
           <Prefetch>
-            <Suspended
-              queryOpts={queryOpts}
-              renderPage={(page) => <div>data: {page.data}</div>}
-            />
+            <Page />
           </Prefetch>
         </React.Suspense>
       )


### PR DESCRIPTION
## 🎯 Changes

Inlines the `describe`-level shared `Suspended` component into each `it` block as a local `Page` component, so each test reads as self-contained (the hook call and rendered pages it exercises are visible in the test itself rather than in a shared generic helper). Removes the now-unused `InfiniteData`/`UseSuspenseInfiniteQueryOptions` type imports that only backed the shared component's generic signature. Applies to both `react-query` and `preact-query`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored infinite-query suspense tests for clearer, more direct coverage.
  * Preserved validation of page rendering, suspense behavior, and fetching subsequent pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->