### PR TITLE
test(svelte-query): replace 'toBeDefined' with exact-value assertion

### DIFF
--- a/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query/tests/QueryClientProvider/QueryClientProvider.svelte.test.ts
@@ -28,6 +28,6 @@ describe('QueryClientProvider', () => {
     await vi.advanceTimersByTimeAsync(10)
     expect(rendered.getByText('Data: test')).toBeInTheDocument()
 
-    expect(queryCache.find({ queryKey: ['hello'] })).toBeDefined()
+    expect(queryCache.find({ queryKey: ['hello'] })?.state.data).toBe('test')
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Continues the recent test-quality series (e.g. #11105, #11093) by converting the `toBeDefined()` assertion in `svelte-query` tests to an exact assertion:

- `QueryClientProvider.svelte.test.ts` — the cache presence check now asserts the exact cached value (`?.state.data`) produced by the test's `queryFn`, confirmed by the rendered `Data: test` text.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.

Local verification detail: `vitest run` on the full package — 168 tests passed, no type errors.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation of cached query data to confirm it contains the expected value.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->