### PR TITLE
docs(config.json): drop redundant 'Functions /' prefix from svelte and angular sidebar labels

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1208,51 +1208,51 @@
               "to": "framework/svelte/reference/index"
             },
             {
-              "label": "Functions / createQuery",
+              "label": "createQuery",
               "to": "framework/svelte/reference/functions/createQuery"
             },
             {
-              "label": "Functions / createQueries",
+              "label": "createQueries",
               "to": "framework/svelte/reference/functions/createQueries"
             },
             {
-              "label": "Functions / createInfiniteQuery",
+              "label": "createInfiniteQuery",
               "to": "framework/svelte/reference/functions/createInfiniteQuery"
             },
             {
-              "label": "Functions / createMutation",
+              "label": "createMutation",
               "to": "framework/svelte/reference/functions/createMutation"
             },
             {
-              "label": "Functions / useIsFetching",
+              "label": "useIsFetching",
               "to": "framework/svelte/reference/functions/useIsFetching"
             },
             {
-              "label": "Functions / useIsMutating",
+              "label": "useIsMutating",
               "to": "framework/svelte/reference/functions/useIsMutating"
             },
             {
-              "label": "Functions / useMutationState",
+              "label": "useMutationState",
               "to": "framework/svelte/reference/functions/useMutationState"
             },
             {
-              "label": "Functions / useQueryClient",
+              "label": "useQueryClient",
               "to": "framework/svelte/reference/functions/useQueryClient"
             },
             {
-              "label": "Functions / queryOptions",
+              "label": "queryOptions",
               "to": "framework/svelte/reference/functions/queryOptions"
             },
             {
-              "label": "Functions / infiniteQueryOptions",
+              "label": "infiniteQueryOptions",
               "to": "framework/svelte/reference/functions/infiniteQueryOptions"
             },
             {
-              "label": "Functions / mutationOptions",
+              "label": "mutationOptions",
               "to": "framework/svelte/reference/functions/mutationOptions"
             },
             {
-              "label": "Functions / useHydrate",
+              "label": "useHydrate",
               "to": "framework/svelte/reference/functions/useHydrate"
             }
           ]
@@ -1342,59 +1342,59 @@
               "to": "framework/angular/reference/index"
             },
             {
-              "label": "Functions / infiniteQueryOptions",
+              "label": "infiniteQueryOptions",
               "to": "framework/angular/reference/functions/infiniteQueryOptions"
             },
             {
-              "label": "Functions / injectInfiniteQuery",
+              "label": "injectInfiniteQuery",
               "to": "framework/angular/reference/functions/injectInfiniteQuery"
             },
             {
-              "label": "Functions / injectIsFetching",
+              "label": "injectIsFetching",
               "to": "framework/angular/reference/functions/injectIsFetching"
             },
             {
-              "label": "Functions / injectIsMutating",
+              "label": "injectIsMutating",
               "to": "framework/angular/reference/functions/injectIsMutating"
             },
             {
-              "label": "Functions / injectIsRestoring",
+              "label": "injectIsRestoring",
               "to": "framework/angular/reference/functions/injectIsRestoring"
             },
             {
-              "label": "Functions / injectMutation",
+              "label": "injectMutation",
               "to": "framework/angular/reference/functions/injectMutation"
             },
             {
-              "label": "Functions / injectMutationState",
+              "label": "injectMutationState",
               "to": "framework/angular/reference/functions/injectMutationState"
             },
             {
-              "label": "Functions / injectQuery",
+              "label": "injectQuery",
               "to": "framework/angular/reference/functions/injectQuery"
             },
             {
-              "label": "Functions / mutationOptions",
+              "label": "mutationOptions",
               "to": "framework/angular/reference/functions/mutationOptions"
             },
             {
-              "label": "Functions / provideIsRestoring",
+              "label": "provideIsRestoring",
               "to": "framework/angular/reference/functions/provideIsRestoring"
             },
             {
-              "label": "Functions / provideQueryClient",
+              "label": "provideQueryClient",
               "to": "framework/angular/reference/functions/provideQueryClient"
             },
             {
-              "label": "Functions / provideTanStackQuery",
+              "label": "provideTanStackQuery",
               "to": "framework/angular/reference/functions/provideTanStackQuery"
             },
             {
-              "label": "Functions / queryFeature",
+              "label": "queryFeature",
               "to": "framework/angular/reference/functions/queryFeature"
             },
             {
-              "label": "Functions / queryOptions",
+              "label": "queryOptions",
               "to": "framework/angular/reference/functions/queryOptions"
             }
           ]


### PR DESCRIPTION
## 🎯 Changes

The Svelte and Angular API Reference sidebars prefix every single function entry with `Functions / ` (e.g. `Functions / useQueryClient`), while React, Vue, Solid, and Preact use bare labels (`useQueryClient`) for the same kind of entries. Since the prefix appears on 100% of the siblings in each of these two frameworks' lists, it distinguishes nothing and is pure visual noise.

- Strip the `Functions / ` prefix from all 12 Svelte entries and all 14 Angular entries
- Leave the `Svelte Reference` / `Angular Reference` index entries untouched — those are the only sidebar path to the `interfaces/`/`type-aliases/` pages, so removing them would be a functional change, not cosmetic
- Leave Lit untouched entirely — its `Functions /` and `Context /` prefixes aren't a mechanical reflection of the TypeDoc-generated folder structure; several `Context /`-prefixed entries actually live under `functions/` on disk, meaning someone hand-grouped them by meaning. That grouping is intentional and shouldn't be flattened.
- Precedent: Preact already ships a TypeDoc-generated `reference/functions/*` folder structure with bare sidebar labels, and TanStack Table's Svelte adapter (same generator) does the same (`createTable`, not `Functions / createTable`) — confirming this prefix is local drift in Query's config, not a house convention.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (docs-only change, no code/tests affected)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Svelte and Angular API reference navigation labels for clearer presentation.
  * Preserved all existing navigation routes and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->