### PR TITLE
test(query-core/queryObserver): use the '.then()' convention consistently

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -103,11 +103,11 @@ describe('queryObserver', () => {
         queryKey: key,
         staleTime: Infinity,
         enabled: () => enabled,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return 'data'
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return 'data'
+          }),
       })
     })
 
@@ -267,11 +267,11 @@ describe('queryObserver', () => {
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
       staleTime: Infinity,
-      queryFn: async () => {
-        await sleep(10)
-        count++
-        return 'data'
-      },
+      queryFn: () =>
+        sleep(10).then(() => {
+          count++
+          return 'data'
+        }),
     })
 
     let unsubscribe = observer.subscribe(vi.fn())


### PR DESCRIPTION
## 🎯 Changes

Two `queryFn`s were left as `async/await` even though the surrounding tests in the file overwhelmingly use the `.then()` convention. Both cases increment a counter strictly after `await sleep(...)`, so they can be expressed as `sleep(...).then(() => { ... })` without changing execution order.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).