### PR TITLE
docs(solid-query/useQuery): document 'throwOnError' default value and its exceptions

### DIFF
--- a/docs/framework/solid/reference/useQuery.md
+++ b/docs/framework/solid/reference/useQuery.md
@@ -293,6 +293,8 @@ function App() {
   - ##### `throwOnError: undefined | boolean | (error: TError, query: Query) => boolean`
     - Optional
     - Defaults to `false`
+    - During SSR, defaults to `true`
+    - If the deprecated `suspense` option is set to `true`, defaults to `true`
     - Set this to `true` if you want errors to be thrown in the render phase and propagate to the nearest error boundary
     - Set this to `false` to disable `suspense`'s default behavior of throwing errors to the error boundary.
     - If set to a function, it will be passed the error and the query, and it should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)

--- a/docs/framework/solid/reference/useQuery.md
+++ b/docs/framework/solid/reference/useQuery.md
@@ -291,6 +291,8 @@ function App() {
     - The time in milliseconds after data is considered stale. This value only applies to the hook it is defined on.
     - If set to `Infinity`, the data will never be considered stale
   - ##### `throwOnError: undefined | boolean | (error: TError, query: Query) => boolean`
+    - Optional
+    - Defaults to `false`
     - Set this to `true` if you want errors to be thrown in the render phase and propagate to the nearest error boundary
     - Set this to `false` to disable `suspense`'s default behavior of throwing errors to the error boundary.
     - If set to a function, it will be passed the error and the query, and it should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)


### PR DESCRIPTION
## Summary
- Add `Optional` / `Defaults to `false`` to the `throwOnError` option, matching the documentation pattern used by other options (`refetchOnMount`, `refetchOnWindowFocus`)
- Document that the default is `true` during SSR, and `true` when the deprecated `suspense` option is set to `true`