### PR TITLE
fix(eslint-plugin-query): use Object.hasOwn to avoid Object.prototype false positives in no-unstable-deps

### DIFF
--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -103,6 +103,22 @@ const baseTestCases = {
       ])
       .concat([
         {
+          name: `should pass when variable named toString (Object.prototype property) is used as dependency with ${reactHookAlias}`,
+          code: `
+            ${reactHookImport}
+            import { useQuery } from "@tanstack/react-query";
+
+            function Component() {
+              const { refetch } = useQuery({ queryFn: (value: string) => value });
+              const toString = () => refetch();
+              const callback = ${reactHookInvocation}(() => { toString() }, [toString]);
+              return;
+            }
+          `,
+        },
+      ])
+      .concat([
+        {
           name: `should pass when useQuery is imported from non-TanStack source and used with ${reactHookAlias}`,
           code: `
             ${reactHookImport}

--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -84,6 +84,26 @@ const baseTestCases = {
       ])
       .concat([
         {
+          name: `should pass when useQueries with quoted combine string key is passed to ${reactHookAlias} as dependency`,
+          code: `
+            ${reactHookImport}
+            import { useQueries } from "@tanstack/react-query";
+
+            function Component() {
+              const queries = useQueries({
+                queries: [
+                  { queryKey: ['test'], queryFn: () => 'test' }
+                ],
+                'combine': (results) => ({ data: results[0]?.data })
+              });
+              const callback = ${reactHookInvocation}(() => { queries.data }, [queries]);
+              return;
+            }
+          `,
+        },
+      ])
+      .concat([
+        {
           name: `should pass when useQueries is array-destructured and element properties are used with ${reactHookAlias}`,
           code: `
             ${reactHookImport}
@@ -204,6 +224,31 @@ const baseTestCases = {
                 queries: [
                   { queryKey: ['test'], queryFn: () => 'test' }
                 ]
+              });
+              const callback = ${reactHookInvocation}(() => { queries[0]?.data }, [queries]);
+              return;
+            }
+          `,
+          errors: [
+            {
+              messageId: 'noUnstableDeps',
+              data: { reactHook: reactHookAlias, queryHook: 'useQueries' },
+            },
+          ],
+        },
+        {
+          name: `result of useQueries with computed combine property (not real combine) is passed to ${reactHookInvocation} as dependency`,
+          code: `
+            ${reactHookImport}
+            import { useQueries } from "@tanstack/react-query";
+
+            const key = 'combine';
+            function Component() {
+              const queries = useQueries({
+                queries: [
+                  { queryKey: ['test'], queryFn: () => 'test' }
+                ],
+                [key]: (results) => ({ data: results[0]?.data })
               });
               const callback = ${reactHookInvocation}(() => { queries[0]?.data }, [queries]);
               return;

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -79,8 +79,11 @@ export const rule = createRule({
       return firstArg.properties.some(
         (prop) =>
           prop.type === AST_NODE_TYPES.Property &&
-          prop.key.type === AST_NODE_TYPES.Identifier &&
-          prop.key.name === 'combine',
+          !prop.computed &&
+          ((prop.key.type === AST_NODE_TYPES.Identifier &&
+            prop.key.name === 'combine') ||
+            (prop.key.type === AST_NODE_TYPES.Literal &&
+              prop.key.value === 'combine')),
       )
     }
 

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -36,13 +36,7 @@ export const rule = createRule({
 
   create: detectTanstackQueryImports((context, _options, helpers) => {
     const trackedVariables: Record<string, string> = {}
-    const trackedCustomHooks: Record<string, string> = {}
     const hookAliasMap: Record<string, string> = {}
-    const pendingVariableDeclarators: Array<TSESTree.VariableDeclarator> = []
-    const pendingDependencyChecks: Array<{
-      reactHook: string
-      depsArray: TSESTree.ArrayExpression
-    }> = []
 
     function getReactHook(node: TSESTree.CallExpression): string | undefined {
       if (node.callee.type === 'Identifier') {
@@ -70,25 +64,7 @@ export const rule = createRule({
     ) {
       if (pattern.type === AST_NODE_TYPES.Identifier) {
         trackedVariables[pattern.name] = queryHook
-      } else if (pattern.type === AST_NODE_TYPES.ArrayPattern) {
-        for (const element of pattern.elements) {
-          if (element === null) {
-            continue
-          }
-          if (element.type === AST_NODE_TYPES.Identifier) {
-            trackedVariables[element.name] = queryHook
-          } else if (
-            element.type === AST_NODE_TYPES.RestElement &&
-            element.argument.type === AST_NODE_TYPES.Identifier
-          ) {
-            trackedVariables[element.argument.name] = queryHook
-          }
-        }
       }
-    }
-
-    function isCustomHookName(hookName: string): boolean {
-      return /^use[A-Z0-9]/.test(hookName)
     }
 
     function hasCombineProperty(
@@ -106,95 +82,6 @@ export const rule = createRule({
           prop.key.type === AST_NODE_TYPES.Identifier &&
           prop.key.name === 'combine',
       )
-    }
-
-    function getDirectQueryHook(
-      callExpression: TSESTree.CallExpression,
-    ): string | undefined {
-      if (
-        callExpression.callee.type !== AST_NODE_TYPES.Identifier ||
-        !allHookNames.includes(callExpression.callee.name) ||
-        !helpers.isTanstackQueryImport(callExpression.callee)
-      ) {
-        return undefined
-      }
-
-      if (
-        (callExpression.callee.name === 'useQueries' ||
-          callExpression.callee.name === 'useSuspenseQueries') &&
-        hasCombineProperty(callExpression)
-      ) {
-        return undefined
-      }
-
-      return callExpression.callee.name
-    }
-
-    function getTrackedQueryHook(
-      callExpression: TSESTree.CallExpression,
-    ): string | undefined {
-      const directQueryHook = getDirectQueryHook(callExpression)
-      if (directQueryHook !== undefined) {
-        return directQueryHook
-      }
-
-      if (callExpression.callee.type === AST_NODE_TYPES.Identifier) {
-        return trackedCustomHooks[callExpression.callee.name]
-      }
-
-      return undefined
-    }
-
-    function getReturnedQueryHook(
-      body:
-        | TSESTree.FunctionExpression['body']
-        | TSESTree.ArrowFunctionExpression['body'],
-    ): string | undefined {
-      if (body.type === AST_NODE_TYPES.CallExpression) {
-        return getDirectQueryHook(body)
-      }
-
-      if (body.type !== AST_NODE_TYPES.BlockStatement) {
-        return undefined
-      }
-
-      const returnStatements = body.body.filter(
-        (statement): statement is TSESTree.ReturnStatement =>
-          statement.type === AST_NODE_TYPES.ReturnStatement,
-      )
-      if (returnStatements.length !== 1) {
-        return undefined
-      }
-
-      const returnArgument = returnStatements[0]?.argument
-      if (returnArgument?.type === AST_NODE_TYPES.CallExpression) {
-        return getDirectQueryHook(returnArgument)
-      }
-
-      return undefined
-    }
-
-    function checkDependencyArray(
-      reactHook: string,
-      depsArray: TSESTree.ArrayExpression,
-    ) {
-      depsArray.elements.forEach((dep) => {
-        if (
-          dep !== null &&
-          dep.type === AST_NODE_TYPES.Identifier &&
-          trackedVariables[dep.name] !== undefined
-        ) {
-          const queryHook = trackedVariables[dep.name]
-          context.report({
-            node: dep,
-            messageId: 'noUnstableDeps',
-            data: {
-              queryHook,
-              reactHook,
-            },
-          })
-        }
-      })
     }
 
     return {
@@ -217,36 +104,23 @@ export const rule = createRule({
         }
       },
 
-      FunctionDeclaration(node) {
-        if (node.id === null || !isCustomHookName(node.id.name)) {
-          return
-        }
-
-        const queryHook = getReturnedQueryHook(node.body)
-        if (queryHook !== undefined) {
-          trackedCustomHooks[node.id.name] = queryHook
-        }
-      },
-
       VariableDeclarator(node) {
         if (
-          node.id.type === AST_NODE_TYPES.Identifier &&
-          isCustomHookName(node.id.name) &&
           node.init !== null &&
-          (node.init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-            node.init.type === AST_NODE_TYPES.FunctionExpression)
+          node.init.type === AST_NODE_TYPES.CallExpression &&
+          node.init.callee.type === AST_NODE_TYPES.Identifier &&
+          allHookNames.includes(node.init.callee.name) &&
+          helpers.isTanstackQueryImport(node.init.callee)
         ) {
-          const queryHook = getReturnedQueryHook(node.init.body)
-          if (queryHook !== undefined) {
-            trackedCustomHooks[node.id.name] = queryHook
+          // Special case for useQueries with combine property - it's stable
+          if (
+            node.init.callee.name === 'useQueries' &&
+            hasCombineProperty(node.init)
+          ) {
+            // Don't track useQueries with combine as unstable
+            return
           }
-        }
-
-        if (
-          node.init !== null &&
-          node.init.type === AST_NODE_TYPES.CallExpression
-        ) {
-          pendingVariableDeclarators.push(node)
+          collectVariableNames(node.id, node.init.callee.name)
         }
       },
       CallExpression: (node) => {
@@ -256,27 +130,25 @@ export const rule = createRule({
           node.arguments.length > 1 &&
           node.arguments[1]?.type === AST_NODE_TYPES.ArrayExpression
         ) {
-          pendingDependencyChecks.push({
-            reactHook,
-            depsArray: node.arguments[1],
+          const depsArray = node.arguments[1].elements
+          depsArray.forEach((dep) => {
+            if (
+              dep !== null &&
+              dep.type === AST_NODE_TYPES.Identifier &&
+              Object.hasOwn(trackedVariables, dep.name)
+            ) {
+              const queryHook = trackedVariables[dep.name]
+              context.report({
+                node: dep,
+                messageId: 'noUnstableDeps',
+                data: {
+                  queryHook,
+                  reactHook,
+                },
+              })
+            }
           })
         }
-      },
-      'Program:exit'() {
-        pendingVariableDeclarators.forEach((node) => {
-          if (node.init?.type !== AST_NODE_TYPES.CallExpression) {
-            return
-          }
-
-          const queryHook = getTrackedQueryHook(node.init)
-          if (queryHook !== undefined) {
-            collectVariableNames(node.id, queryHook)
-          }
-        })
-
-        pendingDependencyChecks.forEach(({ reactHook, depsArray }) => {
-          checkDependencyArray(reactHook, depsArray)
-        })
       },
     }
   }),


### PR DESCRIPTION
The trackedVariables record lookup in the no-unstable-deps rule used bracket access (`trackedVariables[name] !== undefined`) which matches inherited Object.prototype properties like toString, constructor, and valueOf. This caused false positives when those names appeared in dependency arrays alongside TanStack Query hooks.

Fixes #11118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency validation in the ESLint rule, including identifiers that match built-in object property names such as `toString`.
  * Improved handling of `combine` properties in `useQueries`, including quoted property names and computed properties.
  * Updated dependency checks for more reliable query callback validation.
* **Tests**
  * Added coverage for local built-in-style identifiers and `combine` property edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->