### PR TITLE
test(angular-query): replace 'toBeDefined' with exact-value assertion

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -382,8 +382,7 @@ describe('injectMutation', () => {
     const text = debugElement.query(By.css('span')).nativeElement.textContent
     expect(text).toEqual('value')
     const mutation = mutationCache.find({ mutationKey: ['fake', 'value'] })
-    expect(mutation).toBeDefined()
-    expect(mutation!.options.mutationKey).toStrictEqual(['fake', 'value'])
+    expect(mutation?.options.mutationKey).toStrictEqual(['fake', 'value'])
   })
 
   it('should update options on required signal input change', async () => {


### PR DESCRIPTION
## 🎯 Changes

Continues the recent test-quality series (e.g. #11105, #11093) by converting the `toBeDefined()` assertion in `angular-query-experimental` tests to an exact assertion:

- `inject-mutation.test.ts` — the redundant `expect(mutation).toBeDefined()` existence check is removed; the next line already asserts `?.options.mutationKey` on the same value via optional chaining, which fails on `undefined` either way.

After this, `grep -rE 'toBeTruthy\(\)|toBeFalsy\(\)|toBeDefined\(\)' packages/angular-query-experimental/src` returns no matches.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

Local verification detail: `vitest run` on the edited file — 28 tests passed, no type errors.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion handling for required signal inputs without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->