### PR TITLE
docs: regenerate reference docs to fix stale content and Preact source links

### DIFF
--- a/docs/framework/angular/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/angular/reference/functions/infiniteQueryOptions.md
@@ -5,7 +5,7 @@ title: infiniteQueryOptions
 
 # Function: infiniteQueryOptions()
 
-Allows to share and re-use infinite query options in a type-safe way.
+Allows sharing and re-using infinite query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 
@@ -21,7 +21,7 @@ function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam
 
 Defined in: [infinite-query-options.ts:88](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L88)
 
-Allows to share and re-use infinite query options in a type-safe way.
+Allows sharing and re-using infinite query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 
@@ -69,7 +69,7 @@ function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam
 
 Defined in: [infinite-query-options.ts:119](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L119)
 
-Allows to share and re-use infinite query options in a type-safe way.
+Allows sharing and re-using infinite query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 
@@ -117,7 +117,7 @@ function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam
 
 Defined in: [infinite-query-options.ts:150](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L150)
 
-Allows to share and re-use infinite query options in a type-safe way.
+Allows sharing and re-using infinite query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 

--- a/docs/framework/angular/reference/functions/mutationOptions.md
+++ b/docs/framework/angular/reference/functions/mutationOptions.md
@@ -5,7 +5,7 @@ title: mutationOptions
 
 # Function: mutationOptions()
 
-Allows to share and re-use mutation options in a type-safe way.
+Allows sharing and re-using mutation options in a type-safe way.
 
 **Example**
 
@@ -49,7 +49,7 @@ function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): W
 
 Defined in: [mutation-options.ts:39](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/mutation-options.ts#L39)
 
-Allows to share and re-use mutation options in a type-safe way.
+Allows sharing and re-using mutation options in a type-safe way.
 
 **Example**
 
@@ -121,7 +121,7 @@ function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): O
 
 Defined in: [mutation-options.ts:53](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/mutation-options.ts#L53)
 
-Allows to share and re-use mutation options in a type-safe way.
+Allows sharing and re-using mutation options in a type-safe way.
 
 **Example**
 

--- a/docs/framework/angular/reference/functions/provideAngularQuery.md
+++ b/docs/framework/angular/reference/functions/provideAngularQuery.md
@@ -13,7 +13,7 @@ Defined in: [providers.ts:124](https://github.com/TanStack/query/blob/main/packa
 
 Sets up providers necessary to enable TanStack Query functionality for Angular applications.
 
-Allows to configure a `QueryClient`.
+Allows configuring a `QueryClient`.
 
 ## Parameters
 

--- a/docs/framework/angular/reference/functions/provideTanStackQuery.md
+++ b/docs/framework/angular/reference/functions/provideTanStackQuery.md
@@ -13,7 +13,7 @@ Defined in: [providers.ts:105](https://github.com/TanStack/query/blob/main/packa
 
 Sets up providers necessary to enable TanStack Query functionality for Angular applications.
 
-Allows to configure a `QueryClient` and optional features such as developer tools.
+Allows configuring a `QueryClient` and optional features such as developer tools.
 
 **Example - standalone**
 

--- a/docs/framework/angular/reference/functions/queryOptions.md
+++ b/docs/framework/angular/reference/functions/queryOptions.md
@@ -5,7 +5,7 @@ title: queryOptions
 
 # Function: queryOptions()
 
-Allows to share and re-use query options in a type-safe way.
+Allows sharing and re-using query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 
@@ -35,7 +35,7 @@ function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): Omit<Cre
 
 Defined in: [query-options.ts:76](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/query-options.ts#L76)
 
-Allows to share and re-use query options in a type-safe way.
+Allows sharing and re-using query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 
@@ -93,7 +93,7 @@ function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyo
 
 Defined in: [query-options.ts:108](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/query-options.ts#L108)
 
-Allows to share and re-use query options in a type-safe way.
+Allows sharing and re-using query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 
@@ -151,7 +151,7 @@ function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): CreateQu
 
 Defined in: [query-options.ts:140](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/query-options.ts#L140)
 
-Allows to share and re-use query options in a type-safe way.
+Allows sharing and re-using query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.
 

--- a/docs/framework/angular/reference/interfaces/BaseMutationNarrowing.md
+++ b/docs/framework/angular/reference/interfaces/BaseMutationNarrowing.md
@@ -5,7 +5,7 @@ title: BaseMutationNarrowing
 
 # Interface: BaseMutationNarrowing\<TData, TError, TVariables, TOnMutateResult\>
 
-Defined in: [types.ts:190](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L190)
+Defined in: [types.ts:184](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L184)
 
 ## Type Parameters
 
@@ -33,7 +33,7 @@ Defined in: [types.ts:190](https://github.com/TanStack/query/blob/main/packages/
 isError: SignalFunction<(this) => this is CreateMutationResult<TData, TError, TVariables, TOnMutateResult, Override<MutationObserverErrorResult<TData, TError, TVariables, TOnMutateResult>, { mutate: CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> }> & { mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> }>>;
 ```
 
-Defined in: [types.ts:213](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L213)
+Defined in: [types.ts:207](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L207)
 
 ***
 
@@ -43,7 +43,7 @@ Defined in: [types.ts:213](https://github.com/TanStack/query/blob/main/packages/
 isIdle: SignalFunction<(this) => this is CreateMutationResult<TData, TError, TVariables, TOnMutateResult, Override<MutationObserverIdleResult<TData, TError, TVariables, TOnMutateResult>, { mutate: CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> }> & { mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> }>>;
 ```
 
-Defined in: [types.ts:247](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L247)
+Defined in: [types.ts:241](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L241)
 
 ***
 
@@ -53,7 +53,7 @@ Defined in: [types.ts:247](https://github.com/TanStack/query/blob/main/packages/
 isPending: SignalFunction<(this) => this is CreateMutationResult<TData, TError, TVariables, TOnMutateResult, Override<MutationObserverLoadingResult<TData, TError, TVariables, TOnMutateResult>, { mutate: CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> }> & { mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> }>>;
 ```
 
-Defined in: [types.ts:230](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L230)
+Defined in: [types.ts:224](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L224)
 
 ***
 
@@ -63,4 +63,4 @@ Defined in: [types.ts:230](https://github.com/TanStack/query/blob/main/packages/
 isSuccess: SignalFunction<(this) => this is CreateMutationResult<TData, TError, TVariables, TOnMutateResult, Override<MutationObserverSuccessResult<TData, TError, TVariables, TOnMutateResult>, { mutate: CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> }> & { mutateAsync: CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> }>>;
 ```
 
-Defined in: [types.ts:196](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L196)
+Defined in: [types.ts:190](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L190)

--- a/docs/framework/angular/reference/interfaces/BaseQueryNarrowing.md
+++ b/docs/framework/angular/reference/interfaces/BaseQueryNarrowing.md
@@ -5,7 +5,7 @@ title: BaseQueryNarrowing
 
 # Interface: BaseQueryNarrowing\<TData, TError\>
 
-Defined in: [types.ts:57](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L57)
+Defined in: [types.ts:51](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L51)
 
 ## Type Parameters
 
@@ -25,7 +25,7 @@ Defined in: [types.ts:57](https://github.com/TanStack/query/blob/main/packages/a
 isError: (this) => this is CreateBaseQueryResult<TData, TError, CreateStatusBasedQueryResult<"error", TData, TError>>;
 ```
 
-Defined in: [types.ts:65](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L65)
+Defined in: [types.ts:59](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L59)
 
 #### Parameters
 
@@ -45,7 +45,7 @@ Defined in: [types.ts:65](https://github.com/TanStack/query/blob/main/packages/a
 isPending: (this) => this is CreateBaseQueryResult<TData, TError, CreateStatusBasedQueryResult<"pending", TData, TError>>;
 ```
 
-Defined in: [types.ts:72](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L72)
+Defined in: [types.ts:66](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L66)
 
 #### Parameters
 
@@ -65,7 +65,7 @@ Defined in: [types.ts:72](https://github.com/TanStack/query/blob/main/packages/a
 isSuccess: (this) => this is CreateBaseQueryResult<TData, TError, CreateStatusBasedQueryResult<"success", TData, TError>>;
 ```
 
-Defined in: [types.ts:58](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L58)
+Defined in: [types.ts:52](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L52)
 
 #### Parameters
 

--- a/docs/framework/angular/reference/interfaces/CreateInfiniteQueryOptions.md
+++ b/docs/framework/angular/reference/interfaces/CreateInfiniteQueryOptions.md
@@ -5,7 +5,7 @@ title: CreateInfiniteQueryOptions
 
 # Interface: CreateInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
 
-Defined in: [types.ts:81](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L81)
+Defined in: [types.ts:75](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L75)
 
 ## Extends
 

--- a/docs/framework/angular/reference/interfaces/CreateMutationOptions.md
+++ b/docs/framework/angular/reference/interfaces/CreateMutationOptions.md
@@ -5,7 +5,7 @@ title: CreateMutationOptions
 
 # Interface: CreateMutationOptions\<TData, TError, TVariables, TOnMutateResult\>
 
-Defined in: [types.ts:132](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L132)
+Defined in: [types.ts:126](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L126)
 
 ## Extends
 

--- a/docs/framework/angular/reference/type-aliases/CreateBaseMutationResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateBaseMutationResult.md
@@ -11,7 +11,7 @@ type CreateBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Over
 }> & object;
 ```
 
-Defined in: [types.ts:160](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L160)
+Defined in: [types.ts:154](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L154)
 
 ## Type Declaration
 

--- a/docs/framework/angular/reference/type-aliases/CreateBaseQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateBaseQueryResult.md
@@ -9,7 +9,7 @@ title: CreateBaseQueryResult
 type CreateBaseQueryResult<TData, TError, TState> = BaseQueryNarrowing<TData, TError> & MapToSignals<OmitKeyof<TState, keyof BaseQueryNarrowing, "safely">>;
 ```
 
-Defined in: [types.ts:98](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L98)
+Defined in: [types.ts:92](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L92)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/type-aliases/CreateInfiniteQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateInfiniteQueryResult.md
@@ -9,7 +9,7 @@ title: CreateInfiniteQueryResult
 type CreateInfiniteQueryResult<TData, TError> = BaseQueryNarrowing<TData, TError> & MapToSignals<InfiniteQueryObserverResult<TData, TError>>;
 ```
 
-Defined in: [types.ts:117](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L117)
+Defined in: [types.ts:111](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L111)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/type-aliases/CreateMutateAsyncFunction.md
+++ b/docs/framework/angular/reference/type-aliases/CreateMutateAsyncFunction.md
@@ -9,7 +9,7 @@ title: CreateMutateAsyncFunction
 type CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [types.ts:153](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L153)
+Defined in: [types.ts:147](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L147)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/type-aliases/CreateMutateFunction.md
+++ b/docs/framework/angular/reference/type-aliases/CreateMutateFunction.md
@@ -9,7 +9,7 @@ title: CreateMutateFunction
 type CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```
 
-Defined in: [types.ts:142](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L142)
+Defined in: [types.ts:136](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L136)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/type-aliases/CreateMutationResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateMutationResult.md
@@ -9,7 +9,7 @@ title: CreateMutationResult
 type CreateMutationResult<TData, TError, TVariables, TOnMutateResult, TState> = BaseMutationNarrowing<TData, TError, TVariables, TOnMutateResult> & MapToSignals<OmitKeyof<TState, keyof BaseMutationNarrowing, "safely">>;
 ```
 
-Defined in: [types.ts:266](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L266)
+Defined in: [types.ts:260](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L260)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/type-aliases/CreateQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateQueryResult.md
@@ -9,7 +9,7 @@ title: CreateQueryResult
 type CreateQueryResult<TData, TError> = CreateBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [types.ts:105](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L105)
+Defined in: [types.ts:99](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L99)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/type-aliases/DefinedCreateInfiniteQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/DefinedCreateInfiniteQueryResult.md
@@ -9,7 +9,7 @@ title: DefinedCreateInfiniteQueryResult
 type DefinedCreateInfiniteQueryResult<TData, TError, TDefinedInfiniteQueryObserver> = MapToSignals<TDefinedInfiniteQueryObserver>;
 ```
 
-Defined in: [types.ts:123](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L123)
+Defined in: [types.ts:117](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L117)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/type-aliases/DefinedCreateQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/DefinedCreateQueryResult.md
@@ -9,7 +9,7 @@ title: DefinedCreateQueryResult
 type DefinedCreateQueryResult<TData, TError, TState> = BaseQueryNarrowing<TData, TError> & MapToSignals<OmitKeyof<TState, keyof BaseQueryNarrowing, "safely">>;
 ```
 
-Defined in: [types.ts:110](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L110)
+Defined in: [types.ts:104](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L104)
 
 ## Type Parameters
 

--- a/docs/framework/lit/reference/functions/createInfiniteQueryController.md
+++ b/docs/framework/lit/reference/functions/createInfiniteQueryController.md
@@ -12,7 +12,7 @@ function createInfiniteQueryController<TQueryFnData, TError, TData, TQueryKey, T
 queryClient?): InfiniteQueryResultAccessor<TData, TError>;
 ```
 
-Defined in: [packages/lit-query/src/createInfiniteQueryController.ts:364](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createInfiniteQueryController.ts#L364)
+Defined in: [packages/lit-query/src/createInfiniteQueryController.ts:403](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createInfiniteQueryController.ts#L403)
 
 Creates a Lit reactive controller that subscribes the host to an infinite
 query.

--- a/docs/framework/lit/reference/functions/createQueriesController.md
+++ b/docs/framework/lit/reference/functions/createQueriesController.md
@@ -12,7 +12,7 @@ function createQueriesController<TQueryOptions, TCombinedResult>(
 queryClient?): QueriesResultAccessor<TCombinedResult>;
 ```
 
-Defined in: [packages/lit-query/src/createQueriesController.ts:615](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L615)
+Defined in: [packages/lit-query/src/createQueriesController.ts:703](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L703)
 
 Creates a Lit reactive controller that subscribes the host to multiple
 queries.

--- a/docs/framework/lit/reference/functions/createQueryController.md
+++ b/docs/framework/lit/reference/functions/createQueryController.md
@@ -12,7 +12,7 @@ function createQueryController<TQueryFnData, TError, TData, TQueryData, TQueryKe
 queryClient?): QueryResultAccessor<TData, TError>;
 ```
 
-Defined in: [packages/lit-query/src/createQueryController.ts:319](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueryController.ts#L319)
+Defined in: [packages/lit-query/src/createQueryController.ts:356](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueryController.ts#L356)
 
 Creates a Lit reactive controller that subscribes the host to a single query.
 

--- a/docs/framework/lit/reference/functions/useMutationState.md
+++ b/docs/framework/lit/reference/functions/useMutationState.md
@@ -12,7 +12,7 @@ function useMutationState<TResult>(
 queryClient?): MutationStateAccessor<TResult>;
 ```
 
-Defined in: [packages/lit-query/src/useMutationState.ts:187](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L187)
+Defined in: [packages/lit-query/src/useMutationState.ts:192](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L192)
 
 Creates a Lit reactive controller that selects state from matching mutations
 in the mutation cache.

--- a/docs/framework/lit/reference/type-aliases/CreateInfiniteQueryOptions.md
+++ b/docs/framework/lit/reference/type-aliases/CreateInfiniteQueryOptions.md
@@ -9,7 +9,7 @@ title: CreateInfiniteQueryOptions
 type CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [packages/lit-query/src/createInfiniteQueryController.ts:27](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createInfiniteQueryController.ts#L27)
+Defined in: [packages/lit-query/src/createInfiniteQueryController.ts:28](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createInfiniteQueryController.ts#L28)
 
 Options accepted by `createInfiniteQueryController`.
 

--- a/docs/framework/lit/reference/type-aliases/CreateQueriesControllerOptions.md
+++ b/docs/framework/lit/reference/type-aliases/CreateQueriesControllerOptions.md
@@ -9,7 +9,7 @@ title: CreateQueriesControllerOptions
 type CreateQueriesControllerOptions<TQueryOptions, TCombinedResult> = object;
 ```
 
-Defined in: [packages/lit-query/src/createQueriesController.ts:194](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L194)
+Defined in: [packages/lit-query/src/createQueriesController.ts:195](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L195)
 
 Options accepted by `createQueriesController`.
 
@@ -35,7 +35,7 @@ returned accessor.
 optional combine: (result) => TCombinedResult;
 ```
 
-Defined in: [packages/lit-query/src/createQueriesController.ts:208](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L208)
+Defined in: [packages/lit-query/src/createQueriesController.ts:209](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L209)
 
 Optional function that combines the query result array into one value.
 
@@ -59,6 +59,6 @@ queries: Accessor<
 | readonly [...{ [K in keyof TQueryOptions]: GetCreateQueriesInput<TQueryOptions[K]> }]>;
 ```
 
-Defined in: [packages/lit-query/src/createQueriesController.ts:199](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L199)
+Defined in: [packages/lit-query/src/createQueriesController.ts:200](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L200)
 
 Query options to observe, or a getter that returns the current options.

--- a/docs/framework/lit/reference/type-aliases/CreateQueriesInput.md
+++ b/docs/framework/lit/reference/type-aliases/CreateQueriesInput.md
@@ -9,7 +9,7 @@ title: CreateQueriesInput
 type CreateQueriesInput<TQueryFnData, TError, TData, TQueryKey> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>;
 ```
 
-Defined in: [packages/lit-query/src/createQueriesController.ts:30](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L30)
+Defined in: [packages/lit-query/src/createQueriesController.ts:31](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L31)
 
 Options for one query inside `createQueriesController`.
 

--- a/docs/framework/lit/reference/type-aliases/CreateQueryOptions.md
+++ b/docs/framework/lit/reference/type-aliases/CreateQueryOptions.md
@@ -9,7 +9,7 @@ title: CreateQueryOptions
 type CreateQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>;
 ```
 
-Defined in: [packages/lit-query/src/createQueryController.ts:27](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueryController.ts#L27)
+Defined in: [packages/lit-query/src/createQueryController.ts:28](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueryController.ts#L28)
 
 Options accepted by `createQueryController`.
 

--- a/docs/framework/lit/reference/type-aliases/InfiniteQueryResultAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/InfiniteQueryResultAccessor.md
@@ -9,7 +9,7 @@ title: InfiniteQueryResultAccessor
 type InfiniteQueryResultAccessor<TData, TError> = ValueAccessor<InfiniteQueryObserverResult<TData, TError>> & object;
 ```
 
-Defined in: [packages/lit-query/src/createInfiniteQueryController.ts:48](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createInfiniteQueryController.ts#L48)
+Defined in: [packages/lit-query/src/createInfiniteQueryController.ts:49](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createInfiniteQueryController.ts#L49)
 
 Accessor returned by `createInfiniteQueryController`.
 

--- a/docs/framework/lit/reference/type-aliases/MutationStateAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/MutationStateAccessor.md
@@ -9,7 +9,7 @@ title: MutationStateAccessor
 type MutationStateAccessor<TResult> = ValueAccessor<TResult[]> & object;
 ```
 
-Defined in: [packages/lit-query/src/useMutationState.ts:32](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L32)
+Defined in: [packages/lit-query/src/useMutationState.ts:33](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L33)
 
 Accessor returned by `useMutationState`.
 

--- a/docs/framework/lit/reference/type-aliases/MutationStateOptions.md
+++ b/docs/framework/lit/reference/type-aliases/MutationStateOptions.md
@@ -9,7 +9,7 @@ title: MutationStateOptions
 type MutationStateOptions<TResult> = object;
 ```
 
-Defined in: [packages/lit-query/src/useMutationState.ts:19](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L19)
+Defined in: [packages/lit-query/src/useMutationState.ts:20](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L20)
 
 Options accepted by `useMutationState`.
 
@@ -27,7 +27,7 @@ Options accepted by `useMutationState`.
 optional filters: Accessor<MutationFilters>;
 ```
 
-Defined in: [packages/lit-query/src/useMutationState.ts:21](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L21)
+Defined in: [packages/lit-query/src/useMutationState.ts:22](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L22)
 
 Filters used to select mutations from the mutation cache.
 
@@ -39,7 +39,7 @@ Filters used to select mutations from the mutation cache.
 optional select: (mutation) => TResult;
 ```
 
-Defined in: [packages/lit-query/src/useMutationState.ts:23](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L23)
+Defined in: [packages/lit-query/src/useMutationState.ts:24](https://github.com/TanStack/query/blob/main/packages/lit-query/src/useMutationState.ts#L24)
 
 Maps each matching mutation to the value returned by the accessor.
 

--- a/docs/framework/lit/reference/type-aliases/QueriesResultAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/QueriesResultAccessor.md
@@ -9,7 +9,7 @@ title: QueriesResultAccessor
 type QueriesResultAccessor<TCombinedResult> = ValueAccessor<TCombinedResult> & object;
 ```
 
-Defined in: [packages/lit-query/src/createQueriesController.ts:217](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L217)
+Defined in: [packages/lit-query/src/createQueriesController.ts:218](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueriesController.ts#L218)
 
 Accessor returned by `createQueriesController`.
 

--- a/docs/framework/lit/reference/type-aliases/QueryResultAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/QueryResultAccessor.md
@@ -9,7 +9,7 @@ title: QueryResultAccessor
 type QueryResultAccessor<TData, TError> = ValueAccessor<QueryObserverResult<TData, TError>> & object;
 ```
 
-Defined in: [packages/lit-query/src/createQueryController.ts:41](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueryController.ts#L41)
+Defined in: [packages/lit-query/src/createQueryController.ts:42](https://github.com/TanStack/query/blob/main/packages/lit-query/src/createQueryController.ts#L42)
 
 Accessor returned by `createQueryController`.
 

--- a/docs/framework/preact/reference/functions/HydrationBoundary.md
+++ b/docs/framework/preact/reference/functions/HydrationBoundary.md
@@ -6,10 +6,10 @@ title: HydrationBoundary
 # Function: HydrationBoundary()
 
 ```ts
-function HydrationBoundary(__namedParameters): ComponentChildren;
+function HydrationBoundary(__namedParameters): Element;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:24](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L24)
+Defined in: [preact-query/src/HydrationBoundary.tsx:26](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L26)
 
 ## Parameters
 
@@ -19,4 +19,4 @@ Defined in: [preact-query/src/HydrationBoundary.tsx:24](https://github.com/theVe
 
 ## Returns
 
-`ComponentChildren`
+`Element`

--- a/docs/framework/preact/reference/functions/QueryClientProvider.md
+++ b/docs/framework/preact/reference/functions/QueryClientProvider.md
@@ -9,7 +9,7 @@ title: QueryClientProvider
 function QueryClientProvider(__namedParameters): VNode;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:28](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L28)
+Defined in: [preact-query/src/QueryClientProvider.tsx:29](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L29)
 
 ## Parameters
 

--- a/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
@@ -9,7 +9,7 @@ title: QueryErrorResetBoundary
 function QueryErrorResetBoundary(__namedParameters): Element;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:47](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L47)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:48](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L48)
 
 ## Parameters
 

--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -11,7 +11,7 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:75](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L75)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:76](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L76)
 
 ### Type Parameters
 
@@ -51,7 +51,7 @@ Defined in: [preact-query/src/infiniteQueryOptions.ts:75](https://github.com/the
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:99](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L99)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:100](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L100)
 
 ### Type Parameters
 
@@ -91,7 +91,7 @@ Defined in: [preact-query/src/infiniteQueryOptions.ts:99](https://github.com/the
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:123](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L123)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:124](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L124)
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/functions/mutationOptions.md
+++ b/docs/framework/preact/reference/functions/mutationOptions.md
@@ -11,7 +11,7 @@ title: mutationOptions
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): WithRequired<UseMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [preact-query/src/mutationOptions.ts:4](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/mutationOptions.ts#L4)
+Defined in: [preact-query/src/mutationOptions.ts:5](https://github.com/TanStack/query/blob/main/packages/preact-query/src/mutationOptions.ts#L5)
 
 ### Type Parameters
 
@@ -47,7 +47,7 @@ Defined in: [preact-query/src/mutationOptions.ts:4](https://github.com/theVedant
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): Omit<UseMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [preact-query/src/mutationOptions.ts:18](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/mutationOptions.ts#L18)
+Defined in: [preact-query/src/mutationOptions.ts:19](https://github.com/TanStack/query/blob/main/packages/preact-query/src/mutationOptions.ts#L19)
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -11,7 +11,7 @@ title: queryOptions
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:52](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/queryOptions.ts#L52)
+Defined in: [preact-query/src/queryOptions.ts:53](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L53)
 
 ### Type Parameters
 
@@ -47,7 +47,7 @@ Defined in: [preact-query/src/queryOptions.ts:52](https://github.com/theVedanta/
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:63](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/queryOptions.ts#L63)
+Defined in: [preact-query/src/queryOptions.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L64)
 
 ### Type Parameters
 
@@ -83,7 +83,7 @@ Defined in: [preact-query/src/queryOptions.ts:63](https://github.com/theVedanta/
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:74](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/queryOptions.ts#L74)
+Defined in: [preact-query/src/queryOptions.ts:75](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L75)
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -11,7 +11,7 @@ title: useInfiniteQuery
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): DefinedUseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:20](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L20)
+Defined in: [preact-query/src/useInfiniteQuery.ts:21](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L21)
 
 ### Type Parameters
 
@@ -55,7 +55,7 @@ Defined in: [preact-query/src/useInfiniteQuery.ts:20](https://github.com/theVeda
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:37](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L37)
+Defined in: [preact-query/src/useInfiniteQuery.ts:38](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L38)
 
 ### Type Parameters
 
@@ -99,7 +99,7 @@ Defined in: [preact-query/src/useInfiniteQuery.ts:37](https://github.com/theVeda
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:54](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L54)
+Defined in: [preact-query/src/useInfiniteQuery.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L55)
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/functions/useIsFetching.md
+++ b/docs/framework/preact/reference/functions/useIsFetching.md
@@ -9,7 +9,7 @@ title: useIsFetching
 function useIsFetching(filters?, queryClient?): number;
 ```
 
-Defined in: [preact-query/src/useIsFetching.ts:8](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useIsFetching.ts#L8)
+Defined in: [preact-query/src/useIsFetching.ts:8](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useIsFetching.ts#L8)
 
 ## Parameters
 

--- a/docs/framework/preact/reference/functions/useIsMutating.md
+++ b/docs/framework/preact/reference/functions/useIsMutating.md
@@ -9,7 +9,7 @@ title: useIsMutating
 function useIsMutating(filters?, queryClient?): number;
 ```
 
-Defined in: [preact-query/src/useMutationState.ts:13](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useMutationState.ts#L13)
+Defined in: [preact-query/src/useMutationState.ts:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutationState.ts#L14)
 
 ## Parameters
 

--- a/docs/framework/preact/reference/functions/useIsRestoring.md
+++ b/docs/framework/preact/reference/functions/useIsRestoring.md
@@ -9,7 +9,7 @@ title: useIsRestoring
 function useIsRestoring(): boolean;
 ```
 
-Defined in: [preact-query/src/IsRestoringProvider.ts:6](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/IsRestoringProvider.ts#L6)
+Defined in: [preact-query/src/IsRestoringProvider.ts:6](https://github.com/TanStack/query/blob/main/packages/preact-query/src/IsRestoringProvider.ts#L6)
 
 ## Returns
 

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -9,7 +9,7 @@ title: useMutation
 function useMutation<TData, TError, TVariables, TOnMutateResult>(options, queryClient?): UseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/useMutation.ts:19](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useMutation.ts#L19)
+Defined in: [preact-query/src/useMutation.ts:20](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutation.ts#L20)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/useMutationState.md
+++ b/docs/framework/preact/reference/functions/useMutationState.md
@@ -9,7 +9,7 @@ title: useMutationState
 function useMutationState<TResult>(options, queryClient?): TResult[];
 ```
 
-Defined in: [preact-query/src/useMutationState.ts:41](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useMutationState.ts#L41)
+Defined in: [preact-query/src/useMutationState.ts:42](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutationState.ts#L42)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
@@ -9,7 +9,7 @@ title: usePrefetchInfiniteQuery
 function usePrefetchInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): void;
 ```
 
-Defined in: [preact-query/src/usePrefetchInfiniteQuery.tsx:9](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/usePrefetchInfiniteQuery.tsx#L9)
+Defined in: [preact-query/src/usePrefetchInfiniteQuery.tsx:10](https://github.com/TanStack/query/blob/main/packages/preact-query/src/usePrefetchInfiniteQuery.tsx#L10)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/usePrefetchQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchQuery.md
@@ -9,7 +9,7 @@ title: usePrefetchQuery
 function usePrefetchQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): void;
 ```
 
-Defined in: [preact-query/src/usePrefetchQuery.tsx:5](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/usePrefetchQuery.tsx#L5)
+Defined in: [preact-query/src/usePrefetchQuery.tsx:6](https://github.com/TanStack/query/blob/main/packages/preact-query/src/usePrefetchQuery.tsx#L6)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -9,7 +9,7 @@ title: useQueries
 function useQueries<T, TCombinedResult>(__namedParameters, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useQueries.ts:207](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useQueries.ts#L207)
+Defined in: [preact-query/src/useQueries.ts:207](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L207)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -11,7 +11,7 @@ title: useQuery
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): DefinedUseQueryResult<NoInfer<TData>, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:19](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useQuery.ts#L19)
+Defined in: [preact-query/src/useQuery.ts:15](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L15)
 
 ### Type Parameters
 
@@ -51,7 +51,7 @@ Defined in: [preact-query/src/useQuery.ts:19](https://github.com/theVedanta/quer
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<NoInfer<TData>, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:29](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useQuery.ts#L29)
+Defined in: [preact-query/src/useQuery.ts:25](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L25)
 
 ### Type Parameters
 
@@ -91,7 +91,7 @@ Defined in: [preact-query/src/useQuery.ts:29](https://github.com/theVedanta/quer
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<NoInfer<TData>, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:39](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useQuery.ts#L39)
+Defined in: [preact-query/src/useQuery.ts:35](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L35)
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/functions/useQueryClient.md
+++ b/docs/framework/preact/reference/functions/useQueryClient.md
@@ -9,7 +9,7 @@ title: useQueryClient
 function useQueryClient(queryClient?): QueryClient;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:9](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L9)
+Defined in: [preact-query/src/QueryClientProvider.tsx:10](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L10)
 
 ## Parameters
 

--- a/docs/framework/preact/reference/functions/useQueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/useQueryErrorResetBoundary.md
@@ -9,7 +9,7 @@ title: useQueryErrorResetBoundary
 function useQueryErrorResetBoundary(): QueryErrorResetBoundaryValue;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:34](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L34)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:35](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L35)
 
 ## Returns
 

--- a/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
@@ -9,7 +9,7 @@ title: useSuspenseInfiniteQuery
 function useSuspenseInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseSuspenseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:17](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L17)
+Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:18](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L18)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -11,7 +11,7 @@ title: useSuspenseQueries
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:164](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L164)
+Defined in: [preact-query/src/useSuspenseQueries.ts:165](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L165)
 
 ### Type Parameters
 
@@ -50,7 +50,7 @@ Defined in: [preact-query/src/useSuspenseQueries.ts:164](https://github.com/theV
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:177](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L177)
+Defined in: [preact-query/src/useSuspenseQueries.ts:178](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L178)
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/functions/useSuspenseQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQuery.md
@@ -9,7 +9,7 @@ title: useSuspenseQuery
 function useSuspenseQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseSuspenseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseQuery.ts:7](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L7)
+Defined in: [preact-query/src/useSuspenseQuery.ts:8](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L8)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
+++ b/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
@@ -5,7 +5,7 @@ title: HydrationBoundaryProps
 
 # Interface: HydrationBoundaryProps
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:12](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L12)
+Defined in: [preact-query/src/HydrationBoundary.tsx:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L14)
 
 ## Properties
 
@@ -15,7 +15,7 @@ Defined in: [preact-query/src/HydrationBoundary.tsx:12](https://github.com/theVe
 optional children: ComponentChildren;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:20](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L20)
+Defined in: [preact-query/src/HydrationBoundary.tsx:22](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L22)
 
 ***
 
@@ -25,7 +25,7 @@ Defined in: [preact-query/src/HydrationBoundary.tsx:20](https://github.com/theVe
 optional options: OmitKeyof<HydrateOptions, "defaultOptions"> & object;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:14](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L14)
+Defined in: [preact-query/src/HydrationBoundary.tsx:16](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L16)
 
 #### Type Declaration
 
@@ -44,7 +44,7 @@ optional defaultOptions: OmitKeyof<{
 optional queryClient: QueryClient;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:21](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L21)
+Defined in: [preact-query/src/HydrationBoundary.tsx:23](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L23)
 
 ***
 
@@ -54,4 +54,4 @@ Defined in: [preact-query/src/HydrationBoundary.tsx:21](https://github.com/theVe
 state: DehydratedState | null | undefined;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:13](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L13)
+Defined in: [preact-query/src/HydrationBoundary.tsx:15](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L15)

--- a/docs/framework/preact/reference/interfaces/QueryErrorResetBoundaryProps.md
+++ b/docs/framework/preact/reference/interfaces/QueryErrorResetBoundaryProps.md
@@ -5,7 +5,7 @@ title: QueryErrorResetBoundaryProps
 
 # Interface: QueryErrorResetBoundaryProps
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:43](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L43)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:44](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L44)
 
 ## Properties
 
@@ -17,4 +17,4 @@ children:
   | QueryErrorResetBoundaryFunction;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:44](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L44)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:45](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L45)

--- a/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
@@ -5,7 +5,7 @@ title: UseBaseQueryOptions
 
 # Interface: UseBaseQueryOptions\<TQueryFnData, TError, TData, TQueryData, TQueryKey\>
 
-Defined in: [preact-query/src/types.ts:29](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L29)
+Defined in: [preact-query/src/types.ts:28](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L28)
 
 ## Extends
 
@@ -41,7 +41,7 @@ Defined in: [preact-query/src/types.ts:29](https://github.com/theVedanta/query/b
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:46](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L46)
+Defined in: [preact-query/src/types.ts:45](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L45)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
@@ -5,7 +5,7 @@ title: UseInfiniteQueryOptions
 
 # Interface: UseInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
 
-Defined in: [preact-query/src/types.ts:103](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L103)
+Defined in: [preact-query/src/types.ts:102](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L102)
 
 ## Extends
 
@@ -41,7 +41,7 @@ Defined in: [preact-query/src/types.ts:103](https://github.com/theVedanta/query/
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:123](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L123)
+Defined in: [preact-query/src/types.ts:122](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L122)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseMutationOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseMutationOptions.md
@@ -5,7 +5,7 @@ title: UseMutationOptions
 
 # Interface: UseMutationOptions\<TData, TError, TVariables, TOnMutateResult\>
 
-Defined in: [preact-query/src/types.ts:192](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L192)
+Defined in: [preact-query/src/types.ts:191](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L191)
 
 ## Extends
 

--- a/docs/framework/preact/reference/interfaces/UsePrefetchQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UsePrefetchQueryOptions.md
@@ -5,7 +5,7 @@ title: UsePrefetchQueryOptions
 
 # Interface: UsePrefetchQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
 
-Defined in: [preact-query/src/types.ts:49](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L49)
+Defined in: [preact-query/src/types.ts:48](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L48)
 
 ## Extends
 
@@ -37,4 +37,4 @@ Defined in: [preact-query/src/types.ts:49](https://github.com/theVedanta/query/b
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, never>;
 ```
 
-Defined in: [preact-query/src/types.ts:58](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L58)
+Defined in: [preact-query/src/types.ts:57](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L57)

--- a/docs/framework/preact/reference/interfaces/UseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseQueryOptions.md
@@ -5,7 +5,7 @@ title: UseQueryOptions
 
 # Interface: UseQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
 
-Defined in: [preact-query/src/types.ts:65](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L65)
+Defined in: [preact-query/src/types.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L64)
 
 ## Extends
 
@@ -37,7 +37,7 @@ Defined in: [preact-query/src/types.ts:65](https://github.com/theVedanta/query/b
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:46](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L46)
+Defined in: [preact-query/src/types.ts:45](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L45)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
@@ -5,7 +5,7 @@ title: UseSuspenseInfiniteQueryOptions
 
 # Interface: UseSuspenseInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
 
-Defined in: [preact-query/src/types.ts:128](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L128)
+Defined in: [preact-query/src/types.ts:127](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L127)
 
 ## Extends
 
@@ -41,7 +41,7 @@ Defined in: [preact-query/src/types.ts:128](https://github.com/theVedanta/query/
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [preact-query/src/types.ts:138](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L138)
+Defined in: [preact-query/src/types.ts:137](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L137)
 
 ***
 
@@ -51,7 +51,7 @@ Defined in: [preact-query/src/types.ts:138](https://github.com/theVedanta/query/
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:123](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L123)
+Defined in: [preact-query/src/types.ts:122](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L122)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
@@ -5,7 +5,7 @@ title: UseSuspenseQueryOptions
 
 # Interface: UseSuspenseQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
 
-Defined in: [preact-query/src/types.ts:81](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L81)
+Defined in: [preact-query/src/types.ts:80](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L80)
 
 ## Extends
 
@@ -37,7 +37,7 @@ Defined in: [preact-query/src/types.ts:81](https://github.com/theVedanta/query/b
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, never>;
 ```
 
-Defined in: [preact-query/src/types.ts:90](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L90)
+Defined in: [preact-query/src/types.ts:89](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L89)
 
 ***
 
@@ -47,7 +47,7 @@ Defined in: [preact-query/src/types.ts:90](https://github.com/theVedanta/query/b
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:46](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L46)
+Defined in: [preact-query/src/types.ts:45](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L45)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/type-aliases/AnyUseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseBaseQueryOptions.md
@@ -9,4 +9,4 @@ title: AnyUseBaseQueryOptions
 type AnyUseBaseQueryOptions = UseBaseQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:22](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L22)
+Defined in: [preact-query/src/types.ts:21](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L21)

--- a/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
@@ -9,4 +9,4 @@ title: AnyUseInfiniteQueryOptions
 type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:96](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L96)
+Defined in: [preact-query/src/types.ts:95](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L95)

--- a/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
@@ -9,4 +9,4 @@ title: AnyUseMutationOptions
 type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:191](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L191)
+Defined in: [preact-query/src/types.ts:190](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L190)

--- a/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
@@ -9,4 +9,4 @@ title: AnyUseQueryOptions
 type AnyUseQueryOptions = UseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:64](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L64)
+Defined in: [preact-query/src/types.ts:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L63)

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
@@ -9,4 +9,4 @@ title: AnyUseSuspenseInfiniteQueryOptions
 type AnyUseSuspenseInfiniteQueryOptions = UseSuspenseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:126](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L126)
+Defined in: [preact-query/src/types.ts:125](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L125)

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
@@ -9,4 +9,4 @@ title: AnyUseSuspenseQueryOptions
 type AnyUseSuspenseQueryOptions = UseSuspenseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:75](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L75)
+Defined in: [preact-query/src/types.ts:74](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L74)

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -9,7 +9,7 @@ title: DefinedInitialDataInfiniteOptions
 type DefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:56](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L56)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:57](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L57)
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
@@ -9,7 +9,7 @@ title: DefinedInitialDataOptions
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:40](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/queryOptions.ts#L40)
+Defined in: [preact-query/src/queryOptions.ts:41](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L41)
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
@@ -9,7 +9,7 @@ title: DefinedUseInfiniteQueryResult
 type DefinedUseInfiniteQueryResult<TData, TError> = DefinedInfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:178](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L178)
+Defined in: [preact-query/src/types.ts:177](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L177)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
@@ -9,7 +9,7 @@ title: DefinedUseQueryResult
 type DefinedUseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:168](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L168)
+Defined in: [preact-query/src/types.ts:167](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L167)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesOptions.md
@@ -9,7 +9,7 @@ title: QueriesOptions
 type QueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryOptionsForUseQueries[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryOptionsForUseQueries<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesOptions<[...Tails], [...TResults, GetUseQueryOptionsForUseQueries<Head>], [...TDepth, 1]> : ReadonlyArray<unknown> extends T ? T : T extends UseQueryOptionsForUseQueries<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData, TQueryKey>[] : UseQueryOptionsForUseQueries[];
 ```
 
-Defined in: [preact-query/src/useQueries.ts:147](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useQueries.ts#L147)
+Defined in: [preact-query/src/useQueries.ts:147](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L147)
 
 QueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
 

--- a/docs/framework/preact/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesResults.md
@@ -9,7 +9,7 @@ title: QueriesResults
 type QueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesResults<[...Tails], [...TResults, GetUseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useQueries.ts:189](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useQueries.ts#L189)
+Defined in: [preact-query/src/useQueries.ts:189](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L189)
 
 QueriesResults reducer recursively maps type param to results
 

--- a/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
@@ -9,7 +9,7 @@ title: QueryClientProviderProps
 type QueryClientProviderProps = object;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:23](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L23)
+Defined in: [preact-query/src/QueryClientProvider.tsx:24](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L24)
 
 ## Properties
 
@@ -19,7 +19,7 @@ Defined in: [preact-query/src/QueryClientProvider.tsx:23](https://github.com/the
 optional children: ComponentChildren;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:25](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L25)
+Defined in: [preact-query/src/QueryClientProvider.tsx:26](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L26)
 
 ***
 
@@ -29,4 +29,4 @@ Defined in: [preact-query/src/QueryClientProvider.tsx:25](https://github.com/the
 client: QueryClient;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:24](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L24)
+Defined in: [preact-query/src/QueryClientProvider.tsx:25](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L25)

--- a/docs/framework/preact/reference/type-aliases/QueryErrorClearResetFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorClearResetFunction.md
@@ -9,7 +9,7 @@ title: QueryErrorClearResetFunction
 type QueryErrorClearResetFunction = () => void;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:7](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L7)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:8](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L8)
 
 ## Returns
 

--- a/docs/framework/preact/reference/type-aliases/QueryErrorIsResetFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorIsResetFunction.md
@@ -9,7 +9,7 @@ title: QueryErrorIsResetFunction
 type QueryErrorIsResetFunction = () => boolean;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:6](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L6)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:7](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L7)
 
 ## Returns
 

--- a/docs/framework/preact/reference/type-aliases/QueryErrorResetBoundaryFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorResetBoundaryFunction.md
@@ -9,7 +9,7 @@ title: QueryErrorResetBoundaryFunction
 type QueryErrorResetBoundaryFunction = (value) => ComponentChildren;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:39](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L39)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:40](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L40)
 
 ## Parameters
 

--- a/docs/framework/preact/reference/type-aliases/QueryErrorResetFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorResetFunction.md
@@ -9,7 +9,7 @@ title: QueryErrorResetFunction
 type QueryErrorResetFunction = () => void;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:5](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L5)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:6](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L6)
 
 ## Returns
 

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
@@ -9,7 +9,7 @@ title: SuspenseQueriesOptions
 type SuspenseQueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryOptions[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryOptions<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesOptions<[...Tails], [...TResults, GetUseSuspenseQueryOptions<Head>], [...TDepth, 1]> : unknown[] extends T ? T : T extends UseSuspenseQueryOptions<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[] : UseSuspenseQueryOptions[];
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:109](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L109)
+Defined in: [preact-query/src/useSuspenseQueries.ts:110](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L110)
 
 SuspenseQueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
 

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
@@ -9,7 +9,7 @@ title: SuspenseQueriesResults
 type SuspenseQueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesResults<[...Tails], [...TResults, GetUseSuspenseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseSuspenseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:146](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L146)
+Defined in: [preact-query/src/useSuspenseQueries.ts:147](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L147)
 
 SuspenseQueriesResults reducer recursively maps type param to results
 

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
@@ -9,7 +9,7 @@ title: UndefinedInitialDataInfiniteOptions
 type UndefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:13](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L13)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L14)
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
@@ -9,7 +9,7 @@ title: UndefinedInitialDataOptions
 type UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:13](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/queryOptions.ts#L13)
+Defined in: [preact-query/src/queryOptions.ts:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L14)
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
@@ -9,7 +9,7 @@ title: UnusedSkipTokenInfiniteOptions
 type UnusedSkipTokenInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:34](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L34)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:35](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L35)
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
@@ -9,7 +9,7 @@ title: UnusedSkipTokenOptions
 type UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> = OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:25](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/queryOptions.ts#L25)
+Defined in: [preact-query/src/queryOptions.ts:26](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L26)
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
@@ -11,7 +11,7 @@ type UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Overrid
 }> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:220](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L220)
+Defined in: [preact-query/src/types.ts:219](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L219)
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
@@ -9,7 +9,7 @@ title: UseBaseQueryResult
 type UseBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:150](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L150)
+Defined in: [preact-query/src/types.ts:149](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L149)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
@@ -9,7 +9,7 @@ title: UseInfiniteQueryResult
 type UseInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:173](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L173)
+Defined in: [preact-query/src/types.ts:172](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L172)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
@@ -9,7 +9,7 @@ title: UseMutateAsyncFunction
 type UseMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:213](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L213)
+Defined in: [preact-query/src/types.ts:212](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L212)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
@@ -9,7 +9,7 @@ title: UseMutateFunction
 type UseMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```
 
-Defined in: [preact-query/src/types.ts:202](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L202)
+Defined in: [preact-query/src/types.ts:201](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L201)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutationResult.md
@@ -9,7 +9,7 @@ title: UseMutationResult
 type UseMutationResult<TData, TError, TVariables, TOnMutateResult> = UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:237](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L237)
+Defined in: [preact-query/src/types.ts:236](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L236)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseQueryResult.md
@@ -9,7 +9,7 @@ title: UseQueryResult
 type UseQueryResult<TData, TError> = UseBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:155](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L155)
+Defined in: [preact-query/src/types.ts:154](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L154)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
@@ -9,7 +9,7 @@ title: UseSuspenseInfiniteQueryResult
 type UseSuspenseInfiniteQueryResult<TData, TError> = OmitKeyof<DefinedInfiniteQueryObserverResult<TData, TError>, "isPlaceholderData" | "promise">;
 ```
 
-Defined in: [preact-query/src/types.ts:183](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L183)
+Defined in: [preact-query/src/types.ts:182](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L182)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
@@ -9,7 +9,7 @@ title: UseSuspenseQueryResult
 type UseSuspenseQueryResult<TData, TError> = DistributiveOmit<DefinedQueryObserverResult<TData, TError>, "isPlaceholderData" | "promise">;
 ```
 
-Defined in: [preact-query/src/types.ts:160](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/types.ts#L160)
+Defined in: [preact-query/src/types.ts:159](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L159)
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/variables/IsRestoringProvider.md
+++ b/docs/framework/preact/reference/variables/IsRestoringProvider.md
@@ -9,4 +9,4 @@ title: IsRestoringProvider
 const IsRestoringProvider: Provider<boolean> = IsRestoringContext.Provider;
 ```
 
-Defined in: [preact-query/src/IsRestoringProvider.ts:7](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/IsRestoringProvider.ts#L7)
+Defined in: [preact-query/src/IsRestoringProvider.ts:7](https://github.com/TanStack/query/blob/main/packages/preact-query/src/IsRestoringProvider.ts#L7)

--- a/docs/framework/preact/reference/variables/QueryClientContext.md
+++ b/docs/framework/preact/reference/variables/QueryClientContext.md
@@ -9,4 +9,4 @@ title: QueryClientContext
 const QueryClientContext: Context<QueryClient | undefined>;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:5](https://github.com/theVedanta/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L5)
+Defined in: [preact-query/src/QueryClientProvider.tsx:6](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L6)

--- a/docs/framework/svelte/reference/functions/mutationOptions.md
+++ b/docs/framework/svelte/reference/functions/mutationOptions.md
@@ -8,10 +8,10 @@ title: mutationOptions
 ## Call Signature
 
 ```ts
-function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): WithRequired<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>, 'mutationKey'>
+function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): WithRequired<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [packages/svelte-query/src/mutationOptions.ts](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts)
+Defined in: [packages/svelte-query/src/mutationOptions.ts:4](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts#L4)
 
 ### Type Parameters
 
@@ -35,19 +35,19 @@ Defined in: [packages/svelte-query/src/mutationOptions.ts](https://github.com/Ta
 
 #### options
 
-`WithRequired`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `'mutationKey'`\>
+`WithRequired`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>
 
 ### Returns
 
-`WithRequired`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `'mutationKey'`\>
+`WithRequired`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>
 
 ## Call Signature
 
 ```ts
-function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): Omit<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>, 'mutationKey'>
+function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): Omit<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [packages/svelte-query/src/mutationOptions.ts](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts)
+Defined in: [packages/svelte-query/src/mutationOptions.ts:18](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts#L18)
 
 ### Type Parameters
 
@@ -71,8 +71,8 @@ Defined in: [packages/svelte-query/src/mutationOptions.ts](https://github.com/Ta
 
 #### options
 
-`Omit`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `'mutationKey'`\>
+`Omit`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>
 
 ### Returns
 
-`Omit`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `'mutationKey'`\>
+`Omit`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>

--- a/docs/framework/svelte/reference/index.md
+++ b/docs/framework/svelte/reference/index.md
@@ -42,6 +42,7 @@ title: "@tanstack/svelte-query"
 - [getIsRestoringContext](functions/getIsRestoringContext.md)
 - [getQueryClientContext](functions/getQueryClientContext.md)
 - [infiniteQueryOptions](functions/infiniteQueryOptions.md)
+- [mutationOptions](functions/mutationOptions.md)
 - [queryOptions](functions/queryOptions.md)
 - [setIsRestoringContext](functions/setIsRestoringContext.md)
 - [setQueryClientContext](functions/setQueryClientContext.md)

--- a/docs/framework/svelte/reference/type-aliases/HydrationBoundary.md
+++ b/docs/framework/svelte/reference/type-aliases/HydrationBoundary.md
@@ -9,4 +9,4 @@ title: HydrationBoundary
 type HydrationBoundary = SvelteComponent;
 ```
 
-Defined in: node\_modules/.pnpm/svelte@5.39.3/node\_modules/svelte/types/index.d.ts:3092
+Defined in: node\_modules/.pnpm/svelte@5.55.1/node\_modules/svelte/types/index.d.ts:3204

--- a/docs/framework/svelte/reference/variables/HydrationBoundary.md
+++ b/docs/framework/svelte/reference/variables/HydrationBoundary.md
@@ -9,4 +9,4 @@ title: HydrationBoundary
 const HydrationBoundary: LegacyComponentType;
 ```
 
-Defined in: node\_modules/.pnpm/svelte@5.39.3/node\_modules/svelte/types/index.d.ts:3092
+Defined in: node\_modules/.pnpm/svelte@5.55.1/node\_modules/svelte/types/index.d.ts:3204


### PR DESCRIPTION
## 🎯 Changes

Regenerate reference docs via `pnpm run generate-docs` to fix:

- Preact reference docs (64 files) pointing to a contributor fork (`theVedanta/query`) instead of `TanStack/query` in `Defined in:` links
- Stale line numbers and JSDoc text in angular, svelte, and lit reference docs that were left out of sync after their source files changed (e.g. the angular "Allows to share" → "Allows sharing" grammar fix from #10890, and the `mutationOptions` entry from #10175 missing from the svelte reference index)

Verified this isn't a stale local install producing spurious diffs: ran `pnpm install --frozen-lockfile` (no changes) then `pnpm run generate-docs` again, and the working tree stayed clean — regeneration against the pinned toolchain is idempotent and reproduces this exact diff.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (docs-only change, no code/tests affected)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).