### PR TITLE
test(solid-query): use the '.then()' convention consistently

### DIFF
--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -328,11 +328,11 @@ describe('PersistQueryClientProvider', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          fetched = true
-          return 'fetched'
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            fetched = true
+            return 'fetched'
+          }),
         staleTime: Infinity,
       }))
 

--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -956,13 +956,13 @@ describe('useMutation', () => {
 
     function Page() {
       const mutation = useMutation(() => ({
-        mutationFn: async (_text: string) => {
-          await sleep(1)
-          count++
-          return count > 1
-            ? Promise.resolve('data')
-            : Promise.reject(new Error('oops'))
-        },
+        mutationFn: (_text: string) =>
+          sleep(1).then(() => {
+            count++
+            return count > 1
+              ? Promise.resolve('data')
+              : Promise.reject(new Error('oops'))
+          }),
         retry: 1,
         retryDelay: 5,
         networkMode: 'offlineFirst',
@@ -1413,10 +1413,10 @@ describe('useMutation', () => {
 
     function Page() {
       const mutation = useMutation(() => ({
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          throw mutateFnError
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw mutateFnError
+          }),
         onError: () => Promise.reject(error),
       }))
 
@@ -1459,10 +1459,10 @@ describe('useMutation', () => {
 
     function Page() {
       const mutation = useMutation(() => ({
-        mutationFn: async (_text: string) => {
-          await sleep(10)
-          throw mutateFnError
-        },
+        mutationFn: (_text: string) =>
+          sleep(10).then(() => {
+            throw mutateFnError
+          }),
         onSettled: () => Promise.reject(error),
         onError,
       }))
@@ -1500,7 +1500,7 @@ describe('useMutation', () => {
     function Page() {
       const mutation = useMutation(
         () => ({
-          mutationFn: async (text: string) => {
+          mutationFn: (text: string) => {
             return Promise.resolve(text)
           },
         }),

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -348,11 +348,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          fetchCount++
-          return 'data'
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            fetchCount++
+            return 'data'
+          }),
         enabled: false,
         initialData: 'initialData',
       }))
@@ -383,11 +383,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          fetchCount++
-          return 'data'
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            fetchCount++
+            return 'data'
+          }),
         enabled: false,
         initialData: 'initialData',
       }))
@@ -418,11 +418,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          fetchCount++
-          return 'data'
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            fetchCount++
+            return 'data'
+          }),
         enabled: false,
       }))
 
@@ -829,14 +829,14 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return [
-            { id: '1', done: false },
-            { id: '2', done: count > 1 },
-          ]
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return [
+              { id: '1', done: false },
+              { id: '2', done: count > 1 },
+            ]
+          }),
         reconcile: 'id',
       }))
 
@@ -898,11 +898,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count === 1 ? result1 : result2
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count === 1 ? result1 : result2
+          }),
         reconcile: (oldData, newData) => {
           return reconcile(newData)(oldData)
         },
@@ -1002,11 +1002,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
       }))
 
@@ -1075,11 +1075,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         enabled: false,
       }))
 
@@ -1117,11 +1117,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         enabled: false,
       }))
 
@@ -2358,11 +2358,11 @@ describe('useQuery', () => {
     function Page() {
       const result = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          throw new Error('some error')
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            throw new Error('some error')
+          }),
         retry: 2,
 
         retryDelay: 100,
@@ -2422,11 +2422,11 @@ describe('useQuery', () => {
     function Page() {
       const result = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          throw new Error('some error')
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            throw new Error('some error')
+          }),
         retry: 2,
         retryDelay: 100,
       }))
@@ -2868,11 +2868,11 @@ describe('useQuery', () => {
     function Page() {
       const query = useQuery<unknown, string>(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          throw `fetching error ${count}`
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            throw `fetching error ${count}`
+          }),
         retry: 3,
         retryDelay: 1,
       }))
@@ -3112,15 +3112,15 @@ describe('useQuery', () => {
 
       const query = useQuery<unknown, Error>(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          if (counter < 2) {
-            counter++
-            throw new Error('error')
-          } else {
-            return 'data'
-          }
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (counter < 2) {
+              counter++
+              throw new Error('error')
+            } else {
+              return 'data'
+            }
+          }),
         retryDelay: 10,
       }))
 
@@ -3162,11 +3162,11 @@ describe('useQuery', () => {
 
       const query = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         enabled: enabled(),
       }))
 
@@ -4322,11 +4322,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
       }))
 
@@ -4393,11 +4393,11 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          count++
-          return count
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            count++
+            return count
+          }),
         staleTime: Infinity,
         enabled: false,
         notifyOnChangeProps: 'all',
@@ -4681,14 +4681,14 @@ describe('useQuery', () => {
     function Page() {
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          if (count === 0) {
-            count++
-            throw error
-          }
-          return 5
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            if (count === 0) {
+              count++
+              throw error
+            }
+            return 5
+          }),
         retry: false,
       }))
 
@@ -4802,11 +4802,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery<unknown, string, string>(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            return 'data' + count
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              return 'data' + count
+            }),
         }))
 
         return (
@@ -4874,11 +4874,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            return 'data' + count
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              return 'data' + count
+            }),
         }))
 
         return (
@@ -4925,11 +4925,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            return 'data' + count
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              return 'data' + count
+            }),
         }))
 
         return (
@@ -4971,11 +4971,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            return 'data' + count
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              return 'data' + count
+            }),
           initialData: 'initial',
         }))
 
@@ -5020,11 +5020,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            return 'data' + count
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              return 'data' + count
+            }),
           initialData: 'initial',
         }))
 
@@ -5085,11 +5085,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery<unknown, Error>(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            throw new Error('failed' + count)
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              throw new Error('failed' + count)
+            }),
           retry: 2,
           retryDelay: 10,
         }))
@@ -5273,11 +5273,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            return 'data' + count
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              return 'data' + count
+            }),
           refetchOnReconnect: false,
         }))
 
@@ -5400,11 +5400,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            return 'data ' + count
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              return 'data ' + count
+            }),
           networkMode: 'always',
         }))
 
@@ -5438,11 +5438,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            throw new Error('error ' + count)
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              throw new Error('error ' + count)
+            }),
           networkMode: 'always',
           retry: 1,
           retryDelay: 5,
@@ -5488,11 +5488,11 @@ describe('useQuery', () => {
       function Page() {
         const state = useQuery<unknown, Error>(() => ({
           queryKey: key,
-          queryFn: async () => {
-            await sleep(10)
-            count++
-            throw new Error('failed' + count)
-          },
+          queryFn: () =>
+            sleep(10).then(() => {
+              count++
+              throw new Error('failed' + count)
+            }),
           retry: 2,
           retryDelay: 1,
           networkMode: 'offlineFirst',


### PR DESCRIPTION
## 🎯 Changes

Several `queryFn`/`mutationFn` implementations were left as `async/await` even though the surrounding tests in each file overwhelmingly use the `.then()` convention. This PR converts the remaining cases where a side effect (counter increment, throw) happens strictly after `await sleep(...)`, so it can be expressed as `sleep(...).then(() => { ... })` without changing execution order.

Cases where a side effect happens *before* `sleep(...)` are intentionally left as `async/await`, since converting them would require pulling the side effect out of the `.then()` callback and wouldn't shorten or clarify the code.

- `solid-query/useMutation`: converted 3 `mutationFn`s (removed unnecessary `async` on one already-`.then()`-based function)
- `solid-query/useQuery`: converted `queryFn`s with post-sleep side effects/throws across the `networkMode` describe blocks and elsewhere
- `solid-query-persist-client`: converted the `queryFn` in "should not refetch after restoring when data is fresh"

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated query and mutation test scenarios to use consistent promise-based asynchronous patterns.
  * Preserved existing coverage for refetching, retries, errors, cancellation, network modes, and restored query data.
  * No user-facing behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->