### PR TITLE
test(angular-query-persist-client): use the '.then()' convention consistently

### DIFF
--- a/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
+++ b/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
@@ -279,11 +279,11 @@ describe('withPersistQueryClient', () => {
     class Page {
       state = injectQuery(() => ({
         queryKey: key,
-        queryFn: async () => {
-          await sleep(10)
-          fetched = true
-          return 'fetched'
-        },
+        queryFn: () =>
+          sleep(10).then(() => {
+            fetched = true
+            return 'fetched'
+          }),
         staleTime: Infinity,
       }))
 


### PR DESCRIPTION
## 🎯 Changes

The `queryFn` in "should not refetch after restoring when data is fresh" was left as `async/await` even though the rest of the file uses the `.then()` convention. The side effect (`fetched = true`) happens strictly after `await sleep(...)`, so it can be expressed as `sleep(...).then(() => { ... })` without changing execution order.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a persistence test to preserve its timing behavior while verifying that fresh restored data does not trigger an unnecessary refetch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->