### PR TITLE
test({react,preact}-query): use the '.then()' convention consistently

### DIFF
--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1523,18 +1523,17 @@ describe('useInfiniteQuery', () => {
         refetch,
       } = useInfiniteQuery({
         queryKey: key,
-        queryFn: async ({ pageParam }): Promise<Result> => {
-          await sleep(10)
+        queryFn: ({ pageParam }): Promise<Result> => {
           const noNext =
             pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage)
-          return {
+          return sleep(10).then(() => ({
             items: [...new Array(10)]
               .fill(null)
               .map((_, d) => pageParam * pageSize + d),
             nextId: noNext ? undefined : pageParam + 1,
             prevId: pageParam - 1,
             ts: fetchCountRef.current++,
-          }
+          }))
         },
         getNextPageParam: (lastPage) => lastPage.nextId,
         initialPageParam: 0,

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -210,7 +210,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => {
             throw new Error('oops')
           }),
@@ -370,7 +370,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => {
             throw new Error('oops')
           }),
@@ -740,7 +740,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => {
             throw new Error('oops')
           }),
@@ -860,7 +860,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) => Promise.reject(new Error('oops')),
+        mutationFn: (_text: string) => Promise.reject(new Error('oops')),
         onError: () => {
           callbacks.push('useMutation.onError')
           return Promise.resolve()
@@ -911,7 +911,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutate } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => Promise.reject(new Error('oops'))),
         onError: () => {
           callbacks.push('useMutation.onError')
@@ -1238,13 +1238,13 @@ describe('useMutation', () => {
     function Page() {
       const state = useMutation({
         mutationKey: key,
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          count++
-          return count > 1
-            ? Promise.resolve(`data${count}`)
-            : Promise.reject(new Error('oops'))
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            count++
+            return count > 1
+              ? Promise.resolve(`data${count}`)
+              : Promise.reject(new Error('oops'))
+          }),
         retry: 1,
         retryDelay: 5,
         networkMode: 'offlineFirst',
@@ -1808,10 +1808,10 @@ describe('useMutation', () => {
 
     function Page() {
       const mutation = useMutation({
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          throw mutateFnError
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw mutateFnError
+          }),
         onError: () => Promise.reject(error),
       })
 
@@ -1854,10 +1854,10 @@ describe('useMutation', () => {
 
     function Page() {
       const mutation = useMutation({
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          throw mutateFnError
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw mutateFnError
+          }),
         onSettled: () => Promise.reject(error),
         onError,
       })
@@ -1895,7 +1895,7 @@ describe('useMutation', () => {
     function Page() {
       const mutation = useMutation(
         {
-          mutationFn: async (text: string) => {
+          mutationFn: (text: string) => {
             return Promise.resolve(text)
           },
         },
@@ -2017,13 +2017,13 @@ describe('useMutation', () => {
       const [message, setMessage] = useState<string>('idle')
 
       const { mutate } = useMutation({
-        mutationFn: async (shouldFail: boolean) => {
-          await sleep(10)
-          if (shouldFail) {
-            throw new Error('submission failed')
-          }
-          return 'submitted successfully'
-        },
+        mutationFn: (shouldFail: boolean) =>
+          sleep(10).then(() => {
+            if (shouldFail) {
+              throw new Error('submission failed')
+            }
+            return 'submitted successfully'
+          }),
         retry: false,
       })
 
@@ -2059,13 +2059,13 @@ describe('useMutation', () => {
       const [message, setMessage] = useState<string>('idle')
 
       const { mutate } = useMutation({
-        mutationFn: async (shouldFail: boolean) => {
-          await sleep(10)
-          if (shouldFail) {
-            throw new Error('submission failed')
-          }
-          return 'submitted successfully'
-        },
+        mutationFn: (shouldFail: boolean) =>
+          sleep(10).then(() => {
+            if (shouldFail) {
+              throw new Error('submission failed')
+            }
+            return 'submitted successfully'
+          }),
         retry: false,
       })
 
@@ -2103,14 +2103,14 @@ describe('useMutation', () => {
       const [message, setMessage] = useState<string>('idle')
 
       const { mutate } = useMutation({
-        mutationFn: async () => {
-          await sleep(10)
-          attempt++
-          if (attempt < 2) {
-            throw new Error('temporary failure')
-          }
-          return 'success'
-        },
+        mutationFn: () =>
+          sleep(10).then(() => {
+            attempt++
+            if (attempt < 2) {
+              throw new Error('temporary failure')
+            }
+            return 'success'
+          }),
         retry: false,
       })
 
@@ -2309,13 +2309,13 @@ describe('useMutation', () => {
       const [result, setResult] = useState<string>('idle')
 
       const { mutateAsync } = useMutation({
-        mutationFn: async (file: string) => {
-          await sleep(10)
-          if (file === 'file2') {
-            throw new Error('upload failed')
-          }
-          return `uploaded: ${file}`
-        },
+        mutationFn: (file: string) =>
+          sleep(10).then(() => {
+            if (file === 'file2') {
+              throw new Error('upload failed')
+            }
+            return `uploaded: ${file}`
+          }),
         retry: false,
       })
 
@@ -2357,13 +2357,13 @@ describe('useMutation', () => {
       const [result, setResult] = useState<string>('idle')
 
       const { mutateAsync } = useMutation({
-        mutationFn: async (file: string) => {
-          await sleep(10)
-          if (file === 'file2') {
-            throw new Error('upload failed')
-          }
-          return `uploaded: ${file}`
-        },
+        mutationFn: (file: string) =>
+          sleep(10).then(() => {
+            if (file === 'file2') {
+              throw new Error('upload failed')
+            }
+            return `uploaded: ${file}`
+          }),
         retry: false,
       })
 

--- a/packages/preact-query/src/__tests__/useQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useQueries.test.tsx
@@ -74,11 +74,11 @@ describe('useQueries', () => {
         queries: [
           {
             queryKey: key1,
-            queryFn: async () => {
-              await sleep(10)
-              count++
-              return count
-            },
+            queryFn: () =>
+              sleep(10).then(() => {
+                count++
+                return count
+              }),
           },
         ],
       })
@@ -145,7 +145,7 @@ describe('useQueries', () => {
           },
           {
             queryKey: key4,
-            queryFn: async () =>
+            queryFn: () =>
               Promise.reject(
                 new Error('this should not throw because query#2 already did'),
               ),
@@ -213,7 +213,7 @@ describe('useQueries', () => {
           },
           {
             queryKey: key4,
-            queryFn: async () =>
+            queryFn: () =>
               Promise.reject(
                 new Error('this should not throw because query#3 already did'),
               ),
@@ -769,19 +769,19 @@ describe('useQueries', () => {
           queries: [
             {
               queryKey: [key1],
-              queryFn: async () => {
-                await sleep(10)
-                queryFns.push('first result')
-                return 'first result'
-              },
+              queryFn: () =>
+                sleep(10).then(() => {
+                  queryFns.push('first result')
+                  return 'first result'
+                }),
             },
             {
               queryKey: [key2],
-              queryFn: async () => {
-                await sleep(20)
-                queryFns.push('second result')
-                return 'second result'
-              },
+              queryFn: () =>
+                sleep(20).then(() => {
+                  queryFns.push('second result')
+                  return 'second result'
+                }),
             },
           ],
           combine: () => 'foo',

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -758,11 +758,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return `test${count}`
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return `test${count}`
+          }),
       })
 
       states.push(state)
@@ -877,10 +877,7 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return ++count
-        },
+        queryFn: () => sleep(10).then(() => ++count),
         notifyOnChangeProps: 'all',
       })
 
@@ -939,11 +936,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count === 1 ? result1 : result2
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count === 1 ? result1 : result2
+          }),
         notifyOnChangeProps: 'all',
       })
 
@@ -1027,11 +1024,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
       })
 
@@ -1073,11 +1070,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         enabled: false,
       })
 
@@ -1113,11 +1110,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         enabled: false,
       })
 
@@ -1272,12 +1269,7 @@ describe('useQuery', () => {
 
       const state = useQuery({
         queryKey: [key, count],
-        queryFn: async () => {
-          await sleep(10)
-          return {
-            count,
-          }
-        },
+        queryFn: () => sleep(10).then(() => ({ count })),
         select(data) {
           return data.count
         },
@@ -1344,12 +1336,7 @@ describe('useQuery', () => {
 
       const state = useQuery({
         queryKey: [key, count],
-        queryFn: async () => {
-          await sleep(10)
-          return {
-            count,
-          }
-        },
+        queryFn: () => sleep(10).then(() => ({ count })),
         select(data) {
           return data.count
         },
@@ -1399,12 +1386,7 @@ describe('useQuery', () => {
 
       const state = useQuery({
         queryKey: [key, count],
-        queryFn: async () => {
-          await sleep(10)
-          return {
-            count,
-          }
-        },
+        queryFn: () => sleep(10).then(() => ({ count })),
         select(data) {
           return data.count
         },
@@ -1483,13 +1465,13 @@ describe('useQuery', () => {
     function Page({ count }: { count: number }) {
       const state = useQuery<number, Error>({
         queryKey: [key, count],
-        queryFn: async () => {
-          await sleep(10)
-          if (count === 2) {
-            throw new Error('Error test')
-          }
-          return Promise.resolve(count)
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (count === 2) {
+              throw new Error('Error test')
+            }
+            return Promise.resolve(count)
+          }),
         retry: false,
         placeholderData: keepPreviousData,
       })
@@ -2201,11 +2183,10 @@ describe('useQuery', () => {
 
           const state = useQuery({
             queryKey: key,
-            queryFn: async () => {
-              await sleep(5)
-              fetchCounterRef.current++
-              return `fetch counter: ${fetchCounterRef.current}`
-            },
+            queryFn: () =>
+              sleep(5).then(
+                () => `fetch counter: ${++fetchCounterRef.current}`,
+              ),
             notifyOnChangeProps,
           })
 
@@ -2591,10 +2572,7 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return count++
-        },
+        queryFn: () => sleep(10).then(() => count++),
 
         staleTime: Infinity,
         refetchOnWindowFocus: 'always',
@@ -2630,10 +2608,7 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return count++
-        },
+        queryFn: () => sleep(10).then(() => count++),
 
         staleTime: 0,
         retry: 0,
@@ -3996,16 +3971,15 @@ describe('useQuery', () => {
     function Page() {
       const result = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return (
-            queryFn() || {
-              data: {
-                nested: true,
+        queryFn: () =>
+          sleep(10).then(
+            () =>
+              queryFn() || {
+                data: {
+                  nested: true,
+                },
               },
-            }
-          )
-        },
+          ),
       })
 
       useMemo(() => {
@@ -4077,10 +4051,7 @@ describe('useQuery', () => {
     function Page() {
       const queryInfo = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return count++
-        },
+        queryFn: () => sleep(10).then(() => count++),
         refetchInterval: ({ state: { data = 0 } }) => (data < 2 ? 10 : false),
       })
 
@@ -4715,11 +4686,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
       })
 
@@ -4786,11 +4757,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
         enabled: false,
         notifyOnChangeProps: 'all',
@@ -4971,13 +4942,13 @@ describe('useQuery', () => {
     function Page({ id }: { id: number }) {
       const { error, isPending } = useQuery({
         queryKey: [id],
-        queryFn: async () => {
-          await sleep(10)
-          if (id % 2 === 1) {
-            return Promise.reject(new Error('Error'))
-          }
-          return 'data'
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (id % 2 === 1) {
+              return Promise.reject(new Error('Error'))
+            }
+            return 'data'
+          }),
         retry: false,
         retryOnMount: () => false,
         refetchOnMount: false,
@@ -5092,14 +5063,14 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          if (count === 0) {
-            count++
-            throw error
-          }
-          return 5
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (count === 0) {
+              count++
+              throw error
+            }
+            return 5
+          }),
         retry: false,
       })
 

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1602,18 +1602,17 @@ describe('useInfiniteQuery', () => {
         refetch,
       } = useInfiniteQuery({
         queryKey: key,
-        queryFn: async ({ pageParam }): Promise<Result> => {
-          await sleep(10)
+        queryFn: ({ pageParam }): Promise<Result> => {
           const noNext =
             pageParam === MAX || (pageParam === MAX - 1 && isRemovedLastPage)
-          return {
+          return sleep(10).then(() => ({
             items: [...new Array(10)]
               .fill(null)
               .map((_, d) => pageParam * pageSize + d),
             nextId: noNext ? undefined : pageParam + 1,
             prevId: pageParam - 1,
             ts: fetchCountRef.current++,
-          }
+          }))
         },
         getNextPageParam: (lastPage) => lastPage.nextId,
         initialPageParam: 0,
@@ -1795,17 +1794,15 @@ describe('useInfiniteQuery', () => {
       useTrackRenders()
       const fetchCountRef = React.useRef(0)
       const query = useInfiniteQuery({
-        queryFn: async ({ pageParam }): Promise<Result> => {
-          await sleep(10)
-          return {
+        queryFn: ({ pageParam }): Promise<Result> =>
+          sleep(10).then(() => ({
             items: [...new Array(10)]
               .fill(null)
               .map((_, d) => pageParam * pageSize + d),
             nextId: pageParam + 1,
             prevId: pageParam - 1,
             ts: fetchCountRef.current++,
-          }
-        },
+          })),
         getNextPageParam: (lastPage) => lastPage.nextId,
         initialPageParam: 0,
         queryKey: key,

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -209,7 +209,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => {
             throw new Error('oops')
           }),
@@ -369,7 +369,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => {
             throw new Error('oops')
           }),
@@ -739,7 +739,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => {
             throw new Error('oops')
           }),
@@ -859,7 +859,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutateAsync } = useMutation({
-        mutationFn: async (_text: string) => Promise.reject(new Error('oops')),
+        mutationFn: (_text: string) => Promise.reject(new Error('oops')),
         onError: () => {
           callbacks.push('useMutation.onError')
           return Promise.resolve()
@@ -910,7 +910,7 @@ describe('useMutation', () => {
 
     function Page() {
       const { mutate } = useMutation({
-        mutationFn: async (_text: string) =>
+        mutationFn: (_text: string) =>
           sleep(10).then(() => Promise.reject(new Error('oops'))),
         onError: () => {
           callbacks.push('useMutation.onError')
@@ -1237,13 +1237,13 @@ describe('useMutation', () => {
     function Page() {
       const state = useMutation({
         mutationKey: key,
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          count++
-          return count > 1
-            ? Promise.resolve(`data${count}`)
-            : Promise.reject(new Error('oops'))
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            count++
+            return count > 1
+              ? Promise.resolve(`data${count}`)
+              : Promise.reject(new Error('oops'))
+          }),
         retry: 1,
         retryDelay: 5,
         networkMode: 'offlineFirst',
@@ -1807,10 +1807,10 @@ describe('useMutation', () => {
 
     function Page() {
       const mutation = useMutation({
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          throw mutateFnError
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw mutateFnError
+          }),
         onError: () => Promise.reject(error),
       })
 
@@ -1853,10 +1853,10 @@ describe('useMutation', () => {
 
     function Page() {
       const mutation = useMutation({
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          throw mutateFnError
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw mutateFnError
+          }),
         onSettled: () => Promise.reject(error),
         onError,
       })
@@ -1894,7 +1894,7 @@ describe('useMutation', () => {
     function Page() {
       const mutation = useMutation(
         {
-          mutationFn: async (text: string) => {
+          mutationFn: (text: string) => {
             return Promise.resolve(text)
           },
         },
@@ -2016,13 +2016,13 @@ describe('useMutation', () => {
       const [message, setMessage] = React.useState<string>('idle')
 
       const { mutate } = useMutation({
-        mutationFn: async (shouldFail: boolean) => {
-          await sleep(10)
-          if (shouldFail) {
-            throw new Error('submission failed')
-          }
-          return 'submitted successfully'
-        },
+        mutationFn: (shouldFail: boolean) =>
+          sleep(10).then(() => {
+            if (shouldFail) {
+              throw new Error('submission failed')
+            }
+            return 'submitted successfully'
+          }),
         retry: false,
       })
 
@@ -2058,13 +2058,13 @@ describe('useMutation', () => {
       const [message, setMessage] = React.useState<string>('idle')
 
       const { mutate } = useMutation({
-        mutationFn: async (shouldFail: boolean) => {
-          await sleep(10)
-          if (shouldFail) {
-            throw new Error('submission failed')
-          }
-          return 'submitted successfully'
-        },
+        mutationFn: (shouldFail: boolean) =>
+          sleep(10).then(() => {
+            if (shouldFail) {
+              throw new Error('submission failed')
+            }
+            return 'submitted successfully'
+          }),
         retry: false,
       })
 
@@ -2102,14 +2102,14 @@ describe('useMutation', () => {
       const [message, setMessage] = React.useState<string>('idle')
 
       const { mutate } = useMutation({
-        mutationFn: async () => {
-          await sleep(10)
-          attempt++
-          if (attempt < 2) {
-            throw new Error('temporary failure')
-          }
-          return 'success'
-        },
+        mutationFn: () =>
+          sleep(10).then(() => {
+            attempt++
+            if (attempt < 2) {
+              throw new Error('temporary failure')
+            }
+            return 'success'
+          }),
         retry: false,
       })
 
@@ -2308,13 +2308,13 @@ describe('useMutation', () => {
       const [result, setResult] = React.useState<string>('idle')
 
       const { mutateAsync } = useMutation({
-        mutationFn: async (file: string) => {
-          await sleep(10)
-          if (file === 'file2') {
-            throw new Error('upload failed')
-          }
-          return `uploaded: ${file}`
-        },
+        mutationFn: (file: string) =>
+          sleep(10).then(() => {
+            if (file === 'file2') {
+              throw new Error('upload failed')
+            }
+            return `uploaded: ${file}`
+          }),
         retry: false,
       })
 
@@ -2356,13 +2356,13 @@ describe('useMutation', () => {
       const [result, setResult] = React.useState<string>('idle')
 
       const { mutateAsync } = useMutation({
-        mutationFn: async (file: string) => {
-          await sleep(10)
-          if (file === 'file2') {
-            throw new Error('upload failed')
-          }
-          return `uploaded: ${file}`
-        },
+        mutationFn: (file: string) =>
+          sleep(10).then(() => {
+            if (file === 'file2') {
+              throw new Error('upload failed')
+            }
+            return `uploaded: ${file}`
+          }),
         retry: false,
       })
 

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -73,11 +73,11 @@ describe('useQueries', () => {
         queries: [
           {
             queryKey: key1,
-            queryFn: async () => {
-              await sleep(10)
-              count++
-              return count
-            },
+            queryFn: () =>
+              sleep(10).then(() => {
+                count++
+                return count
+              }),
           },
         ],
       })
@@ -144,7 +144,7 @@ describe('useQueries', () => {
           },
           {
             queryKey: key4,
-            queryFn: async () =>
+            queryFn: () =>
               Promise.reject(
                 new Error('this should not throw because query#2 already did'),
               ),
@@ -212,7 +212,7 @@ describe('useQueries', () => {
           },
           {
             queryKey: key4,
-            queryFn: async () =>
+            queryFn: () =>
               Promise.reject(
                 new Error('this should not throw because query#3 already did'),
               ),
@@ -768,19 +768,19 @@ describe('useQueries', () => {
           queries: [
             {
               queryKey: [key1],
-              queryFn: async () => {
-                await sleep(10)
-                queryFns.push('first result')
-                return 'first result'
-              },
+              queryFn: () =>
+                sleep(10).then(() => {
+                  queryFns.push('first result')
+                  return 'first result'
+                }),
             },
             {
               queryKey: [key2],
-              queryFn: async () => {
-                await sleep(20)
-                queryFns.push('second result')
-                return 'second result'
-              },
+              queryFn: () =>
+                sleep(20).then(() => {
+                  queryFns.push('second result')
+                  return 'second result'
+                }),
             },
           ],
           combine: () => 'foo',

--- a/packages/react-query/src/__tests__/useQuery.promise.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.promise.test.tsx
@@ -499,14 +499,14 @@ describe('useQuery().promise', { timeout: 10_000 }, () => {
     function Page() {
       const query = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          if (++queryCount > 1) {
-            // second time this query mounts, it should not throw
-            return 'data'
-          }
-          throw new Error('Error test')
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (++queryCount > 1) {
+              // second time this query mounts, it should not throw
+              return 'data'
+            }
+            throw new Error('Error test')
+          }),
         retry: false,
       })
 
@@ -1393,13 +1393,13 @@ describe('useQuery().promise', { timeout: 10_000 }, () => {
     function Page() {
       const query = useInfiniteQuery({
         queryKey: key,
-        queryFn: async ({ pageParam = 0 }) => {
-          await sleep(10)
-          if (pageParam === 0) {
-            return { nextCursor: 1, data: 'page-1' }
-          }
-          throw new Error('page error')
-        },
+        queryFn: ({ pageParam = 0 }) =>
+          sleep(10).then(() => {
+            if (pageParam === 0) {
+              return { nextCursor: 1, data: 'page-1' }
+            }
+            throw new Error('page error')
+          }),
         initialPageParam: 0,
         getNextPageParam: (lastPage) => lastPage.nextCursor,
         retry: false,

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -750,11 +750,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return 'test' + count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return 'test' + count
+          }),
       })
 
       states.push(state)
@@ -869,10 +869,7 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return ++count
-        },
+        queryFn: () => sleep(10).then(() => ++count),
         notifyOnChangeProps: 'all',
       })
 
@@ -931,11 +928,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count === 1 ? result1 : result2
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count === 1 ? result1 : result2
+          }),
         notifyOnChangeProps: 'all',
       })
 
@@ -1019,11 +1016,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
       })
 
@@ -1065,11 +1062,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         enabled: false,
       })
 
@@ -1105,11 +1102,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         enabled: false,
       })
 
@@ -1460,13 +1457,13 @@ describe('useQuery', () => {
     function Page({ count }: { count: number }) {
       const state = useQuery<number, Error>({
         queryKey: [key, count],
-        queryFn: async () => {
-          await sleep(10)
-          if (count === 2) {
-            throw new Error('Error test')
-          }
-          return Promise.resolve(count)
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (count === 2) {
+              throw new Error('Error test')
+            }
+            return Promise.resolve(count)
+          }),
         retry: false,
         placeholderData: keepPreviousData,
       })
@@ -2178,11 +2175,10 @@ describe('useQuery', () => {
 
           const state = useQuery({
             queryKey: key,
-            queryFn: async () => {
-              await sleep(5)
-              fetchCounterRef.current++
-              return `fetch counter: ${fetchCounterRef.current}`
-            },
+            queryFn: () =>
+              sleep(5).then(
+                () => `fetch counter: ${++fetchCounterRef.current}`,
+              ),
             notifyOnChangeProps,
           })
 
@@ -2568,10 +2564,7 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return count++
-        },
+        queryFn: () => sleep(10).then(() => count++),
 
         staleTime: Infinity,
         refetchOnWindowFocus: 'always',
@@ -2607,10 +2600,7 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return count++
-        },
+        queryFn: () => sleep(10).then(() => count++),
 
         staleTime: 0,
         retry: 0,
@@ -3974,16 +3964,15 @@ describe('useQuery', () => {
     function Page() {
       const result = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return (
-            queryFn() || {
-              data: {
-                nested: true,
+        queryFn: () =>
+          sleep(10).then(
+            () =>
+              queryFn() || {
+                data: {
+                  nested: true,
+                },
               },
-            }
-          )
-        },
+          ),
       })
 
       React.useMemo(() => {
@@ -4055,10 +4044,7 @@ describe('useQuery', () => {
     function Page() {
       const queryInfo = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          return count++
-        },
+        queryFn: () => sleep(10).then(() => count++),
         refetchInterval: ({ state: { data = 0 } }) => (data < 2 ? 10 : false),
       })
 
@@ -4694,11 +4680,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
       })
 
@@ -4765,11 +4751,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
         enabled: false,
         notifyOnChangeProps: 'all',
@@ -4950,14 +4936,14 @@ describe('useQuery', () => {
     function Page({ id }: { id: number }) {
       const { error, isPending } = useQuery({
         queryKey: [id],
-        queryFn: async () => {
-          await sleep(10)
-          if (id % 2 === 1) {
-            return Promise.reject(new Error('Error'))
-          } else {
-            return 'data'
-          }
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (id % 2 === 1) {
+              return Promise.reject(new Error('Error'))
+            } else {
+              return 'data'
+            }
+          }),
         retry: false,
         retryOnMount: () => false,
         refetchOnMount: false,
@@ -5072,14 +5058,14 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          if (count === 0) {
-            count++
-            throw error
-          }
-          return 5
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (count === 0) {
+              count++
+              throw error
+            }
+            return 5
+          }),
         retry: false,
       })
 

--- a/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -839,7 +839,7 @@ describe('useSuspenseQuery', () => {
 
       const state = useSuspenseQuery({
         queryKey: stateKey,
-        queryFn: async () => sleep(10).then(() => ++count),
+        queryFn: () => sleep(10).then(() => ++count),
       })
 
       states.push(state)


### PR DESCRIPTION
## 🎯 Changes

Several `queryFn`/`mutationFn` implementations were left as `async/await` even though the surrounding tests in each file overwhelmingly use the `.then()` convention. This PR converts the remaining cases where a side effect (counter increment, `.push()`, throw) happens strictly after `await sleep(...)`, so it can be expressed as `sleep(...).then(() => { ... })` without changing execution order.

Cases where a side effect happens *before* `sleep(...)` are intentionally left as `async/await`, since converting them would require pulling the side effect out of the `.then()` callback and wouldn't shorten or clarify the code.

- `useInfiniteQuery`: converted 2 `queryFn`s in both `react-query` and `preact-query`
- `useMutation`: converted several `mutationFn`s (removed unnecessary `async` on already-`.then()`-based functions, converted sleep-then-effect cases) in both packages
- `useQueries`: converted `queryFn`s with post-sleep side effects, removed unnecessary `async` on functions with no `await`
- `useQuery` (+ `useQuery.promise`, `useSuspenseQuery` in `react-query`): converted `queryFn`s with post-sleep side effects/throws

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated asynchronous test scenarios across query, mutation, infinite query, suspense, and multi-query behavior.
  - Preserved coverage for refetching, retries, error handling, pagination, promise combinations, and rendering behavior.
  - Standardized test promise handling without changing expected results or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->