### PR TITLE
fix(scripts): make the docs link check work on Windows

### DIFF
--- a/scripts/verify-links.ts
+++ b/scripts/verify-links.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from 'node:fs'
-import { extname, resolve } from 'node:path'
+import { extname, resolve, sep } from 'node:path'
 import { glob } from 'tinyglobby'
 // @ts-ignore Could not find a declaration file for module 'markdown-link-extractor'.
 import markdownLinkExtractor from 'markdown-link-extractor'
@@ -52,6 +52,11 @@ function relativeLinkExists(link: string, file: string): boolean {
     })
     return false
   }
+
+  // `resolve` uses the platform separator, but the patterns below are written
+  // with forward slashes, so match against a normalized copy of the path.
+  // Node accepts forward slashes on Windows too, so the result stays usable.
+  absPath = absPath.split(sep).join('/')
 
   // Check if this is an example path
   const isExample = absPath.includes('/examples/')


### PR DESCRIPTION
Fixes #11177

### The problem

`relativeLinkExists` builds the target path with `path.resolve`, which uses the platform separator, and then matches that path against patterns written with forward slashes:

```ts
const isExample = absPath.includes('/examples/')

if (isExample) {
  absPath = absPath.replace(
    /\/docs\/framework\/([^/]+)\/examples\//,
    '/examples/$1/',
  )
  exists = existsSync(absPath) && statSync(absPath).isDirectory()
}
```

On Windows the resolved path uses backslashes, so neither pattern matches. Every documentation link pointing at an example skips the rewrite and gets looked up as a markdown file under `docs/framework/<name>/examples/` instead of a directory under `examples/<name>/`.

`pnpm test:docs` then reports 27 broken links that are all fine. CI does not catch it because it runs on Linux, and the reported `resolved:` path shows the problem directly.

### The change

Normalize the separators once, before the two comparisons. Node accepts forward slashes on Windows, so the path stays usable for `existsSync` and `statSync`, and the value printed in the error report stays readable.

The `docsRoot` containment check above it still runs on the platform native path, so it is unaffected.

### Tests

`node scripts/verify-links.ts` on Windows goes from 27 reported broken links to "No broken links found". Behaviour on Linux is unchanged, since `split(sep).join('/')` is a no-op there.

No changeset, this is repository tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link verification consistency across operating systems.
  * Ensured example paths are detected reliably regardless of platform-specific path separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->