### PR TITLE
docs(config.json): register missing angular API reference functions in sidebar

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1334,12 +1334,60 @@
               "to": "framework/angular/reference/index"
             },
             {
-              "label": "Functions / injectQuery",
-              "to": "framework/angular/reference/functions/injectQuery"
+              "label": "Functions / infiniteQueryOptions",
+              "to": "framework/angular/reference/functions/infiniteQueryOptions"
+            },
+            {
+              "label": "Functions / injectInfiniteQuery",
+              "to": "framework/angular/reference/functions/injectInfiniteQuery"
+            },
+            {
+              "label": "Functions / injectIsFetching",
+              "to": "framework/angular/reference/functions/injectIsFetching"
+            },
+            {
+              "label": "Functions / injectIsMutating",
+              "to": "framework/angular/reference/functions/injectIsMutating"
+            },
+            {
+              "label": "Functions / injectIsRestoring",
+              "to": "framework/angular/reference/functions/injectIsRestoring"
             },
             {
               "label": "Functions / injectMutation",
               "to": "framework/angular/reference/functions/injectMutation"
+            },
+            {
+              "label": "Functions / injectMutationState",
+              "to": "framework/angular/reference/functions/injectMutationState"
+            },
+            {
+              "label": "Functions / injectQuery",
+              "to": "framework/angular/reference/functions/injectQuery"
+            },
+            {
+              "label": "Functions / mutationOptions",
+              "to": "framework/angular/reference/functions/mutationOptions"
+            },
+            {
+              "label": "Functions / provideIsRestoring",
+              "to": "framework/angular/reference/functions/provideIsRestoring"
+            },
+            {
+              "label": "Functions / provideQueryClient",
+              "to": "framework/angular/reference/functions/provideQueryClient"
+            },
+            {
+              "label": "Functions / provideTanStackQuery",
+              "to": "framework/angular/reference/functions/provideTanStackQuery"
+            },
+            {
+              "label": "Functions / queryFeature",
+              "to": "framework/angular/reference/functions/queryFeature"
+            },
+            {
+              "label": "Functions / queryOptions",
+              "to": "framework/angular/reference/functions/queryOptions"
             }
           ]
         },


### PR DESCRIPTION
## 🎯 Changes

The Angular API Reference sidebar (`docs/config.json`) only linked to 2 of the 16 functions that actually exist under `docs/framework/angular/reference/functions/` (generated via `pnpm run generate-docs`). The rest were reachable only by direct URL, not from the sidebar.

- Register the 12 missing, non-deprecated functions: `infiniteQueryOptions`, `injectInfiniteQuery`, `injectIsFetching`, `injectIsMutating`, `injectIsRestoring`, `injectMutationState`, `mutationOptions`, `provideIsRestoring`, `provideQueryClient`, `provideTanStackQuery`, `queryFeature`, `queryOptions`
- Follow the existing local label convention (`Functions / <name>`) already used by the two pre-existing entries
- Intentionally skip `injectQueryClient` and `provideAngularQuery` — both are marked `@deprecated` in source (in favor of `inject(QueryClient)` and `provideTanStackQuery` respectively) and shown struck through in `framework/angular/reference/index.md`
- `Interfaces` / `Type Aliases` pages are left out of the sidebar, consistent with how Preact, Svelte, and Lit's generated reference docs are registered (functions only)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (docs-only change, no code/tests affected)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Angular API Reference navigation with additional entries for query options, infinite queries, mutations, injection helpers, query clients, and query features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->