### PR TITLE
test({react,preact,solid}-query/useInfiniteQuery): inline the shared 'fetchItems' helper into the tests that use it

### DIFF
--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -29,21 +29,6 @@ interface Result {
 
 const pageSize = 10
 
-const fetchItems = async (
-  page: number,
-  ts: number,
-  noNext?: boolean,
-  noPrev?: boolean,
-): Promise<Result> => {
-  await sleep(10)
-  return {
-    items: [...new Array(10)].fill(null).map((_, d) => page * pageSize + d),
-    nextId: noNext ? undefined : page + 1,
-    prevId: noPrev ? undefined : page - 1,
-    ts,
-  }
-}
-
 describe('useInfiniteQuery', () => {
   let queryCache: QueryCache
   let queryClient: QueryClient
@@ -1538,12 +1523,19 @@ describe('useInfiniteQuery', () => {
         refetch,
       } = useInfiniteQuery({
         queryKey: key,
-        queryFn: ({ pageParam }) =>
-          fetchItems(
-            pageParam,
-            fetchCountRef.current++,
-            pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage),
-          ),
+        queryFn: async ({ pageParam }): Promise<Result> => {
+          await sleep(10)
+          const noNext =
+            pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage)
+          return {
+            items: [...new Array(10)]
+              .fill(null)
+              .map((_, d) => pageParam * pageSize + d),
+            nextId: noNext ? undefined : pageParam + 1,
+            prevId: pageParam - 1,
+            ts: fetchCountRef.current++,
+          }
+        },
         getNextPageParam: (lastPage) => lastPage.nextId,
         initialPageParam: 0,
       })

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -30,21 +30,6 @@ interface Result {
 
 const pageSize = 10
 
-const fetchItems = async (
-  page: number,
-  ts: number,
-  noNext?: boolean,
-  noPrev?: boolean,
-): Promise<Result> => {
-  await sleep(10)
-  return {
-    items: [...new Array(10)].fill(null).map((_, d) => page * pageSize + d),
-    nextId: noNext ? undefined : page + 1,
-    prevId: noPrev ? undefined : page - 1,
-    ts,
-  }
-}
-
 describe('useInfiniteQuery', () => {
   let queryCache: QueryCache
   let queryClient: QueryClient
@@ -1617,12 +1602,19 @@ describe('useInfiniteQuery', () => {
         refetch,
       } = useInfiniteQuery({
         queryKey: key,
-        queryFn: ({ pageParam }) =>
-          fetchItems(
-            pageParam,
-            fetchCountRef.current++,
-            pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage),
-          ),
+        queryFn: async ({ pageParam }): Promise<Result> => {
+          await sleep(10)
+          const noNext =
+            pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage)
+          return {
+            items: [...new Array(10)]
+              .fill(null)
+              .map((_, d) => pageParam * pageSize + d),
+            nextId: noNext ? undefined : pageParam + 1,
+            prevId: pageParam - 1,
+            ts: fetchCountRef.current++,
+          }
+        },
         getNextPageParam: (lastPage) => lastPage.nextId,
         initialPageParam: 0,
       })
@@ -1803,8 +1795,17 @@ describe('useInfiniteQuery', () => {
       useTrackRenders()
       const fetchCountRef = React.useRef(0)
       const query = useInfiniteQuery({
-        queryFn: ({ pageParam }) =>
-          fetchItems(pageParam, fetchCountRef.current++),
+        queryFn: async ({ pageParam }): Promise<Result> => {
+          await sleep(10)
+          return {
+            items: [...new Array(10)]
+              .fill(null)
+              .map((_, d) => pageParam * pageSize + d),
+            nextId: pageParam + 1,
+            prevId: pageParam - 1,
+            ts: fetchCountRef.current++,
+          }
+        },
         getNextPageParam: (lastPage) => lastPage.nextId,
         initialPageParam: 0,
         queryKey: key,

--- a/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -36,19 +36,6 @@ interface Result {
 
 const pageSize = 10
 
-const fetchItems = (
-  page: number,
-  ts: number,
-  noNext?: boolean,
-  noPrev?: boolean,
-): Promise<Result> =>
-  sleep(10).then(() => ({
-    items: [...new Array(10)].fill(null).map((_, d) => page * pageSize + d),
-    nextId: noNext ? undefined : page + 1,
-    prevId: noPrev ? undefined : page - 1,
-    ts,
-  }))
-
 describe('useInfiniteQuery', () => {
   let queryCache: QueryCache
   let queryClient: QueryClient
@@ -1752,12 +1739,18 @@ describe('useInfiniteQuery', () => {
 
       const state = useInfiniteQuery(() => ({
         queryKey: key,
-        queryFn: ({ pageParam }) =>
-          fetchItems(
-            pageParam,
-            fetchCountRef++,
-            pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage()),
-          ),
+        queryFn: ({ pageParam }): Promise<Result> => {
+          const noNext =
+            pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage())
+          return sleep(10).then(() => ({
+            items: [...new Array(10)]
+              .fill(null)
+              .map((_, d) => pageParam * pageSize + d),
+            nextId: noNext ? undefined : pageParam + 1,
+            prevId: pageParam - 1,
+            ts: fetchCountRef++,
+          }))
+        },
         initialPageParam: 0,
         getNextPageParam: (lastPage) => lastPage.nextId,
       }))


### PR DESCRIPTION
## 🎯 Changes

Inlines the `fetchItems` helper (a plain async mock queryFn generator, defined at the top of each file but used in only 1–2 tests) directly into the `it` block(s) that use it, matching the dominant pattern in these files where each test defines its own `queryFn` inline. The 4th (`noPrev`) parameter is dropped since no call site ever passed it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated infinite-query test scenarios across supported frameworks to define paginated test data directly within each case.
  * Preserved coverage for pagination, refetching, removed pages, next-page detection, and Suspense behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->