### PR TITLE
fix(lit-query): brand infiniteQueryOptions queryKey with DataTag

### DIFF
--- a/.changeset/quiet-mice-invent.md
+++ b/.changeset/quiet-mice-invent.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/lit-query': patch
+---
+
+feat: add `DataTag` branding to `infiniteQueryOptions` queryKey so `setQueryData`/`getQueryData` infer the `InfiniteData` type, matching `queryOptions` and the other adapters

--- a/packages/lit-query/src/infiniteQueryOptions.ts
+++ b/packages/lit-query/src/infiniteQueryOptions.ts
@@ -1,4 +1,5 @@
 import type {
+  DataTag,
   DefaultError,
   InfiniteData,
   InfiniteQueryObserverOptions,
@@ -43,6 +44,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> {
+> & {
+  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
+} {
   return options
 }

--- a/packages/lit-query/src/tests/type-inference.test.ts
+++ b/packages/lit-query/src/tests/type-inference.test.ts
@@ -2,6 +2,7 @@ import {
   dataTagSymbol,
   QueryClient,
   type DefinedQueryObserverResult,
+  type InfiniteData,
   type QueryObserverResult,
 } from '@tanstack/query-core'
 import { describe, expectTypeOf, it } from 'vitest'
@@ -205,6 +206,27 @@ describe('type inference', () => {
     )
     expectTypeOf(infinite().data?.pages).toEqualTypeOf<
       Array<{ page: number }> | undefined
+    >()
+
+    const infiniteOpts = infiniteQueryOptions({
+      queryKey: ['type-inference', 'infinite-options'] as const,
+      initialPageParam: 0,
+      queryFn: async () => ({ page: 2 }),
+      getNextPageParam: (lastPage) => lastPage.page + 1,
+    })
+    expectTypeOf(infiniteOpts.queryKey[dataTagSymbol]).toEqualTypeOf<
+      InfiniteData<{ page: number }>
+    >()
+    const cachedInfinite = client.getQueryData(infiniteOpts.queryKey)
+    expectTypeOf(cachedInfinite).toEqualTypeOf<
+      InfiniteData<{ page: number }> | undefined
+    >()
+    const updatedInfinite = client.setQueryData(infiniteOpts.queryKey, {
+      pages: [{ page: 3 }],
+      pageParams: [0],
+    })
+    expectTypeOf(updatedInfinite).toEqualTypeOf<
+      InfiniteData<{ page: number }> | undefined
     >()
   })
 })


### PR DESCRIPTION
Fix [lit-query] `infiniteQueryOptions` missing `DataTag` on `queryKey` (#11142).

## Problem

`infiniteQueryOptions` was the only `*QueryOptions` helper not branding its `queryKey` with `DataTag`. As a result, `queryClient.setQueryData(infiniteQuerySlugType, ...)` / `getQueryData` could not infer the `InfiniteData` type from a tagged key — the updater's `old` data fell back to `unknown`, and caching through a shared options object lost its type safety.

`queryOptions` already brands the key (with type tests), and react-query, vue-query and solid-query all brand it in their `infiniteQueryOptions` — lit-query was the outlier.

## Changes

- `packages/lit-query/src/infiniteQueryOptions.ts`: return type now intersects `{ queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError> }` — same shape as react-query/vue-query.
- `packages/lit-query/src/tests/type-inference.test.ts`: regression tests mirroring the existing `queryOptions` checks — `queryKey[dataTagSymbol]` is `InfiniteData<{ page: number }>`, and `getQueryData`/`setQueryData` infer the tagged data (the exact scenario from the issue).
- `.changeset/quiet-mice-invent.md`: `patch` for `@tanstack/lit-query`.

## Test

The lit-query `test:lib` suite (type-inference tests run under `vitest` + `tsc`) is exercised by CI on this PR; could not run locally without installing the monorepo.

Closes #11142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for infinite query options.
  * `getQueryData` and `setQueryData` now correctly infer infinite query data types from associated query keys.

* **Tests**
  * Added coverage for inferred infinite-query data, cached data, and update results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->