### PR TITLE
fix(react-query): hydrate deferred queries before observers subscribe to avoid a redundant refetch

### DIFF
--- a/.changeset/hungry-planes-tease.md
+++ b/.changeset/hungry-planes-tease.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Hydrate deferred queries in a layout effect so a remounting `useQuery` no longer refetches data the dehydrated state already contains.

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -1,7 +1,7 @@
 'use client'
 import * as React from 'react'
 
-import { hydrate } from '@tanstack/query-core'
+import { hydrate, isServer } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
   DehydratedState,
@@ -9,6 +9,12 @@ import type {
   OmitKeyof,
   QueryClient,
 } from '@tanstack/query-core'
+
+// Hook choice has to be static, so this intentionally uses the static
+// isServer check instead of environmentManager
+const useIsomorphicLayoutEffect = isServer
+  ? React.useEffect
+  : React.useLayoutEffect
 
 export interface HydrationBoundaryProps {
   state: DehydratedState | null | undefined
@@ -31,7 +37,7 @@ export const HydrationBoundary = ({
   const client = useQueryClient(queryClient)
 
   const optionsRef = React.useRef(options)
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     optionsRef.current = options
   })
 
@@ -101,7 +107,14 @@ export const HydrationBoundary = ({
       return undefined
     }, [client, state])
 
-  React.useEffect(() => {
+  // This must be a layout effect so the queue is hydrated before any
+  // useSyncExternalStore subscriptions in children run in their passive
+  // effects. A remounting observer that subscribes before hydration would
+  // see the old, possibly stale data and kick off a redundant refetch of
+  // the data the dehydrated state already contains. Layout effects still
+  // only run when the tree commits, so aborted transitions keep discarding
+  // the queue.
+  useIsomorphicLayoutEffect(() => {
     if (hydrationQueue) {
       hydrate(client, { queries: hydrationQueue }, optionsRef.current)
     }

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -149,14 +149,15 @@ describe('React hydration', () => {
         </QueryClientProvider>,
       )
 
-      // Existing observer should not have updated at this point,
-      // as that would indicate a side effect in the render phase
-      expect(rendered.getByText('string')).toBeInTheDocument()
+      // The existing observer picks up the hydrated data once effects have
+      // flushed, but not during the render phase (the aborted transition
+      // test guards the render phase)
+      expect(rendered.getByText('should change')).toBeInTheDocument()
       // New query data should be available immediately
       expect(rendered.getByText('added')).toBeInTheDocument()
 
       await vi.advanceTimersByTimeAsync(0)
-      // After effects phase has had time to run, the observer should have updated
+      // Nothing changes after the effects phase has had time to run
       expect(rendered.queryByText('string')).not.toBeInTheDocument()
       expect(rendered.getByText('should change')).toBeInTheDocument()
 
@@ -479,6 +480,65 @@ describe('React hydration', () => {
     hydrateSpy.mockRestore()
     prefetchQueryClient.clear()
     clientQueryClient.clear()
+  })
+
+  it('should not refetch an inactive query when hydrated data is fresh', async () => {
+    const queryClient = new QueryClient()
+    const queryFn = vi.fn(() => sleep(10).then(() => 'client'))
+
+    function Page() {
+      const { data } = useQuery({
+        queryKey: ['data'],
+        queryFn,
+        staleTime: 1000,
+      })
+      return <div>{data}</div>
+    }
+
+    // First visit fetches and caches the data
+    const rendered = render(
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>,
+    )
+    await vi.advanceTimersByTimeAsync(11)
+    expect(rendered.getByText('client')).toBeInTheDocument()
+
+    // Navigate away; the cached data goes stale while the page is unmounted
+    rendered.rerender(
+      <QueryClientProvider client={queryClient}>
+        <div />
+      </QueryClientProvider>,
+    )
+    await vi.advanceTimersByTimeAsync(2000)
+
+    // A loader fetches fresh data on the revisit and dehydrates it
+    const loaderClient = new QueryClient()
+    loaderClient.prefetchQuery({
+      queryKey: ['data'],
+      queryFn: () => sleep(10).then(() => 'loader'),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+    const dehydratedState = dehydrate(loaderClient)
+    loaderClient.clear()
+
+    queryFn.mockClear()
+    rendered.rerender(
+      <QueryClientProvider client={queryClient}>
+        <HydrationBoundary state={dehydratedState}>
+          <Page />
+        </HydrationBoundary>
+      </QueryClientProvider>,
+    )
+
+    // Hydration lands before the remounted useQuery subscribes, so the
+    // fresh data is used as is instead of triggering a refetch
+    expect(rendered.getByText('loader')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(11)
+    expect(queryFn).toHaveBeenCalledTimes(0)
+    expect(rendered.getByText('loader')).toBeInTheDocument()
+
+    queryClient.clear()
   })
 
   it('should not refetch when query has enabled set to false', async () => {

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -149,14 +149,16 @@ describe('React hydration', () => {
         </QueryClientProvider>,
       )
 
-      // Existing observer should not have updated at this point,
-      // as that would indicate a side effect in the render phase
-      expect(rendered.getByText('string')).toBeInTheDocument()
+      // The existing observer has the hydrated data as soon as the tree
+      // commits, the layout effect has already run by this line. It still
+      // doesn't happen during render, that's what the aborted transition
+      // test guards
+      expect(rendered.getByText('should change')).toBeInTheDocument()
       // New query data should be available immediately
       expect(rendered.getByText('added')).toBeInTheDocument()
 
       await vi.advanceTimersByTimeAsync(0)
-      // After effects phase has had time to run, the observer should have updated
+      // Nothing changes after the effects phase has had time to run
       expect(rendered.queryByText('string')).not.toBeInTheDocument()
       expect(rendered.getByText('should change')).toBeInTheDocument()
 
@@ -479,6 +481,116 @@ describe('React hydration', () => {
     hydrateSpy.mockRestore()
     prefetchQueryClient.clear()
     clientQueryClient.clear()
+  })
+
+  it('should not refetch an inactive query when hydrated data is fresh', async () => {
+    const queryClient = new QueryClient()
+    const queryFn = vi.fn(() => sleep(10).then(() => 'client'))
+
+    function Page() {
+      const { data } = useQuery({
+        queryKey: ['data'],
+        queryFn,
+        staleTime: 1000,
+      })
+      return <div>{data}</div>
+    }
+
+    // First visit fetches and caches the data
+    const rendered = render(
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>,
+    )
+    await vi.advanceTimersByTimeAsync(11)
+    expect(rendered.getByText('client')).toBeInTheDocument()
+
+    // Navigate away; the cached data goes stale while the page is unmounted
+    rendered.rerender(
+      <QueryClientProvider client={queryClient}>
+        <div />
+      </QueryClientProvider>,
+    )
+    await vi.advanceTimersByTimeAsync(2000)
+
+    // A loader fetches fresh data on the revisit and dehydrates it
+    const loaderClient = new QueryClient()
+    loaderClient.prefetchQuery({
+      queryKey: ['data'],
+      queryFn: () => sleep(10).then(() => 'loader'),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+    const dehydratedState = dehydrate(loaderClient)
+    loaderClient.clear()
+
+    queryFn.mockClear()
+    rendered.rerender(
+      <QueryClientProvider client={queryClient}>
+        <HydrationBoundary state={dehydratedState}>
+          <Page />
+        </HydrationBoundary>
+      </QueryClientProvider>,
+    )
+
+    // Hydration lands before the remounted useQuery subscribes, so the
+    // fresh data is used as is instead of triggering a refetch
+    expect(rendered.getByText('loader')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(11)
+    expect(queryFn).toHaveBeenCalledTimes(0)
+    expect(rendered.getByText('loader')).toBeInTheDocument()
+
+    queryClient.clear()
+  })
+
+  it('should not refetch a query that remounts in the same commit as the boundary', async () => {
+    const queryClient = new QueryClient()
+    const queryFn = vi.fn(() => sleep(10).then(() => 'client'))
+
+    function Page() {
+      const { data } = useQuery({
+        queryKey: ['data'],
+        queryFn,
+        staleTime: 1000,
+      })
+      return <div>{data}</div>
+    }
+
+    const rendered = render(
+      <QueryClientProvider client={queryClient}>
+        <Page />
+      </QueryClientProvider>,
+    )
+    await vi.advanceTimersByTimeAsync(11)
+    expect(rendered.getByText('client')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(2000)
+
+    const loaderClient = new QueryClient()
+    loaderClient.prefetchQuery({
+      queryKey: ['data'],
+      queryFn: () => sleep(10).then(() => 'loader'),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+    const dehydratedState = dehydrate(loaderClient)
+    loaderClient.clear()
+
+    queryFn.mockClear()
+    // Wrapping the page in the boundary remounts it, so the old observer is
+    // torn down and a new one subscribes in one go. The old subscription is
+    // only cleaned up in the passive phase, so it is still on the query while
+    // this commit's layout effects run
+    rendered.rerender(
+      <QueryClientProvider client={queryClient}>
+        <HydrationBoundary state={dehydratedState}>
+          <Page />
+        </HydrationBoundary>
+      </QueryClientProvider>,
+    )
+
+    expect(rendered.getByText('loader')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(11)
+    expect(queryFn).toHaveBeenCalledTimes(0)
+
+    queryClient.clear()
   })
 
   it('should not refetch when query has enabled set to false', async () => {


### PR DESCRIPTION
## 🎯 Changes

Fixes #9610.

`HydrationBoundary` defers hydration of queries that already exist in the cache to an effect, so that transitions don't update existing observers mid-render. But `useQuery`'s `useSyncExternalStore` subscription is also a passive effect, and children's effects run before parents'. On a revisit, where the query is cached but was unmounted, the observer subscribes first, sees the old stale entry and starts a refetch of the exact data the dehydrated state already contains. The server computes it in the loader and the client immediately fetches it again.

This moves the deferred hydration, and the `optionsRef` sync it reads, to a layout effect. All layout effects run before any passive effect, so hydration lands in the cache before a remounting observer decides whether to fetch. Layout effects still only run when the tree commits, so the aborted transition behaviour is unchanged and its test stays green.

Behaviour change worth noting: already-mounted observers now get hydrated data at commit time rather than after paint. One timing assertion in an existing test was updated for that. The render phase guarantee is still covered by the aborted transition test.

I tried a narrower version that only hydrates queries with no subscribers, so mounted observers keep their old timing. It doesn't work here: React cleans up a deleted subtree's subscriptions in the passive phase, after this layout effect, so when a page unmounts and remounts in the same commit the outgoing observer is still on the query and the refetch comes back. There's a test for that case now.

Verified with tests that fail on `main` and pass with the fix, plus a jsdom repro of the React Router loader flow from the issue against the built package.

Not covered: a `useSuspenseQuery` over a query that is in `pending` state with no data starts its fetch during render, before any layout effect. That pre-existing path is unaffected by this change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration timing so deferred query data is available before effects run.
  * Prevented remounted queries from unnecessarily refetching data already present in dehydrated state.
  * Preserved correct behavior for stale and inactive queries during hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->