### PR TITLE
test({react,preact}-query): replace 'toBeDefined'/'toBeFalsy' with exact-value assertions

### DIFF
--- a/packages/preact-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/preact-query/src/__tests__/QueryClientProvider.test.tsx
@@ -47,7 +47,7 @@ describe('QueryClientProvider', () => {
     await vi.advanceTimersByTimeAsync(11)
     expect(rendered.getByText('test')).toBeInTheDocument()
 
-    expect(queryCache.find({ queryKey: key })).toBeDefined()
+    expect(queryCache.find({ queryKey: key })?.state.data).toBe('test')
   })
 
   it('allows multiple caches to be partitioned', async () => {
@@ -100,10 +100,10 @@ describe('QueryClientProvider', () => {
     expect(rendered.getByText('test1')).toBeInTheDocument()
     expect(rendered.getByText('test2')).toBeInTheDocument()
 
-    expect(queryCache1.find({ queryKey: key1 })).toBeDefined()
-    expect(queryCache1.find({ queryKey: key2 })).not.toBeDefined()
-    expect(queryCache2.find({ queryKey: key1 })).not.toBeDefined()
-    expect(queryCache2.find({ queryKey: key2 })).toBeDefined()
+    expect(queryCache1.find({ queryKey: key1 })?.state.data).toBe('test1')
+    expect(queryCache1.find({ queryKey: key2 })).toBeUndefined()
+    expect(queryCache2.find({ queryKey: key1 })).toBeUndefined()
+    expect(queryCache2.find({ queryKey: key2 })?.state.data).toBe('test2')
   })
 
   it("uses defaultOptions for queries when they don't provide their own config", async () => {
@@ -141,7 +141,6 @@ describe('QueryClientProvider', () => {
     await vi.advanceTimersByTimeAsync(11)
     expect(rendered.getByText('test')).toBeInTheDocument()
 
-    expect(queryCache.find({ queryKey: key })).toBeDefined()
     expect(queryCache.find({ queryKey: key })?.options.gcTime).toBe(Infinity)
   })
 

--- a/packages/preact-query/src/__tests__/mutationOptions.test.tsx
+++ b/packages/preact-query/src/__tests__/mutationOptions.test.tsx
@@ -532,6 +532,5 @@ describe('mutationOptions', () => {
     await vi.advanceTimersByTimeAsync(11)
     expect(mutationStateArray.length).toEqual(1)
     expect(mutationStateArray[0]?.data).toEqual('data1')
-    expect(mutationStateArray[1]).toBeFalsy()
   })
 })

--- a/packages/preact-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -206,7 +206,7 @@ describe('useSuspenseQuery', () => {
 
     expect(rendered.queryByText('loading')).not.toBeInTheDocument()
     expect(rendered.queryByText('rendered')).not.toBeInTheDocument()
-    expect(queryCache.find({ queryKey: key })).toBeFalsy()
+    expect(queryCache.find({ queryKey: key })).toBeUndefined()
 
     fireEvent.click(rendered.getByLabelText('toggle'))
     expect(rendered.getByText('loading')).toBeInTheDocument()

--- a/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
+++ b/packages/react-query/src/__tests__/QueryClientProvider.test.tsx
@@ -46,7 +46,7 @@ describe('QueryClientProvider', () => {
     await vi.advanceTimersByTimeAsync(11)
     expect(rendered.getByText('test')).toBeInTheDocument()
 
-    expect(queryCache.find({ queryKey: key })).toBeDefined()
+    expect(queryCache.find({ queryKey: key })?.state.data).toBe('test')
   })
 
   it('allows multiple caches to be partitioned', async () => {
@@ -99,10 +99,10 @@ describe('QueryClientProvider', () => {
     expect(rendered.getByText('test1')).toBeInTheDocument()
     expect(rendered.getByText('test2')).toBeInTheDocument()
 
-    expect(queryCache1.find({ queryKey: key1 })).toBeDefined()
-    expect(queryCache1.find({ queryKey: key2 })).not.toBeDefined()
-    expect(queryCache2.find({ queryKey: key1 })).not.toBeDefined()
-    expect(queryCache2.find({ queryKey: key2 })).toBeDefined()
+    expect(queryCache1.find({ queryKey: key1 })?.state.data).toBe('test1')
+    expect(queryCache1.find({ queryKey: key2 })).toBeUndefined()
+    expect(queryCache2.find({ queryKey: key1 })).toBeUndefined()
+    expect(queryCache2.find({ queryKey: key2 })?.state.data).toBe('test2')
   })
 
   it("uses defaultOptions for queries when they don't provide their own config", async () => {
@@ -140,7 +140,6 @@ describe('QueryClientProvider', () => {
     await vi.advanceTimersByTimeAsync(11)
     expect(rendered.getByText('test')).toBeInTheDocument()
 
-    expect(queryCache.find({ queryKey: key })).toBeDefined()
     expect(queryCache.find({ queryKey: key })?.options.gcTime).toBe(Infinity)
   })
 

--- a/packages/react-query/src/__tests__/mutationOptions.test.tsx
+++ b/packages/react-query/src/__tests__/mutationOptions.test.tsx
@@ -522,6 +522,5 @@ describe('mutationOptions', () => {
     await vi.advanceTimersByTimeAsync(11)
     expect(mutationStateArray.length).toEqual(1)
     expect(mutationStateArray[0]?.data).toEqual('data1')
-    expect(mutationStateArray[1]).toBeFalsy()
   })
 })

--- a/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQuery.test.tsx
@@ -192,7 +192,7 @@ describe('useSuspenseQuery', () => {
 
     expect(rendered.queryByText('loading')).not.toBeInTheDocument()
     expect(rendered.queryByText('rendered')).not.toBeInTheDocument()
-    expect(queryCache.find({ queryKey: key })).toBeFalsy()
+    expect(queryCache.find({ queryKey: key })).toBeUndefined()
 
     fireEvent.click(rendered.getByLabelText('toggle'))
     expect(rendered.getByText('loading')).toBeInTheDocument()


### PR DESCRIPTION
## 🎯 Changes

Continues the recent test-quality series (e.g. #11105, #11093) by converting the `toBeTruthy()` / `toBeFalsy()` / `toBeDefined()` assertions in `react-query` and `preact-query` tests to exact assertions. The changes are identical across both packages (react-query and preact-query mirror each other test-for-test), so they're bundled in one PR:

- **`QueryClientProvider`** — cache presence checks now assert the exact cached value (`?.state.data`) produced by the test's `queryFn`, and the cross-cache absence checks in the partitioning test use `toBeUndefined()` instead of `not.toBeDefined()`. One redundant existence check was removed where the next line already asserts `?.options.gcTime` on the same query.
- **`mutationOptions`** — removed a redundant `toBeFalsy()` check: the preceding `length).toEqual(1)` (react-query) / array-length assertion (preact-query) already guarantees there is no second entry.
- **`useSuspenseQuery`** — the cache absence check before mount uses `toBeUndefined()` instead of `toBeFalsy()`.

After this, neither package's `src` directory has any remaining `toBeTruthy()` / `toBeFalsy()` / `toBeDefined()` matches for these test files.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

Local verification detail: `vitest run` on both packages — react-query 564 passed (1 pre-existing unrelated skip), preact-query 502 passed, no type errors.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of cached query results and cache partitioning.
  * Strengthened checks for mutation state filtering and returned data.
  * Clarified that unmounted suspense queries are fully removed from the cache.
  * Removed redundant assertions while preserving coverage of default options and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->