### PR TITLE
chore: upgrade to solid v2 beta 29

### DIFF
--- a/.changeset/solid-beta-29-upgrade.md
+++ b/.changeset/solid-beta-29-upgrade.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/solid-query': patch
+'@tanstack/solid-query-devtools': patch
+'@tanstack/solid-query-persist-client': patch
+---
+
+chore: upgrade to solid v2 beta 29

--- a/examples/solid/astro/package.json
+++ b/examples/solid/astro/package.json
@@ -18,8 +18,8 @@
     "@tanstack/solid-query": "^6.0.0-beta.6",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.6",
     "astro": "^5.5.6",
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.29",
     "tailwindcss": "^3.4.7",
     "typescript": "5.8.3"
   }

--- a/examples/solid/basic-graphql-request/package.json
+++ b/examples/solid/basic-graphql-request/package.json
@@ -12,12 +12,12 @@
     "@tanstack/solid-query-devtools": "^6.0.0-beta.6",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.2",
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21"
+    "@solidjs/web": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.29"
   },
   "devDependencies": {
     "typescript": "5.8.3",
     "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   }
 }

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -10,12 +10,12 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.6",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.6",
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21"
+    "@solidjs/web": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.29"
   },
   "devDependencies": {
     "typescript": "5.8.3",
     "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   }
 }

--- a/examples/solid/default-query-function/package.json
+++ b/examples/solid/default-query-function/package.json
@@ -10,12 +10,12 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.6",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.6",
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21"
+    "@solidjs/web": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.29"
   },
   "devDependencies": {
     "typescript": "5.8.3",
     "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   }
 }

--- a/examples/solid/offline/package.json
+++ b/examples/solid/offline/package.json
@@ -13,13 +13,13 @@
     "@tanstack/solid-query-devtools": "^6.0.0-beta.6",
     "@tanstack/solid-query-persist-client": "^6.0.0-beta.6",
     "msw": "^2.6.6",
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21"
+    "@solidjs/web": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.29"
   },
   "devDependencies": {
     "typescript": "5.8.3",
     "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   },
   "msw": {
     "workerDirectory": [

--- a/examples/solid/simple/package.json
+++ b/examples/solid/simple/package.json
@@ -10,13 +10,13 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.6",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.6",
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21"
+    "@solidjs/web": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.29"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.101.0",
     "typescript": "5.8.3",
     "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   }
 }

--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -14,8 +14,8 @@
     "@solidjs/start": "^1.1.3",
     "@tanstack/solid-query": "^6.0.0-beta.6",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.6",
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.29",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/integrations/solid-vite/package.json
+++ b/integrations/solid-vite/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "@tanstack/solid-query": "workspace:*",
     "@tanstack/solid-query-devtools": "workspace:*",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.29",
     "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.14",
-    "@solidjs/web": "2.0.0-beta.21"
+    "vite-plugin-solid": "3.0.0-next.21",
+    "@solidjs/web": "2.0.0-beta.29"
   }
 }

--- a/packages/solid-query-devtools/package.json
+++ b/packages/solid-query-devtools/package.json
@@ -67,15 +67,15 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.18.6",
-    "@solidjs/signals": "^2.0.0-beta.21",
+    "@solidjs/signals": "^2.0.0-beta.29",
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.29",
     "@tanstack/solid-query": "workspace:*",
-    "babel-preset-solid": "2.0.0-beta.21",
+    "babel-preset-solid": "2.0.0-beta.29",
     "npm-run-all2": "^5.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.29",
     "tsup-preset-solid": "^2.2.0",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   },
   "peerDependencies": {
     "@tanstack/solid-query": "workspace:^",

--- a/packages/solid-query-persist-client/package.json
+++ b/packages/solid-query-persist-client/package.json
@@ -69,14 +69,14 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.18.6",
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.29",
     "@tanstack/query-test-utils": "workspace:*",
     "@tanstack/solid-query": "workspace:*",
-    "babel-preset-solid": "2.0.0-beta.21",
+    "babel-preset-solid": "2.0.0-beta.29",
     "npm-run-all2": "^5.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.29",
     "tsup-preset-solid": "^2.2.0",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   },
   "peerDependencies": {
     "@tanstack/solid-query": "workspace:^",

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -71,13 +71,13 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.18.6",
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.29",
     "@tanstack/query-test-utils": "workspace:*",
-    "babel-preset-solid": "2.0.0-beta.21",
+    "babel-preset-solid": "2.0.0-beta.29",
     "npm-run-all2": "^5.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.29",
     "tsup-preset-solid": "^2.2.0",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.21"
   },
   "peerDependencies": {
     "solid-js": ">=2.0.0-beta.0 <3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,7 +1590,7 @@ importers:
         version: 9.5.5(astro@5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       '@astrojs/solid-js':
         specifier: ^5.0.7
-        version: 5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-beta.21)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-beta.29)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@astrojs/tailwind':
         specifier: ^6.0.2
         version: 6.0.2(astro@5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -1598,8 +1598,8 @@ importers:
         specifier: ^8.1.3
         version: 8.2.11(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1)(typescript@5.8.3)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(astro@5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(next@16.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0))(react@19.2.4)(rollup@4.60.1)(svelte@5.55.1)(vue@3.5.31(typescript@5.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query
@@ -1610,8 +1610,8 @@ importers:
         specifier: ^5.5.6
         version: 5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
       tailwindcss:
         specifier: ^3.4.7
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -1622,8 +1622,8 @@ importers:
   examples/solid/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query
@@ -1631,8 +1631,8 @@ importers:
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -1641,14 +1641,14 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/basic-graphql-request:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query
@@ -1662,8 +1662,8 @@ importers:
         specifier: ^7.1.2
         version: 7.4.0(graphql@16.13.2)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -1672,14 +1672,14 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/default-query-function:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query
@@ -1687,8 +1687,8 @@ importers:
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -1697,14 +1697,14 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/offline:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/query-async-storage-persister':
         specifier: ^5.101.0
         version: link:../../../packages/query-async-storage-persister
@@ -1721,8 +1721,8 @@ importers:
         specifier: ^2.6.6
         version: 2.12.14(@types/node@22.19.15)(typescript@5.8.3)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -1731,14 +1731,14 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/simple:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query
@@ -1746,8 +1746,8 @@ importers:
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
     devDependencies:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.101.0
@@ -1759,23 +1759,23 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/solid-start-streaming:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@2.0.0-beta.21)
+        version: 0.29.4(solid-js@2.0.0-beta.29)
       '@solidjs/router':
         specifier: ^0.15.3
-        version: 0.15.4(solid-js@2.0.0-beta.21)
+        version: 0.15.4(solid-js@2.0.0-beta.29)
       '@solidjs/start':
         specifier: ^1.1.3
-        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query
@@ -1783,8 +1783,8 @@ importers:
         specifier: ^6.0.0-beta.6
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
       vinxi:
         specifier: ^0.5.3
         version: 0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -2393,8 +2393,8 @@ importers:
   integrations/solid-vite:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: workspace:*
         version: link:../../packages/solid-query
@@ -2402,14 +2402,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   integrations/svelte-vite:
     devDependencies:
@@ -2955,28 +2955,28 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/query-test-utils':
         specifier: workspace:*
         version: link:../query-test-utils
       babel-preset-solid:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/solid-query-devtools:
     dependencies:
@@ -2991,32 +2991,32 @@ importers:
         specifier: ^7.18.6
         version: 7.28.5(@babel/core@7.29.0)
       '@solidjs/signals':
-        specifier: ^2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: ^2.0.0-beta.29
+        version: 2.0.0-beta.29
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/solid-query':
         specifier: workspace:*
         version: link:../solid-query
       babel-preset-solid:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/solid-query-persist-client:
     dependencies:
@@ -3032,10 +3032,10 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@tanstack/query-test-utils':
         specifier: workspace:*
         version: link:../query-test-utils
@@ -3043,20 +3043,20 @@ importers:
         specifier: workspace:*
         version: link:../solid-query
       babel-preset-solid:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.29
+        version: 2.0.0-beta.29
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.0-next.21
+        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/svelte-query:
     dependencies:
@@ -4694,44 +4694,44 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24':
-    resolution: {integrity: sha512-IqPQQdgINMg6ev95xd/qfCH4stdooGRvNHiFzYitvKkv3fnqfc8+d72CuMX7eLJ9X2pVsyPzmrbEzwfrK1JoTA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.34':
+    resolution: {integrity: sha512-mcH1h/FgNkf9jatVCuU/tE9PUGRxQfT3862GXh+IbCcH9PKEbxQKoA3GsKpixsOmLVkbcW2auJxKIV8u8WacOw==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
-    resolution: {integrity: sha512-lT+WW7ehe7vZrWv9ZTkX9UXRa+73v84C2r9MdsNzj1EeGuHH29yYCh0idKAEtH9hS0+YS7LTAaGDO5x+0deRoQ==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.34':
+    resolution: {integrity: sha512-MkIi1jWuVPaFoyM6qXlx3EPYXgUyySCDUJ/2zxpqzITW6/fkVvCQ++o2MrumgNFjQ/wxXdg8j0WMLcarnJ2H2Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
-    resolution: {integrity: sha512-Y2SaEwGRZxTPjSVsrmYcvsb9jblxfY1IfXwAGGMPYFgZmYUrL9QyTEF9nnqwsHEdg7pdQk5YRINQmQ302hCF8g==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.34':
+    resolution: {integrity: sha512-T7epwdLa+0WZBWvme3vHvYPz3Zc8APFsDAZh0N+OPlQywRjsIKymqP9Z5DAOScSIkZP3FERgThHk++vbv6pMhQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-rx44q0WNxcB3TYrCJt07J0ZBdGFrieWAmg2ZDpjXcxCT1V2VgCoOARyLGv4FAM1dDlmJ2nymZ5XG3/H3CD8Tvg==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.34':
+    resolution: {integrity: sha512-5Q9D+qPS/djpfRrMPxCkYKkSzIweFk72hpZcKdQnXNnttmj6pi7L4rp5ZzupX3XVGTsZGXIjjuirViysfjiIoQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-bmNfa4eMECDo39L35SvXgycIpIha591O5Vs2DmUNc3Ryo9I1uxvWJ+uH/EKRZOe4XATzAR8hSXxbWtXczUhksg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.34':
+    resolution: {integrity: sha512-aPXMQM3KoZPOWv7AYBKz7oT9mUdPkLjJZoiYftua7AM59A4VJ+I6RvvXYnRNK28uk1zzt+IkZxrEKIQFOptDBg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
-    resolution: {integrity: sha512-IAdMBNx+T2Eb7ea5L3ak1WPQBo4FI1uwZm/xorenmJ4heYbGsptMwRC1Fi/aW+HoQGH9LqFA+wnoYeZx7dcEWQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.34':
+    resolution: {integrity: sha512-XpghiRyhrY5/Zxg5q1dcUCCNCSOqnNZQ1IX87MfwrDWdIZ3ZDaGrcCFUcT37veeZgzgbb3bpt5fSKwyN9VAq3w==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
-    resolution: {integrity: sha512-FQ2yrh3DUcfQ6hgwQNs0ghc1DYbx5kSh+Kq0buIGWxsDujOQF8LkXln0T2rwn6FVluu1UFx0cFoJOCEZ4keTuw==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.34':
+    resolution: {integrity: sha512-4+RLrBo//1Ruok1GG1qIDv2wn0vRWIMi5lhphp6i6H0zwUTPgOLPY6ksMz8ZyEiAIh86jBTNiLj5rKCAU4pepQ==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.24':
-    resolution: {integrity: sha512-L5+bnXh+6ODiGTVTNGilBgqxtgsZyKypJI77Fi4XjiIMwVD6P3WdV0HY4gOcJGpk0doPSpOp6bTWMA+Z311loA==}
+  '@dom-expressions/compiler@0.50.0-next.34':
+    resolution: {integrity: sha512-XGlXicYgEKB2hesd37GT+HuctvbLRShd/G3ij2sxAIEEo6clza2jB64ZezyuuZY6iZn/QJwxAIyUVEChZ+Tl9g==}
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -5024,7 +5024,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -7220,8 +7220,8 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  '@solidjs/signals@2.0.0-beta.21':
-    resolution: {integrity: sha512-dVBzBxWVvO3SubC1f8KZLeVqkiIp5TNNosCEbamggsOyLkfaWTWgOkRi7J/q6G9u4o1+dZ8LhqK70TJmimiZ9g==}
+  '@solidjs/signals@2.0.0-beta.29':
+    resolution: {integrity: sha512-/W4goRwA/t9SqA0acIcD008pBJr2p5BMxVpzcdvWMYNswyE88se1ecJKQO/QTa6DjVRZvplOOtKEtDRHpEo3rQ==}
 
   '@solidjs/start@1.3.2':
     resolution: {integrity: sha512-tasDl3utVbtP0rr4InB3ntBIFV2upvEiFrOOCkRrAA3yBfjx9elpxnc94sJQXo65PNYdAAAkPIC6h93vLrtwHg==}
@@ -7238,10 +7238,10 @@ packages:
       '@solidjs/router':
         optional: true
 
-  '@solidjs/web@2.0.0-beta.21':
-    resolution: {integrity: sha512-QlpU6eAjcdsuggjy5groIfyAfU2S+YwAmka8eG+5kzSRSluxDYc9St8Xc+632KNpyOJS9kFjps2jjK4t20j6xg==}
+  '@solidjs/web@2.0.0-beta.29':
+    resolution: {integrity: sha512-Bsb1JP1n6OIuiCQiYlE1B3+cNY0UlDPyA1UUYC3trFudUMs0aDCxGmY/B5KXnmw4NNcRIUA2bW46h3FC9qhWXA==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.29
 
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
@@ -8747,11 +8747,11 @@ packages:
       solid-js:
         optional: true
 
-  babel-preset-solid@2.0.0-beta.21:
-    resolution: {integrity: sha512-CbqiWmV+zXjfZM4HL+aT4JYkM41Kuaujch6sICkIbQLt5bmDoost+whFKUJa6/0e3iio4S5jWIr7iRV7InVerA==}
+  babel-preset-solid@2.0.0-beta.29:
+    resolution: {integrity: sha512-k3kDFDYdThcPZo5/PEIdZa+tYw/f4TVJomRjL7U2par3OWZxu49O3I9fHyezwEIfYjtyIyLygIKVfQ8Apu5wEg==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.29
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -14778,8 +14778,8 @@ packages:
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
-  solid-js@2.0.0-beta.21:
-    resolution: {integrity: sha512-Z8YwRMXxnkseNrmWYE2l25orrAN2cRnIFanAPl3YbQyer8BIFOSaDQrmy7zQWZKiDn8Cp9JHPC143u44wVHAxQ==}
+  solid-js@2.0.0-beta.29:
+    resolution: {integrity: sha512-Jv0jRw7joECw63cRfeqo5lnEVNVhAcH1hWt1nSvyp5npTgk6eyCmP5UDLTNWm6ox5G5LmBJzFkBulm+hp9+vmA==}
 
   solid-presence@0.1.8:
     resolution: {integrity: sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==}
@@ -15986,12 +15986,12 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite-plugin-solid@3.0.0-next.14:
-    resolution: {integrity: sha512-WDy9TDa5Ekg/L94297+FKOOHOmrOyUlONRRkbGGOct/EB7SWyaobA3KRTy1pgeluy0pFrcquULhEeUg+4qKK2g==}
+  vite-plugin-solid@3.0.0-next.21:
+    resolution: {integrity: sha512-N9NJtw87jbdcQHSmwK//bvTJpDdrcZJ8zWMko4y9dq+XPoip7kmgUZSK8hwG+d9qz8Z+WyC1fUcu78hpesbPzQ==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.29 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      solid-js: '>=2.0.0-beta.29 <2.0.0-experimental.0'
       vite: ^6.4.1
     peerDependenciesMeta:
       '@testing-library/jest-dom':
@@ -17101,11 +17101,11 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/solid-js@5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-beta.21)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+  '@astrojs/solid-js@5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-beta.29)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
       vite: 6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - '@types/node'
@@ -18585,7 +18585,7 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.29.0)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.34(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.18.6
@@ -18595,36 +18595,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.34':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.34':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.34':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.34':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.34':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.34':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.24':
+  '@dom-expressions/compiler@0.50.0-next.34':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.24
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.24
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.24
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.34
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.34
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.34
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.34
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.34
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.34
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
@@ -19968,8 +19968,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -21124,22 +21124,22 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.21)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.29)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
 
   '@solidjs/router@0.15.4(solid-js@1.9.12)':
     dependencies:
       solid-js: 1.9.12
     optional: true
 
-  '@solidjs/router@0.15.4(solid-js@2.0.0-beta.21)':
+  '@solidjs/router@0.15.4(solid-js@2.0.0-beta.29)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
 
-  '@solidjs/signals@2.0.0-beta.21': {}
+  '@solidjs/signals@2.0.0-beta.29': {}
 
-  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -21153,10 +21153,10 @@ snapshots:
       seroval-plugins: 1.5.1(seroval@1.5.1)
       shiki: 1.29.2
       source-map-js: 1.2.1
-      terracotta: 1.1.0(solid-js@2.0.0-beta.21)
+      terracotta: 1.1.0(solid-js@2.0.0-beta.29)
       tinyglobby: 0.2.15
       vinxi: 0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -21170,18 +21170,18 @@ snapshots:
     optionalDependencies:
       '@solidjs/router': 0.15.4(solid-js@1.9.12)
 
-  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)':
+  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
     optionalDependencies:
-      '@solidjs/router': 0.15.4(solid-js@2.0.0-beta.21)
+      '@solidjs/router': 0.15.4(solid-js@2.0.0-beta.29)
 
-  '@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21)':
+  '@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
 
   '@speed-highlight/core@1.2.15': {}
 
@@ -23337,19 +23337,19 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.12
 
-  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.29):
     dependencies:
       '@babel/core': 7.29.0
       babel-plugin-jsx-dom-expressions: 0.40.6(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29):
     dependencies:
       '@babel/core': 7.29.0
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.29.0)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.34(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
 
   bail@2.0.2: {}
 
@@ -24901,13 +24901,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-plugin-solid@0.5.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21):
+  esbuild-plugin-solid@0.5.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
       esbuild: 0.27.4
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
     transitivePeerDependencies:
       - supports-color
 
@@ -30987,9 +30987,9 @@ snapshots:
       seroval: 1.5.1
       seroval-plugins: 1.5.1(seroval@1.5.1)
 
-  solid-js@2.0.0-beta.21:
+  solid-js@2.0.0-beta.29:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.21
+      '@solidjs/signals': 2.0.0-beta.29
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -31013,12 +31013,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-refresh@0.6.3(solid-js@2.0.0-beta.21):
+  solid-refresh@0.6.3(solid-js@2.0.0-beta.29):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/helper-module-imports': 7.28.6
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
     transitivePeerDependencies:
       - supports-color
 
@@ -31028,9 +31028,9 @@ snapshots:
       '@solid-primitives/transition-group': 1.1.2(solid-js@1.9.12)
       solid-js: 1.9.12
 
-  solid-use@0.9.1(solid-js@2.0.0-beta.21):
+  solid-use@0.9.1(solid-js@2.0.0-beta.29):
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
 
   sort-by@1.2.0:
     dependencies:
@@ -31543,10 +31543,10 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terracotta@1.1.0(solid-js@2.0.0-beta.21):
+  terracotta@1.1.0(solid-js@2.0.0-beta.29):
     dependencies:
-      solid-js: 2.0.0-beta.21
-      solid-use: 0.9.1(solid-js@2.0.0-beta.21)
+      solid-js: 2.0.0-beta.29
+      solid-use: 0.9.1(solid-js@2.0.0-beta.29)
 
   terser-webpack-plugin@1.4.6(webpack@4.47.0):
     dependencies:
@@ -31762,9 +31762,9 @@ snapshots:
       - solid-js
       - supports-color
 
-  tsup-preset-solid@2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
+  tsup-preset-solid@2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      esbuild-plugin-solid: 0.5.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21)
+      esbuild-plugin-solid: 0.5.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29)
       tsup: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
@@ -32439,14 +32439,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
-      solid-refresh: 0.6.3(solid-js@2.0.0-beta.21)
+      solid-js: 2.0.0-beta.29
+      solid-refresh: 0.6.3(solid-js@2.0.0-beta.29)
       vite: 6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
@@ -32454,14 +32454,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
-      solid-refresh: 0.6.3(solid-js@2.0.0-beta.21)
+      solid-js: 2.0.0-beta.29
+      solid-refresh: 0.6.3(solid-js@2.0.0-beta.29)
       vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
@@ -32469,16 +32469,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.21)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-solid@3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.29)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.0
-      '@dom-expressions/compiler': 0.50.0-next.24
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+      '@dom-expressions/compiler': 0.50.0-next.34
+      '@solidjs/web': 2.0.0-beta.29(solid-js@2.0.0-beta.29)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.29
       vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:


### PR DESCRIPTION
Follow-up to #11092, bumping the Solid v2 ecosystem to the latest betas.

| Package | From | To |
| --- | --- | --- |
| `solid-js` | 2.0.0-beta.21 | 2.0.0-beta.29 |
| `vite-plugin-solid` | 3.0.0-next.14 | 3.0.0-next.21 |
| `@solidjs/web` | 2.0.0-beta.21 | 2.0.0-beta.29 |
| `babel-preset-solid` | 2.0.0-beta.21 | 2.0.0-beta.29 |
| `@solidjs/signals` | ^2.0.0-beta.21 | ^2.0.0-beta.29 |

Applied across `packages/solid-query`, `packages/solid-query-devtools`, `packages/solid-query-persist-client`, `integrations/solid-vite`, and the `examples/solid/*` apps. `packages/query-devtools` stays on the Solid 1.x line.

Unlike the beta.21 upgrade, no source or test-setup changes were needed.

## Testing

`solid-query`, `solid-query-devtools`, and `solid-query-persist-client` suites pass unchanged — 357 tests (322 / 28 / 7), no type errors.

## Note for reviewers

`pnpm install` currently fails on this repo whenever a dependency change forces full re-resolution, independent of this PR: `trustPolicy: 'no-downgrade'` rejects `undici-types@6.21.0` (via `@types/node@22.x`) and `ua-parser-js@1.0.41` (via `react-native-web`). Both versions are already pinned in the committed lockfile, and both are on major lines published without provenance attestations while later majors have them. `pnpm install --frozen-lockfile` is unaffected, so CI should be green.

The lockfile here was regenerated with a one-off `--trust-policy-ignore-after 43200` (30 days), which clears long-published packages while still fully trust-checking the freshly-published Solid betas. `pnpm-workspace.yaml` is deliberately unchanged — a durable fix (a persistent `trustPolicyIgnoreAfter`, or adding both packages to `trustPolicyExclude`) felt like a separate policy call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)