### PR TITLE
docs(vue-query/guides/suspense): update example to v5 object syntax

### DIFF
--- a/docs/framework/vue/guides/suspense.md
+++ b/docs/framework/vue/guides/suspense.md
@@ -40,7 +40,10 @@ const todoFetcher = async () =>
 export default defineComponent({
   name: 'SuspendableComponent',
   async setup() {
-    const { data, suspense } = useQuery(['todos'], todoFetcher)
+    const { data, suspense } = useQuery({
+      queryKey: ['todos'],
+      queryFn: todoFetcher,
+    })
     await suspense()
 
     return { data }


### PR DESCRIPTION
The Vue suspense guide's second example still uses the v4 positional-arguments call:

```ts
const { data, suspense } = useQuery(['todos'], todoFetcher)
```

v5 accepts only a single options object, so copying this snippet into a v5 app produces an error. Updated it to the object form:

```ts
const { data, suspense } = useQuery({
  queryKey: ['todos'],
  queryFn: todoFetcher,
})
```

As far as I can tell this was the last v4-style positional call left in the docs outside the migration guides. Docs-only change, no behavior affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Vue Query `useQuery` example to use the current object-based options syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->