### PR TITLE
fix(docs): Normalize example link paths on Windows

### DIFF
--- a/scripts/verify-links.test.ts
+++ b/scripts/verify-links.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from 'node:assert'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+
+const verifyLinks = fileURLToPath(new URL('./verify-links.ts', import.meta.url))
+
+test('accepts framework example links on every platform', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'tanstack-query-verify-links-'))
+
+  try {
+    mkdirSync(join(fixture, 'docs/framework/react'), { recursive: true })
+    mkdirSync(join(fixture, 'examples/react/basic'), { recursive: true })
+    writeFileSync(
+      join(fixture, 'docs/framework/react/quick-start.md'),
+      '[Basic example](./examples/basic)\n',
+    )
+
+    const output = execFileSync(
+      process.execPath,
+      ['--experimental-strip-types', verifyLinks],
+      { cwd: fixture, encoding: 'utf8' },
+    )
+
+    assert.match(output, /No broken links found/)
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})

--- a/scripts/verify-links.ts
+++ b/scripts/verify-links.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from 'node:fs'
-import { extname, resolve } from 'node:path'
+import { extname, resolve, sep } from 'node:path'
 import { glob } from 'tinyglobby'
 // @ts-ignore Could not find a declaration file for module 'markdown-link-extractor'.
 import markdownLinkExtractor from 'markdown-link-extractor'
@@ -25,6 +25,10 @@ function isRelativeLink(link: string) {
 /** Remove any trailing .md */
 function stripExtension(p: string): string {
   return p.replace(`${extname(p)}`, '')
+}
+
+export function normalizePathForMatching(path: string): string {
+  return path.split(sep).join('/')
 }
 
 function relativeLinkExists(link: string, file: string): boolean {
@@ -53,14 +57,15 @@ function relativeLinkExists(link: string, file: string): boolean {
     return false
   }
 
-  // Check if this is an example path
-  const isExample = absPath.includes('/examples/')
+  // Normalize only the path used by the slash-based example mapping.
+  const normalizedAbsPath = normalizePathForMatching(absPath)
+  const isExample = normalizedAbsPath.includes('/examples/')
 
   let exists = false
 
   if (isExample) {
     // Transform /docs/framework/{framework}/examples/ to /examples/{framework}/
-    absPath = absPath.replace(
+    absPath = normalizedAbsPath.replace(
       /\/docs\/framework\/([^/]+)\/examples\//,
       '/examples/$1/',
     )


### PR DESCRIPTION
## Summary

Fixes #11177.

`verify-links.ts` uses forward-slash checks when it maps framework example links from `docs/framework/{framework}/examples/` to `examples/{framework}/`. Windows resolves the intermediate path with backslashes, so valid example links are treated as missing Markdown files.

This change normalizes platform separators only for the existing example-path matching and rewrite, while keeping native paths for filesystem checks. It also adds an integration regression that runs the link verifier against a temporary framework-example fixture.

## Verification

- `node --experimental-strip-types --test scripts/verify-links.test.ts` on Linux
- `node --experimental-strip-types --test scripts/verify-links.test.ts` on Windows Node 22.22.0
- `prettier --config prettier.config.js --check scripts/verify-links.ts scripts/verify-links.test.ts`

The unmodified script reproduces the reported broken link on Windows; the patched script passes the same fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation link verification across operating systems by consistently handling different path separators.
  * Preserved accurate filesystem checks while matching example and documentation paths.

* **Tests**
  * Added automated coverage using temporary documentation fixtures to confirm link verification succeeds across platforms.
  * Temporary test files are reliably cleaned up after each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->