### PR TITLE
fix(query-core): fall back to query's own staleTime in isStatic() when no observers exist

### DIFF
--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -298,7 +298,9 @@ export class Query<
       )
     }
 
-    return false
+    // if a query has no observers, fall back to the query's own staleTime
+    // (mirrors isDisabled's no-observer fallback pattern)
+    return resolveStaleTime((this.options as any).staleTime, this) === 'static'
   }
 
   isStale(): boolean {


### PR DESCRIPTION
fix(query-core): fall back to query's own staleTime in isStatic() when no observers exist

## Description

`staleTime: 'static'` stops being honoured as soon as a query has no observers, so `refetchQueries({ type: 'all' })` and `invalidateQueries({ refetchType: 'all' })` re-run the `queryFn` for queries that the docs promise will never refetch.

`Query.isStatic()` derives 'static' **only** from live observers. When there are no observers, it returns `false`, contradicting the documented behaviour:

> set `staleTime` to `'static'` to **never** trigger a refetch, even if the Query is invalidated manually

The neighbouring `isDisabled()` method already handles the no-observer case correctly with an explicit fallback. This fix mirrors that pattern.

## Changes

- **`packages/query-core/src/query.ts`**: When `isStatic()` has no observers, fall back to the query's own `staleTime` option instead of returning `false`.

## Fix details

```ts
// Before: returns false when no observers
return false

// After: mirrors isDisabled's no-observer fallback pattern
return resolveStaleTime((this.options as any).staleTime, this) === 'static'
```

The `as any` cast is needed because `staleTime` is declared on `QueryObserverOptions` and `FetchQueryOptions`, not on the base `QueryOptions` interface — but the value is always present at runtime since `Query.setOptions` stores the full merged options object.

## Test results

The fix is verified against the issue author's test cases:
- A: `prefetchQuery`, never observed → calls=1
- C: `fetchQuery`, never observed → calls=1
- D: observer subscribed then unmounted → calls=1
- E: non-static query → calls=2 (still refetches, no over-blocking)
- F: `staleTime: Infinity` → calls=2 (still invalidatable, per the documented distinction)

Full `packages/query-core` suite: 554 passed.

Fixes #11190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queries without active observers now correctly recognize when their configured stale time is set to “static.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->