### PR TITLE
fix(examples): use webpack in Next.js examples for StackBlitz compatibility

### DIFF
--- a/examples/react/auto-refetching/package.json
+++ b/examples/react/auto-refetching/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/infinite-query-with-max-pages/package.json
+++ b/examples/react/infinite-query-with-max-pages/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/load-more-infinite-scroll/package.json
+++ b/examples/react/load-more-infinite-scroll/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/nextjs-app-prefetching/package.json
+++ b/examples/react/nextjs-app-prefetching/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/nextjs/package.json
+++ b/examples/react/nextjs/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/optimistic-updates-cache/package.json
+++ b/examples/react/optimistic-updates-cache/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/optimistic-updates-ui/package.json
+++ b/examples/react/optimistic-updates-ui/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/pagination/package.json
+++ b/examples/react/pagination/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/react/prefetching/package.json
+++ b/examples/react/prefetching/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start"
   },

--- a/integrations/react-next-15/package.json
+++ b/integrations/react-next-15/package.json
@@ -2,7 +2,7 @@
   "name": "react-next-15",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build"
   },
   "dependencies": {

--- a/integrations/react-next-16/package.json
+++ b/integrations/react-next-16/package.json
@@ -2,7 +2,7 @@
   "name": "react-next-16",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #11063. StackBlitz WebContainers currently do not support the native bindings required for Turbopack (the default in Next.js 15+). This updates all Next.js examples to use the --webpack flag in their dev scripts so the interactive sandboxes in the docs run without crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development startup commands across React and Next.js examples and integrations to explicitly use Webpack.
  * Development environments now launch with `next dev --webpack` for more consistent local behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->