### PR TITLE
fix(angular-query): hold a pending task while a query subscription fetches

### DIFF
--- a/.changeset/afraid-plums-shave.md
+++ b/.changeset/afraid-plums-shave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-query-experimental': patch
+---
+
+Register the Angular pending task as soon as a query subscription starts a fetch, so `whenStable()` no longer resolves while the query is still loading

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -773,6 +773,9 @@ describe('injectQuery', () => {
       TestBed.tick()
 
       const stablePromise = app.whenStable()
+      // Let the batched observer notification run so the finished fetch is
+      // reported and the pending task is released
+      await vi.advanceTimersByTimeAsync(10)
       await stablePromise
 
       expect(query.status()).toBe('success')
@@ -841,7 +844,11 @@ describe('injectQuery', () => {
       // Synchronize pending effects
       TestBed.tick()
 
-      await app.whenStable()
+      const stablePromise = app.whenStable()
+      // Let the batched observer notification run so the finished fetch is
+      // reported and the pending task is released
+      await vi.advanceTimersByTimeAsync(10)
+      await stablePromise
       expect(query.status()).toBe('success')
       expect(query.data()).toBe('sync-data-1')
       expect(callCount).toBe(1)

--- a/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
@@ -1,6 +1,7 @@
 import {
   ApplicationRef,
   Component,
+  effect,
   provideZonelessChangeDetection,
 } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
@@ -152,6 +153,44 @@ describe('PendingTasks Integration', () => {
 
       expect(mutation.isError()).toBe(true)
       expect(mutation.error()).toEqual(new Error('sync-mutation-error'))
+    })
+  })
+
+  // The observer reports a running fetch through a batched notification that
+  // only lands in a later task. This test uses real timers because it asserts
+  // on what `whenStable()` does before that notification arrives.
+  describe('Task registration timing', () => {
+    it('should let whenStable wait for the fetch a component just started', async () => {
+      vi.useRealTimers()
+
+      const key = queryKey()
+      const seenInEffect: Array<boolean> = []
+
+      @Component({
+        selector: 'app-timing-query',
+        template: `{{ query.isSuccess() }}`,
+        standalone: true,
+      })
+      class TimingQueryComponent {
+        query = injectQuery(() => ({
+          queryKey: key,
+          queryFn: () => Promise.resolve('component-data'),
+        }))
+
+        constructor() {
+          effect(() => {
+            seenInEffect.push(this.query.isSuccess())
+          })
+        }
+      }
+
+      const fixture = TestBed.createComponent(TimingQueryComponent)
+      fixture.detectChanges()
+      await fixture.whenStable()
+
+      expect(fixture.componentInstance.query.status()).toBe('success')
+      expect(fixture.componentInstance.query.data()).toBe('component-data')
+      expect(seenInEffect).toContain(true)
     })
   })
 

--- a/packages/angular-query-experimental/src/create-base-query.ts
+++ b/packages/angular-query-experimental/src/create-base-query.ts
@@ -144,6 +144,19 @@ export function createBaseQuery<
           }),
         )
 
+    // Subscribing can start a fetch straight away, but the first observer
+    // notification is batched and only arrives in a later task. Without this
+    // check the app is considered stable in between, so `whenStable()` resolves
+    // while the query is still fetching.
+    untracked(() => {
+      if (
+        !pendingTaskRef &&
+        observer.getCurrentResult().fetchStatus !== 'idle'
+      ) {
+        pendingTaskRef = pendingTasks.add()
+      }
+    })
+
     onCleanup(() => {
       if (pendingTaskRef) {
         pendingTaskRef()


### PR DESCRIPTION
Fixes #9981
Fixes #9910
Fixes #10046

### The problem

`createBaseQuery` registers the Angular pending task from inside the observer subscription callback:

```ts
observer.subscribe(
  notifyManager.batchCalls((state) => {
    ngZone.run(() => {
      if (state.fetchStatus === 'fetching' && !pendingTaskRef) {
        pendingTaskRef = pendingTasks.add()
      }
      ...
```

Subscribing is what starts the fetch, but the callback is batched through the notify manager, so it runs in a later task than the fetch it reports. In between there is no pending task, the application counts as stable, and `whenStable()` resolves while the query is still loading.

That is what the three linked issues run into. In a `TestBed` test the usual `fixture.detectChanges()` followed by `await fixture.whenStable()` returns with the query still `pending`, `data()` still `undefined`, and any `effect()` reading `isSuccess()` never seeing `true`. The workaround people have landed on is an arbitrary `setTimeout(0)` before `whenStable()`, which #10046 describes.

### The change

After subscribing, take the pending task straight away if the observer is already fetching. The release path is unchanged, so the task is still handed back on the first notification that reports `fetchStatus: 'idle'` and on cleanup.

### Tests

Added a test to `pending-tasks.test.ts` that mounts a component the way the issues describe, with a template reading `isSuccess()` and an `effect()` observing it, and asserts on the state after `fixture.whenStable()`. It fails on `main` and passes here.

Two existing tests in `inject-query.test.ts` awaited `whenStable()` without letting the batched notification run and only passed because of this gap. They now advance the timers while waiting, which is the pattern the rest of `pending-tasks.test.ts` already uses.

Whole `@tanstack/angular-query-experimental` suite is green: 219 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Angular applications now correctly remain unstable while a query is actively fetching.
  - `whenStable()` waits for asynchronous query loading to finish, including batched or delayed notifications.
  - Improved reliability for components that depend on query results during initialization.
- **Tests**
  - Added coverage for asynchronous query completion and Angular stability behavior.
  - Updated timing-sensitive tests to ensure pending tasks are released correctly after fetching completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->