### PR TITLE
fix(vue-query): export queryOptions declaration types

### DIFF
--- a/.changeset/calm-vue-query-options.md
+++ b/.changeset/calm-vue-query-options.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/query-core': patch
+'@tanstack/vue-query': patch
+---
+
+Export query option declaration helper types for portable Vue queryOptions factories.

--- a/.changeset/calm-vue-query-options.md
+++ b/.changeset/calm-vue-query-options.md
@@ -4,3 +4,5 @@
 ---
 
 Export query option declaration helper types for portable Vue queryOptions factories.
+The previous `useQuery`-specific initial-data helper types remain available as
+`UndefinedInitialUseQueryOptions` and `DefinedInitialUseQueryOptions`.

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -20,6 +20,8 @@ export type { QueryCacheNotifyEvent } from './queryCache'
 export { QueryClient } from './queryClient'
 export { QueryObserver } from './queryObserver'
 export { CancelledError, isCancelledError } from './retryer'
+export type { RetryDelayValue, RetryValue } from './retryer'
+export type { QueryBehavior } from './query'
 export {
   timeoutManager,
   type ManagedTimerId,

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -5,6 +5,8 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { queryOptions } from '../queryOptions'
 import { useQuery } from '../useQuery'
+import type { ComputedRef, Ref } from 'vue-demi'
+import type { DataTag } from '@tanstack/query-core'
 import type { QueryOptionsDataTag, UndefinedInitialQueryOptions } from '..'
 
 describe('queryOptions', () => {
@@ -309,7 +311,11 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve({ id: '1' }),
     })
 
-    expectTypeOf(options.queryKey).not.toBeUndefined()
+    expectTypeOf(options.queryKey).toEqualTypeOf<
+      ComputedRef<
+        DataTag<readonly ['foo', string | null], { id: string }, Error>
+      >
+    >()
   })
 
   it('should allow ref as queryKey', () => {
@@ -320,7 +326,9 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve({ id: '1' }),
     })
 
-    expectTypeOf(options.queryKey).not.toBeUndefined()
+    expectTypeOf(options.queryKey).toEqualTypeOf<
+      Ref<DataTag<readonly ['foo', '1'], { id: string }, Error>>
+    >()
   })
 
   it('should allow getter function as queryKey', () => {
@@ -331,7 +339,9 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve({ id: '1' }),
     })
 
-    expectTypeOf(options.queryKey).not.toBeUndefined()
+    expectTypeOf(options.queryKey).toEqualTypeOf<
+      () => DataTag<readonly ['foo', string | null], { id: string }, Error>
+    >()
   })
 
   it('should allow public queryOptions types to be used in declaration emit', () => {

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -5,6 +5,7 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { queryOptions } from '../queryOptions'
 import { useQuery } from '../useQuery'
+import type { QueryOptionsDataTag, UndefinedInitialQueryOptions } from '..'
 
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
@@ -331,5 +332,43 @@ describe('queryOptions', () => {
     })
 
     expectTypeOf(options.queryKey).not.toBeUndefined()
+  })
+
+  it('should allow public queryOptions types to be used in declaration emit', () => {
+    type Todo = {
+      id: number
+      name: string
+    }
+
+    type TodoOptions = UndefinedInitialQueryOptions<
+      Todo,
+      Error,
+      Todo,
+      readonly ['todo']
+    >
+
+    function todoOptions(): TodoOptions {
+      return queryOptions({
+        queryKey: ['todo'] as const,
+        queryFn: () => Promise.resolve({ id: 1, name: 'one' }),
+      })
+    }
+
+    expectTypeOf(
+      queryOptions({
+        queryKey: ['todo'] as const,
+        queryFn: (): Promise<Todo> => Promise.resolve({ id: 1, name: 'one' }),
+      }),
+    ).toEqualTypeOf<
+      QueryOptionsDataTag<TodoOptions, Todo, Error, readonly ['todo']>
+    >()
+
+    queryOptions({
+      ...todoOptions(),
+      select: (data) => {
+        expectTypeOf(data).toEqualTypeOf<Todo>()
+        return data.name
+      },
+    })
   })
 })

--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -6,7 +6,12 @@ export { VueQueryPlugin } from './vueQueryPlugin'
 export { QueryClient } from './queryClient'
 export { QueryCache } from './queryCache'
 export { queryOptions } from './queryOptions'
-export { type QueryOptions } from './queryOptions'
+export type {
+  DefinedInitialQueryOptions,
+  QueryOptions,
+  QueryOptionsDataTag,
+  UndefinedInitialQueryOptions,
+} from './queryOptions'
 export { infiniteQueryOptions } from './infiniteQueryOptions'
 export type {
   DefinedInitialDataInfiniteOptions,
@@ -30,15 +35,13 @@ export type {
   UseQueryOptions,
   UseQueryReturnType,
   UseQueryDefinedReturnType,
-  UndefinedInitialQueryOptions,
-  DefinedInitialQueryOptions,
 } from './useQuery'
 export type {
   UseInfiniteQueryOptions,
   UseInfiniteQueryReturnType,
 } from './useInfiniteQuery'
 export type { UseMutationOptions, UseMutationReturnType } from './useMutation'
-export type { MutationOptions } from './types'
+export type { MaybeRefOrGetter, MutationOptions, ShallowOption } from './types'
 export type { UseQueriesOptions, UseQueriesResults } from './useQueries'
 export type { MutationFilters, MutationStateOptions } from './useMutationState'
 export type { QueryFilters } from './useIsFetching'

--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -35,6 +35,8 @@ export type {
   UseQueryOptions,
   UseQueryReturnType,
   UseQueryDefinedReturnType,
+  UndefinedInitialQueryOptions as UndefinedInitialUseQueryOptions,
+  DefinedInitialQueryOptions as DefinedInitialUseQueryOptions,
 } from './useQuery'
 export type {
   UseInfiniteQueryOptions,

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -65,6 +65,11 @@ export type DefinedInitialQueryOptions<
     | (() => NonUndefinedGuard<TQueryFnData>)
 }
 
+export type QueryOptionsDataTag<TOptions, TQueryFnData, TError, TQueryKey> =
+  Omit<TOptions, 'queryKey'> & {
+    queryKey: DataTag<TQueryKey, TQueryFnData, TError>
+  }
+
 export function queryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -72,9 +77,12 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): QueryOptionsDataTag<
+  DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  TQueryFnData,
+  TError,
+  TQueryKey
+>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -88,9 +96,12 @@ export function queryOptions<
     TData,
     TQueryKey
   >,
-): () => DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): () => QueryOptionsDataTag<
+  DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  TQueryFnData,
+  TError,
+  TQueryKey
+>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -99,9 +110,12 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): QueryOptionsDataTag<
+  UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  TQueryFnData,
+  TError,
+  TQueryKey
+>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -115,14 +129,12 @@ export function queryOptions<
     TData,
     TQueryKey
   >,
-): () => UndefinedInitialQueryOptions<
+): () => QueryOptionsDataTag<
+  UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   TQueryFnData,
   TError,
-  TData,
   TQueryKey
-> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+>
 
 export function queryOptions(options: unknown) {
   return options

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -1,4 +1,5 @@
 import type { DeepUnwrapRef, MaybeRefOrGetter, ShallowOption } from './types'
+import type { ComputedRef, Ref } from 'vue-demi'
 import type {
   DataTag,
   DefaultError,
@@ -67,51 +68,42 @@ export type DefinedInitialQueryOptions<
 
 export type QueryOptionsDataTag<TOptions, TQueryFnData, TError, TQueryKey> =
   Omit<TOptions, 'queryKey'> & {
-    queryKey: DataTag<TQueryKey, TQueryFnData, TError>
+    queryKey: TaggedQueryKey<
+      TOptions,
+      TQueryFnData,
+      TError,
+      TQueryKey
+    >
   }
 
-export function queryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): QueryOptionsDataTag<
-  DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  TQueryFnData,
-  TError,
-  TQueryKey
->
+type TaggedQueryKey<TOptions, TQueryFnData, TError, TQueryKey> =
+  TOptions extends { queryKey: infer TQueryKeyOption }
+    ? TQueryKeyOption extends () => infer TQueryKeyFromGetter
+      ? () => DataTag<TQueryKeyFromGetter, TQueryFnData, TError>
+      : TQueryKeyOption extends ComputedRef<infer TQueryKeyFromComputed>
+        ? ComputedRef<DataTag<TQueryKeyFromComputed, TQueryFnData, TError>>
+        : TQueryKeyOption extends Ref<infer TQueryKeyFromRef>
+          ? Ref<DataTag<TQueryKeyFromRef, TQueryFnData, TError>>
+          : TQueryKeyOption extends QueryKey
+            ? DataTag<TQueryKeyOption, TQueryFnData, TError>
+            : DataTag<TQueryKey, TQueryFnData, TError>
+    : DataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
->(
-  options: () => DefinedInitialQueryOptions<
+  TOptions extends DefinedInitialQueryOptions<
     TQueryFnData,
     TError,
     TData,
     TQueryKey
-  >,
-): () => QueryOptionsDataTag<
-  DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  TQueryFnData,
-  TError,
-  TQueryKey
->
-
-export function queryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
+  > = DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 >(
-  options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: TOptions,
 ): QueryOptionsDataTag<
-  UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  TOptions,
   TQueryFnData,
   TError,
   TQueryKey
@@ -122,15 +114,56 @@ export function queryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
->(
-  options: () => UndefinedInitialQueryOptions<
+  TOptions extends DefinedInitialQueryOptions<
     TQueryFnData,
     TError,
     TData,
     TQueryKey
-  >,
+  > = DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+>(
+  options: () => TOptions,
 ): () => QueryOptionsDataTag<
-  UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  TOptions,
+  TQueryFnData,
+  TError,
+  TQueryKey
+>
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TOptions extends UndefinedInitialQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey
+  > = UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+>(
+  options: TOptions,
+): QueryOptionsDataTag<
+  TOptions,
+  TQueryFnData,
+  TError,
+  TQueryKey
+>
+
+export function queryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TOptions extends UndefinedInitialQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey
+  > = UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+>(
+  options: () => TOptions,
+): () => QueryOptionsDataTag<
+  TOptions,
   TQueryFnData,
   TError,
   TQueryKey


### PR DESCRIPTION
## 🎯 Changes

- Export reusable `queryOptions` declaration types from Vue Query.
- Expose the matching Query Core declaration types needed by the Vue exports.
- Preserve direct, `ref`, `computed`, and getter `queryKey` shapes while retaining `DataTag` metadata.
- Keep the previous `useQuery` initial-data helper types available as `UndefinedInitialUseQueryOptions` and `DefinedInitialUseQueryOptions`.

Fixes #11042

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

Targeted local verification:

- `pnpm exec nx run @tanstack/vue-query:test:types --skip-nx-cache`
- `pnpm exec nx run @tanstack/vue-query:build --skip-nx-cache`

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the public TypeScript API for Vue Query and core packages with additional query behavior, retry configuration, and query option helper types.
  * Improved `queryOptions` type inference for query keys, data tags, and `select` callbacks, including portable factory patterns.
* **Tests**
  * Strengthened type-level coverage and added declaration-emit checks for reliable compile-time behavior.
* **Release**
  * Published patch releases for the core and Vue Query packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->