### PR TITLE
fix(eslint-plugin-query): prevent Object.prototype false positives in no-unstable-deps

### DIFF
--- a/.changeset/fix-no-unstable-deps-prototype-lookup.md‎
+++ b/.changeset/fix-no-unstable-deps-prototype-lookup.md‎
@@ -1,0 +1,5 @@
+---
+'@tanstack/eslint-plugin-query': patch
+---
+
+Fix false positive in `no-unstable-deps` when a variable is assigned from a call whose name matches an `Object.prototype` method (e.g. `toString`, `valueOf`, `constructor`).

--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -405,3 +405,29 @@ reactHookNames.forEach((reactHookName) => {
     },
   )
 })
+
+const protoMethodNames = [
+  'toString',
+  'valueOf',
+  'constructor',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+] as const
+
+ruleTester.run('no-unstable-deps', rule, {
+  valid: protoMethodNames.map((method) => ({
+    name: `should not flag variable from "${method}()" call as unstable dep`,
+    code: `
+      import { useCallback } from "React";
+
+      function Component() {
+        const result = ${method}();
+        const cb = useCallback(() => { result }, [result]);
+        return null;
+      }
+    `,
+  })),
+  invalid: [],
+})

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -139,7 +139,10 @@ export const rule = createRule({
       }
 
       if (callExpression.callee.type === AST_NODE_TYPES.Identifier) {
-        return trackedCustomHooks[callExpression.callee.name]
+        const calleeName = callExpression.callee.name
+        return Object.hasOwn(trackedCustomHooks, calleeName)
+          ? trackedCustomHooks[calleeName]
+          : undefined
       }
 
       return undefined


### PR DESCRIPTION
## Summary

Fixes a false positive in the `@tanstack/query/no-unstable-deps` rule caused by inherited `Object.prototype` properties being treated as tracked custom hooks.

## Root Cause

`getTrackedQueryHook` performs a direct property lookup on `trackedCustomHooks`:

```ts
return trackedCustomHooks[callExpression.callee.name]
```

Since `trackedCustomHooks` is a plain object, property names inherited from `Object.prototype` (such as `toString`, `valueOf`, and `constructor`) resolve to their inherited implementations instead of `undefined`.

As a result, unrelated functions with these names (for example, Lodash's `toString`) are incorrectly treated as tracked TanStack Query hooks, causing false positives from `no-unstable-deps`.

### Example

```ts
import { toString } from 'lodash'

const sessionId = toString(router.query.sessionId)

useCallback(() => {
  console.log(sessionId)
}, [sessionId])
```

Here, `sessionId` is incorrectly reported as an unstable dependency even though it is unrelated to TanStack Query.

## Fix

Use `Object.hasOwn` before reading from `trackedCustomHooks` so only explicitly tracked custom hooks are considered.

## Tests

Added regression tests covering inherited `Object.prototype` property names to ensure they are no longer treated as tracked custom hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a false positive in the `no-unstable-deps` ESLint rule when variables are assigned from calls to common JavaScript prototype methods such as `toString`, `valueOf`, or `constructor`.
  * Improved detection of custom query hooks so inherited property names are not incorrectly treated as tracked hooks.

* **Chores**
  * Released a patch update for the ESLint plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->