### PR TITLE
chore(generate-docs): hide redundant TypeDoc page title heading

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -115,6 +115,7 @@ async function generatePackageReferenceDocs(pkg: PackageReferenceDocsConfig) {
     entryFileName: 'index',
     hideBreadcrumbs: true,
     hidePageHeader: true,
+    hidePageTitle: true,
     useCodeBlocks: true,
     excludePrivate: true,
     excludeInternal: true,


### PR DESCRIPTION
## 🎯 Changes

Every TypeDoc-generated reference page (Angular, Svelte, Preact, Lit) currently renders a redundant `# Function: injectIsFetching()`-style heading in the body, in addition to the page's `title` frontmatter and the sidebar entry — the same name ends up repeated three times on the page. `typedoc-plugin-markdown` already generates this heading from `pageTitleTemplates` unless `hidePageTitle` is explicitly disabled; `hideBreadcrumbs`/`hidePageHeader` are already set for the equivalent site chrome, but `hidePageTitle` was missing.

- Add `hidePageTitle: true` to the shared TypeDoc options in `generatePackageReferenceDocs`

This PR intentionally does **not** include the regenerated markdown output (running `pnpm run generate-docs` after this change touches ~200 files across `docs/framework/{angular,svelte,preact,lit}/reference`). Opening this as a scripts-only change first so the option itself can be reviewed before the large regenerated diff is proposed separately.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (docs tooling change only, no code/tests affected)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generated documentation to hide redundant page titles for a cleaner reading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->