### PR TITLE
fix(lit-query): add DataTag to the queryKey returned by infiniteQueryOptions

### DIFF
--- a/.changeset/wise-doors-shout.md
+++ b/.changeset/wise-doors-shout.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/lit-query': patch
+---
+
+Brand the `queryKey` returned by `infiniteQueryOptions` with `DataTag` so `getQueryData` and `setQueryData` infer `InfiniteData` instead of `unknown`.

--- a/packages/lit-query/src/infiniteQueryOptions.ts
+++ b/packages/lit-query/src/infiniteQueryOptions.ts
@@ -1,4 +1,5 @@
 import type {
+  DataTag,
   DefaultError,
   InfiniteData,
   InfiniteQueryObserverOptions,
@@ -6,10 +7,11 @@ import type {
 } from '@tanstack/query-core'
 
 /**
- * Preserves and types infinite query options for reuse across Lit Query APIs.
+ * Brands infinite query options so the `queryKey` carries the infinite query
+ * data and error types across TanStack Query APIs.
  *
- * @param options - Infinite query options to preserve.
- * @returns The same options object.
+ * @param options - Infinite query options to preserve and brand.
+ * @returns The same options object with a typed `queryKey`.
  *
  * @example
  * ```ts
@@ -43,6 +45,10 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> {
+> & {
+  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
+}
+
+export function infiniteQueryOptions(options: unknown) {
   return options
 }

--- a/packages/lit-query/src/tests/type-inference.test.ts
+++ b/packages/lit-query/src/tests/type-inference.test.ts
@@ -2,6 +2,7 @@ import {
   dataTagSymbol,
   QueryClient,
   type DefinedQueryObserverResult,
+  type InfiniteData,
   type QueryObserverResult,
 } from '@tanstack/query-core'
 import { describe, expectTypeOf, it } from 'vitest'
@@ -205,6 +206,27 @@ describe('type inference', () => {
     )
     expectTypeOf(infinite().data?.pages).toEqualTypeOf<
       Array<{ page: number }> | undefined
+    >()
+
+    const infiniteQueryOpts = infiniteQueryOptions({
+      queryKey: ['type-inference', 'infinite-query-options'] as const,
+      initialPageParam: 0,
+      queryFn: async () => ({ page: 3 }),
+      getNextPageParam: (lastPage) => lastPage.page + 1,
+    })
+    expectTypeOf(infiniteQueryOpts.queryKey[dataTagSymbol]).toEqualTypeOf<
+      InfiniteData<{ page: number }>
+    >()
+    const cachedPages = client.getQueryData(infiniteQueryOpts.queryKey)
+    expectTypeOf(cachedPages).toEqualTypeOf<
+      InfiniteData<{ page: number }> | undefined
+    >()
+    const updatedPages = client.setQueryData(infiniteQueryOpts.queryKey, {
+      pages: [{ page: 4 }],
+      pageParams: [0],
+    })
+    expectTypeOf(updatedPages).toEqualTypeOf<
+      InfiniteData<{ page: number }> | undefined
     >()
   })
 })

--- a/packages/lit-query/src/tests/type-inference.test.ts
+++ b/packages/lit-query/src/tests/type-inference.test.ts
@@ -1,4 +1,5 @@
 import {
+  dataTagErrorSymbol,
   dataTagSymbol,
   QueryClient,
   type DefinedQueryObserverResult,
@@ -217,6 +218,9 @@ describe('type inference', () => {
     expectTypeOf(infiniteQueryOpts.queryKey[dataTagSymbol]).toEqualTypeOf<
       InfiniteData<{ page: number }>
     >()
+    expectTypeOf(
+      infiniteQueryOpts.queryKey[dataTagErrorSymbol],
+    ).toEqualTypeOf<Error>()
     const cachedPages = client.getQueryData(infiniteQueryOpts.queryKey)
     expectTypeOf(cachedPages).toEqualTypeOf<
       InfiniteData<{ page: number }> | undefined
@@ -226,6 +230,18 @@ describe('type inference', () => {
       pageParams: [0],
     })
     expectTypeOf(updatedPages).toEqualTypeOf<
+      InfiniteData<{ page: number }> | undefined
+    >()
+    const updatedPagesViaCallback = client.setQueryData(
+      infiniteQueryOpts.queryKey,
+      (previous) => {
+        expectTypeOf(previous).toEqualTypeOf<
+          InfiniteData<{ page: number }> | undefined
+        >()
+        return previous
+      },
+    )
+    expectTypeOf(updatedPagesViaCallback).toEqualTypeOf<
       InfiniteData<{ page: number }> | undefined
     >()
   })


### PR DESCRIPTION
## 🎯 Changes

`infiniteQueryOptions` in lit-query returns the options unchanged, without the `DataTag` brand its own `queryOptions` already applies. The `queryKey` carries no data type, so `client.getQueryData(opts.queryKey)` and `setQueryData` fall back to `unknown` and the updater argument can't be used.

The return type now intersects `queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>`, mirroring `queryOptions.ts` here and `infiniteQueryOptions` in react-query. Added a case to `type-inference.test.ts` next to the existing `queryOptions` one.

Fixes #11142

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Local verification detail: `vitest run` and `test:types` on `lit-query`, 102 tests passed, no type errors. The new assertions fail on `main`, where `getQueryData` resolves to `unknown`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type inference for infinite query data and errors.
  - Cached infinite-query reads and updates now correctly recognize `InfiniteData` instead of falling back to unknown types.
  - Callback-based cache updates provide more accurate data and error typing.
  - Improved type safety when working with infinite-query results across query APIs.

- **Documentation**
  - Clarified the type behavior of infinite query options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->