### PR TITLE
test(svelte-query/createQuery): replace 'toBeDefined' with exact-value assertion

### DIFF
--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -1607,12 +1607,16 @@ describe('createQuery', () => {
         () => currentClient,
       )
 
-      expect(queryClient1.getQueryCache().find({ queryKey: key })?.queryKey).toEqual(key)
+      expect(
+        queryClient1.getQueryCache().find({ queryKey: key })?.queryKey,
+      ).toEqual(key)
 
       currentClient = queryClient2
       flushSync()
 
-      expect(queryClient2.getQueryCache().find({ queryKey: key })?.queryKey).toEqual(key)
+      expect(
+        queryClient2.getQueryCache().find({ queryKey: key })?.queryKey,
+      ).toEqual(key)
     }),
   )
 

--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -1607,12 +1607,12 @@ describe('createQuery', () => {
         () => currentClient,
       )
 
-      expect(queryClient1.getQueryCache().find({ queryKey: key })).toBeDefined()
+      expect(queryClient1.getQueryCache().find({ queryKey: key })?.queryKey).toEqual(key)
 
       currentClient = queryClient2
       flushSync()
 
-      expect(queryClient2.getQueryCache().find({ queryKey: key })).toBeDefined()
+      expect(queryClient2.getQueryCache().find({ queryKey: key })?.queryKey).toEqual(key)
     }),
   )
 


### PR DESCRIPTION
## 🎯 Changes

Continues the recent test-quality series (e.g. https://github.com/TanStack/query/pull/11105, https://github.com/TanStack/query/pull/11093, https://github.com/TanStack/query/pull/11124) by converting the toBeDefined() assertion in svelte-query tests to an exact assertion:

- `createQuery.svelte.test.ts` — the cache presence checks now assert the exact `queryKey` (`?.queryKey`) registered in each client's cache, confirming that the query is correctly re-registered under the new client after the reactive swap from `queryClient1` to `queryClient2`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for switching query clients by verifying that cached entries retain the expected query key for both the initial and updated clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->