### PR TITLE
fix(react-query): keep unsubscribed useQueries idle

### DIFF
--- a/.changeset/tidy-pandas-wait.md
+++ b/.changeset/tidy-pandas-wait.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+fix(react-query): don't show optimistic fetching for unsubscribed useQueries

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -63,6 +63,34 @@ describe('useQueries', () => {
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
   })
 
+  it('should not optimistically show fetching when unsubscribed', () => {
+    const key = queryKey()
+    const queryFn = vi.fn(() => Promise.resolve('data'))
+
+    function Page() {
+      const [query] = useQueries({
+        queries: [{ queryKey: key, queryFn }],
+        subscribed: false,
+      })
+
+      return (
+        <div>
+          <span>isFetching: {String(query.isFetching)}</span>
+          <span>fetchStatus: {query.fetchStatus}</span>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    expect(queryFn).not.toHaveBeenCalled()
+    expect(
+      queryClient.getQueryCache().find({ queryKey: key })!.observers.length,
+    ).toBe(0)
+    rendered.getByText('isFetching: false')
+    rendered.getByText('fetchStatus: idle')
+  })
+
   it('should track results', async () => {
     const key1 = queryKey()
     const results: Array<Array<UseQueryResult>> = []

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -223,6 +223,7 @@ export function useQueries<
   const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
   const errorResetBoundary = useQueryErrorResetBoundary()
+  const subscribed = options.subscribed !== false
 
   const defaultedQueries = React.useMemo(
     () =>
@@ -234,11 +235,13 @@ export function useQueries<
         // Make sure the results are already in fetching state before subscribing or updating options
         defaultedOptions._optimisticResults = isRestoring
           ? 'isRestoring'
-          : 'optimistic'
+          : subscribed
+            ? 'optimistic'
+            : undefined
 
         return defaultedOptions
       }),
-    [queries, client, isRestoring],
+    [queries, client, isRestoring, subscribed],
   )
 
   defaultedQueries.forEach((queryOptions) => {
@@ -265,7 +268,7 @@ export function useQueries<
       (options as QueriesObserverOptions<TCombinedResult>).combine,
     )
 
-  const shouldSubscribe = !isRestoring && options.subscribed !== false
+  const shouldSubscribe = !isRestoring && subscribed
   React.useSyncExternalStore(
     React.useCallback(
       (onStoreChange) =>


### PR DESCRIPTION
## Summary

- Keep `useQueries` results aligned with the cache when `subscribed: false`.
- Add a regression test for the initial unsubscribed render.
- Add a patch changeset for `@tanstack/react-query`.

## Root cause

`useQueries` stopped subscriptions for `subscribed: false`, but still assigned `_optimisticResults: 'optimistic'` to every child observer. An unmounted observer then synthesized `isFetching: true` and `fetchStatus: 'fetching'` even though it did not run the query function and the cache remained idle.

This completes the `useQueries` portion of the fix proposed in #10739. PR #10759 corrected `useBaseQuery`, but did not change `useQueries`.

## Validation

- `vitest src/__tests__/useQueries.test.tsx` — 23 passing tests, including the new regression.
- `test:types:tscurrent`
- targeted ESLint and Prettier checks
- Confirmed red-to-green: the new test fails on the pre-fix implementation with `isFetching: true` / `fetchStatus: fetching`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `useQueries` so unsubscribed queries no longer display optimistic fetching states.
  - Unsubscribed queries now correctly remain idle and avoid initiating query functions.

- **Tests**
  - Added coverage verifying fetching status, query execution, and observer behavior for unsubscribed queries.

- **Release**
  - Included a patch release update for `@tanstack/react-query`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->