### PR TITLE
docs: fix in-page anchor links to match the docs site's slug format

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -11,7 +11,7 @@ For deeper examples on hydration + prefetching (including code splitting), see t
 
 For advanced server rendering patterns, such as streaming, Server Components and the new Next.js app router, see the [Advanced Server Rendering guide](./advanced-ssr.md).
 
-If you just want to see some code, you can skip ahead to the [Full Next.js pages router example](#full-nextjs-pages-router-example) or the [Full Remix example](#full-remix-example) below.
+If you just want to see some code, you can skip ahead to the [Full Next.js pages router example](#full-next-js-pages-router-example) or the [Full Remix example](#full-remix-example) below.
 
 ## Server Rendering & React Query
 

--- a/docs/reference/MutationCache.md
+++ b/docs/reference/MutationCache.md
@@ -22,9 +22,9 @@ const mutationCache = new MutationCache({
 
 Its available methods are:
 
-- [`getAll`](#mutationcachegetall)
-- [`subscribe`](#mutationcachesubscribe)
-- [`clear`](#mutationcacheclear)
+- [`getAll`](#mutationcache-getall)
+- [`subscribe`](#mutationcache-subscribe)
+- [`clear`](#mutationcache-clear)
 
 **Options**
 

--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -27,10 +27,10 @@ const query = queryCache.find({ queryKey: ['posts'] })
 
 Its available methods are:
 
-- [`queryCache.find`](#querycachefind)
-- [`queryCache.findAll`](#querycachefindall)
-- [`queryCache.subscribe`](#querycachesubscribe)
-- [`queryCache.clear`](#querycacheclear)
+- [`queryCache.find`](#querycache-find)
+- [`queryCache.findAll`](#querycache-findall)
+- [`queryCache.subscribe`](#querycache-subscribe)
+- [`queryCache.clear`](#querycache-clear)
 - [Further reading](#further-reading)
 
 **Options**

--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -23,34 +23,34 @@ await queryClient.prefetchQuery({ queryKey: ['posts'], queryFn: fetchPosts })
 
 Its available methods are:
 
-- [`queryClient.fetchQuery`](#queryclientfetchquery)
-- [`queryClient.fetchInfiniteQuery`](#queryclientfetchinfinitequery)
-- [`queryClient.prefetchQuery`](#queryclientprefetchquery)
-- [`queryClient.prefetchInfiniteQuery`](#queryclientprefetchinfinitequery)
-- [`queryClient.getQueryData`](#queryclientgetquerydata)
-- [`queryClient.ensureQueryData`](#queryclientensurequerydata)
-- [`queryClient.ensureInfiniteQueryData`](#queryclientensureinfinitequerydata)
-- [`queryClient.getQueriesData`](#queryclientgetqueriesdata)
-- [`queryClient.setQueryData`](#queryclientsetquerydata)
-- [`queryClient.getQueryState`](#queryclientgetquerystate)
-- [`queryClient.setQueriesData`](#queryclientsetqueriesdata)
-- [`queryClient.invalidateQueries`](#queryclientinvalidatequeries)
-- [`queryClient.refetchQueries`](#queryclientrefetchqueries)
-- [`queryClient.cancelQueries`](#queryclientcancelqueries)
-- [`queryClient.removeQueries`](#queryclientremovequeries)
-- [`queryClient.resetQueries`](#queryclientresetqueries)
-- [`queryClient.isFetching`](#queryclientisfetching)
-- [`queryClient.isMutating`](#queryclientismutating)
-- [`queryClient.getDefaultOptions`](#queryclientgetdefaultoptions)
-- [`queryClient.setDefaultOptions`](#queryclientsetdefaultoptions)
-- [`queryClient.getQueryDefaults`](#queryclientgetquerydefaults)
-- [`queryClient.setQueryDefaults`](#queryclientsetquerydefaults)
-- [`queryClient.getMutationDefaults`](#queryclientgetmutationdefaults)
-- [`queryClient.setMutationDefaults`](#queryclientsetmutationdefaults)
-- [`queryClient.getQueryCache`](#queryclientgetquerycache)
-- [`queryClient.getMutationCache`](#queryclientgetmutationcache)
-- [`queryClient.clear`](#queryclientclear)
-- [`queryClient.resumePausedMutations`](#queryclientresumepausedmutations)
+- [`queryClient.fetchQuery`](#queryclient-fetchquery)
+- [`queryClient.fetchInfiniteQuery`](#queryclient-fetchinfinitequery)
+- [`queryClient.prefetchQuery`](#queryclient-prefetchquery)
+- [`queryClient.prefetchInfiniteQuery`](#queryclient-prefetchinfinitequery)
+- [`queryClient.getQueryData`](#queryclient-getquerydata)
+- [`queryClient.ensureQueryData`](#queryclient-ensurequerydata)
+- [`queryClient.ensureInfiniteQueryData`](#queryclient-ensureinfinitequerydata)
+- [`queryClient.getQueriesData`](#queryclient-getqueriesdata)
+- [`queryClient.setQueryData`](#queryclient-setquerydata)
+- [`queryClient.getQueryState`](#queryclient-getquerystate)
+- [`queryClient.setQueriesData`](#queryclient-setqueriesdata)
+- [`queryClient.invalidateQueries`](#queryclient-invalidatequeries)
+- [`queryClient.refetchQueries`](#queryclient-refetchqueries)
+- [`queryClient.cancelQueries`](#queryclient-cancelqueries)
+- [`queryClient.removeQueries`](#queryclient-removequeries)
+- [`queryClient.resetQueries`](#queryclient-resetqueries)
+- [`queryClient.isFetching`](#queryclient-isfetching)
+- [`queryClient.isMutating`](#queryclient-ismutating)
+- [`queryClient.getDefaultOptions`](#queryclient-getdefaultoptions)
+- [`queryClient.setDefaultOptions`](#queryclient-setdefaultoptions)
+- [`queryClient.getQueryDefaults`](#queryclient-getquerydefaults)
+- [`queryClient.setQueryDefaults`](#queryclient-setquerydefaults)
+- [`queryClient.getMutationDefaults`](#queryclient-getmutationdefaults)
+- [`queryClient.setMutationDefaults`](#queryclient-setmutationdefaults)
+- [`queryClient.getQueryCache`](#queryclient-getquerycache)
+- [`queryClient.getMutationCache`](#queryclient-getmutationcache)
+- [`queryClient.clear`](#queryclient-clear)
+- [`queryClient.resumePausedMutations`](#queryclient-resumepausedmutations)
 
 **Options**
 
@@ -116,7 +116,7 @@ try {
 
 **Options**
 
-The options for `fetchInfiniteQuery` are exactly the same as those of [`fetchQuery`](#queryclientfetchquery).
+The options for `fetchInfiniteQuery` are exactly the same as those of [`fetchQuery`](#queryclient-fetchquery).
 
 **Returns**
 
@@ -138,7 +138,7 @@ await queryClient.prefetchQuery({ queryKey })
 
 **Options**
 
-The options for `prefetchQuery` are exactly the same as those of [`fetchQuery`](#queryclientfetchquery).
+The options for `prefetchQuery` are exactly the same as those of [`fetchQuery`](#queryclient-fetchquery).
 
 **Returns**
 
@@ -155,7 +155,7 @@ await queryClient.prefetchInfiniteQuery({ queryKey, queryFn })
 
 **Options**
 
-The options for `prefetchInfiniteQuery` are exactly the same as those of [`fetchQuery`](#queryclientfetchquery).
+The options for `prefetchInfiniteQuery` are exactly the same as those of [`fetchQuery`](#queryclient-fetchquery).
 
 **Returns**
 
@@ -189,7 +189,7 @@ const data = await queryClient.ensureQueryData({ queryKey, queryFn })
 
 **Options**
 
-- the same options as [`fetchQuery`](#queryclientfetchquery)
+- the same options as [`fetchQuery`](#queryclient-fetchquery)
 - `revalidateIfStale: boolean`
   - Optional
   - Defaults to `false`
@@ -214,7 +214,7 @@ const data = await queryClient.ensureInfiniteQueryData({
 
 **Options**
 
-- the same options as [`fetchInfiniteQuery`](#queryclientfetchinfinitequery)
+- the same options as [`fetchInfiniteQuery`](#queryclient-fetchinfinitequery)
 - `revalidateIfStale: boolean`
   - Optional
   - Defaults to `false`
@@ -250,7 +250,7 @@ This distinction is more a "convenience" for ts devs that know which structure w
 
 ## `queryClient.setQueryData`
 
-`setQueryData` is a synchronous function that can be used to immediately update a query's cached data. If the query does not exist, it will be created. **If the query is not utilized by a query hook within the default `gcTime`, the query will be garbage collected. If the default `gcTime` has not been configured, it defaults to 5 minutes.** To update multiple queries at once and match query keys partially, you need to use [`queryClient.setQueriesData`](#queryclientsetqueriesdata) instead.
+`setQueryData` is a synchronous function that can be used to immediately update a query's cached data. If the query does not exist, it will be created. **If the query is not utilized by a query hook within the default `gcTime`, the query will be garbage collected. If the default `gcTime` has not been configured, it defaults to 5 minutes.** To update multiple queries at once and match query keys partially, you need to use [`queryClient.setQueriesData`](#queryclient-setqueriesdata) instead.
 
 > The difference between using `setQueryData` and `fetchQuery` is that `setQueryData` is sync and assumes that you already synchronously have the data available. If you need to fetch the data asynchronously, it's suggested that you either refetch the query key or use `fetchQuery` to handle the asynchronous fetch.
 
@@ -302,7 +302,7 @@ console.log(state.dataUpdatedAt)
 
 ## `queryClient.setQueriesData`
 
-`setQueriesData` is a synchronous function that can be used to immediately update cached data of multiple queries by using filter function or partially matching the query key. Only queries that match the passed queryKey or queryFilter will be updated - no new cache entries will be created. Under the hood, [`setQueryData`](#queryclientsetquerydata) is called for each existing query.
+`setQueriesData` is a synchronous function that can be used to immediately update cached data of multiple queries by using filter function or partially matching the query key. Only queries that match the passed queryKey or queryFilter will be updated - no new cache entries will be created. Under the hood, [`setQueryData`](#queryclient-setquerydata) is called for each existing query.
 
 ```tsx
 queryClient.setQueriesData(filters, updater)
@@ -313,7 +313,7 @@ queryClient.setQueriesData(filters, updater)
 - `filters: QueryFilters`: [Query Filters](../framework/react/guides/filters.md#query-filters)
   - if a filter is passed, queryKeys matching the filter will be updated
 - `updater: TQueryFnData | (oldData: TQueryFnData | undefined) => TQueryFnData`
-  - the [setQueryData](#queryclientsetquerydata) updater function or new data, will be called for each matching queryKey
+  - the [setQueryData](#queryclient-setquerydata) updater function or new data, will be called for each matching queryKey
 
 ## `queryClient.invalidateQueries`
 
@@ -321,7 +321,7 @@ The `invalidateQueries` method can be used to invalidate and refetch single or m
 
 - If you **do not want active queries to refetch**, and simply be marked as invalid, you can use the `refetchType: 'none'` option.
 - If you **want inactive queries to refetch** as well, use the `refetchType: 'all'` option
-- For refetching, [queryClient.refetchQueries](#queryclientrefetchqueries) is called.
+- For refetching, [queryClient.refetchQueries](#queryclient-refetchqueries) is called.
 
 ```tsx
 await queryClient.invalidateQueries(
@@ -354,8 +354,8 @@ await queryClient.invalidateQueries(
 
 **Notes**
 
-- Unlike [`refetchQueries`](#queryclientrefetchqueries), `invalidateQueries` marks matching queries as invalidated and then refetches `active` queries (unless otherwise specified with the `refetchType` option).
-- Unlike [`removeQueries`](#queryclientremovequeries), `invalidateQueries` keeps matching queries in the cache.
+- Unlike [`refetchQueries`](#queryclient-refetchqueries), `invalidateQueries` marks matching queries as invalidated and then refetches `active` queries (unless otherwise specified with the `refetchType` option).
+- Unlike [`removeQueries`](#queryclient-removequeries), `invalidateQueries` keeps matching queries in the cache.
 
 ## `queryClient.refetchQueries`
 
@@ -400,7 +400,7 @@ This function returns a promise that will resolve when all of the queries are do
 
 - Queries that are "disabled" because they only have disabled Observers will never be refetched.
 - Queries that are "static" because they only have Observers with a Static StaleTime will never be refetched.
-- Unlike [`invalidateQueries`](#queryclientinvalidatequeries), `refetchQueries` refetches all matching queries.
+- Unlike [`invalidateQueries`](#queryclient-invalidatequeries), `refetchQueries` refetches all matching queries.
 
 ## `queryClient.cancelQueries`
 
@@ -442,7 +442,7 @@ This method does not return anything
 
 **Notes**
 
-- Unlike [`invalidateQueries`](#queryclientinvalidatequeries) or [`refetchQueries`](#queryclientrefetchqueries), `removeQueries` removes matching queries from the cache instead of refetching them.
+- Unlike [`invalidateQueries`](#queryclient-invalidatequeries) or [`refetchQueries`](#queryclient-refetchqueries), `removeQueries` removes matching queries from the cache instead of refetching them.
 
 ## `queryClient.resetQueries`
 
@@ -543,7 +543,7 @@ const defaultOptions = queryClient.getQueryDefaults(['posts'])
 ```
 
 > Note that if several query defaults match the given query key, they will be merged together based on the order of registration.
-> See [`setQueryDefaults`](#queryclientsetquerydefaults).
+> See [`setQueryDefaults`](#queryclient-setquerydefaults).
 
 ## `queryClient.setQueryDefaults`
 
@@ -562,7 +562,7 @@ function Component() {
 - `queryKey: QueryKey`: [Query Keys](../framework/react/guides/query-keys.md)
 - `options: QueryOptions`
 
-> As stated in [`getQueryDefaults`](#queryclientgetquerydefaults), the order of registration of query defaults does matter.
+> As stated in [`getQueryDefaults`](#queryclient-getquerydefaults), the order of registration of query defaults does matter.
 > Since the matching defaults are merged by `getQueryDefaults`, the registration should be made in the following order: from the **most generic key** to the **least generic one** .
 > This way, more specific defaults will override more generic defaults.
 
@@ -591,7 +591,7 @@ function Component() {
 - `mutationKey: unknown[]`
 - `options: MutationOptions`
 
-> Similar to [`setQueryDefaults`](#queryclientsetquerydefaults), the order of registration does matter here.
+> Similar to [`setQueryDefaults`](#queryclient-setquerydefaults), the order of registration does matter here.
 
 ## `queryClient.getQueryCache`
 

--- a/docs/reference/environmentManager.md
+++ b/docs/reference/environmentManager.md
@@ -11,8 +11,8 @@ Use this manager to override server detection globally for runtimes that are not
 
 Its available methods are:
 
-- [`isServer`](#environmentmanagerisserver)
-- [`setIsServer`](#environmentmanagersetisserver)
+- [`isServer`](#environmentmanager-isserver)
+- [`setIsServer`](#environmentmanager-setisserver)
 
 ## `environmentManager.isServer`
 

--- a/docs/reference/focusManager.md
+++ b/docs/reference/focusManager.md
@@ -9,10 +9,10 @@ It can be used to change the default event listeners or to manually change the f
 
 Its available methods are:
 
-- [`setEventListener`](#focusmanagerseteventlistener)
-- [`subscribe`](#focusmanagersubscribe)
-- [`setFocused`](#focusmanagersetfocused)
-- [`isFocused`](#focusmanagerisfocused)
+- [`setEventListener`](#focusmanager-seteventlistener)
+- [`subscribe`](#focusmanager-subscribe)
+- [`setFocused`](#focusmanager-setfocused)
+- [`isFocused`](#focusmanager-isfocused)
 
 ## `focusManager.setEventListener`
 

--- a/docs/reference/notifyManager.md
+++ b/docs/reference/notifyManager.md
@@ -7,12 +7,12 @@ The `notifyManager` handles scheduling and batching callbacks in TanStack Query.
 
 It exposes the following methods:
 
-- [batch](#notifymanagerbatch)
-- [batchCalls](#notifymanagerbatchcalls)
-- [schedule](#notifymanagerschedule)
-- [setNotifyFunction](#notifymanagersetnotifyfunction)
-- [setBatchNotifyFunction](#notifymanagersetbatchnotifyfunction)
-- [setScheduler](#notifymanagersetscheduler)
+- [batch](#notifymanager-batch)
+- [batchCalls](#notifymanager-batchcalls)
+- [schedule](#notifymanager-schedule)
+- [setNotifyFunction](#notifymanager-setnotifyfunction)
+- [setBatchNotifyFunction](#notifymanager-setbatchnotifyfunction)
+- [setScheduler](#notifymanager-setscheduler)
 
 ## `notifyManager.batch`
 

--- a/docs/reference/onlineManager.md
+++ b/docs/reference/onlineManager.md
@@ -15,10 +15,10 @@ The `OnlineManager` manages the online state within TanStack Query. It can be us
 
 Its available methods are:
 
-- [`setEventListener`](#onlinemanagerseteventlistener)
-- [`subscribe`](#onlinemanagersubscribe)
-- [`setOnline`](#onlinemanagersetonline)
-- [`isOnline`](#onlinemanagerisonline)
+- [`setEventListener`](#onlinemanager-seteventlistener)
+- [`subscribe`](#onlinemanager-subscribe)
+- [`setOnline`](#onlinemanager-setonline)
+- [`isOnline`](#onlinemanager-isonline)
 
 ## `onlineManager.setEventListener`
 

--- a/docs/reference/timeoutManager.md
+++ b/docs/reference/timeoutManager.md
@@ -11,12 +11,12 @@ By default, TimeoutManager uses the global `setTimeout` and `setInterval`, but i
 
 Its available methods are:
 
-- [`timeoutManager.setTimeoutProvider`](#timeoutmanagersettimeoutprovider)
+- [`timeoutManager.setTimeoutProvider`](#timeoutmanager-settimeoutprovider)
   - [`TimeoutProvider`](#timeoutprovider)
-- [`timeoutManager.setTimeout`](#timeoutmanagersettimeout)
-- [`timeoutManager.clearTimeout`](#timeoutmanagercleartimeout)
-- [`timeoutManager.setInterval`](#timeoutmanagersetinterval)
-- [`timeoutManager.clearInterval`](#timeoutmanagerclearinterval)
+- [`timeoutManager.setTimeout`](#timeoutmanager-settimeout)
+- [`timeoutManager.clearTimeout`](#timeoutmanager-cleartimeout)
+- [`timeoutManager.setInterval`](#timeoutmanager-setinterval)
+- [`timeoutManager.clearInterval`](#timeoutmanager-clearinterval)
 
 ## `timeoutManager.setTimeoutProvider`
 


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

I updated the format of the links used to navigate between sections in the documentation.
Currently, clicking a section link in the documentation does not navigate to the corresponding section on the web.
The . in the section name needs to be replaced with '-' for the link to work correctly on the web.

**Before**

https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientfetchquery

**After**

https://tanstack.com/query/latest/docs/reference/QueryClient#queryclient-fetchquery

The trade off is that section navigation no longer works in the IDE with the new format.
However, I think web navigation should take priority since the documentation is primarily accessed through the web.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected internal links across the React SSR guide and API reference pages.
  * Updated table-of-contents and cross-reference anchors to reliably navigate to documented methods and sections.
  * Improved navigation for query, mutation, cache, environment, focus, notification, online, and timeout management references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->