### PR TITLE
fix(angular-query): hold a pending task while a triggered mutation runs

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-query-experimental': patch
+---
+
+Register the Angular pending task when `mutate` is called, so `whenStable()` no longer resolves while the mutation is still running

--- a/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/pending-tasks.test.ts
@@ -155,6 +155,31 @@ describe('PendingTasks Integration', () => {
     })
   })
 
+  // The observer reports a running mutation through a batched notification that
+  // only lands in a later task. This test uses real timers because it asserts
+  // on what `whenStable()` does before that notification arrives.
+  describe('Task registration timing', () => {
+    it('should let whenStable wait for a mutation that was just triggered', async () => {
+      vi.useRealTimers()
+
+      const app = TestBed.inject(ApplicationRef)
+
+      const mutation = TestBed.runInInjectionContext(() =>
+        injectMutation(() => ({
+          mutationFn: (value: string) => sleep(5).then(() => value),
+        })),
+      )
+
+      TestBed.tick()
+      mutation.mutate('mutated')
+
+      await app.whenStable()
+
+      expect(mutation.status()).toBe('success')
+      expect(mutation.data()).toBe('mutated')
+    })
+  })
+
   describe('Race Conditions', () => {
     it('should handle query that completes during initial subscription', async () => {
       const key = queryKey()

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -87,7 +87,15 @@ export function injectMutation<
   >(() => {
     const observer = observerSignal()
     return (variables, mutateOptions) => {
-      observer.mutate(variables, mutateOptions).catch(noop)
+      // `mutate` is fire and forget, so nothing else keeps the application
+      // busy while the mutation runs. The observer reports the pending state
+      // in a batched notification that only arrives in a later task, so hold a
+      // pending task from the moment the mutation starts instead.
+      const releasePendingTask = pendingTasks.add()
+      observer
+        .mutate(variables, mutateOptions)
+        .catch(noop)
+        .finally(releasePendingTask)
     }
   })
 


### PR DESCRIPTION
﻿Fixes #11176

### The problem

`injectMutation` registers the Angular pending task from inside the observer subscription callback, which is batched through the notify manager. That callback runs in a later task than the `mutate()` call that started the mutation, so between the two there is no pending task and the application counts as stable.

The result is that `ApplicationRef.whenStable()` resolves while the mutation is still in flight. The result signals have not been updated at that point either, so `status()` still reads `idle`.

`mutate()` is fire and forget, so nothing else keeps the application busy for the duration of the mutation.

### The change

Take the pending task in `mutate` itself and release it once the mutation settles.

`mutateAsync` is left alone. It hands the caller a promise, so the caller already has a way to wait for the result, and wrapping it would mean rebuilding the observer bound `mutate` that the result object exposes.

### Tests

Added a test to `pending-tasks.test.ts` that calls `mutate()` and then awaits `whenStable()`. It fails on `main` with `expected 'idle' to be 'success'` and passes here.

Whole `@tanstack/angular-query-experimental` suite is green: 219 tests.

### Related

The query side has the same batching gap and is covered separately in #9981, #9910 and #10046.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mutation task tracking so Angular stability checks wait until mutations finish.
  * Ensured delayed mutations complete before `whenStable()` resolves.
  * Preserved existing fire-and-forget behavior and error handling.

* **Tests**
  * Added integration coverage for mutation completion and reported results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->