### PR TITLE
docs(angular-query): fix invalid imports and syntax error in guide examples

### DIFF
--- a/docs/framework/angular/guides/disabling-queries.md
+++ b/docs/framework/angular/guides/disabling-queries.md
@@ -70,7 +70,7 @@ export class TodosComponent {
 [//]: # 'Example3'
 
 ```angular-ts
-import { skipToken, injectQuery } from '@tanstack/query-angular'
+import { skipToken, injectQuery } from '@tanstack/angular-query-experimental'
 
 @Component({
   selector: 'todos',

--- a/docs/framework/angular/guides/query-functions.md
+++ b/docs/framework/angular/guides/query-functions.md
@@ -8,7 +8,7 @@ ref: docs/framework/react/guides/query-functions.md
 
 ```ts
 injectQuery(() => ({ queryKey: ['todos'], queryFn: fetchAllTodos }))
-injectQuery(() => ({ queryKey: ['todos', todoId], queryFn: () => fetchTodoById(todoId) })
+injectQuery(() => ({ queryKey: ['todos', todoId], queryFn: () => fetchTodoById(todoId) }))
 injectQuery(() => ({
   queryKey: ['todos', todoId],
   queryFn: async () => {

--- a/docs/framework/angular/guides/query-functions.md
+++ b/docs/framework/angular/guides/query-functions.md
@@ -8,7 +8,10 @@ ref: docs/framework/react/guides/query-functions.md
 
 ```ts
 injectQuery(() => ({ queryKey: ['todos'], queryFn: fetchAllTodos }))
-injectQuery(() => ({ queryKey: ['todos', todoId], queryFn: () => fetchTodoById(todoId) }))
+injectQuery(() => ({
+  queryKey: ['todos', todoId],
+  queryFn: () => fetchTodoById(todoId),
+}))
 injectQuery(() => ({
   queryKey: ['todos', todoId],
   queryFn: async () => {

--- a/docs/framework/angular/guides/query-retries.md
+++ b/docs/framework/angular/guides/query-retries.md
@@ -33,7 +33,7 @@ const result = injectQuery(() => ({
 import {
   QueryCache,
   QueryClient,
-  QueryClientProvider,
+  provideTanStackQuery,
 } from '@tanstack/angular-query-experimental'
 
 const queryClient = new QueryClient({


### PR DESCRIPTION
Three defects in the Angular guides, each verified against the repo itself.

### `guides/query-functions.md:11` — missing closing paren

```diff
-injectQuery(() => ({ queryKey: ['todos', todoId], queryFn: () => fetchTodoById(todoId) })
+injectQuery(() => ({ queryKey: ['todos', todoId], queryFn: () => fetchTodoById(todoId) }))
```

The line directly above it closes with `}))`, and the React version of the same guide is balanced too.

### `guides/disabling-queries.md:73` — package does not exist

```diff
-import { skipToken, injectQuery } from '@tanstack/query-angular'
+import { skipToken, injectQuery } from '@tanstack/angular-query-experimental'
```

There is no `@tanstack/query-angular` package — `packages/` contains only `angular-query-experimental` and `angular-query-persist-client`. This was the only occurrence of that name in the docs; every other Angular guide imports from `@tanstack/angular-query-experimental`.

### `guides/query-retries.md:36` — importing a symbol that isn't exported

```diff
   QueryCache,
   QueryClient,
-  QueryClientProvider,
+  provideTanStackQuery,
 } from '@tanstack/angular-query-experimental'
```

`QueryClientProvider` is a React export and is not in `packages/angular-query-experimental/src/index.ts`. The snippet meanwhile calls `provideTanStackQuery(queryClient)` twelve lines down without importing it, so swapping the two makes the import match what the example actually uses.

Docs only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Angular guide examples to use the current experimental query package imports.
  * Aligned the “Disabling Queries” and “Query Retries” configuration snippets with the latest setup approach.
  * Fixed a syntax issue in the “Query Functions” example so it renders and compiles correctly as written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->