### PR TITLE
chore: upgrade to solid v2 rc, rename vite-plugin-solid, move branch to rc

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "beta",
+  "tag": "rc",
   "initialVersions": {
     "@tanstack/angular-query-experimental": "5.90.28",
     "@tanstack/angular-query-persist-client": "5.62.32",

--- a/.changeset/solid-rc-upgrade.md
+++ b/.changeset/solid-rc-upgrade.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/solid-query': patch
+'@tanstack/solid-query-devtools': patch
+'@tanstack/solid-query-persist-client': patch
+---
+
+chore: upgrade to solid v2 rc and rename `vite-plugin-solid` to `@solidjs/vite-plugin`

--- a/examples/solid/astro/package.json
+++ b/examples/solid/astro/package.json
@@ -18,8 +18,8 @@
     "@tanstack/solid-query": "^6.0.0-beta.8",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.8",
     "astro": "^5.5.6",
-    "@solidjs/web": "2.0.0-beta.33",
-    "solid-js": "2.0.0-beta.33",
+    "@solidjs/web": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.0",
     "tailwindcss": "^3.4.7",
     "typescript": "5.8.3"
   }

--- a/examples/solid/basic-graphql-request/package.json
+++ b/examples/solid/basic-graphql-request/package.json
@@ -12,12 +12,12 @@
     "@tanstack/solid-query-devtools": "^6.0.0-beta.8",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.2",
-    "@solidjs/web": "2.0.0-beta.33",
-    "solid-js": "2.0.0-beta.33"
+    "@solidjs/web": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.0"
   },
   "devDependencies": {
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
     "typescript": "5.8.3",
-    "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "vite": "^6.4.1"
   }
 }

--- a/examples/solid/basic-graphql-request/vite.config.ts
+++ b/examples/solid/basic-graphql-request/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -10,12 +10,12 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.8",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.8",
-    "@solidjs/web": "2.0.0-beta.33",
-    "solid-js": "2.0.0-beta.33"
+    "@solidjs/web": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.0"
   },
   "devDependencies": {
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
     "typescript": "5.8.3",
-    "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "vite": "^6.4.1"
   }
 }

--- a/examples/solid/basic/vite.config.ts
+++ b/examples/solid/basic/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/examples/solid/default-query-function/package.json
+++ b/examples/solid/default-query-function/package.json
@@ -10,12 +10,12 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.8",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.8",
-    "@solidjs/web": "2.0.0-beta.33",
-    "solid-js": "2.0.0-beta.33"
+    "@solidjs/web": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.0"
   },
   "devDependencies": {
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
     "typescript": "5.8.3",
-    "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "vite": "^6.4.1"
   }
 }

--- a/examples/solid/default-query-function/vite.config.ts
+++ b/examples/solid/default-query-function/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/examples/solid/offline/package.json
+++ b/examples/solid/offline/package.json
@@ -13,13 +13,13 @@
     "@tanstack/solid-query-devtools": "^6.0.0-beta.8",
     "@tanstack/solid-query-persist-client": "^6.0.0-beta.8",
     "msw": "^2.6.6",
-    "@solidjs/web": "2.0.0-beta.33",
-    "solid-js": "2.0.0-beta.33"
+    "@solidjs/web": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.0"
   },
   "devDependencies": {
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
     "typescript": "5.8.3",
-    "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "vite": "^6.4.1"
   },
   "msw": {
     "workerDirectory": [

--- a/examples/solid/offline/vite.config.ts
+++ b/examples/solid/offline/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/examples/solid/simple/package.json
+++ b/examples/solid/simple/package.json
@@ -10,13 +10,13 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.8",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.8",
-    "@solidjs/web": "2.0.0-beta.33",
-    "solid-js": "2.0.0-beta.33"
+    "@solidjs/web": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.0"
   },
   "devDependencies": {
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
     "@tanstack/eslint-plugin-query": "^5.101.0",
     "typescript": "5.8.3",
-    "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "vite": "^6.4.1"
   }
 }

--- a/examples/solid/simple/vite.config.ts
+++ b/examples/solid/simple/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/examples/solid/solid-start-streaming/package.json
+++ b/examples/solid/solid-start-streaming/package.json
@@ -14,8 +14,8 @@
     "@solidjs/start": "^1.1.3",
     "@tanstack/solid-query": "^6.0.0-beta.8",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.8",
-    "@solidjs/web": "2.0.0-beta.33",
-    "solid-js": "2.0.0-beta.33",
+    "@solidjs/web": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.0",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/integrations/solid-vite/package.json
+++ b/integrations/solid-vite/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "@tanstack/solid-query": "workspace:*",
     "@tanstack/solid-query-devtools": "workspace:*",
-    "solid-js": "2.0.0-beta.33",
+    "solid-js": "^2.0.0-rc.0",
     "vite": "^6.4.1",
-    "vite-plugin-solid": "3.0.0-next.21",
-    "@solidjs/web": "2.0.0-beta.33"
+    "@solidjs/web": "^2.0.0-rc.0",
+    "@solidjs/vite-plugin": "^3.0.0-next.27"
   }
 }

--- a/integrations/solid-vite/vite.config.js
+++ b/integrations/solid-vite/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:pr": "nx affected --targets=test:sherif,test:knip,test:docs,test:eslint,test:lib,test:types,test:build,build",
     "test:ci": "nx run-many --targets=test:sherif,test:knip,test:docs,test:eslint,test:lib,test:types,test:build,build",
     "test:eslint": "nx affected --target=test:eslint",
-    "test:sherif": "sherif -i typescript -i solid-js -i vite-plugin-solid -p \"./integrations/*\" -p \"./examples/*\"",
+    "test:sherif": "sherif -i typescript -i solid-js -p \"./integrations/*\" -p \"./examples/*\"",
     "test:size": "size-limit",
     "test:lib": "nx affected --target=test:lib --exclude=examples/**",
     "test:lib:dev": "pnpm run test:lib && nx watch --all -- pnpm run test:lib",

--- a/packages/solid-query-devtools/package.json
+++ b/packages/solid-query-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/solid-query-devtools",
-  "version": "6.0.0-beta.8",
+  "version": "6.0.0-rc",
   "description": "Developer tools to interact with and visualize the TanStack/solid-query Query cache",
   "author": "tannerlinsley",
   "license": "MIT",
@@ -67,15 +67,15 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.18.6",
-    "@solidjs/signals": "^2.0.0-beta.33",
+    "@solidjs/signals": "^2.0.0-rc.0",
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.33",
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
+    "@solidjs/web": "^2.0.0-rc.0",
     "@tanstack/solid-query": "workspace:*",
-    "babel-preset-solid": "2.0.0-beta.33",
+    "babel-preset-solid": "^2.0.0-rc.0",
     "npm-run-all2": "^5.0.0",
-    "solid-js": "2.0.0-beta.33",
-    "tsup-preset-solid": "^2.2.0",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "solid-js": "^2.0.0-rc.0",
+    "tsup-preset-solid": "^2.2.0"
   },
   "peerDependencies": {
     "@tanstack/solid-query": "workspace:^",

--- a/packages/solid-query-devtools/vite.config.ts
+++ b/packages/solid-query-devtools/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 import packageJson from './package.json'
 

--- a/packages/solid-query-persist-client/package.json
+++ b/packages/solid-query-persist-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/solid-query-persist-client",
-  "version": "6.0.0-beta.8",
+  "version": "6.0.0-rc",
   "description": "Solid.js bindings to work with persisters in TanStack/solid-query",
   "author": "tannerlinsley",
   "license": "MIT",
@@ -69,14 +69,14 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.18.6",
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.33",
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
+    "@solidjs/web": "^2.0.0-rc.0",
     "@tanstack/query-test-utils": "workspace:*",
     "@tanstack/solid-query": "workspace:*",
-    "babel-preset-solid": "2.0.0-beta.33",
+    "babel-preset-solid": "^2.0.0-rc.0",
     "npm-run-all2": "^5.0.0",
-    "solid-js": "2.0.0-beta.33",
-    "tsup-preset-solid": "^2.2.0",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "solid-js": "^2.0.0-rc.0",
+    "tsup-preset-solid": "^2.2.0"
   },
   "peerDependencies": {
     "@tanstack/solid-query": "workspace:^",

--- a/packages/solid-query-persist-client/vite.config.ts
+++ b/packages/solid-query-persist-client/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 import packageJson from './package.json'
 

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/solid-query",
-  "version": "6.0.0-beta.8",
+  "version": "6.0.0-rc",
   "description": "Primitives for managing, caching and syncing asynchronous and remote data in Solid",
   "author": "tannerlinsley",
   "license": "MIT",
@@ -71,15 +71,15 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.18.6",
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.33",
+    "@solidjs/vite-plugin": "^3.0.0-next.27",
+    "@solidjs/web": "^2.0.0-rc.0",
     "@tanstack/query-test-utils": "workspace:*",
-    "babel-preset-solid": "2.0.0-beta.33",
+    "babel-preset-solid": "^2.0.0-rc.0",
     "npm-run-all2": "^5.0.0",
-    "solid-js": "2.0.0-beta.33",
-    "tsup-preset-solid": "^2.2.0",
-    "vite-plugin-solid": "3.0.0-next.21"
+    "solid-js": "^2.0.0-rc.0",
+    "tsup-preset-solid": "^2.2.0"
   },
   "peerDependencies": {
-    "solid-js": ">=2.0.0-beta.33 <3.0.0"
+    "solid-js": ">=2.0.0-rc.0 <3.0.0"
   }
 }

--- a/packages/solid-query/src/__tests__/fixtures/hydration/build-and-render.mjs
+++ b/packages/solid-query/src/__tests__/fixtures/hydration/build-and-render.mjs
@@ -10,7 +10,7 @@ import { execFileSync } from 'node:child_process'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { build } from 'vite'
-import solidPlugin from 'vite-plugin-solid'
+import solidPlugin from '@solidjs/vite-plugin'
 
 const fixtureDir = fileURLToPath(new URL('.', import.meta.url))
 const packageRoot = path.join(fixtureDir, '..', '..', '..', '..')

--- a/packages/solid-query/vite.config.ts
+++ b/packages/solid-query/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 import packageJson from './package.json'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,7 +1590,7 @@ importers:
         version: 9.5.5(astro@5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       '@astrojs/solid-js':
         specifier: ^5.0.7
-        version: 5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-beta.33)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-rc.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@astrojs/tailwind':
         specifier: ^6.0.2
         version: 6.0.2(astro@5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -1598,8 +1598,8 @@ importers:
         specifier: ^8.1.3
         version: 8.2.11(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1)(typescript@5.8.3)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(astro@5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(next@16.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0))(react@19.2.4)(rollup@4.60.1)(svelte@5.55.1)(vue@3.5.31(typescript@5.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query
@@ -1610,8 +1610,8 @@ importers:
         specifier: ^5.5.6
         version: 5.18.1(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
       tailwindcss:
         specifier: ^3.4.7
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -1622,8 +1622,8 @@ importers:
   examples/solid/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query
@@ -1631,24 +1631,24 @@ importers:
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/basic-graphql-request:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query
@@ -1662,24 +1662,24 @@ importers:
         specifier: ^7.1.2
         version: 7.4.0(graphql@16.13.2)
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/default-query-function:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query
@@ -1687,24 +1687,24 @@ importers:
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/offline:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/query-async-storage-persister':
         specifier: ^5.101.0
         version: link:../../../packages/query-async-storage-persister
@@ -1721,24 +1721,24 @@ importers:
         specifier: ^2.6.6
         version: 2.12.14(@types/node@22.19.15)(typescript@5.8.3)
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/simple:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query
@@ -1746,9 +1746,12 @@ importers:
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/eslint-plugin-query':
         specifier: ^5.101.0
         version: link:../../../packages/eslint-plugin-query
@@ -1758,24 +1761,21 @@ importers:
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/solid/solid-start-streaming:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@2.0.0-beta.33)
+        version: 0.29.4(solid-js@2.0.0-rc.0)
       '@solidjs/router':
         specifier: ^0.15.3
-        version: 0.15.4(solid-js@2.0.0-beta.33)
+        version: 0.15.4(solid-js@2.0.0-rc.0)
       '@solidjs/start':
         specifier: ^1.1.3
-        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query
@@ -1783,8 +1783,8 @@ importers:
         specifier: ^6.0.0-beta.8
         version: link:../../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
       vinxi:
         specifier: ^0.5.3
         version: 0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -2392,9 +2392,12 @@ importers:
 
   integrations/solid-vite:
     dependencies:
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: workspace:*
         version: link:../../packages/solid-query
@@ -2402,14 +2405,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/solid-query-devtools
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   integrations/svelte-vite:
     devDependencies:
@@ -2955,28 +2955,28 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.33))(solid-js@2.0.0-beta.33)
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-rc.0))(solid-js@2.0.0-rc.0)
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/query-test-utils':
         specifier: workspace:*
         version: link:../query-test-utils
       babel-preset-solid:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(@babel/core@7.29.0)(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(@babel/core@7.29.0)(solid-js@2.0.0-rc.0)
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.33)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-rc.0)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
 
   packages/solid-query-devtools:
     dependencies:
@@ -2991,32 +2991,32 @@ importers:
         specifier: ^7.18.6
         version: 7.28.5(@babel/core@7.29.0)
       '@solidjs/signals':
-        specifier: ^2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.33))(solid-js@2.0.0-beta.33)
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-rc.0))(solid-js@2.0.0-rc.0)
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/solid-query':
         specifier: workspace:*
         version: link:../solid-query
       babel-preset-solid:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(@babel/core@7.29.0)(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(@babel/core@7.29.0)(solid-js@2.0.0-rc.0)
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.33)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-rc.0)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
 
   packages/solid-query-persist-client:
     dependencies:
@@ -3032,10 +3032,13 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.33))(solid-js@2.0.0-beta.33)
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-rc.0))(solid-js@2.0.0-rc.0)
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
       '@tanstack/query-test-utils':
         specifier: workspace:*
         version: link:../query-test-utils
@@ -3043,20 +3046,17 @@ importers:
         specifier: workspace:*
         version: link:../solid-query
       babel-preset-solid:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33(@babel/core@7.29.0)(solid-js@2.0.0-beta.33)
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0(@babel/core@7.29.0)(solid-js@2.0.0-rc.0)
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
       solid-js:
-        specifier: 2.0.0-beta.33
-        version: 2.0.0-beta.33
+        specifier: ^2.0.0-rc.0
+        version: 2.0.0-rc.0
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.33)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
-      vite-plugin-solid:
-        specifier: 3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.2.0(esbuild@0.27.4)(solid-js@2.0.0-rc.0)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
 
   packages/svelte-query:
     dependencies:
@@ -4694,49 +4694,49 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.34':
-    resolution: {integrity: sha512-mcH1h/FgNkf9jatVCuU/tE9PUGRxQfT3862GXh+IbCcH9PKEbxQKoA3GsKpixsOmLVkbcW2auJxKIV8u8WacOw==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
   '@dom-expressions/babel-plugin-jsx@0.50.0-next.41':
     resolution: {integrity: sha512-JQnjahkQysfo5P5ahsOqtA1yN3GeAIaAke1FA4s/vy+ZEOpUHbI5IpdF43+RrVghoTcgtML9tEC0fINtJ4Cmpg==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.34':
-    resolution: {integrity: sha512-MkIi1jWuVPaFoyM6qXlx3EPYXgUyySCDUJ/2zxpqzITW6/fkVvCQ++o2MrumgNFjQ/wxXdg8j0WMLcarnJ2H2Q==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
+    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.40':
+    resolution: {integrity: sha512-+3aXdhw4SVt08fvgAsEM56ky/wdCVPXT0Wtxo164Cchgg7sapPsRqo8Gwwn0UU5AhVcEp3CIhdB5+pMoUicKFg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.34':
-    resolution: {integrity: sha512-T7epwdLa+0WZBWvme3vHvYPz3Zc8APFsDAZh0N+OPlQywRjsIKymqP9Z5DAOScSIkZP3FERgThHk++vbv6pMhQ==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.40':
+    resolution: {integrity: sha512-Tbjg6ZQEIhKLKGd/Ep6MKqD76arPdV6SE2d3fkrP4qooIv2gYvAkvUw90qNdZxVHcuyjutrbJE0WpXYY9nSIIQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.34':
-    resolution: {integrity: sha512-5Q9D+qPS/djpfRrMPxCkYKkSzIweFk72hpZcKdQnXNnttmj6pi7L4rp5ZzupX3XVGTsZGXIjjuirViysfjiIoQ==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.40':
+    resolution: {integrity: sha512-tIJMY8dPyjiYNSL5uc4JA5l88Sw0WoMwoAilqTTHpGYdCL5GwzGq6ZOV1bndw8XKEYFYfnTr276FDHyYpLtRYQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.34':
-    resolution: {integrity: sha512-aPXMQM3KoZPOWv7AYBKz7oT9mUdPkLjJZoiYftua7AM59A4VJ+I6RvvXYnRNK28uk1zzt+IkZxrEKIQFOptDBg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.40':
+    resolution: {integrity: sha512-H/K/3Ykk8aCSNuKDlv/sgbPdSks+zqFxZ4mzqaGJmlDqEfeaWYXan5fsvwQbACdNDJeKoKLO4GhnlnKlKWjiJg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.34':
-    resolution: {integrity: sha512-XpghiRyhrY5/Zxg5q1dcUCCNCSOqnNZQ1IX87MfwrDWdIZ3ZDaGrcCFUcT37veeZgzgbb3bpt5fSKwyN9VAq3w==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.40':
+    resolution: {integrity: sha512-2SAfc35FEvvxkUz2yeh/4aNx0s9waZnce4KS64oUMlVpYEFtNBdfnZKCB/bgzJFvTxXjMs+HcU6OInGltH5jHA==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.34':
-    resolution: {integrity: sha512-4+RLrBo//1Ruok1GG1qIDv2wn0vRWIMi5lhphp6i6H0zwUTPgOLPY6ksMz8ZyEiAIh86jBTNiLj5rKCAU4pepQ==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.40':
+    resolution: {integrity: sha512-bBdHMxdfUHtIrS5xrt9udqdGRnGKdYQgKxJNIts+Il3Fs8QGyNwaZpi0tjnlRjYa0+GdWEC3Gw1Pmq/HFXzFeQ==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.34':
-    resolution: {integrity: sha512-XGlXicYgEKB2hesd37GT+HuctvbLRShd/G3ij2sxAIEEo6clza2jB64ZezyuuZY6iZn/QJwxAIyUVEChZ+Tl9g==}
+  '@dom-expressions/compiler@0.50.0-next.40':
+    resolution: {integrity: sha512-RI/kHU+QkLOHo4CQyqLTn9c7sAfl/GEULMsOpS1YqkPJgy7R8MCPWXFN4sI0QDBbM6ePtEyuW+2bsdsXqyxkzQ==}
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -7225,8 +7225,8 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  '@solidjs/signals@2.0.0-beta.33':
-    resolution: {integrity: sha512-W+ftJ7bzIE+wfJnx2oM2fEFTejHTce+vKRP3PcopBFqoEFNLZKgnnXxXyyD65QZVNr/CPv2Z/Naa+NuzGHFvVg==}
+  '@solidjs/signals@2.0.0-rc.0':
+    resolution: {integrity: sha512-oKZSfvsCcKw1uJjOGbUkJ+OqlhXLHtZ+rShSyu9KH0lUH7UUwfMfsKeh81JPiQxDDg4YLhEwI38hg0JkwzTdvA==}
 
   '@solidjs/start@1.3.2':
     resolution: {integrity: sha512-tasDl3utVbtP0rr4InB3ntBIFV2upvEiFrOOCkRrAA3yBfjx9elpxnc94sJQXo65PNYdAAAkPIC6h93vLrtwHg==}
@@ -7243,10 +7243,21 @@ packages:
       '@solidjs/router':
         optional: true
 
-  '@solidjs/web@2.0.0-beta.33':
-    resolution: {integrity: sha512-4wGUjG9jFGbI1dHHYBa8q/Z7w6ijFCNV99UsifQCDxo25ZH1kkK5qR6b2yU/mrKiKgdBbY0SBPcJGYMVIiSUBQ==}
+  '@solidjs/vite-plugin@3.0.0-next.27':
+    resolution: {integrity: sha512-wytjSKLe1YkUhi/TXr1yNOxZUjoajn3SILCF6TCHk7QJckrNRxddnsIIuzVbPbCm1icpkow75iIuF7EENBB7fQ==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.33
+      '@solidjs/web': '>=2.0.0-beta.32 <2.0.0-experimental.0'
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: '>=2.0.0-beta.32 <2.0.0-experimental.0'
+      vite: ^6.4.1
+    peerDependenciesMeta:
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.0':
+    resolution: {integrity: sha512-pYSaA9+dH8H1h/d/ZF/P2kR6omfzFGNcdzKhWTcg9fJghXhn8+5UrXUr2iYxDdYNOXZzxxFQhYHSJ7P4HKDqgw==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.0
 
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
@@ -8752,20 +8763,20 @@ packages:
       solid-js:
         optional: true
 
-  babel-preset-solid@2.0.0-beta.29:
-    resolution: {integrity: sha512-k3kDFDYdThcPZo5/PEIdZa+tYw/f4TVJomRjL7U2par3OWZxu49O3I9fHyezwEIfYjtyIyLygIKVfQ8Apu5wEg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.29
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   babel-preset-solid@2.0.0-beta.33:
     resolution: {integrity: sha512-YB1O8FBbIJ9GOAZ3AZrA5T3w86RjO5lPV/Oge8c5XccQYatjUtostD946JgKK/xO/7W7lwpWBjXhDJkKXnh8cQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
       solid-js: ^2.0.0-beta.33
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  babel-preset-solid@2.0.0-rc.0:
+    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^2.0.0-rc.0
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -14792,8 +14803,8 @@ packages:
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
-  solid-js@2.0.0-beta.33:
-    resolution: {integrity: sha512-nayHb+qIYS1PsyJwzN+zc4mJxdaptLWzWaHMCIU+zS/byrp1xaO5Vsl22meoPciDtafUmxoyO4TxnjwQQobNgQ==}
+  solid-js@2.0.0-rc.0:
+    resolution: {integrity: sha512-3enTJ71VL69nM5p/it2InVBDBt316Cqfij+F0S7VuHZLITc8YV7Rvavjoy52nAKKxYWXM+BcXh2K7KcLTf1zdQ==}
 
   solid-presence@0.1.8:
     resolution: {integrity: sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==}
@@ -16000,17 +16011,6 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite-plugin-solid@3.0.0-next.21:
-    resolution: {integrity: sha512-N9NJtw87jbdcQHSmwK//bvTJpDdrcZJ8zWMko4y9dq+XPoip7kmgUZSK8hwG+d9qz8Z+WyC1fUcu78hpesbPzQ==}
-    peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.29 <2.0.0-experimental.0'
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.29 <2.0.0-experimental.0'
-      vite: ^6.4.1
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
-        optional: true
-
   vite-prerender-plugin@0.5.13:
     resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
     peerDependencies:
@@ -17115,11 +17115,11 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/solid-js@5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-beta.33)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+  '@astrojs/solid-js@5.1.3(@testing-library/jest-dom@6.9.1)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(solid-js@2.0.0-rc.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
       vite: 6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - '@types/node'
@@ -18599,16 +18599,6 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.34(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
   '@dom-expressions/babel-plugin-jsx@0.50.0-next.41(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -18619,36 +18609,46 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.34':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.34':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.34':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.34':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.34':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.40':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.34':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.34':
+  '@dom-expressions/compiler@0.50.0-next.40':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.34
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.34
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.34
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.34
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.34
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.34
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.40
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.40
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.40
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.40
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.40
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.40
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
@@ -21148,22 +21148,22 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.33)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-rc.0)':
     dependencies:
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
 
   '@solidjs/router@0.15.4(solid-js@1.9.12)':
     dependencies:
       solid-js: 1.9.12
     optional: true
 
-  '@solidjs/router@0.15.4(solid-js@2.0.0-beta.33)':
+  '@solidjs/router@0.15.4(solid-js@2.0.0-rc.0)':
     dependencies:
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
 
-  '@solidjs/signals@2.0.0-beta.33': {}
+  '@solidjs/signals@2.0.0-rc.0': {}
 
-  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -21177,10 +21177,10 @@ snapshots:
       seroval-plugins: 1.5.1(seroval@1.5.1)
       shiki: 1.29.2
       source-map-js: 1.2.1
-      terracotta: 1.1.0(solid-js@2.0.0-beta.33)
+      terracotta: 1.1.0(solid-js@2.0.0-rc.0)
       tinyglobby: 0.2.15
       vinxi: 0.5.11(@types/node@22.19.15)(@vercel/functions@2.2.13)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -21194,18 +21194,35 @@ snapshots:
     optionalDependencies:
       '@solidjs/router': 0.15.4(solid-js@1.9.12)
 
-  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-beta.33))(solid-js@2.0.0-beta.33)':
+  '@solidjs/testing-library@0.8.10(@solidjs/router@0.15.4(solid-js@2.0.0-rc.0))(solid-js@2.0.0-rc.0)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
     optionalDependencies:
-      '@solidjs/router': 0.15.4(solid-js@2.0.0-beta.33)
+      '@solidjs/router': 0.15.4(solid-js@2.0.0-rc.0)
 
-  '@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33)':
+  '@solidjs/vite-plugin@3.0.0-next.27(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.29.0
+      '@dom-expressions/compiler': 0.50.0-next.40
+      '@solidjs/web': 2.0.0-rc.0(solid-js@2.0.0-rc.0)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 2.0.0-beta.33(@babel/core@7.29.0)(solid-js@2.0.0-rc.0)
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.0
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    optionalDependencies:
+      '@testing-library/jest-dom': 6.9.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
 
   '@speed-highlight/core@1.2.15': {}
 
@@ -23361,26 +23378,26 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.12
 
-  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.33):
+  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-rc.0):
     dependencies:
       '@babel/core': 7.29.0
       babel-plugin-jsx-dom-expressions: 0.40.6(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
 
-  babel-preset-solid@2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.33):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.34(@babel/core@7.29.0)
-    optionalDependencies:
-      solid-js: 2.0.0-beta.33
-
-  babel-preset-solid@2.0.0-beta.33(@babel/core@7.29.0)(solid-js@2.0.0-beta.33):
+  babel-preset-solid@2.0.0-beta.33(@babel/core@7.29.0)(solid-js@2.0.0-rc.0):
     dependencies:
       '@babel/core': 7.29.0
       '@dom-expressions/babel-plugin-jsx': 0.50.0-next.41(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
+
+  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.0)(solid-js@2.0.0-rc.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.0)
+    optionalDependencies:
+      solid-js: 2.0.0-rc.0
 
   bail@2.0.2: {}
 
@@ -24932,13 +24949,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-plugin-solid@0.5.0(esbuild@0.27.4)(solid-js@2.0.0-beta.33):
+  esbuild-plugin-solid@0.5.0(esbuild@0.27.4)(solid-js@2.0.0-rc.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.33)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-rc.0)
       esbuild: 0.27.4
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
     transitivePeerDependencies:
       - supports-color
 
@@ -31018,9 +31035,9 @@ snapshots:
       seroval: 1.5.1
       seroval-plugins: 1.5.1(seroval@1.5.1)
 
-  solid-js@2.0.0-beta.33:
+  solid-js@2.0.0-rc.0:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.33
+      '@solidjs/signals': 2.0.0-rc.0
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -31044,12 +31061,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-refresh@0.6.3(solid-js@2.0.0-beta.33):
+  solid-refresh@0.6.3(solid-js@2.0.0-rc.0):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/helper-module-imports': 7.28.6
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
     transitivePeerDependencies:
       - supports-color
 
@@ -31059,9 +31076,9 @@ snapshots:
       '@solid-primitives/transition-group': 1.1.2(solid-js@1.9.12)
       solid-js: 1.9.12
 
-  solid-use@0.9.1(solid-js@2.0.0-beta.33):
+  solid-use@0.9.1(solid-js@2.0.0-rc.0):
     dependencies:
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
 
   sort-by@1.2.0:
     dependencies:
@@ -31574,10 +31591,10 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terracotta@1.1.0(solid-js@2.0.0-beta.33):
+  terracotta@1.1.0(solid-js@2.0.0-rc.0):
     dependencies:
-      solid-js: 2.0.0-beta.33
-      solid-use: 0.9.1(solid-js@2.0.0-beta.33)
+      solid-js: 2.0.0-rc.0
+      solid-use: 0.9.1(solid-js@2.0.0-rc.0)
 
   terser-webpack-plugin@1.4.6(webpack@4.47.0):
     dependencies:
@@ -31793,9 +31810,9 @@ snapshots:
       - solid-js
       - supports-color
 
-  tsup-preset-solid@2.2.0(esbuild@0.27.4)(solid-js@2.0.0-beta.33)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
+  tsup-preset-solid@2.2.0(esbuild@0.27.4)(solid-js@2.0.0-rc.0)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      esbuild-plugin-solid: 0.5.0(esbuild@0.27.4)(solid-js@2.0.0-beta.33)
+      esbuild-plugin-solid: 0.5.0(esbuild@0.27.4)(solid-js@2.0.0-rc.0)
       tsup: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
@@ -32470,14 +32487,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.33)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-rc.0)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.33
-      solid-refresh: 0.6.3(solid-js@2.0.0-beta.33)
+      solid-js: 2.0.0-rc.0
+      solid-refresh: 0.6.3(solid-js@2.0.0-rc.0)
       vite: 6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
@@ -32485,31 +32502,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-rc.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-beta.33)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@2.0.0-rc.0)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.33
-      solid-refresh: 0.6.3(solid-js@2.0.0-beta.33)
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-    optionalDependencies:
-      '@testing-library/jest-dom': 6.9.1
-    transitivePeerDependencies:
-      - supports-color
-
-  vite-plugin-solid@3.0.0-next.21(@solidjs/web@2.0.0-beta.33(solid-js@2.0.0-beta.33))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.33)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/core': 7.29.0
-      '@dom-expressions/compiler': 0.50.0-next.34
-      '@solidjs/web': 2.0.0-beta.33(solid-js@2.0.0-beta.33)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.33)
-      merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.33
+      solid-js: 2.0.0-rc.0
+      solid-refresh: 0.6.3(solid-js@2.0.0-rc.0)
       vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:


### PR DESCRIPTION
Moves the v6 prerelease line onto the Solid 2.0 RC and switches this branch's prerelease tag from `beta` to `rc`.

## Solid RC, with carets

`solid-js`, `@solidjs/web`, `@solidjs/signals` and `babel-preset-solid` go from the pinned `2.0.0-beta.33` to `^2.0.0-rc.0` across the three solid packages, the `solid-vite` integration and the solid examples. This also flips these deps from exact pins to carets so the rc line is tracked as it moves.

`packages/query-devtools` is untouched — it is still on Solid 1.x.

`@tanstack/solid-query`'s peer floor moves to `>=2.0.0-rc.0 <3.0.0`. The deliberately broader `>=2.0.0-beta.0 <3.0.0` floors on `solid-query-devtools` and `solid-query-persist-client` are left alone, matching how previous bumps handled them.

## `vite-plugin-solid` → `@solidjs/vite-plugin`

Renamed to `@solidjs/vite-plugin` at `^3.0.0-next.27` — the version published under both names, so a clean cut-over point. Covers every manifest, every vite config, and the hydration test fixture in `packages/solid-query/src/__tests__/fixtures/hydration/build-and-render.mjs`.

`packages/query-devtools` stays on `vite-plugin-solid@^2.11.6`; the scoped package has no 2.x line.

The `-i vite-plugin-solid` sherif ignore is dropped — with the rename the dependency no longer resolves to more than one version, so the ignore is redundant (verified sherif still passes without it).

## Prerelease tag → `rc`, landing on `6.0.0-rc.0`

`.changeset/pre.json` moves from `"tag": "beta"` to `"tag": "rc"`. No workflow change is needed: `solid-query-v6-pre` still matches the `*-pre` glob in `release.yml`, which sets `prerelease=true` and passes no `--tag`, so `changeset publish` picks the dist-tag up from pre.json.

Changesets derives the pre number as `(prerelease[1] ?? -1) + 1`, so switching the tag alone would have continued the beta counter and produced `6.0.0-rc.9` from `6.0.0-beta.8`. To land on `6.0.0-rc.0` instead, the three solid packages are set to the sentinel version **`6.0.0-rc`** — valid semver with no numeric prerelease part, so the pre number resolves to `0` while `semver.inc("6.0.0-rc", "patch")` still yields `6.0.0`.

That sentinel only lives here until the next `ci: Version Packages` commit rewrites it; nothing publishes from it, since the release action runs `version` before `publish`.

Verified by running the real `changeset version` against a throwaway copy of this tree:

```
6.0.0-rc.0     @tanstack/solid-query
6.0.0-rc.0     @tanstack/solid-query-devtools
6.0.0-rc.0     @tanstack/solid-query-persist-client
5.101.0        @tanstack/query-core      (untouched)
5.101.0        @tanstack/react-query     (untouched)
6.1.34         @tanstack/svelte-query    (untouched)
```

with the changelog entry landing as `## 6.0.0-rc.0` directly above `## 6.0.0-beta.8`.

## Known peer warning

`pnpm install` reports an unmet peer for `@solidjs/vite-plugin@3.0.0-next.27`, which declares `solid-js` / `@solidjs/web` as `>=2.0.0-beta.32 <2.0.0-experimental.0`. Prerelease identifiers sort alphabetically, so the real ordering is `beta.32 < experimental.0 < rc.0` — the upper bound excludes the RC by accident.

It is metadata only and warning only (no `strict-peer-dependencies` in this repo, and pnpm defaults it to `false`); the plugin works against rc.0. It should clear when Solid ships a plugin release with a corrected bound. `@solidjs/vite-plugin` currently has exactly one published version, so there is nothing newer to move to.

## Verification

- `test:lib` on the three solid packages: 336 tests pass, no type errors
- `test:types`, `test:build`, `test:eslint` on the three solid packages: pass
- `sherif` and `knip`: pass
- Real vite builds of `integrations/solid-vite` and `examples/solid/basic`: pass

No source changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)