### PR TITLE
test({react,preact}-query/usePrefetchQuery): inline the 'generateQueryFn' factory into each call site

### DIFF
--- a/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -14,11 +14,6 @@ import {
 import { ErrorBoundary } from './ErrorBoundary'
 import { renderWithClient } from './utils'
 
-const generateQueryFn = (data: string) =>
-  vi
-    .fn<(...args: Array<any>) => Promise<string>>()
-    .mockImplementation(() => sleep(10).then(() => data))
-
 describe('usePrefetchQuery', () => {
   let queryCache: QueryCache
   let queryClient: QueryClient
@@ -37,12 +32,12 @@ describe('usePrefetchQuery', () => {
   it('should prefetch query if query state does not exist', async () => {
     const queryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('prefetchQuery'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'prefetchQuery')),
     }
 
     const componentQueryOpts = {
       ...queryOpts,
-      queryFn: generateQueryFn('useSuspenseQuery'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'useSuspenseQuery')),
     }
 
     function Page() {
@@ -72,7 +67,9 @@ describe('usePrefetchQuery', () => {
   it('should not prefetch query if query state exists', async () => {
     const queryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('The usePrefetchQuery hook is smart!'),
+      queryFn: vi.fn(() =>
+        sleep(10).then(() => 'The usePrefetchQuery hook is smart!'),
+      ),
     }
 
     function Page() {
@@ -105,7 +102,7 @@ describe('usePrefetchQuery', () => {
   it('should let errors fall through and not refetch failed queries', async () => {
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
-    const queryFn = generateQueryFn('Not an error')
+    const queryFn = vi.fn(() => sleep(10).then(() => 'Not an error'))
 
     const queryOpts = {
       queryKey: queryKey(),
@@ -148,7 +145,7 @@ describe('usePrefetchQuery', () => {
   })
 
   it('should not create an endless loop when using inside a suspense boundary', async () => {
-    const queryFn = generateQueryFn('prefetchedQuery')
+    const queryFn = vi.fn(() => sleep(10).then(() => 'prefetchedQuery'))
 
     const queryOpts = {
       queryKey: queryKey(),
@@ -184,7 +181,9 @@ describe('usePrefetchQuery', () => {
   it('should be able to recover from errors and try fetching again', async () => {
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
-    const queryFn = generateQueryFn('This is fine :dog: :fire:')
+    const queryFn = vi.fn(() =>
+      sleep(10).then(() => 'This is fine :dog: :fire:'),
+    )
 
     const queryOpts = {
       queryKey: queryKey(),
@@ -242,17 +241,19 @@ describe('usePrefetchQuery', () => {
   it('should not create a suspense waterfall if prefetch is fired', async () => {
     const firstQueryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('Prefetch is nice!'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'Prefetch is nice!')),
     }
 
     const secondQueryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('Prefetch is really nice!!'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'Prefetch is really nice!!')),
     }
 
     const thirdQueryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('Prefetch does not create waterfalls!!'),
+      queryFn: vi.fn(() =>
+        sleep(10).then(() => 'Prefetch does not create waterfalls!!'),
+      ),
     }
 
     const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)

--- a/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -37,7 +37,7 @@ describe('usePrefetchQuery', () => {
 
     const componentQueryOpts = {
       ...queryOpts,
-      queryFn: vi.fn(() => sleep(10).then(() => 'useSuspenseQuery')),
+      queryFn: () => sleep(10).then(() => 'useSuspenseQuery'),
     }
 
     function Page() {

--- a/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -35,7 +35,7 @@ describe('usePrefetchQuery', () => {
 
     const componentQueryOpts = {
       ...queryOpts,
-      queryFn: vi.fn(() => sleep(10).then(() => 'useSuspenseQuery')),
+      queryFn: () => sleep(10).then(() => 'useSuspenseQuery'),
     }
 
     function Page() {

--- a/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -12,11 +12,6 @@ import {
 } from '..'
 import { renderWithClient } from './utils'
 
-const generateQueryFn = (data: string) =>
-  vi
-    .fn<(...args: Array<any>) => Promise<string>>()
-    .mockImplementation(() => sleep(10).then(() => data))
-
 describe('usePrefetchQuery', () => {
   let queryCache: QueryCache
   let queryClient: QueryClient
@@ -35,12 +30,12 @@ describe('usePrefetchQuery', () => {
   it('should prefetch query if query state does not exist', async () => {
     const queryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('prefetchQuery'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'prefetchQuery')),
     }
 
     const componentQueryOpts = {
       ...queryOpts,
-      queryFn: generateQueryFn('useSuspenseQuery'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'useSuspenseQuery')),
     }
 
     function Page() {
@@ -70,7 +65,9 @@ describe('usePrefetchQuery', () => {
   it('should not prefetch query if query state exists', async () => {
     const queryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('The usePrefetchQuery hook is smart!'),
+      queryFn: vi.fn(() =>
+        sleep(10).then(() => 'The usePrefetchQuery hook is smart!'),
+      ),
     }
 
     function Page() {
@@ -103,7 +100,7 @@ describe('usePrefetchQuery', () => {
   it('should let errors fall through and not refetch failed queries', async () => {
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
-    const queryFn = generateQueryFn('Not an error')
+    const queryFn = vi.fn(() => sleep(10).then(() => 'Not an error'))
 
     const queryOpts = {
       queryKey: queryKey(),
@@ -146,7 +143,7 @@ describe('usePrefetchQuery', () => {
   })
 
   it('should not create an endless loop when using inside a suspense boundary', async () => {
-    const queryFn = generateQueryFn('prefetchedQuery')
+    const queryFn = vi.fn(() => sleep(10).then(() => 'prefetchedQuery'))
 
     const queryOpts = {
       queryKey: queryKey(),
@@ -182,7 +179,9 @@ describe('usePrefetchQuery', () => {
   it('should be able to recover from errors and try fetching again', async () => {
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)
-    const queryFn = generateQueryFn('This is fine :dog: :fire:')
+    const queryFn = vi.fn(() =>
+      sleep(10).then(() => 'This is fine :dog: :fire:'),
+    )
 
     const queryOpts = {
       queryKey: queryKey(),
@@ -240,17 +239,19 @@ describe('usePrefetchQuery', () => {
   it('should not create a suspense waterfall if prefetch is fired', async () => {
     const firstQueryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('Prefetch is nice!'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'Prefetch is nice!')),
     }
 
     const secondQueryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('Prefetch is really nice!!'),
+      queryFn: vi.fn(() => sleep(10).then(() => 'Prefetch is really nice!!')),
     }
 
     const thirdQueryOpts = {
       queryKey: queryKey(),
-      queryFn: generateQueryFn('Prefetch does not create waterfalls!!'),
+      queryFn: vi.fn(() =>
+        sleep(10).then(() => 'Prefetch does not create waterfalls!!'),
+      ),
     }
 
     const Fallback = vi.fn().mockImplementation(() => <div>Loading...</div>)


### PR DESCRIPTION
## 🎯 Changes

Inlines the `generateQueryFn` factory (used 9 times) directly at each call site as `vi.fn(() => sleep(10).then(() => '...'))`, matching the plain inline `queryFn` style used elsewhere in the test suite. `vi.fn()` is retained (not a bare arrow function) because several assertions depend on it being a spy: `toHaveBeenCalledTimes`, `.mockClear()`, and `.mockImplementationOnce()` to simulate a failed fetch. The explicit generic type parameter on the removed factory wasn't load-bearing — `vi.fn(impl)` infers the same signature from its implementation. Applies to both `react-query` and `preact-query`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved `usePrefetchQuery` tests with scenario-specific mocked `queryFn` implementations instead of a shared helper.
  - Verified prefetch behavior when cached state is missing versus already present.
  - Strengthened coverage for error handling, retry recovery, suspense boundary edge cases, and prevention of suspense waterfalls.
  - Confirmed sequential prefetch operations behave correctly and that failed queries aren’t unnecessarily re-fetched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->