### PR TITLE
fix(eslint-plugin-query): only match own properties in no-unstable-deps

### DIFF
--- a/.changeset/lucky-eels-count.md
+++ b/.changeset/lucky-eels-count.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/eslint-plugin-query': patch
+---
+
+Stop `no-unstable-deps` from resolving identifiers such as `toString` or `constructor` through `Object.prototype`, which reported unrelated code

--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -405,3 +405,54 @@ reactHookNames.forEach((reactHookName) => {
     },
   )
 })
+
+// Identifiers that collide with properties inherited from Object.prototype must
+// not be mistaken for tracked hooks, tracked variables or React hook aliases.
+ruleTester.run('no-unstable-deps', rule, {
+  valid: [
+    {
+      name: 'should pass when a dependency is named after an inherited Object.prototype property',
+      code: `
+        import { useCallback } from "React";
+        import { useQuery } from "@tanstack/react-query";
+        import { toString } from "lodash";
+
+        function Component() {
+          const { data } = useQuery({ queryFn: () => 'data' });
+          const label = toString(data);
+          const callback = useCallback(() => label, [label, toString, constructor, valueOf]);
+          return callback;
+        }
+      `,
+    },
+    {
+      name: 'should pass when a call is named after an inherited Object.prototype property',
+      code: `
+        import { useQuery } from "@tanstack/react-query";
+        import { constructor, valueOf } from "some-library";
+
+        function Component() {
+          const query = useQuery({ queryFn: () => 'data' });
+          constructor(() => {}, [query]);
+          valueOf(() => {}, [query]);
+          return null;
+        }
+      `,
+    },
+    {
+      name: 'should pass when a custom hook is named after an inherited Object.prototype property',
+      code: `
+        import { useCallback } from "React";
+        import { useQuery } from "@tanstack/react-query";
+        import { toString } from "some-library";
+
+        function Component() {
+          const value = toString();
+          const callback = useCallback(() => value, [value]);
+          return callback;
+        }
+      `,
+    },
+  ],
+  invalid: [],
+})

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -48,7 +48,10 @@ export const rule = createRule({
       if (node.callee.type === 'Identifier') {
         const calleeName = node.callee.name
         // Check if the identifier is a known React hook or an alias
-        if (reactHookNames.includes(calleeName) || calleeName in hookAliasMap) {
+        if (
+          reactHookNames.includes(calleeName) ||
+          Object.hasOwn(hookAliasMap, calleeName)
+        ) {
           return calleeName
         }
       } else if (
@@ -138,7 +141,10 @@ export const rule = createRule({
         return directQueryHook
       }
 
-      if (callExpression.callee.type === AST_NODE_TYPES.Identifier) {
+      if (
+        callExpression.callee.type === AST_NODE_TYPES.Identifier &&
+        Object.hasOwn(trackedCustomHooks, callExpression.callee.name)
+      ) {
         return trackedCustomHooks[callExpression.callee.name]
       }
 
@@ -182,7 +188,7 @@ export const rule = createRule({
         if (
           dep !== null &&
           dep.type === AST_NODE_TYPES.Identifier &&
-          trackedVariables[dep.name] !== undefined
+          Object.hasOwn(trackedVariables, dep.name)
         ) {
           const queryHook = trackedVariables[dep.name]
           context.report({


### PR DESCRIPTION
Fixes #11118

### The problem

`no-unstable-deps` keeps three plain objects keyed by identifier name, and reads all three without checking that the key is an own property:

```ts
// hook aliases
if (reactHookNames.includes(calleeName) || calleeName in hookAliasMap)

// tracked custom hooks
return trackedCustomHooks[callExpression.callee.name]

// tracked variables
if (dep.type === AST_NODE_TYPES.Identifier && trackedVariables[dep.name] !== undefined)
```

Names inherited from `Object.prototype` therefore resolve to a prototype member instead of `undefined`, and unrelated code gets reported. #11118 covers the `trackedCustomHooks` lookup. The other two produce their own false positives:

- a dependency named `toString`, `constructor` or `valueOf` is reported as the result of a query hook, with the inherited function interpolated into the message
- a call such as `constructor(fn, [query])` is treated as a React hook invocation, and its second argument is checked as a dependency array

The `toString` case is the one from the issue's StackBlitz, where `toString` comes from Lodash.

### The change

Guard all three lookups with `Object.hasOwn`, which is what the issue suggests.

### Tests

Three cases added to `no-unstable-deps.test.ts`, one per lookup. All three fail on `main` and pass here. Rule suite is green: 246 tests.

### Note

There are two open PRs on this issue, #11117 and #11125, and both fix the `trackedCustomHooks` lookup only. I ran into the other two lookups while checking whether that was the whole story, so this covers all three. Happy to rebase on either of them, or to close this if you would rather take one of those and have the remaining two handled as a follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `no-unstable-deps` incorrectly recognizing inherited names such as `toString` and `constructor` as React hooks, custom hooks, or tracked dependencies.
  * Improved dependency analysis to only recognize explicitly tracked identifiers.

* **Tests**
  * Added regression coverage for identifiers that conflict with inherited object properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->