### PR TITLE
test({react,preact}-query/usePrefetchInfiniteQuery): inline single-use helpers and adopt the 'pageParam' mock convention

### DIFF
--- a/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent } from '@testing-library/preact'
 import type { VNode } from 'preact'
 import { Suspense } from 'preact/compat'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Mock } from 'vitest'
 
 import {
   QueryCache,
@@ -12,33 +11,6 @@ import {
   useSuspenseInfiniteQuery,
 } from '..'
 import { renderWithClient } from './utils'
-
-const generateInfiniteQueryOptions = (
-  data: Array<{ data: string; currentPage: number; totalPages: number }>,
-) => {
-  let currentPage = 0
-
-  return {
-    queryFn: vi
-      .fn<(...args: Array<any>) => Promise<(typeof data)[number]>>()
-      .mockImplementation(async () => {
-        const currentPageData = data[currentPage]
-        if (!currentPageData) {
-          throw new Error(`No data defined for page ${currentPage}`)
-        }
-
-        await sleep(10)
-        currentPage++
-
-        return currentPageData
-      }),
-    initialPageParam: 1,
-    getNextPageParam: (lastPage: (typeof data)[number]) =>
-      lastPage.currentPage === lastPage.totalPages
-        ? undefined
-        : lastPage.currentPage + 1,
-  }
-}
 
 describe('usePrefetchInfiniteQuery', () => {
   let queryCache: QueryCache
@@ -60,18 +32,21 @@ describe('usePrefetchInfiniteQuery', () => {
 
   it('should prefetch an infinite query if query state does not exist', async () => {
     const data = [
-      { data: 'Do you fetch on render?', currentPage: 1, totalPages: 3 },
-      { data: 'Or do you render as you fetch?', currentPage: 2, totalPages: 3 },
-      {
-        data: 'Either way, Tanstack Query helps you!',
-        currentPage: 3,
-        totalPages: 3,
-      },
+      'Do you fetch on render?',
+      'Or do you render as you fetch?',
+      'Either way, Tanstack Query helps you!',
     ]
 
     const queryOpts = {
       queryKey: queryKey(),
-      ...generateInfiniteQueryOptions(data),
+      queryFn: vi
+        .fn<(context: { pageParam: number }) => Promise<string>>()
+        .mockImplementation(({ pageParam }) =>
+          sleep(10).then(() => data[pageParam]!),
+        ),
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage: string, allPages: Array<string>) =>
+        allPages.length < data.length ? allPages.length : undefined,
     }
 
     function Page() {
@@ -80,7 +55,7 @@ describe('usePrefetchInfiniteQuery', () => {
       return (
         <div>
           {state.data.pages.map((page, index) => (
-            <div key={index}>data: {page.data}</div>
+            <div key={index}>data: {page}</div>
           ))}
           <button onClick={() => state.fetchNextPage()}>Next Page</button>
         </div>
@@ -114,18 +89,27 @@ describe('usePrefetchInfiniteQuery', () => {
   })
 
   it('should not display fallback if the query cache is already populated', async () => {
+    const data = [
+      'Prefetch rocks!',
+      'No waterfalls, boy!',
+      'Tanstack Query #ftw',
+    ]
+
     const queryOpts = {
       queryKey: queryKey(),
-      ...generateInfiniteQueryOptions([
-        { data: 'Prefetch rocks!', currentPage: 1, totalPages: 3 },
-        { data: 'No waterfalls, boy!', currentPage: 2, totalPages: 3 },
-        { data: 'Tanstack Query #ftw', currentPage: 3, totalPages: 3 },
-      ]),
+      queryFn: vi
+        .fn<(context: { pageParam: number }) => Promise<string>>()
+        .mockImplementation(({ pageParam }) =>
+          sleep(10).then(() => data[pageParam]!),
+        ),
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage: string, allPages: Array<string>) =>
+        allPages.length < data.length ? allPages.length : undefined,
     }
 
     queryClient.prefetchInfiniteQuery({ ...queryOpts, pages: 3 })
     await vi.advanceTimersByTimeAsync(30)
-    ;(queryOpts.queryFn as Mock).mockClear()
+    queryOpts.queryFn.mockClear()
 
     function Page() {
       const state = useSuspenseInfiniteQuery(queryOpts)
@@ -133,7 +117,7 @@ describe('usePrefetchInfiniteQuery', () => {
       return (
         <div>
           {state.data.pages.map((page, index) => (
-            <div key={index}>data: {page.data}</div>
+            <div key={index}>data: {page}</div>
           ))}
           <button onClick={() => state.fetchNextPage()}>Next Page</button>
         </div>
@@ -162,13 +146,20 @@ describe('usePrefetchInfiniteQuery', () => {
   })
 
   it('should not create an endless loop when using inside a suspense boundary', async () => {
+    const data = ['Infinite Page 1', 'Infinite Page 2', 'Infinite Page 3']
+
     const queryOpts = {
       queryKey: queryKey(),
-      ...generateInfiniteQueryOptions([
-        { data: 'Infinite Page 1', currentPage: 1, totalPages: 3 },
-        { data: 'Infinite Page 2', currentPage: 1, totalPages: 3 },
-        { data: 'Infinite Page 3', currentPage: 1, totalPages: 3 },
-      ]),
+      queryFn: vi
+        .fn<(context: { pageParam: number }) => Promise<string>>()
+        .mockImplementation(({ pageParam }) =>
+          sleep(10).then(() => data[pageParam]!),
+        ),
+      initialPageParam: 0,
+      // always reports another page available, to guard against an endless
+      // auto-advance loop rather than a bounded pagination sequence
+      getNextPageParam: (_lastPage: string, allPages: Array<string>) =>
+        allPages.length,
     }
 
     function Prefetch({ children }: { children: VNode }) {
@@ -182,7 +173,7 @@ describe('usePrefetchInfiniteQuery', () => {
       return (
         <div>
           {state.data.pages.map((page, index) => (
-            <div key={index}>data: {page.data}</div>
+            <div key={index}>data: {page}</div>
           ))}
           <button onClick={() => state.fetchNextPage()}>Next Page</button>
         </div>

--- a/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -9,37 +9,6 @@ import {
   useSuspenseInfiniteQuery,
 } from '..'
 import { renderWithClient } from './utils'
-import type { Mock } from 'vitest'
-
-const createFallback = () =>
-  vi.fn().mockImplementation(() => <div>Loading...</div>)
-
-const generateInfiniteQueryOptions = (
-  data: Array<{ data: string; currentPage: number; totalPages: number }>,
-) => {
-  let currentPage = 0
-
-  return {
-    queryFn: vi
-      .fn<(...args: Array<any>) => Promise<(typeof data)[number]>>()
-      .mockImplementation(async () => {
-        const currentPageData = data[currentPage]
-        if (!currentPageData) {
-          throw new Error('No data defined for page ' + currentPage)
-        }
-
-        await sleep(10)
-        currentPage++
-
-        return currentPageData
-      }),
-    initialPageParam: 1,
-    getNextPageParam: (lastPage: (typeof data)[number]) =>
-      lastPage.currentPage === lastPage.totalPages
-        ? undefined
-        : lastPage.currentPage + 1,
-  }
-}
 
 describe('usePrefetchInfiniteQuery', () => {
   let queryCache: QueryCache
@@ -57,20 +26,23 @@ describe('usePrefetchInfiniteQuery', () => {
   })
 
   it('should prefetch an infinite query if query state does not exist', async () => {
-    const Fallback = createFallback()
+    const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)
     const data = [
-      { data: 'Do you fetch on render?', currentPage: 1, totalPages: 3 },
-      { data: 'Or do you render as you fetch?', currentPage: 2, totalPages: 3 },
-      {
-        data: 'Either way, Tanstack Query helps you!',
-        currentPage: 3,
-        totalPages: 3,
-      },
+      'Do you fetch on render?',
+      'Or do you render as you fetch?',
+      'Either way, Tanstack Query helps you!',
     ]
 
     const queryOpts = {
       queryKey: queryKey(),
-      ...generateInfiniteQueryOptions(data),
+      queryFn: vi
+        .fn<(context: { pageParam: number }) => Promise<string>>()
+        .mockImplementation(({ pageParam }) =>
+          sleep(10).then(() => data[pageParam]!),
+        ),
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage: string, allPages: Array<string>) =>
+        allPages.length < data.length ? allPages.length : undefined,
     }
 
     function Page() {
@@ -79,7 +51,7 @@ describe('usePrefetchInfiniteQuery', () => {
       return (
         <div>
           {state.data.pages.map((page, index) => (
-            <div key={index}>data: {page.data}</div>
+            <div key={index}>data: {page}</div>
           ))}
           <button onClick={() => state.fetchNextPage()}>Next Page</button>
         </div>
@@ -113,19 +85,28 @@ describe('usePrefetchInfiniteQuery', () => {
   })
 
   it('should not display fallback if the query cache is already populated', async () => {
-    const Fallback = createFallback()
+    const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)
+    const data = [
+      'Prefetch rocks!',
+      'No waterfalls, boy!',
+      'Tanstack Query #ftw',
+    ]
+
     const queryOpts = {
       queryKey: queryKey(),
-      ...generateInfiniteQueryOptions([
-        { data: 'Prefetch rocks!', currentPage: 1, totalPages: 3 },
-        { data: 'No waterfalls, boy!', currentPage: 2, totalPages: 3 },
-        { data: 'Tanstack Query #ftw', currentPage: 3, totalPages: 3 },
-      ]),
+      queryFn: vi
+        .fn<(context: { pageParam: number }) => Promise<string>>()
+        .mockImplementation(({ pageParam }) =>
+          sleep(10).then(() => data[pageParam]!),
+        ),
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage: string, allPages: Array<string>) =>
+        allPages.length < data.length ? allPages.length : undefined,
     }
 
     queryClient.prefetchInfiniteQuery({ ...queryOpts, pages: 3 })
     await vi.advanceTimersByTimeAsync(30)
-    ;(queryOpts.queryFn as Mock).mockClear()
+    queryOpts.queryFn.mockClear()
 
     function Page() {
       const state = useSuspenseInfiniteQuery(queryOpts)
@@ -133,7 +114,7 @@ describe('usePrefetchInfiniteQuery', () => {
       return (
         <div>
           {state.data.pages.map((page, index) => (
-            <div key={index}>data: {page.data}</div>
+            <div key={index}>data: {page}</div>
           ))}
           <button onClick={() => state.fetchNextPage()}>Next Page</button>
         </div>
@@ -162,13 +143,20 @@ describe('usePrefetchInfiniteQuery', () => {
   })
 
   it('should not create an endless loop when using inside a suspense boundary', async () => {
+    const data = ['Infinite Page 1', 'Infinite Page 2', 'Infinite Page 3']
+
     const queryOpts = {
       queryKey: queryKey(),
-      ...generateInfiniteQueryOptions([
-        { data: 'Infinite Page 1', currentPage: 1, totalPages: 3 },
-        { data: 'Infinite Page 2', currentPage: 1, totalPages: 3 },
-        { data: 'Infinite Page 3', currentPage: 1, totalPages: 3 },
-      ]),
+      queryFn: vi
+        .fn<(context: { pageParam: number }) => Promise<string>>()
+        .mockImplementation(({ pageParam }) =>
+          sleep(10).then(() => data[pageParam]!),
+        ),
+      initialPageParam: 0,
+      // always reports another page available, to guard against an endless
+      // auto-advance loop rather than a bounded pagination sequence
+      getNextPageParam: (_lastPage: string, allPages: Array<string>) =>
+        allPages.length,
     }
 
     function Prefetch({ children }: { children: React.ReactNode }) {
@@ -182,7 +170,7 @@ describe('usePrefetchInfiniteQuery', () => {
       return (
         <div>
           {state.data.pages.map((page, index) => (
-            <div key={index}>data: {page.data}</div>
+            <div key={index}>data: {page}</div>
           ))}
           <button onClick={() => state.fetchNextPage()}>Next Page</button>
         </div>


### PR DESCRIPTION
## 🎯 Changes

Inlines the `createFallback` factory (called only twice) directly at each call site, and rewrites `generateInfiniteQueryOptions` — a stateful closure-based page mock — to use the `pageParam`-driven `queryFn`/`getNextPageParam` convention already used by `useInfiniteQuery.test.tsx`, removing the shared helper entirely. Applies to both `react-query` and `preact-query`.

The `should not create an endless loop when using inside a suspense boundary` test's `getNextPageParam` always reports another page available (never returns `undefined`), preserving the original's perpetual-`hasNextPage` semantics that make `toHaveBeenCalledTimes(3)` a meaningful guard against runaway auto-advancing. The other two tests terminate pagination at 3 pages, matching their originals.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified infinite-query test scenarios with inline pagination options.
  * Updated page rendering assertions to reflect the current string-based page data format.
  * Improved mock query setup and cleanup across standard and suspense-related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->