### PR TITLE
fix(eslint-plugin-query): avoid prototype property false-positives in no-unstable-deps

### DIFF
--- a/.changeset/fix-no-unstable-deps-prototype-lookups.md
+++ b/.changeset/fix-no-unstable-deps-prototype-lookups.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/eslint-plugin-query': patch
+---
+
+Fix false-positive warnings in `no-unstable-deps` rule caused by `Object.prototype` property lookups (`toString`, `valueOf`, etc.).

--- a/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
+++ b/packages/eslint-plugin-query/src/__tests__/no-unstable-deps.test.ts
@@ -128,6 +128,55 @@ const baseTestCases = {
             }
           `,
         },
+        {
+          name: `should pass when functions or variables with Object.prototype names are used with ${reactHookAlias}`,
+          code: `
+            ${reactHookImport}
+            import { useQuery } from "@tanstack/react-query";
+
+            function Component() {
+              const toString = () => 'str';
+              const valueOf = 42;
+              const callback = ${reactHookInvocation}(() => { toString() }, [toString, valueOf]);
+              return;
+            }
+          `,
+        },
+        {
+          name: `should pass when custom functions named after Object.prototype methods are invoked`,
+          code: `
+            ${reactHookImport}
+            import { useQuery } from "@tanstack/react-query";
+
+            function toString() {
+              return 'test';
+            }
+
+            function Component() {
+              const res = toString();
+              const callback = ${reactHookInvocation}(() => { res }, [res]);
+              return;
+            }
+          `,
+        },
+        {
+          name: `should pass when a local function named after Object.prototype method is called alongside destructured query result with ${reactHookAlias}`,
+          code: `
+            ${reactHookImport}
+            import { useQuery } from "@tanstack/react-query";
+
+            function toString() {
+              return 'formatted';
+            }
+
+            function Component() {
+              const { data } = useQuery({ queryKey: ['test'], queryFn: () => 'test' });
+              const formatted = toString();
+              const callback = ${reactHookInvocation}(() => { formatted }, [data, formatted]);
+              return;
+            }
+          `,
+        },
       ]),
   invalid: ({
     reactHookImport,

--- a/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
+++ b/packages/eslint-plugin-query/src/rules/no-unstable-deps/no-unstable-deps.rule.ts
@@ -35,9 +35,9 @@ export const rule = createRule({
   defaultOptions: [],
 
   create: detectTanstackQueryImports((context, _options, helpers) => {
-    const trackedVariables: Record<string, string> = {}
-    const trackedCustomHooks: Record<string, string> = {}
-    const hookAliasMap: Record<string, string> = {}
+    const trackedVariables: Record<string, string> = Object.create(null)
+    const trackedCustomHooks: Record<string, string> = Object.create(null)
+    const hookAliasMap: Record<string, string> = Object.create(null)
     const pendingVariableDeclarators: Array<TSESTree.VariableDeclarator> = []
     const pendingDependencyChecks: Array<{
       reactHook: string


### PR DESCRIPTION
## 🎯 Changes

In `@tanstack/eslint-plugin-query`'s `no-unstable-deps` rule, AST lookup records (`trackedVariables`, `trackedCustomHooks`, `hookAliasMap`) were initialized as plain object literals (`{}`). 

Because plain objects inherit from `Object.prototype`:
- `calleeName in hookAliasMap` evaluated to `true` for standard built-in prototype property names (such as `toString`, `valueOf`, `hasOwnProperty`, `constructor`).
- `trackedVariables[depName]` and `trackedCustomHooks[calleeName]` returned truthy prototype methods rather than `undefined`.

This caused standard functions or variables matching `Object.prototype` method names to be mistakenly identified as unstable TanStack Query results and flagged with false-positive lint warnings in hook dependency arrays.

### Solution:
- Initialized `trackedVariables`, `trackedCustomHooks`, and `hookAliasMap` with `Object.create(null)` to eliminate prototype inheritance.
- Added unit tests in `no-unstable-deps.test.ts` verifying that passing/invoking functions with `Object.prototype` property names does not trigger lint warnings.
- Added a patch changeset for `@tanstack/eslint-plugin-query`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positives in the `no-unstable-deps` lint rule when stable dependencies use names matching built-in object methods.
  * Custom functions and variables with these names are now correctly recognized as valid dependencies.

* **Tests**
  * Added coverage for built-in method names and custom functions used as stable dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->