### PR TITLE
test(solid-query): assert exact values instead of loose matchers

### DIFF
--- a/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/solid-query/src/__tests__/QueryClientProvider.test.tsx
@@ -41,7 +41,7 @@ describe('QueryClientProvider', () => {
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('test')).toBeInTheDocument()
 
-    expect(queryCache.find({ queryKey: key })).toBeDefined()
+    expect(queryCache.find({ queryKey: key })?.state.data).toBe('test')
   })
 
   it('allows multiple caches to be partitioned', async () => {
@@ -94,10 +94,10 @@ describe('QueryClientProvider', () => {
     expect(rendered.getByText('test1')).toBeInTheDocument()
     expect(rendered.getByText('test2')).toBeInTheDocument()
 
-    expect(queryCache1.find({ queryKey: key1 })).toBeDefined()
-    expect(queryCache1.find({ queryKey: key2 })).not.toBeDefined()
-    expect(queryCache2.find({ queryKey: key1 })).not.toBeDefined()
-    expect(queryCache2.find({ queryKey: key2 })).toBeDefined()
+    expect(queryCache1.find({ queryKey: key1 })?.state.data).toBe('test1')
+    expect(queryCache1.find({ queryKey: key2 })).toBeUndefined()
+    expect(queryCache2.find({ queryKey: key1 })).toBeUndefined()
+    expect(queryCache2.find({ queryKey: key2 })?.state.data).toBe('test2')
   })
 
   it("uses defaultOptions for queries when they don't provide their own config", async () => {
@@ -135,7 +135,6 @@ describe('QueryClientProvider', () => {
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('test')).toBeInTheDocument()
 
-    expect(queryCache.find({ queryKey: key })).toBeDefined()
     expect(queryCache.find({ queryKey: key })?.options.gcTime).toBe(Infinity)
   })
 

--- a/packages/solid-query/src/__tests__/mutationOptions.test.tsx
+++ b/packages/solid-query/src/__tests__/mutationOptions.test.tsx
@@ -507,6 +507,5 @@ describe('mutationOptions', () => {
     const lastSnapshot = mutationStateArray[mutationStateArray.length - 1]!
     expect(lastSnapshot.length).toEqual(1)
     expect(lastSnapshot[0]?.data).toEqual('data1')
-    expect(lastSnapshot[1]).toBeFalsy()
   })
 })

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -196,7 +196,7 @@ describe("useQuery's in Suspense mode", () => {
     const rendered = renderWithClient(queryClient, () => <App />)
 
     expect(rendered.queryByText('rendered')).not.toBeInTheDocument()
-    expect(queryCache.find({ queryKey: key })).toBeFalsy()
+    expect(queryCache.find({ queryKey: key })).toBeUndefined()
 
     fireEvent.click(rendered.getByLabelText('toggle'))
     await vi.advanceTimersByTimeAsync(10)

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -5746,7 +5746,9 @@ describe('useQuery', () => {
     await vi.advanceTimersByTimeAsync(10)
 
     expect(rendered.getByText('status: success')).toBeInTheDocument()
-    expect(queryClient1.getQueryCache().find({ queryKey: key })).toBeDefined()
+    expect(
+      queryClient1.getQueryCache().find({ queryKey: key })?.state.data,
+    ).toBe('data')
     expect(queryFn).toHaveBeenCalledTimes(1)
 
     setClient(queryClient2)


### PR DESCRIPTION
## 🎯 Changes

Continues the recent test-quality series (e.g. #11057, #11093) by converting the `toBeTruthy()` / `toBeFalsy()` / `toBeDefined()` assertions in `solid-query` tests to exact assertions:

- **`QueryClientProvider`** — cache presence checks now assert the exact cached value (`?.state.data`) produced by the test's `queryFn`, and the cross-cache absence checks in the partitioning test use `toBeUndefined()` instead of `not.toBeDefined()`. One redundant existence check was removed where the next line already asserts `?.options.gcTime` on the same query (it fails on `undefined` either way).
- **`suspense`** — the cache absence check before mount uses `toBeUndefined()` instead of `toBeFalsy()`.
- **`useQuery`** — after the first fetch in the client-switch test, the presence check on `queryClient1`'s cache now asserts the exact cached value.
- **`mutationOptions`** — removed `expect(lastSnapshot[1]).toBeFalsy()`: the preceding `expect(lastSnapshot.length).toEqual(1)` already guarantees there is no second entry.

One `toBeDefined()` is intentionally left in place: in `useQuery` → *"should refetch query when queryClient changes"*, tightening the `queryClient2` cache check to `?.state.data` fails. After `setClient(queryClient2)`, the second `queryFn` call actually lands in **`queryClient1`'s** cache (its `dataUpdateCount` goes to 2) while the entry in `queryClient2`'s cache stays `status: 'pending'` / `fetchStatus: 'idle'` and never fetches. This looks like an observer re-subscription ordering issue in `useBaseQuery` (in the `on(client, ...)` computed, `createClientSubscriber()` is called before `setObserver(newObserver)`, so the subscription attaches to the old observer). I'd rather report and fix that separately than encode the current behavior into an exact assertion here.

After this, `grep -rE 'toBeTruthy\(\)|toBeFalsy\(\)|toBeDefined\(\)' packages/solid-query/src` only matches the site described above.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

Local verification detail: `vitest run` on the four edited files — 162 tests passed, no type errors; `test:eslint` and prettier clean; full-suite failure set identical to `main` in the same environment.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened cache validation to confirm stored query data and correct separation across caches.
  * Improved mutation state assertions to verify returned successful data.
  * Clarified unmount behavior by checking that removed queries are absent.
  * Tightened refetch validation to confirm expected cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->