### PR TITLE
fix({react,preact}-query): add NoInfer to infinite and suspense hook return types

### DIFF
--- a/.changeset/noinfer-infinite-suspense-hooks.md
+++ b/.changeset/noinfer-infinite-suspense-hooks.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-query': patch
+'@tanstack/preact-query': patch
+---
+
+Add `NoInfer` to the return types of `useInfiniteQuery`, `useSuspenseQuery`, and `useSuspenseInfiniteQuery` so that an explicitly annotated result type can no longer reverse-infer `TData`, matching `useQuery`. A distributive wrapper is used so discriminated-union narrowing on `data` keeps working.

--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -3,6 +3,7 @@ import type { InfiniteData } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { describe, expectTypeOf, it } from 'vitest'
 
+import type { UseInfiniteQueryResult } from '../types'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 
 describe('pageParam', () => {
@@ -140,5 +141,41 @@ describe('error booleans', () => {
     expectTypeOf(isFetchPreviousPageError).toEqualTypeOf<boolean>()
     expectTypeOf(isLoadingError).toEqualTypeOf<boolean>()
     expectTypeOf(isRefetchError).toEqualTypeOf<boolean>()
+  })
+})
+
+describe('NoInfer', () => {
+  // eslint-disable-next-line vitest/expect-expect
+  it('TData should depend only on the arguments, not the annotated result', () => {
+    // @ts-expect-error
+    const result: UseInfiniteQueryResult<InfiniteData<{ wow: string }>> =
+      useInfiniteQuery({
+        queryKey: queryKey(),
+        queryFn: () => ({ wow: true }),
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+      })
+
+    void result
+  })
+
+  it('should preserve discriminated-union narrowing on data', () => {
+    type Item =
+      | { type: 'first'; first: string }
+      | { type: 'second'; second: string }
+
+    const { data } = useInfiniteQuery({
+      queryKey: queryKey(),
+      queryFn: (): Item => ({ type: 'first', first: 'a' }),
+      initialPageParam: 1,
+      getNextPageParam: () => undefined,
+      select: (infiniteData) => infiniteData.pages[0],
+    })
+
+    const second = data?.type === 'first' ? undefined : data
+
+    expectTypeOf(second).toEqualTypeOf<
+      { type: 'second'; second: string } | undefined
+    >()
   })
 })

--- a/packages/preact-query/src/__tests__/useSuspenseInfiniteQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseInfiniteQuery.test-d.tsx
@@ -3,6 +3,7 @@ import type { InfiniteData } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 
+import type { UseSuspenseInfiniteQueryResult } from '../types'
 import { useSuspenseInfiniteQuery } from '../useSuspenseInfiniteQuery'
 
 describe('useSuspenseInfiniteQuery', () => {
@@ -91,5 +92,41 @@ describe('useSuspenseInfiniteQuery', () => {
     })
 
     expectTypeOf(query).not.toHaveProperty('isPlaceholderData')
+  })
+})
+
+describe('NoInfer', () => {
+  // eslint-disable-next-line vitest/expect-expect
+  it('TData should depend only on the arguments, not the annotated result', () => {
+    // @ts-expect-error
+    const result: UseSuspenseInfiniteQueryResult<InfiniteData<{ wow: string }>> =
+      useSuspenseInfiniteQuery({
+        queryKey: queryKey(),
+        queryFn: () => ({ wow: true }),
+        initialPageParam: 1,
+        getNextPageParam: () => 1,
+      })
+
+    void result
+  })
+
+  it('should preserve discriminated-union narrowing on data', () => {
+    type Item =
+      | { type: 'first'; first: string }
+      | { type: 'second'; second: string }
+
+    const { data } = useSuspenseInfiniteQuery({
+      queryKey: queryKey(),
+      queryFn: (): Item => ({ type: 'first', first: 'a' }),
+      initialPageParam: 1,
+      getNextPageParam: () => 1,
+      select: (infiniteData) => infiniteData.pages[0],
+    })
+
+    const second = data?.type === 'first' ? undefined : data
+
+    expectTypeOf(second).toEqualTypeOf<
+      { type: 'second'; second: string } | undefined
+    >()
   })
 })

--- a/packages/preact-query/src/__tests__/useSuspenseQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQuery.test-d.tsx
@@ -2,6 +2,7 @@ import { skipToken } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 
+import type { UseSuspenseQueryResult } from '../types'
 import { useSuspenseQuery } from '../useSuspenseQuery'
 
 describe('useSuspenseQuery', () => {
@@ -86,5 +87,35 @@ describe('useSuspenseQuery', () => {
     if (query.status === 'error') {
       expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
+  })
+})
+
+describe('NoInfer', () => {
+  // eslint-disable-next-line vitest/expect-expect
+  it('TData should depend only on the arguments, not the annotated result', () => {
+    // @ts-expect-error
+    const result: UseSuspenseQueryResult<{ wow: string }> = useSuspenseQuery({
+      queryKey: queryKey(),
+      queryFn: () => ({ wow: true }),
+    })
+
+    void result
+  })
+
+  it('should preserve discriminated-union narrowing on data', () => {
+    type Result =
+      | { type: 'first'; first: string }
+      | { type: 'second'; second: string }
+
+    const { data } = useSuspenseQuery({
+      queryKey: queryKey(),
+      queryFn: (): Result => ({ type: 'first', first: 'a' }),
+    })
+
+    const second = data.type === 'first' ? undefined : data
+
+    expectTypeOf(second).toEqualTypeOf<
+      { type: 'second'; second: string } | undefined
+    >()
   })
 })

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -18,6 +18,8 @@ import type {
 } from './types'
 import { useBaseQuery } from './useBaseQuery'
 
+type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never
+
 export function useInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
@@ -33,7 +35,7 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): DefinedUseInfiniteQueryResult<TData, TError>
+): DefinedUseInfiniteQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useInfiniteQuery<
   TQueryFnData,
@@ -50,7 +52,7 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useInfiniteQuery<
   TQueryFnData,
@@ -67,7 +69,7 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useInfiniteQuery(
   options: UseInfiniteQueryOptions,

--- a/packages/preact-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/preact-query/src/useSuspenseInfiniteQuery.ts
@@ -15,6 +15,8 @@ import type {
 } from './types'
 import { useBaseQuery } from './useBaseQuery'
 
+type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never
+
 export function useSuspenseInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
@@ -30,7 +32,7 @@ export function useSuspenseInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseSuspenseInfiniteQueryResult<TData, TError> {
+): UseSuspenseInfiniteQueryResult<NarrowableNoInfer<TData>, TError> {
   if (process.env.NODE_ENV !== 'production') {
     if ((options.queryFn as any) === skipToken) {
       console.error('skipToken is not allowed for useSuspenseInfiniteQuery')

--- a/packages/preact-query/src/useSuspenseQuery.ts
+++ b/packages/preact-query/src/useSuspenseQuery.ts
@@ -5,6 +5,8 @@ import { defaultThrowOnError } from './suspense'
 import type { UseSuspenseQueryOptions, UseSuspenseQueryResult } from './types'
 import { useBaseQuery } from './useBaseQuery'
 
+type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never
+
 export function useSuspenseQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -13,7 +15,7 @@ export function useSuspenseQuery<
 >(
   options: UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseSuspenseQueryResult<TData, TError> {
+): UseSuspenseQueryResult<NarrowableNoInfer<TData>, TError> {
   if (process.env.NODE_ENV !== 'production') {
     if ((options.queryFn as any) === skipToken) {
       console.error('skipToken is not allowed for useSuspenseQuery')

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -3,6 +3,7 @@ import { QueryClient } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import type { InfiniteData } from '@tanstack/query-core'
+import type { UseInfiniteQueryResult } from '../types'
 
 describe('pageParam', () => {
   it('initialPageParam should define type of param passed to queryFunctionContext', () => {
@@ -139,5 +140,41 @@ describe('error booleans', () => {
     expectTypeOf(isFetchPreviousPageError).toEqualTypeOf<boolean>()
     expectTypeOf(isLoadingError).toEqualTypeOf<boolean>()
     expectTypeOf(isRefetchError).toEqualTypeOf<boolean>()
+  })
+})
+
+describe('NoInfer', () => {
+  // eslint-disable-next-line vitest/expect-expect
+  it('TData should depend only on the arguments, not the annotated result', () => {
+    // @ts-expect-error
+    const result: UseInfiniteQueryResult<InfiniteData<{ wow: string }>> =
+      useInfiniteQuery({
+        queryKey: queryKey(),
+        queryFn: () => ({ wow: true }),
+        initialPageParam: 1,
+        getNextPageParam: () => undefined,
+      })
+
+    void result
+  })
+
+  it('should preserve discriminated-union narrowing on data', () => {
+    type Item =
+      | { type: 'first'; first: string }
+      | { type: 'second'; second: string }
+
+    const { data } = useInfiniteQuery({
+      queryKey: queryKey(),
+      queryFn: (): Item => ({ type: 'first', first: 'a' }),
+      initialPageParam: 1,
+      getNextPageParam: () => undefined,
+      select: (infiniteData) => infiniteData.pages[0],
+    })
+
+    const second = data?.type === 'first' ? undefined : data
+
+    expectTypeOf(second).toEqualTypeOf<
+      { type: 'second'; second: string } | undefined
+    >()
   })
 })

--- a/packages/react-query/src/__tests__/useSuspenseInfiniteQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseInfiniteQuery.test-d.tsx
@@ -3,6 +3,7 @@ import { skipToken } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { useSuspenseInfiniteQuery } from '../useSuspenseInfiniteQuery'
 import type { InfiniteData } from '@tanstack/query-core'
+import type { UseSuspenseInfiniteQueryResult } from '../types'
 
 describe('useSuspenseInfiniteQuery', () => {
   it('should always have data defined', () => {
@@ -90,5 +91,41 @@ describe('useSuspenseInfiniteQuery', () => {
     })
 
     expectTypeOf(query).not.toHaveProperty('isPlaceholderData')
+  })
+})
+
+describe('NoInfer', () => {
+  // eslint-disable-next-line vitest/expect-expect
+  it('TData should depend only on the arguments, not the annotated result', () => {
+    // @ts-expect-error
+    const result: UseSuspenseInfiniteQueryResult<InfiniteData<{ wow: string }>> =
+      useSuspenseInfiniteQuery({
+        queryKey: queryKey(),
+        queryFn: () => ({ wow: true }),
+        initialPageParam: 1,
+        getNextPageParam: () => 1,
+      })
+
+    void result
+  })
+
+  it('should preserve discriminated-union narrowing on data', () => {
+    type Item =
+      | { type: 'first'; first: string }
+      | { type: 'second'; second: string }
+
+    const { data } = useSuspenseInfiniteQuery({
+      queryKey: queryKey(),
+      queryFn: (): Item => ({ type: 'first', first: 'a' }),
+      initialPageParam: 1,
+      getNextPageParam: () => 1,
+      select: (infiniteData) => infiniteData.pages[0],
+    })
+
+    const second = data?.type === 'first' ? undefined : data
+
+    expectTypeOf(second).toEqualTypeOf<
+      { type: 'second'; second: string } | undefined
+    >()
   })
 })

--- a/packages/react-query/src/__tests__/useSuspenseQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQuery.test-d.tsx
@@ -2,6 +2,7 @@ import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { skipToken } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { useSuspenseQuery } from '../useSuspenseQuery'
+import type { UseSuspenseQueryResult } from '../types'
 
 describe('useSuspenseQuery', () => {
   it('should always have data defined', () => {
@@ -85,5 +86,35 @@ describe('useSuspenseQuery', () => {
     if (query.status === 'error') {
       expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
+  })
+})
+
+describe('NoInfer', () => {
+  // eslint-disable-next-line vitest/expect-expect
+  it('TData should depend only on the arguments, not the annotated result', () => {
+    // @ts-expect-error
+    const result: UseSuspenseQueryResult<{ wow: string }> = useSuspenseQuery({
+      queryKey: queryKey(),
+      queryFn: () => ({ wow: true }),
+    })
+
+    void result
+  })
+
+  it('should preserve discriminated-union narrowing on data', () => {
+    type Result =
+      | { type: 'first'; first: string }
+      | { type: 'second'; second: string }
+
+    const { data } = useSuspenseQuery({
+      queryKey: queryKey(),
+      queryFn: (): Result => ({ type: 'first', first: 'a' }),
+    })
+
+    const second = data.type === 'first' ? undefined : data
+
+    expectTypeOf(second).toEqualTypeOf<
+      { type: 'second'; second: string } | undefined
+    >()
   })
 })

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -18,6 +18,8 @@ import type {
   UndefinedInitialDataInfiniteOptions,
 } from './infiniteQueryOptions'
 
+type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never
+
 export function useInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
@@ -33,7 +35,7 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): DefinedUseInfiniteQueryResult<TData, TError>
+): DefinedUseInfiniteQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useInfiniteQuery<
   TQueryFnData,
@@ -50,7 +52,7 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useInfiniteQuery<
   TQueryFnData,
@@ -67,7 +69,7 @@ export function useInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseInfiniteQueryResult<TData, TError>
+): UseInfiniteQueryResult<NarrowableNoInfer<TData>, TError>
 
 export function useInfiniteQuery(
   options: UseInfiniteQueryOptions,

--- a/packages/react-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/react-query/src/useSuspenseInfiniteQuery.ts
@@ -15,6 +15,8 @@ import type {
   UseSuspenseInfiniteQueryResult,
 } from './types'
 
+type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never
+
 export function useSuspenseInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
@@ -30,7 +32,7 @@ export function useSuspenseInfiniteQuery<
     TPageParam
   >,
   queryClient?: QueryClient,
-): UseSuspenseInfiniteQueryResult<TData, TError> {
+): UseSuspenseInfiniteQueryResult<NarrowableNoInfer<TData>, TError> {
   if (process.env.NODE_ENV !== 'production') {
     if ((options.queryFn as any) === skipToken) {
       console.error('skipToken is not allowed for useSuspenseInfiniteQuery')

--- a/packages/react-query/src/useSuspenseQuery.ts
+++ b/packages/react-query/src/useSuspenseQuery.ts
@@ -5,6 +5,8 @@ import { defaultThrowOnError } from './suspense'
 import type { UseSuspenseQueryOptions, UseSuspenseQueryResult } from './types'
 import type { DefaultError, QueryClient, QueryKey } from '@tanstack/query-core'
 
+type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never
+
 export function useSuspenseQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -13,7 +15,7 @@ export function useSuspenseQuery<
 >(
   options: UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseSuspenseQueryResult<TData, TError> {
+): UseSuspenseQueryResult<NarrowableNoInfer<TData>, TError> {
   if (process.env.NODE_ENV !== 'production') {
     if ((options.queryFn as any) === skipToken) {
       console.error('skipToken is not allowed for useSuspenseQuery')


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #8639: `useQuery`'s return types already fence `TData` with `NoInfer`, but `useInfiniteQuery`, `useSuspenseQuery`, and `useSuspenseInfiniteQuery` still let an explicitly annotated result type reverse-infer `TData` — an annotation that contradicts the actual `queryFn`/`select` type compiles fine and then fails at runtime (the scenario reported in #8639).

- Wrap `TData` in the return types of `useInfiniteQuery` (all three overloads), `useSuspenseQuery`, and `useSuspenseInfiniteQuery`, in both `react-query` and `preact-query` (mirroring the cross-package approach of #11147).
- Use a distributive wrapper (`type NarrowableNoInfer<T> = T extends unknown ? NoInfer<T> : never`) instead of plain `NoInfer`: plain `NoInfer` breaks negative-branch discriminated-union narrowing on `data` — the regression #11018 reports for `useQuery`, and the same shape #11022 proposes there. I kept the helper file-local to avoid touching `useQuery.ts` and conflicting with that PR; happy to consolidate once either lands.
- Add type tests for each hook: the annotated-result reverse-inference guard (mirroring the existing `useQuery` test) plus a discriminated-union narrowing case.

Runtime behavior is unchanged — types only.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type inference for infinite and suspense query hooks.
  * Explicitly annotated result types no longer incorrectly influence inferred query data types.
  * Preserved discriminated-union narrowing when transforming or selecting query data.

* **Tests**
  * Added coverage for improved inference and type narrowing across React and Preact query hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->