### PR TITLE
fix(eslint-plugin-query): add TypeScript 7 to peer dependency range

### DIFF
--- a/.changeset/typescript-7-peer-dep.md
+++ b/.changeset/typescript-7-peer-dep.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/eslint-plugin-query": patch
+---
+
+Add TypeScript 7 to peer dependency range

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-    "typescript": "^5.4.0 || ^6.0.0"
+    "typescript": "^5.4.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2518,7 +2518,7 @@ importers:
         specifier: 8.58.1
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       typescript:
-        specifier: ^5.4.0 || ^6.0.0
+        specifier: ^5.4.0 || ^6.0.0 || ^7.0.0
         version: 5.9.3
     devDependencies:
       '@typescript-eslint/parser':


### PR DESCRIPTION
## Summary

- Expands `@tanstack/eslint-plugin-query` `peerDependencies.typescript` to include `^7.0.0`
- Fixes install failures in projects using TypeScript 7 (reported in #11131)
- Follows the same pattern used when TypeScript 6 support was added in #10182

## Test plan

- [x] `pnpm nx run @tanstack/eslint-plugin-query:test:lib` — 1709 tests pass
- [x] `pnpm nx run @tanstack/eslint-plugin-query:test:eslint` — pass
- [x] `pnpm nx run @tanstack/eslint-plugin-query:test:types` — pass (TS 5.4–6.0-rc matrix)
- [x] `pnpm nx run @tanstack/eslint-plugin-query:build` — pass
- [x] `pnpm nx run @tanstack/eslint-plugin-query:test:build` — pass
- [x] Manual `typescript@7.0.2 --build` on eslint-plugin-query — pass
- [x] Patch changeset included

Fixes #11131

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added support for TypeScript 7 in the ESLint plugin’s supported peer dependency range.

* **Release**
  * Prepared a patch release reflecting the expanded TypeScript compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->