### PR TITLE
ci: update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,10 +3,11 @@
   "configMigration": true,
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     "group:allNonMajor",
     "schedule:weekly",
+    "security:minimumReleaseAgeNpm",
     ":approveMajorUpdates",
-    ":automergeMinor",
     ":disablePeerDependencies",
     ":maintainLockFilesMonthly",
     ":semanticCommits",


### PR DESCRIPTION
## 🎯 Changes

- Add `security:minimumReleaseAgeNpm` to comply with pnpm defaults
- Add `helpers:pinGitHubActionDigests` to keep actions pinned
- Remove `:automergeMinor` to ensure dependency updates are manually reviewed

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated dependency update controls.
  - GitHub Actions references are now pinned to specific commit digests.
  - Newly released npm packages must meet a minimum age before updates are proposed.
  - Major dependency updates now require approval before adoption.
  - Minor updates are no longer automatically merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->