### PR TITLE
test(lit-query): replace 'toBeDefined'/'toBeGreaterThan' with exact-value assertions

### DIFF
--- a/packages/lit-query/src/tests/counters-and-state.test.ts
+++ b/packages/lit-query/src/tests/counters-and-state.test.ts
@@ -272,8 +272,9 @@ describe('useIsFetching/useIsMutating/useMutationState', () => {
     await waitFor(() => consumer.isMutating() === 0)
 
     expect(
-      explicitClient.getQueryCache().find({ queryKey: consumer.queryKey }),
-    ).toBeDefined()
+      explicitClient.getQueryCache().find({ queryKey: consumer.queryKey })
+        ?.state.data,
+    ).toBe('query-ok')
     expect(
       providerClient.getQueryCache().find({ queryKey: consumer.queryKey }),
     ).toBeUndefined()

--- a/packages/lit-query/src/tests/infinite-and-options.test.ts
+++ b/packages/lit-query/src/tests/infinite-and-options.test.ts
@@ -118,8 +118,9 @@ describe('createInfiniteQueryController', () => {
     await waitFor(() => consumer.infinite().isSuccess)
     expect(consumer.infinite().data?.pages).toEqual([0])
     expect(
-      explicitClient.getQueryCache().find({ queryKey: consumer.queryKey }),
-    ).toBeDefined()
+      explicitClient.getQueryCache().find({ queryKey: consumer.queryKey })
+        ?.state.data,
+    ).toEqual({ pages: [0], pageParams: [0] })
     expect(
       providerClient.getQueryCache().find({ queryKey: consumer.queryKey }),
     ).toBeUndefined()

--- a/packages/lit-query/src/tests/queries-controller.test.ts
+++ b/packages/lit-query/src/tests/queries-controller.test.ts
@@ -179,8 +179,9 @@ describe('createQueriesController', () => {
     )
 
     expect(
-      explicitClient.getQueryCache().find({ queryKey: consumer.queryKeys[0]! }),
-    ).toBeDefined()
+      explicitClient.getQueryCache().find({ queryKey: consumer.queryKeys[0]! })
+        ?.state.data,
+    ).toBe('alpha')
     expect(
       providerClient.getQueryCache().find({ queryKey: consumer.queryKeys[0]! }),
     ).toBeUndefined()

--- a/packages/lit-query/src/tests/query-controller.test.ts
+++ b/packages/lit-query/src/tests/query-controller.test.ts
@@ -1154,7 +1154,7 @@ describe('createQueryController', () => {
     await waitFor(() => query().isSuccess)
 
     const cacheQuery = client.getQueryCache().find({ queryKey })
-    expect(cacheQuery).toBeDefined()
+    expect(cacheQuery?.state.data).toEqual(['a', 'b'])
     expect(cacheQuery?.getObserversCount()).toBe(1)
 
     host.disconnect()
@@ -1196,8 +1196,8 @@ describe('createQueryController', () => {
     await consumer.updateComplete
 
     await waitFor(() => consumer.query().isSuccess)
-    expect(consumer.query().data).toBeDefined()
-    expect(consumer.queryCalls).toBeGreaterThan(0)
+    expect(consumer.queryCalls).toBe(1)
+    expect(consumer.query().data).toBe('value-1')
 
     consumer.query.destroy()
     provider.remove()
@@ -1232,7 +1232,7 @@ describe('createQueryController', () => {
     await consumer.updateComplete
     await waitFor(() => consumer.query().isSuccess)
 
-    expect(consumer.query().data).toBeDefined()
+    expect(consumer.query().data).toBe('value-1')
 
     consumer.query.destroy()
     provider.remove()


### PR DESCRIPTION
## 🎯 Changes

Continues the recent test-quality series (e.g. #11105, #11093) by converting the `toBeDefined()` / `toBeFalsy()` assertions in `lit-query` tests to exact assertions:

- **`counters-and-state.test.ts`** — cache presence check now asserts the exact cached value (`?.state.data`) produced by the test's `queryFn`.
- **`infinite-and-options.test.ts`** — cache presence check now asserts the exact cached `pages`/`pageParams` shape.
- **`queries-controller.test.ts`** — cache presence check now asserts the exact cached value for the first query key.
- **`query-controller.test.ts`** — three cases strengthened: an existence check now asserts `?.state.data` against the resolved array, and two `data`/call-count checks now assert exact literals instead of `toBeDefined()` / `toBeGreaterThan(0)`.

Each strengthening is guarded by a preceding `waitFor(... isSuccess)` (or equivalent) that guarantees the fetch has settled at the assertion point.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

Local verification detail: `vitest run` on the four edited files — 102 tests passed, no type errors.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened query and infinite-query tests to verify exact cached data values.
  * Added precise checks for query results and execution counts during reconnects and provider resolution.
  * Improved coverage for explicit client precedence and provider-backed query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->