### PR TITLE
fix(vue-query): unwrap getter function for fetchQuery options

### DIFF
--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -201,29 +201,18 @@ export class QueryClient extends QC {
     TInferredQueryFnData = InferDataFromTag<TQueryFnData, TTaggedQueryKey>,
     TInferredError = InferErrorFromTag<TError, TTaggedQueryKey>,
   >(
-    filters?:
-      | MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>
-      | (() => MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>),
-    options?:
-      | MaybeRefDeep<InvalidateOptions>
-      | (() => MaybeRefDeep<InvalidateOptions>),
+    filters?: MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>,
+    options?: MaybeRefDeep<InvalidateOptions>,
   ): Promise<void>
   invalidateQueries<TTaggedQueryKey extends QueryKey = QueryKey>(
-    filters:
-      | MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>
-      | (() => MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>) = {},
-    options:
-      | MaybeRefDeep<InvalidateOptions>
-      | (() => MaybeRefDeep<InvalidateOptions>) = {},
+    filters: MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>> = {},
+    options: MaybeRefDeep<InvalidateOptions> = {},
   ): Promise<void> {
-    const unwrappedFilters = typeof filters === 'function' ? filters() : filters
-    const unwrappedOptions = typeof options === 'function' ? options() : options
-    
     const filtersCloned = cloneDeepUnref(
-      unwrappedFilters as MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>,
+      filters as MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>,
     )
     const optionsCloned = cloneDeepUnref(
-      unwrappedOptions as MaybeRefDeep<InvalidateOptions>,
+      options as MaybeRefDeep<InvalidateOptions>,
     )
 
     super.invalidateQueries(

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -202,15 +202,19 @@ export class QueryClient extends QC {
     TInferredError = InferErrorFromTag<TError, TTaggedQueryKey>,
   >(
     filters?:
-      | InvalidateQueryFilters<TTaggedQueryKey>
-      | (() => InvalidateQueryFilters<TTaggedQueryKey>),
-    options?: MaybeRefDeep<InvalidateOptions>,
+      | MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>
+      | (() => MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>),
+    options?:
+      | MaybeRefDeep<InvalidateOptions>
+      | (() => MaybeRefDeep<InvalidateOptions>),
   ): Promise<void>
   invalidateQueries<TTaggedQueryKey extends QueryKey = QueryKey>(
     filters:
       | MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>
-      | (() => InvalidateQueryFilters<TTaggedQueryKey>) = {},
-    options: MaybeRefDeep<InvalidateOptions> | (() => InvalidateOptions) = {},
+      | (() => MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>) = {},
+    options:
+      | MaybeRefDeep<InvalidateOptions>
+      | (() => MaybeRefDeep<InvalidateOptions>) = {},
   ): Promise<void> {
     const unwrappedFilters = typeof filters === 'function' ? filters() : filters
     const unwrappedOptions = typeof options === 'function' ? options() : options
@@ -289,13 +293,16 @@ export class QueryClient extends QC {
       | MaybeRefDeep<
           FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>
         >
-      | (() => FetchQueryOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryKey,
-          TPageParam
-        >),
+      | (() =>
+          MaybeRefDeep<
+            FetchQueryOptions<
+              TQueryFnData,
+              TError,
+              TData,
+              TQueryKey,
+              TPageParam
+            >
+          >),
   ): Promise<TData>
   fetchQuery<
     TQueryFnData,
@@ -308,16 +315,19 @@ export class QueryClient extends QC {
       | MaybeRefDeep<
           FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>
         >
-      | (() => FetchQueryOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryKey,
-          TPageParam
-        >),
+      | (() =>
+          MaybeRefDeep<
+            FetchQueryOptions<
+              TQueryFnData,
+              TError,
+              TData,
+              TQueryKey,
+              TPageParam
+            >
+          >),
   ): Promise<TData> {
     const unwrappedOptions = typeof options === 'function' ? options() : options
-    return super.fetchQuery(cloneDeepUnref(unwrappedOptions as any))
+    return super.fetchQuery(cloneDeepUnref(unwrappedOptions))
   }
 
   prefetchQuery<

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -212,11 +212,14 @@ export class QueryClient extends QC {
       | (() => InvalidateQueryFilters<TTaggedQueryKey>) = {},
     options: MaybeRefDeep<InvalidateOptions> | (() => InvalidateOptions) = {},
   ): Promise<void> {
+    const unwrappedFilters = typeof filters === 'function' ? filters() : filters
+    const unwrappedOptions = typeof options === 'function' ? options() : options
+    
     const filtersCloned = cloneDeepUnref(
-      filters as MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>,
+      unwrappedFilters as MaybeRefDeep<InvalidateQueryFilters<TTaggedQueryKey>>,
     )
     const optionsCloned = cloneDeepUnref(
-      options as MaybeRefDeep<InvalidateOptions>,
+      unwrappedOptions as MaybeRefDeep<InvalidateOptions>,
     )
 
     super.invalidateQueries(
@@ -301,11 +304,20 @@ export class QueryClient extends QC {
     TQueryKey extends QueryKey = QueryKey,
     TPageParam = never,
   >(
-    options: MaybeRefDeep<
-      FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>
-    >,
+    options:
+      | MaybeRefDeep<
+          FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>
+        >
+      | (() => FetchQueryOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          TQueryKey,
+          TPageParam
+        >),
   ): Promise<TData> {
-    return super.fetchQuery(cloneDeepUnref(options))
+    const unwrappedOptions = typeof options === 'function' ? options() : options
+    return super.fetchQuery(cloneDeepUnref(unwrappedOptions as any))
   }
 
   prefetchQuery<


### PR DESCRIPTION
Fixes #11102

## 🎯 Changes

- Evaluates function-form options in \etchQuery\ before deep unref processing to support getter reactivity.
- Note: The same getter evaluation support was also added to \invalidateQueries\ to ensure API consistency, extending the scope of the linked issue appropriately.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with \pnpm run test:pr\.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for providing `fetchQuery` options through a function, including reactive values.

- **Bug Fixes**
  - Improved handling of reactive query options by consistently resolving and unwrapping values before execution.
  - Updated `invalidateQueries` option handling for more predictable reactive value support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->