### PR TITLE
fix(query-core): release the retryer once a fetch settles

### DIFF
--- a/.changeset/release-settled-retryer.md
+++ b/.changeset/release-settled-retryer.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Release a query's retryer once its fetch settles, so the settled promise no longer keeps that fetch's raw result in memory alongside the structurally shared `state.data` (or after the query is reset or removed).

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -7,6 +7,7 @@ import {
 import {
   CancelledError,
   Query,
+  QueryCache,
   QueryClient,
   QueryObserver,
   dehydrate,
@@ -14,12 +15,7 @@ import {
 } from '..'
 import { hashQueryKeyByOptions } from '../utils'
 import { mockOnlineManagerIsOnline, setIsServer } from './utils'
-import type {
-  QueryCache,
-  QueryFunctionContext,
-  QueryKey,
-  QueryObserverResult,
-} from '..'
+import type { QueryFunctionContext, QueryKey, QueryObserverResult } from '..'
 
 describe('query', () => {
   let queryClient: QueryClient
@@ -541,6 +537,35 @@ describe('query', () => {
 
     expect(query.state.error).toBe(error)
     expect(query.state.error).not.toBeInstanceOf(CancelledError)
+  })
+
+  it('should release the retryer once its fetch has settled', async () => {
+    const key = queryKey()
+    let refetch: Promise<unknown> | undefined
+    const testCache = new QueryCache({
+      onSuccess: (_data, query) => {
+        refetch ??= query.fetch()
+      },
+    })
+    const testClient = new QueryClient({ queryCache: testCache })
+
+    const prefetch = testClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'data'),
+    })
+    const query = testCache.find({ queryKey: key })!
+    const firstPromise = query.promise
+    expect(firstPromise).toBeDefined()
+
+    await vi.advanceTimersByTimeAsync(10)
+    await prefetch
+    expect(query.promise).toBeDefined()
+    expect(query.promise).not.toBe(firstPromise)
+
+    await vi.advanceTimersByTimeAsync(10)
+    await refetch
+    expect(query.state.data).toBe('data')
+    expect(query.promise).toBeUndefined()
   })
 
   it('the previous query status should be kept when refetching', async () => {

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -533,7 +533,7 @@ export class Query<
     }
 
     // Try to fetch the data
-    this.#retryer = createRetryer({
+    const retryer = (this.#retryer = createRetryer({
       initialPromise: fetchOptions?.initialPromise as
         | Promise<TData>
         | undefined,
@@ -560,10 +560,10 @@ export class Query<
       retryDelay: context.options.retryDelay,
       networkMode: context.options.networkMode,
       canRun: () => true,
-    })
+    }))
 
     try {
-      const data = await this.#retryer.start()
+      const data = await retryer.start()
       // this is more of a runtime guard
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (data === undefined) {
@@ -619,6 +619,11 @@ export class Query<
 
       throw error // rethrow the error for further handling
     } finally {
+      // The settled retryer's promise would otherwise pin this fetch's raw
+      // result (a second copy after structural sharing) for the query's lifetime
+      if (this.#retryer === retryer) {
+        this.#retryer = undefined
+      }
       // Schedule query gc after fetching
       this.scheduleGc()
     }


### PR DESCRIPTION
## 🎯 Changes

`Query.fetch()` leaves `#retryer` set after the fetch settles. The retryer's resolved promise still holds the raw result of that fetch, so once a query has refetched it holds its data twice: the structurally shared objects in `state.data`, plus the fresh result the promise resolved with. It also means `reset()` and `removeQueries()` don't free the data while anything still points at the query.

This clears `#retryer` in the existing `finally` once the fetch has settled. The identity check is there so a fetch started synchronously from a cache `onSuccess`/`onSettled` callback keeps its own retryer. The other readers of `#retryer` are already behind `?.` or a `fetchStatus` check, so the only visible change is that `query.promise` is `undefined` after a fetch has settled instead of the settled promise.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Released query retry resources after fetches settle, queries reset, or queries are removed.
  * Prevented settled promises from retaining unnecessary fetch results.
  * Ensured callback-triggered refetches complete correctly after an initial fetch.

* **Release**
  * Included in a patch release of the query core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
