### PR TITLE
docs(config.json): register missing svelte API reference functions in sidebar

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1236,6 +1236,10 @@
               "to": "framework/svelte/reference/functions/useMutationState"
             },
             {
+              "label": "Functions / useQueryClient",
+              "to": "framework/svelte/reference/functions/useQueryClient"
+            },
+            {
               "label": "Functions / queryOptions",
               "to": "framework/svelte/reference/functions/queryOptions"
             },
@@ -1246,6 +1250,10 @@
             {
               "label": "Functions / mutationOptions",
               "to": "framework/svelte/reference/functions/mutationOptions"
+            },
+            {
+              "label": "Functions / useHydrate",
+              "to": "framework/svelte/reference/functions/useHydrate"
             }
           ]
         },


### PR DESCRIPTION
## 🎯 Changes

The Svelte API Reference sidebar (`docs/config.json`) was missing links to two functions that exist under `docs/framework/svelte/reference/functions/` (generated via `pnpm run generate-docs`) and are publicly exported from `@tanstack/svelte-query`:

- `useQueryClient` — already registered for React, Vue, and Preact; Svelte was the outlier missing it
- `useHydrate` — Svelte's function-based equivalent of the `HydrationBoundary`/hydration API that other frameworks expose in their reference docs

Other candidates found in the same gap analysis were intentionally excluded:
- `useIsRestoring` — not registered in React's reference sidebar either; it's documented inline in the `persistQueryClient` plugin guide instead, which Svelte doesn't currently have
- `getQueryClientContext` / `setQueryClientContext` / `getIsRestoringContext` / `setIsRestoringContext` — internal plumbing used by `useQueryClient` and `QueryClientProvider.svelte` themselves, not user-facing APIs, with no usage in any guide or plugin doc

Neither of the two added functions is marked `@deprecated` in source or struck through in `framework/svelte/reference/index.md`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (docs-only change, no code/tests affected)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Svelte API reference navigation to include `useQueryClient` and `useHydrate`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->