### PR TITLE
fix(solid-query): address suspense detachment in solid query

### DIFF
--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -182,8 +182,11 @@ export function useBaseQuery<
     return obs.subscribe((result) => {
       observerResult = result
       queueMicrotask(() => {
-        if (unsubscribe) {
+        if (!unsubscribe) return
+        if (resolver || result.isLoading || result.isError) {
           refetch()
+        } else {
+          setStateWithReconciliation(result)
         }
       })
     })

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -182,8 +182,8 @@ export function useBaseQuery<
     return obs.subscribe((result) => {
       observerResult = result
       queueMicrotask(() => {
-        if (!unsubscribe) return
-        if (resolver || result.isLoading || result.isError) {
+        if (!unsubscribe || observer() !== obs) return
+        if (resolver || result.isLoading || (result.isFetching && result.isError)) {
           refetch()
         } else {
           setStateWithReconciliation(result)


### PR DESCRIPTION
Resolves an issue in Solid Query where suspense detachment causes queries to fail or hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-side subscription handling to prevent redundant refetches when results haven’t changed.
  * Updated behavior to reuse fresh results directly when not in loading/error states, while still refetching when appropriate.
  * Enhanced observer result update logic for more reliable and efficient data refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->