### PR TITLE
fix(solid-query): subscribe to new observer when queryClient accessor switches

### DIFF
--- a/.changeset/solid-client-switch-observer.md
+++ b/.changeset/solid-client-switch-observer.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+fix: subscribe to the new observer when the queryClient accessor switches


### PR DESCRIPTION
## Changes
Fixes #11106.
When the `queryClient` accessor passed to `useQuery` / `useBaseQuery` switched, `createClientSubscriber()` ran before `setObserver(newObserver)`, so the subscription re-attached to the old observer. Refetches landed in the previous client's cache and the new client's entry stayed `pending`/`idle`.
- Reorder: `setObserver(newObserver)` then `createClientSubscriber()`
- Tighten `"should refetch query when queryClient changes"` to assert `queryClient2` cache `state.data === 'data'`
- Patch changeset for `@tanstack/solid-query`
## Checklist
- [x] Followed the Contributing guide
- [x] Tested locally (`vitest` for the client-switch case / solid-query suite)
- [x] Changeset included (published code)
## Release Impact
- [x] Affects published code — changeset included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query updates not being observed after switching the active query client in Solid Query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->