### PR TITLE
docs: regenerate reference docs to drop redundant TypeDoc page title heading

### DIFF
--- a/docs/framework/angular/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/angular/reference/functions/infiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: infiniteQueryOptions
 title: infiniteQueryOptions
 ---
 
-# Function: infiniteQueryOptions()
-
 Allows sharing and re-using infinite query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.

--- a/docs/framework/angular/reference/functions/injectInfiniteQuery.md
+++ b/docs/framework/angular/reference/functions/injectInfiniteQuery.md
@@ -3,8 +3,6 @@ id: injectInfiniteQuery
 title: injectInfiniteQuery
 ---
 
-# Function: injectInfiniteQuery()
-
 Injects an infinite query: a declarative dependency on an asynchronous source of data that is tied to a unique key.
 Infinite queries can additively "load more" data onto an existing set of data or "infinite scroll"
 

--- a/docs/framework/angular/reference/functions/injectIsFetching.md
+++ b/docs/framework/angular/reference/functions/injectIsFetching.md
@@ -3,8 +3,6 @@ id: injectIsFetching
 title: injectIsFetching
 ---
 
-# Function: injectIsFetching()
-
 ```ts
 function injectIsFetching(filters?, options?): Signal<number>;
 ```

--- a/docs/framework/angular/reference/functions/injectIsMutating.md
+++ b/docs/framework/angular/reference/functions/injectIsMutating.md
@@ -3,8 +3,6 @@ id: injectIsMutating
 title: injectIsMutating
 ---
 
-# Function: injectIsMutating()
-
 ```ts
 function injectIsMutating(filters?, options?): Signal<number>;
 ```

--- a/docs/framework/angular/reference/functions/injectIsRestoring.md
+++ b/docs/framework/angular/reference/functions/injectIsRestoring.md
@@ -3,8 +3,6 @@ id: injectIsRestoring
 title: injectIsRestoring
 ---
 
-# Function: injectIsRestoring()
-
 ```ts
 function injectIsRestoring(options?): Signal<boolean>;
 ```

--- a/docs/framework/angular/reference/functions/injectMutation.md
+++ b/docs/framework/angular/reference/functions/injectMutation.md
@@ -3,8 +3,6 @@ id: injectMutation
 title: injectMutation
 ---
 
-# Function: injectMutation()
-
 ```ts
 function injectMutation<TData, TError, TVariables, TOnMutateResult>(injectMutationFn, options?): CreateMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/angular/reference/functions/injectMutationState.md
+++ b/docs/framework/angular/reference/functions/injectMutationState.md
@@ -3,8 +3,6 @@ id: injectMutationState
 title: injectMutationState
 ---
 
-# Function: injectMutationState()
-
 ```ts
 function injectMutationState<TResult>(injectMutationStateFn, options?): Signal<TResult[]>;
 ```

--- a/docs/framework/angular/reference/functions/injectQuery.md
+++ b/docs/framework/angular/reference/functions/injectQuery.md
@@ -3,8 +3,6 @@ id: injectQuery
 title: injectQuery
 ---
 
-# Function: injectQuery()
-
 Injects a query: a declarative dependency on an asynchronous source of data that is tied to a unique key.
 
 **Basic example**

--- a/docs/framework/angular/reference/functions/injectQueryClient.md
+++ b/docs/framework/angular/reference/functions/injectQueryClient.md
@@ -3,8 +3,6 @@ id: injectQueryClient
 title: injectQueryClient
 ---
 
-# ~~Function: injectQueryClient()~~
-
 ```ts
 function injectQueryClient(injectOptions): QueryClient;
 ```

--- a/docs/framework/angular/reference/functions/mutationOptions.md
+++ b/docs/framework/angular/reference/functions/mutationOptions.md
@@ -3,8 +3,6 @@ id: mutationOptions
 title: mutationOptions
 ---
 
-# Function: mutationOptions()
-
 Allows sharing and re-using mutation options in a type-safe way.
 
 **Example**

--- a/docs/framework/angular/reference/functions/provideAngularQuery.md
+++ b/docs/framework/angular/reference/functions/provideAngularQuery.md
@@ -3,8 +3,6 @@ id: provideAngularQuery
 title: provideAngularQuery
 ---
 
-# ~~Function: provideAngularQuery()~~
-
 ```ts
 function provideAngularQuery(queryClient): Provider[];
 ```

--- a/docs/framework/angular/reference/functions/provideIsRestoring.md
+++ b/docs/framework/angular/reference/functions/provideIsRestoring.md
@@ -3,8 +3,6 @@ id: provideIsRestoring
 title: provideIsRestoring
 ---
 
-# Function: provideIsRestoring()
-
 ```ts
 function provideIsRestoring(isRestoring): Provider;
 ```

--- a/docs/framework/angular/reference/functions/provideQueryClient.md
+++ b/docs/framework/angular/reference/functions/provideQueryClient.md
@@ -3,8 +3,6 @@ id: provideQueryClient
 title: provideQueryClient
 ---
 
-# Function: provideQueryClient()
-
 ```ts
 function provideQueryClient(queryClient): Provider;
 ```

--- a/docs/framework/angular/reference/functions/provideTanStackQuery.md
+++ b/docs/framework/angular/reference/functions/provideTanStackQuery.md
@@ -3,8 +3,6 @@ id: provideTanStackQuery
 title: provideTanStackQuery
 ---
 
-# Function: provideTanStackQuery()
-
 ```ts
 function provideTanStackQuery(queryClient, ...features): Provider[];
 ```

--- a/docs/framework/angular/reference/functions/queryFeature.md
+++ b/docs/framework/angular/reference/functions/queryFeature.md
@@ -3,8 +3,6 @@ id: queryFeature
 title: queryFeature
 ---
 
-# Function: queryFeature()
-
 ```ts
 function queryFeature<TFeatureKind>(kind, providers): QueryFeature<TFeatureKind>;
 ```

--- a/docs/framework/angular/reference/functions/queryOptions.md
+++ b/docs/framework/angular/reference/functions/queryOptions.md
@@ -3,8 +3,6 @@ id: queryOptions
 title: queryOptions
 ---
 
-# Function: queryOptions()
-
 Allows sharing and re-using query options in a type-safe way.
 
 The `queryKey` will be tagged with the type from `queryFn`.

--- a/docs/framework/angular/reference/index.md
+++ b/docs/framework/angular/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/angular-query-experimental"
 title: "@tanstack/angular-query-experimental"
 ---
 
-# @tanstack/angular-query-experimental
-
 ## Interfaces
 
 - [BaseMutationNarrowing](interfaces/BaseMutationNarrowing.md)

--- a/docs/framework/angular/reference/interfaces/BaseMutationNarrowing.md
+++ b/docs/framework/angular/reference/interfaces/BaseMutationNarrowing.md
@@ -3,8 +3,6 @@ id: BaseMutationNarrowing
 title: BaseMutationNarrowing
 ---
 
-# Interface: BaseMutationNarrowing\<TData, TError, TVariables, TOnMutateResult\>
-
 Defined in: [types.ts:184](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L184)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/BaseQueryNarrowing.md
+++ b/docs/framework/angular/reference/interfaces/BaseQueryNarrowing.md
@@ -3,8 +3,6 @@ id: BaseQueryNarrowing
 title: BaseQueryNarrowing
 ---
 
-# Interface: BaseQueryNarrowing\<TData, TError\>
-
 Defined in: [types.ts:51](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L51)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/CreateBaseQueryOptions.md
+++ b/docs/framework/angular/reference/interfaces/CreateBaseQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateBaseQueryOptions
 title: CreateBaseQueryOptions
 ---
 
-# Interface: CreateBaseQueryOptions\<TQueryFnData, TError, TData, TQueryData, TQueryKey\>
-
 Defined in: [types.ts:21](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L21)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/CreateInfiniteQueryOptions.md
+++ b/docs/framework/angular/reference/interfaces/CreateInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateInfiniteQueryOptions
 title: CreateInfiniteQueryOptions
 ---
 
-# Interface: CreateInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 Defined in: [types.ts:75](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L75)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/CreateMutationOptions.md
+++ b/docs/framework/angular/reference/interfaces/CreateMutationOptions.md
@@ -3,8 +3,6 @@ id: CreateMutationOptions
 title: CreateMutationOptions
 ---
 
-# Interface: CreateMutationOptions\<TData, TError, TVariables, TOnMutateResult\>
-
 Defined in: [types.ts:126](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L126)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/CreateQueryOptions.md
+++ b/docs/framework/angular/reference/interfaces/CreateQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateQueryOptions
 title: CreateQueryOptions
 ---
 
-# Interface: CreateQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 Defined in: [types.ts:35](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/types.ts#L35)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/InjectInfiniteQueryOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: InjectInfiniteQueryOptions
 title: InjectInfiniteQueryOptions
 ---
 
-# Interface: InjectInfiniteQueryOptions
-
 Defined in: [inject-infinite-query.ts:25](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/inject-infinite-query.ts#L25)
 
 ## Properties

--- a/docs/framework/angular/reference/interfaces/InjectIsFetchingOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectIsFetchingOptions.md
@@ -3,8 +3,6 @@ id: InjectIsFetchingOptions
 title: InjectIsFetchingOptions
 ---
 
-# Interface: InjectIsFetchingOptions
-
 Defined in: [inject-is-fetching.ts:13](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/inject-is-fetching.ts#L13)
 
 ## Properties

--- a/docs/framework/angular/reference/interfaces/InjectIsMutatingOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectIsMutatingOptions.md
@@ -3,8 +3,6 @@ id: InjectIsMutatingOptions
 title: InjectIsMutatingOptions
 ---
 
-# Interface: InjectIsMutatingOptions
-
 Defined in: [inject-is-mutating.ts:13](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/inject-is-mutating.ts#L13)
 
 ## Properties

--- a/docs/framework/angular/reference/interfaces/InjectMutationOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectMutationOptions.md
@@ -3,8 +3,6 @@ id: InjectMutationOptions
 title: InjectMutationOptions
 ---
 
-# Interface: InjectMutationOptions
-
 Defined in: [inject-mutation.ts:28](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/inject-mutation.ts#L28)
 
 ## Properties

--- a/docs/framework/angular/reference/interfaces/InjectMutationStateOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectMutationStateOptions.md
@@ -3,8 +3,6 @@ id: InjectMutationStateOptions
 title: InjectMutationStateOptions
 ---
 
-# Interface: InjectMutationStateOptions
-
 Defined in: [inject-mutation-state.ts:45](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/inject-mutation-state.ts#L45)
 
 ## Properties

--- a/docs/framework/angular/reference/interfaces/InjectQueryOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectQueryOptions.md
@@ -3,8 +3,6 @@ id: InjectQueryOptions
 title: InjectQueryOptions
 ---
 
-# Interface: InjectQueryOptions
-
 Defined in: [inject-query.ts:20](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/inject-query.ts#L20)
 
 ## Properties

--- a/docs/framework/angular/reference/interfaces/QueryFeature.md
+++ b/docs/framework/angular/reference/interfaces/QueryFeature.md
@@ -3,8 +3,6 @@ id: QueryFeature
 title: QueryFeature
 ---
 
-# Interface: QueryFeature\<TFeatureKind\>
-
 Defined in: [providers.ts:135](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/providers.ts#L135)
 
 Helper type to represent a Query feature.

--- a/docs/framework/angular/reference/type-aliases/CreateBaseMutationResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateBaseMutationResult.md
@@ -3,8 +3,6 @@ id: CreateBaseMutationResult
 title: CreateBaseMutationResult
 ---
 
-# Type Alias: CreateBaseMutationResult\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Override<MutationObserverResult<TData, TError, TVariables, TOnMutateResult>, {
   mutate: CreateMutateFunction<TData, TError, TVariables, TOnMutateResult>;

--- a/docs/framework/angular/reference/type-aliases/CreateBaseQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateBaseQueryResult.md
@@ -3,8 +3,6 @@ id: CreateBaseQueryResult
 title: CreateBaseQueryResult
 ---
 
-# Type Alias: CreateBaseQueryResult\<TData, TError, TState\>
-
 ```ts
 type CreateBaseQueryResult<TData, TError, TState> = BaseQueryNarrowing<TData, TError> & MapToSignals<OmitKeyof<TState, keyof BaseQueryNarrowing, "safely">>;
 ```

--- a/docs/framework/angular/reference/type-aliases/CreateInfiniteQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateInfiniteQueryResult.md
@@ -3,8 +3,6 @@ id: CreateInfiniteQueryResult
 title: CreateInfiniteQueryResult
 ---
 
-# Type Alias: CreateInfiniteQueryResult\<TData, TError\>
-
 ```ts
 type CreateInfiniteQueryResult<TData, TError> = BaseQueryNarrowing<TData, TError> & MapToSignals<InfiniteQueryObserverResult<TData, TError>>;
 ```

--- a/docs/framework/angular/reference/type-aliases/CreateMutateAsyncFunction.md
+++ b/docs/framework/angular/reference/type-aliases/CreateMutateAsyncFunction.md
@@ -3,8 +3,6 @@ id: CreateMutateAsyncFunction
 title: CreateMutateAsyncFunction
 ---
 
-# Type Alias: CreateMutateAsyncFunction\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/angular/reference/type-aliases/CreateMutateFunction.md
+++ b/docs/framework/angular/reference/type-aliases/CreateMutateFunction.md
@@ -3,8 +3,6 @@ id: CreateMutateFunction
 title: CreateMutateFunction
 ---
 
-# Type Alias: CreateMutateFunction()\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```

--- a/docs/framework/angular/reference/type-aliases/CreateMutationResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateMutationResult.md
@@ -3,8 +3,6 @@ id: CreateMutationResult
 title: CreateMutationResult
 ---
 
-# Type Alias: CreateMutationResult\<TData, TError, TVariables, TOnMutateResult, TState\>
-
 ```ts
 type CreateMutationResult<TData, TError, TVariables, TOnMutateResult, TState> = BaseMutationNarrowing<TData, TError, TVariables, TOnMutateResult> & MapToSignals<OmitKeyof<TState, keyof BaseMutationNarrowing, "safely">>;
 ```

--- a/docs/framework/angular/reference/type-aliases/CreateQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/CreateQueryResult.md
@@ -3,8 +3,6 @@ id: CreateQueryResult
 title: CreateQueryResult
 ---
 
-# Type Alias: CreateQueryResult\<TData, TError\>
-
 ```ts
 type CreateQueryResult<TData, TError> = CreateBaseQueryResult<TData, TError>;
 ```

--- a/docs/framework/angular/reference/type-aliases/DefinedCreateInfiniteQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/DefinedCreateInfiniteQueryResult.md
@@ -3,8 +3,6 @@ id: DefinedCreateInfiniteQueryResult
 title: DefinedCreateInfiniteQueryResult
 ---
 
-# Type Alias: DefinedCreateInfiniteQueryResult\<TData, TError, TDefinedInfiniteQueryObserver\>
-
 ```ts
 type DefinedCreateInfiniteQueryResult<TData, TError, TDefinedInfiniteQueryObserver> = MapToSignals<TDefinedInfiniteQueryObserver>;
 ```

--- a/docs/framework/angular/reference/type-aliases/DefinedCreateQueryResult.md
+++ b/docs/framework/angular/reference/type-aliases/DefinedCreateQueryResult.md
@@ -3,8 +3,6 @@ id: DefinedCreateQueryResult
 title: DefinedCreateQueryResult
 ---
 
-# Type Alias: DefinedCreateQueryResult\<TData, TError, TState\>
-
 ```ts
 type DefinedCreateQueryResult<TData, TError, TState> = BaseQueryNarrowing<TData, TError> & MapToSignals<OmitKeyof<TState, keyof BaseQueryNarrowing, "safely">>;
 ```

--- a/docs/framework/angular/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/angular/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -3,8 +3,6 @@ id: DefinedInitialDataInfiniteOptions
 title: DefinedInitialDataInfiniteOptions
 ---
 
-# Type Alias: DefinedInitialDataInfiniteOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type DefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```

--- a/docs/framework/angular/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/angular/reference/type-aliases/DefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: DefinedInitialDataOptions
 title: DefinedInitialDataOptions
 ---
 
-# Type Alias: DefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = Omit<CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```

--- a/docs/framework/angular/reference/type-aliases/DevtoolsFeature.md
+++ b/docs/framework/angular/reference/type-aliases/DevtoolsFeature.md
@@ -3,8 +3,6 @@ id: DevtoolsFeature
 title: DevtoolsFeature
 ---
 
-# Type Alias: DevtoolsFeature
-
 ```ts
 type DevtoolsFeature = QueryFeature<"Devtools">;
 ```

--- a/docs/framework/angular/reference/type-aliases/PersistQueryClientFeature.md
+++ b/docs/framework/angular/reference/type-aliases/PersistQueryClientFeature.md
@@ -3,8 +3,6 @@ id: PersistQueryClientFeature
 title: PersistQueryClientFeature
 ---
 
-# Type Alias: PersistQueryClientFeature
-
 ```ts
 type PersistQueryClientFeature = QueryFeature<"PersistQueryClient">;
 ```

--- a/docs/framework/angular/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/angular/reference/type-aliases/QueriesOptions.md
@@ -3,8 +3,6 @@ id: QueriesOptions
 title: QueriesOptions
 ---
 
-# Type Alias: QueriesOptions\<T, TResults, TDepth\>
-
 ```ts
 type QueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? QueryObserverOptionsForCreateQueries[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetCreateQueryOptionsForCreateQueries<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesOptions<[...Tails], [...TResults, GetCreateQueryOptionsForCreateQueries<Head>], [...TDepth, 1]> : ReadonlyArray<unknown> extends T ? T : T extends QueryObserverOptionsForCreateQueries<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? QueryObserverOptionsForCreateQueries<TQueryFnData, TError, TData, TQueryKey>[] : QueryObserverOptionsForCreateQueries[];
 ```

--- a/docs/framework/angular/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/angular/reference/type-aliases/QueriesResults.md
@@ -3,8 +3,6 @@ id: QueriesResults
 title: QueriesResults
 ---
 
-# Type Alias: QueriesResults\<T, TResults, TDepth\>
-
 ```ts
 type QueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? CreateQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetCreateQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesResults<[...Tails], [...TResults, GetCreateQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetCreateQueryResult<T[K]> };
 ```

--- a/docs/framework/angular/reference/type-aliases/QueryFeatures.md
+++ b/docs/framework/angular/reference/type-aliases/QueryFeatures.md
@@ -3,8 +3,6 @@ id: QueryFeatures
 title: QueryFeatures
 ---
 
-# Type Alias: QueryFeatures
-
 ```ts
 type QueryFeatures = 
   | DevtoolsFeature

--- a/docs/framework/angular/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/angular/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
@@ -3,8 +3,6 @@ id: UndefinedInitialDataInfiniteOptions
 title: UndefinedInitialDataInfiniteOptions
 ---
 
-# Type Alias: UndefinedInitialDataInfiniteOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type UndefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```

--- a/docs/framework/angular/reference/type-aliases/UndefinedInitialDataOptions.md
+++ b/docs/framework/angular/reference/type-aliases/UndefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: UndefinedInitialDataOptions
 title: UndefinedInitialDataOptions
 ---
 
-# Type Alias: UndefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object;
 ```

--- a/docs/framework/angular/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
+++ b/docs/framework/angular/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
@@ -3,8 +3,6 @@ id: UnusedSkipTokenInfiniteOptions
 title: UnusedSkipTokenInfiniteOptions
 ---
 
-# Type Alias: UnusedSkipTokenInfiniteOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type UnusedSkipTokenInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = OmitKeyof<CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```

--- a/docs/framework/angular/reference/type-aliases/UnusedSkipTokenOptions.md
+++ b/docs/framework/angular/reference/type-aliases/UnusedSkipTokenOptions.md
@@ -3,8 +3,6 @@ id: UnusedSkipTokenOptions
 title: UnusedSkipTokenOptions
 ---
 
-# Type Alias: UnusedSkipTokenOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> = OmitKeyof<CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```

--- a/docs/framework/lit/reference/classes/QueryClientProvider.md
+++ b/docs/framework/lit/reference/classes/QueryClientProvider.md
@@ -3,8 +3,6 @@ id: QueryClientProvider
 title: QueryClientProvider
 ---
 
-# Class: QueryClientProvider
-
 Defined in: [packages/lit-query/src/QueryClientProvider.ts:64](https://github.com/TanStack/query/blob/main/packages/lit-query/src/QueryClientProvider.ts#L64)
 
 Lit element that provides a `QueryClient` to descendant Lit Query

--- a/docs/framework/lit/reference/functions/createInfiniteQueryController.md
+++ b/docs/framework/lit/reference/functions/createInfiniteQueryController.md
@@ -3,8 +3,6 @@ id: createInfiniteQueryController
 title: createInfiniteQueryController
 ---
 
-# Function: createInfiniteQueryController()
-
 ```ts
 function createInfiniteQueryController<TQueryFnData, TError, TData, TQueryKey, TPageParam>(
    host,

--- a/docs/framework/lit/reference/functions/createMutationController.md
+++ b/docs/framework/lit/reference/functions/createMutationController.md
@@ -3,8 +3,6 @@ id: createMutationController
 title: createMutationController
 ---
 
-# Function: createMutationController()
-
 ```ts
 function createMutationController<TData, TError, TVariables, TOnMutateResult>(
    host,

--- a/docs/framework/lit/reference/functions/createQueriesController.md
+++ b/docs/framework/lit/reference/functions/createQueriesController.md
@@ -3,8 +3,6 @@ id: createQueriesController
 title: createQueriesController
 ---
 
-# Function: createQueriesController()
-
 ```ts
 function createQueriesController<TQueryOptions, TCombinedResult>(
    host,

--- a/docs/framework/lit/reference/functions/createQueryController.md
+++ b/docs/framework/lit/reference/functions/createQueryController.md
@@ -3,8 +3,6 @@ id: createQueryController
 title: createQueryController
 ---
 
-# Function: createQueryController()
-
 ```ts
 function createQueryController<TQueryFnData, TError, TData, TQueryData, TQueryKey>(
    host,

--- a/docs/framework/lit/reference/functions/getDefaultQueryClient.md
+++ b/docs/framework/lit/reference/functions/getDefaultQueryClient.md
@@ -3,8 +3,6 @@ id: getDefaultQueryClient
 title: getDefaultQueryClient
 ---
 
-# Function: getDefaultQueryClient()
-
 ```ts
 function getDefaultQueryClient(): QueryClient | undefined;
 ```

--- a/docs/framework/lit/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/lit/reference/functions/infiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: infiniteQueryOptions
 title: infiniteQueryOptions
 ---
 
-# Function: infiniteQueryOptions()
-
 ```ts
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```

--- a/docs/framework/lit/reference/functions/mutationOptions.md
+++ b/docs/framework/lit/reference/functions/mutationOptions.md
@@ -3,8 +3,6 @@ id: mutationOptions
 title: mutationOptions
 ---
 
-# Function: mutationOptions()
-
 ```ts
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): MutationObserverOptions<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/lit/reference/functions/queryOptions.md
+++ b/docs/framework/lit/reference/functions/queryOptions.md
@@ -3,8 +3,6 @@ id: queryOptions
 title: queryOptions
 ---
 
-# Function: queryOptions()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/lit/reference/functions/registerDefaultQueryClient.md
+++ b/docs/framework/lit/reference/functions/registerDefaultQueryClient.md
@@ -3,8 +3,6 @@ id: registerDefaultQueryClient
 title: registerDefaultQueryClient
 ---
 
-# Function: registerDefaultQueryClient()
-
 ```ts
 function registerDefaultQueryClient(client): void;
 ```

--- a/docs/framework/lit/reference/functions/resolveQueryClient.md
+++ b/docs/framework/lit/reference/functions/resolveQueryClient.md
@@ -3,8 +3,6 @@ id: resolveQueryClient
 title: resolveQueryClient
 ---
 
-# Function: resolveQueryClient()
-
 ```ts
 function resolveQueryClient(explicit?): QueryClient;
 ```

--- a/docs/framework/lit/reference/functions/unregisterDefaultQueryClient.md
+++ b/docs/framework/lit/reference/functions/unregisterDefaultQueryClient.md
@@ -3,8 +3,6 @@ id: unregisterDefaultQueryClient
 title: unregisterDefaultQueryClient
 ---
 
-# Function: unregisterDefaultQueryClient()
-
 ```ts
 function unregisterDefaultQueryClient(client): void;
 ```

--- a/docs/framework/lit/reference/functions/useIsFetching.md
+++ b/docs/framework/lit/reference/functions/useIsFetching.md
@@ -3,8 +3,6 @@ id: useIsFetching
 title: useIsFetching
 ---
 
-# Function: useIsFetching()
-
 ```ts
 function useIsFetching(
    host,

--- a/docs/framework/lit/reference/functions/useIsMutating.md
+++ b/docs/framework/lit/reference/functions/useIsMutating.md
@@ -3,8 +3,6 @@ id: useIsMutating
 title: useIsMutating
 ---
 
-# Function: useIsMutating()
-
 ```ts
 function useIsMutating(
    host,

--- a/docs/framework/lit/reference/functions/useMutationState.md
+++ b/docs/framework/lit/reference/functions/useMutationState.md
@@ -3,8 +3,6 @@ id: useMutationState
 title: useMutationState
 ---
 
-# Function: useMutationState()
-
 ```ts
 function useMutationState<TResult>(
    host,

--- a/docs/framework/lit/reference/functions/useQueryClient.md
+++ b/docs/framework/lit/reference/functions/useQueryClient.md
@@ -3,8 +3,6 @@ id: useQueryClient
 title: useQueryClient
 ---
 
-# Function: useQueryClient()
-
 ```ts
 function useQueryClient(): QueryClient;
 ```

--- a/docs/framework/lit/reference/index.md
+++ b/docs/framework/lit/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/lit-query"
 title: "@tanstack/lit-query"
 ---
 
-# @tanstack/lit-query
-
 ## Classes
 
 - [QueryClientProvider](classes/QueryClientProvider.md)

--- a/docs/framework/lit/reference/type-aliases/Accessor.md
+++ b/docs/framework/lit/reference/type-aliases/Accessor.md
@@ -3,8 +3,6 @@ id: Accessor
 title: Accessor
 ---
 
-# Type Alias: Accessor\<T\>
-
 ```ts
 type Accessor<T> = T | () => T;
 ```

--- a/docs/framework/lit/reference/type-aliases/CreateInfiniteQueryOptions.md
+++ b/docs/framework/lit/reference/type-aliases/CreateInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateInfiniteQueryOptions
 title: CreateInfiniteQueryOptions
 ---
 
-# Type Alias: CreateInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```

--- a/docs/framework/lit/reference/type-aliases/CreateMutationOptions.md
+++ b/docs/framework/lit/reference/type-aliases/CreateMutationOptions.md
@@ -3,8 +3,6 @@ id: CreateMutationOptions
 title: CreateMutationOptions
 ---
 
-# Type Alias: CreateMutationOptions\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateMutationOptions<TData, TError, TVariables, TOnMutateResult> = MutationObserverOptions<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/lit/reference/type-aliases/CreateQueriesControllerOptions.md
+++ b/docs/framework/lit/reference/type-aliases/CreateQueriesControllerOptions.md
@@ -3,8 +3,6 @@ id: CreateQueriesControllerOptions
 title: CreateQueriesControllerOptions
 ---
 
-# Type Alias: CreateQueriesControllerOptions\<TQueryOptions, TCombinedResult\>
-
 ```ts
 type CreateQueriesControllerOptions<TQueryOptions, TCombinedResult> = object;
 ```

--- a/docs/framework/lit/reference/type-aliases/CreateQueriesInput.md
+++ b/docs/framework/lit/reference/type-aliases/CreateQueriesInput.md
@@ -3,8 +3,6 @@ id: CreateQueriesInput
 title: CreateQueriesInput
 ---
 
-# Type Alias: CreateQueriesInput\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type CreateQueriesInput<TQueryFnData, TError, TData, TQueryKey> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>;
 ```

--- a/docs/framework/lit/reference/type-aliases/CreateQueryOptions.md
+++ b/docs/framework/lit/reference/type-aliases/CreateQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateQueryOptions
 title: CreateQueryOptions
 ---
 
-# Type Alias: CreateQueryOptions\<TQueryFnData, TError, TData, TQueryData, TQueryKey\>
-
 ```ts
 type CreateQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>;
 ```

--- a/docs/framework/lit/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/lit/reference/type-aliases/DefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: DefinedInitialDataOptions
 title: DefinedInitialDataOptions
 ---
 
-# Type Alias: DefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = Omit<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryFn"> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/InfiniteQueryControllerOptions.md
+++ b/docs/framework/lit/reference/type-aliases/InfiniteQueryControllerOptions.md
@@ -3,8 +3,6 @@ id: InfiniteQueryControllerOptions
 title: InfiniteQueryControllerOptions
 ---
 
-# Type Alias: InfiniteQueryControllerOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type InfiniteQueryControllerOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = Accessor<CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>>;
 ```

--- a/docs/framework/lit/reference/type-aliases/InfiniteQueryResultAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/InfiniteQueryResultAccessor.md
@@ -3,8 +3,6 @@ id: InfiniteQueryResultAccessor
 title: InfiniteQueryResultAccessor
 ---
 
-# Type Alias: InfiniteQueryResultAccessor\<TData, TError\>
-
 ```ts
 type InfiniteQueryResultAccessor<TData, TError> = ValueAccessor<InfiniteQueryObserverResult<TData, TError>> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/IsFetchingAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/IsFetchingAccessor.md
@@ -3,8 +3,6 @@ id: IsFetchingAccessor
 title: IsFetchingAccessor
 ---
 
-# Type Alias: IsFetchingAccessor
-
 ```ts
 type IsFetchingAccessor = ValueAccessor<number> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/IsMutatingAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/IsMutatingAccessor.md
@@ -3,8 +3,6 @@ id: IsMutatingAccessor
 title: IsMutatingAccessor
 ---
 
-# Type Alias: IsMutatingAccessor
-
 ```ts
 type IsMutatingAccessor = ValueAccessor<number> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/MutationControllerOptions.md
+++ b/docs/framework/lit/reference/type-aliases/MutationControllerOptions.md
@@ -3,8 +3,6 @@ id: MutationControllerOptions
 title: MutationControllerOptions
 ---
 
-# Type Alias: MutationControllerOptions\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type MutationControllerOptions<TData, TError, TVariables, TOnMutateResult> = Accessor<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>>;
 ```

--- a/docs/framework/lit/reference/type-aliases/MutationControllerResult.md
+++ b/docs/framework/lit/reference/type-aliases/MutationControllerResult.md
@@ -3,8 +3,6 @@ id: MutationControllerResult
 title: MutationControllerResult
 ---
 
-# Type Alias: MutationControllerResult\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type MutationControllerResult<TData, TError, TVariables, TOnMutateResult> = MutationObserverResult<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/lit/reference/type-aliases/MutationResultAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/MutationResultAccessor.md
@@ -3,8 +3,6 @@ id: MutationResultAccessor
 title: MutationResultAccessor
 ---
 
-# Type Alias: MutationResultAccessor\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type MutationResultAccessor<TData, TError, TVariables, TOnMutateResult> = ValueAccessor<MutationObserverResult<TData, TError, TVariables, TOnMutateResult>> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/MutationStateAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/MutationStateAccessor.md
@@ -3,8 +3,6 @@ id: MutationStateAccessor
 title: MutationStateAccessor
 ---
 
-# Type Alias: MutationStateAccessor\<TResult\>
-
 ```ts
 type MutationStateAccessor<TResult> = ValueAccessor<TResult[]> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/MutationStateOptions.md
+++ b/docs/framework/lit/reference/type-aliases/MutationStateOptions.md
@@ -3,8 +3,6 @@ id: MutationStateOptions
 title: MutationStateOptions
 ---
 
-# Type Alias: MutationStateOptions\<TResult\>
-
 ```ts
 type MutationStateOptions<TResult> = object;
 ```

--- a/docs/framework/lit/reference/type-aliases/QueriesControllerOptions.md
+++ b/docs/framework/lit/reference/type-aliases/QueriesControllerOptions.md
@@ -3,8 +3,6 @@ id: QueriesControllerOptions
 title: QueriesControllerOptions
 ---
 
-# Type Alias: QueriesControllerOptions\<TQueryOptions, TCombinedResult\>
-
 ```ts
 type QueriesControllerOptions<TQueryOptions, TCombinedResult> = Accessor<CreateQueriesControllerOptions<TQueryOptions, TCombinedResult>>;
 ```

--- a/docs/framework/lit/reference/type-aliases/QueriesResultAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/QueriesResultAccessor.md
@@ -3,8 +3,6 @@ id: QueriesResultAccessor
 title: QueriesResultAccessor
 ---
 
-# Type Alias: QueriesResultAccessor\<TCombinedResult\>
-
 ```ts
 type QueriesResultAccessor<TCombinedResult> = ValueAccessor<TCombinedResult> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/QueryControllerOptions.md
+++ b/docs/framework/lit/reference/type-aliases/QueryControllerOptions.md
@@ -3,8 +3,6 @@ id: QueryControllerOptions
 title: QueryControllerOptions
 ---
 
-# Type Alias: QueryControllerOptions\<TQueryFnData, TError, TData, TQueryData, TQueryKey\>
-
 ```ts
 type QueryControllerOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = Accessor<CreateQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>>;
 ```

--- a/docs/framework/lit/reference/type-aliases/QueryControllerResult.md
+++ b/docs/framework/lit/reference/type-aliases/QueryControllerResult.md
@@ -3,8 +3,6 @@ id: QueryControllerResult
 title: QueryControllerResult
 ---
 
-# Type Alias: QueryControllerResult\<TData, TError\>
-
 ```ts
 type QueryControllerResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/lit/reference/type-aliases/QueryResultAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/QueryResultAccessor.md
@@ -3,8 +3,6 @@ id: QueryResultAccessor
 title: QueryResultAccessor
 ---
 
-# Type Alias: QueryResultAccessor\<TData, TError\>
-
 ```ts
 type QueryResultAccessor<TData, TError> = ValueAccessor<QueryObserverResult<TData, TError>> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/UndefinedInitialDataOptions.md
+++ b/docs/framework/lit/reference/type-aliases/UndefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: UndefinedInitialDataOptions
 title: UndefinedInitialDataOptions
 ---
 
-# Type Alias: UndefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/UnusedSkipTokenOptions.md
+++ b/docs/framework/lit/reference/type-aliases/UnusedSkipTokenOptions.md
@@ -3,8 +3,6 @@ id: UnusedSkipTokenOptions
 title: UnusedSkipTokenOptions
 ---
 
-# Type Alias: UnusedSkipTokenOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> = OmitKeyof<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryFn"> & object;
 ```

--- a/docs/framework/lit/reference/type-aliases/ValueAccessor.md
+++ b/docs/framework/lit/reference/type-aliases/ValueAccessor.md
@@ -3,8 +3,6 @@ id: ValueAccessor
 title: ValueAccessor
 ---
 
-# Type Alias: ValueAccessor\<T\>
-
 ```ts
 type ValueAccessor<T> = () => T & object;
 ```

--- a/docs/framework/lit/reference/variables/queryClientContext.md
+++ b/docs/framework/lit/reference/variables/queryClientContext.md
@@ -3,8 +3,6 @@ id: queryClientContext
 title: queryClientContext
 ---
 
-# Variable: queryClientContext
-
 ```ts
 const queryClientContext: object;
 ```

--- a/docs/framework/preact/reference/functions/HydrationBoundary.md
+++ b/docs/framework/preact/reference/functions/HydrationBoundary.md
@@ -3,8 +3,6 @@ id: HydrationBoundary
 title: HydrationBoundary
 ---
 
-# Function: HydrationBoundary()
-
 ```ts
 function HydrationBoundary(__namedParameters): Element;
 ```

--- a/docs/framework/preact/reference/functions/QueryClientProvider.md
+++ b/docs/framework/preact/reference/functions/QueryClientProvider.md
@@ -3,8 +3,6 @@ id: QueryClientProvider
 title: QueryClientProvider
 ---
 
-# Function: QueryClientProvider()
-
 ```ts
 function QueryClientProvider(__namedParameters): VNode;
 ```

--- a/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
@@ -3,8 +3,6 @@ id: QueryErrorResetBoundary
 title: QueryErrorResetBoundary
 ---
 
-# Function: QueryErrorResetBoundary()
-
 ```ts
 function QueryErrorResetBoundary(__namedParameters): Element;
 ```

--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: infiniteQueryOptions
 title: infiniteQueryOptions
 ---
 
-# Function: infiniteQueryOptions()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/mutationOptions.md
+++ b/docs/framework/preact/reference/functions/mutationOptions.md
@@ -3,8 +3,6 @@ id: mutationOptions
 title: mutationOptions
 ---
 
-# Function: mutationOptions()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -3,8 +3,6 @@ id: queryOptions
 title: queryOptions
 ---
 
-# Function: queryOptions()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -3,8 +3,6 @@ id: useInfiniteQuery
 title: useInfiniteQuery
 ---
 
-# Function: useInfiniteQuery()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useIsFetching.md
+++ b/docs/framework/preact/reference/functions/useIsFetching.md
@@ -3,8 +3,6 @@ id: useIsFetching
 title: useIsFetching
 ---
 
-# Function: useIsFetching()
-
 ```ts
 function useIsFetching(filters?, queryClient?): number;
 ```

--- a/docs/framework/preact/reference/functions/useIsMutating.md
+++ b/docs/framework/preact/reference/functions/useIsMutating.md
@@ -3,8 +3,6 @@ id: useIsMutating
 title: useIsMutating
 ---
 
-# Function: useIsMutating()
-
 ```ts
 function useIsMutating(filters?, queryClient?): number;
 ```

--- a/docs/framework/preact/reference/functions/useIsRestoring.md
+++ b/docs/framework/preact/reference/functions/useIsRestoring.md
@@ -3,8 +3,6 @@ id: useIsRestoring
 title: useIsRestoring
 ---
 
-# Function: useIsRestoring()
-
 ```ts
 function useIsRestoring(): boolean;
 ```

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -3,8 +3,6 @@ id: useMutation
 title: useMutation
 ---
 
-# Function: useMutation()
-
 ```ts
 function useMutation<TData, TError, TVariables, TOnMutateResult>(options, queryClient?): UseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/preact/reference/functions/useMutationState.md
+++ b/docs/framework/preact/reference/functions/useMutationState.md
@@ -3,8 +3,6 @@ id: useMutationState
 title: useMutationState
 ---
 
-# Function: useMutationState()
-
 ```ts
 function useMutationState<TResult>(options, queryClient?): TResult[];
 ```

--- a/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
@@ -3,8 +3,6 @@ id: usePrefetchInfiniteQuery
 title: usePrefetchInfiniteQuery
 ---
 
-# Function: usePrefetchInfiniteQuery()
-
 ```ts
 function usePrefetchInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): void;
 ```

--- a/docs/framework/preact/reference/functions/usePrefetchQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchQuery.md
@@ -3,8 +3,6 @@ id: usePrefetchQuery
 title: usePrefetchQuery
 ---
 
-# Function: usePrefetchQuery()
-
 ```ts
 function usePrefetchQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): void;
 ```

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -3,8 +3,6 @@ id: useQueries
 title: useQueries
 ---
 
-# Function: useQueries()
-
 ```ts
 function useQueries<T, TCombinedResult>(__namedParameters, queryClient?): TCombinedResult;
 ```

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -3,8 +3,6 @@ id: useQuery
 title: useQuery
 ---
 
-# Function: useQuery()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useQueryClient.md
+++ b/docs/framework/preact/reference/functions/useQueryClient.md
@@ -3,8 +3,6 @@ id: useQueryClient
 title: useQueryClient
 ---
 
-# Function: useQueryClient()
-
 ```ts
 function useQueryClient(queryClient?): QueryClient;
 ```

--- a/docs/framework/preact/reference/functions/useQueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/useQueryErrorResetBoundary.md
@@ -3,8 +3,6 @@ id: useQueryErrorResetBoundary
 title: useQueryErrorResetBoundary
 ---
 
-# Function: useQueryErrorResetBoundary()
-
 ```ts
 function useQueryErrorResetBoundary(): QueryErrorResetBoundaryValue;
 ```

--- a/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
@@ -3,8 +3,6 @@ id: useSuspenseInfiniteQuery
 title: useSuspenseInfiniteQuery
 ---
 
-# Function: useSuspenseInfiniteQuery()
-
 ```ts
 function useSuspenseInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseSuspenseInfiniteQueryResult<TData, TError>;
 ```

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -3,8 +3,6 @@ id: useSuspenseQueries
 title: useSuspenseQueries
 ---
 
-# Function: useSuspenseQueries()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useSuspenseQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQuery.md
@@ -3,8 +3,6 @@ id: useSuspenseQuery
 title: useSuspenseQuery
 ---
 
-# Function: useSuspenseQuery()
-
 ```ts
 function useSuspenseQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseSuspenseQueryResult<TData, TError>;
 ```

--- a/docs/framework/preact/reference/index.md
+++ b/docs/framework/preact/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/preact-query"
 title: "@tanstack/preact-query"
 ---
 
-# @tanstack/preact-query
-
 ## Interfaces
 
 - [HydrationBoundaryProps](interfaces/HydrationBoundaryProps.md)

--- a/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
+++ b/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
@@ -3,8 +3,6 @@ id: HydrationBoundaryProps
 title: HydrationBoundaryProps
 ---
 
-# Interface: HydrationBoundaryProps
-
 Defined in: [preact-query/src/HydrationBoundary.tsx:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L14)
 
 ## Properties

--- a/docs/framework/preact/reference/interfaces/QueryErrorResetBoundaryProps.md
+++ b/docs/framework/preact/reference/interfaces/QueryErrorResetBoundaryProps.md
@@ -3,8 +3,6 @@ id: QueryErrorResetBoundaryProps
 title: QueryErrorResetBoundaryProps
 ---
 
-# Interface: QueryErrorResetBoundaryProps
-
 Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:44](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L44)
 
 ## Properties

--- a/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
@@ -3,8 +3,6 @@ id: UseBaseQueryOptions
 title: UseBaseQueryOptions
 ---
 
-# Interface: UseBaseQueryOptions\<TQueryFnData, TError, TData, TQueryData, TQueryKey\>
-
 Defined in: [preact-query/src/types.ts:28](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L28)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: UseInfiniteQueryOptions
 title: UseInfiniteQueryOptions
 ---
 
-# Interface: UseInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 Defined in: [preact-query/src/types.ts:102](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L102)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/UseMutationOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseMutationOptions.md
@@ -3,8 +3,6 @@ id: UseMutationOptions
 title: UseMutationOptions
 ---
 
-# Interface: UseMutationOptions\<TData, TError, TVariables, TOnMutateResult\>
-
 Defined in: [preact-query/src/types.ts:191](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L191)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/UsePrefetchQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UsePrefetchQueryOptions.md
@@ -3,8 +3,6 @@ id: UsePrefetchQueryOptions
 title: UsePrefetchQueryOptions
 ---
 
-# Interface: UsePrefetchQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 Defined in: [preact-query/src/types.ts:48](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L48)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/UseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseQueryOptions.md
@@ -3,8 +3,6 @@ id: UseQueryOptions
 title: UseQueryOptions
 ---
 
-# Interface: UseQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 Defined in: [preact-query/src/types.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L64)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: UseSuspenseInfiniteQueryOptions
 title: UseSuspenseInfiniteQueryOptions
 ---
 
-# Interface: UseSuspenseInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 Defined in: [preact-query/src/types.ts:127](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L127)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
@@ -3,8 +3,6 @@ id: UseSuspenseQueryOptions
 title: UseSuspenseQueryOptions
 ---
 
-# Interface: UseSuspenseQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 Defined in: [preact-query/src/types.ts:80](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L80)
 
 ## Extends

--- a/docs/framework/preact/reference/type-aliases/AnyUseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseBaseQueryOptions.md
@@ -3,8 +3,6 @@ id: AnyUseBaseQueryOptions
 title: AnyUseBaseQueryOptions
 ---
 
-# Type Alias: AnyUseBaseQueryOptions
-
 ```ts
 type AnyUseBaseQueryOptions = UseBaseQueryOptions<any, any, any, any, any>;
 ```

--- a/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: AnyUseInfiniteQueryOptions
 title: AnyUseInfiniteQueryOptions
 ---
 
-# Type Alias: AnyUseInfiniteQueryOptions
-
 ```ts
 type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<any, any, any, any, any>;
 ```

--- a/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
@@ -3,8 +3,6 @@ id: AnyUseMutationOptions
 title: AnyUseMutationOptions
 ---
 
-# Type Alias: AnyUseMutationOptions
-
 ```ts
 type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>;
 ```

--- a/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
@@ -3,8 +3,6 @@ id: AnyUseQueryOptions
 title: AnyUseQueryOptions
 ---
 
-# Type Alias: AnyUseQueryOptions
-
 ```ts
 type AnyUseQueryOptions = UseQueryOptions<any, any, any, any>;
 ```

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: AnyUseSuspenseInfiniteQueryOptions
 title: AnyUseSuspenseInfiniteQueryOptions
 ---
 
-# Type Alias: AnyUseSuspenseInfiniteQueryOptions
-
 ```ts
 type AnyUseSuspenseInfiniteQueryOptions = UseSuspenseInfiniteQueryOptions<any, any, any, any, any>;
 ```

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
@@ -3,8 +3,6 @@ id: AnyUseSuspenseQueryOptions
 title: AnyUseSuspenseQueryOptions
 ---
 
-# Type Alias: AnyUseSuspenseQueryOptions
-
 ```ts
 type AnyUseSuspenseQueryOptions = UseSuspenseQueryOptions<any, any, any, any>;
 ```

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -3,8 +3,6 @@ id: DefinedInitialDataInfiniteOptions
 title: DefinedInitialDataInfiniteOptions
 ---
 
-# Type Alias: DefinedInitialDataInfiniteOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type DefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: DefinedInitialDataOptions
 title: DefinedInitialDataOptions
 ---
 
-# Type Alias: DefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```

--- a/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
@@ -3,8 +3,6 @@ id: DefinedUseInfiniteQueryResult
 title: DefinedUseInfiniteQueryResult
 ---
 
-# Type Alias: DefinedUseInfiniteQueryResult\<TData, TError\>
-
 ```ts
 type DefinedUseInfiniteQueryResult<TData, TError> = DefinedInfiniteQueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
@@ -3,8 +3,6 @@ id: DefinedUseQueryResult
 title: DefinedUseQueryResult
 ---
 
-# Type Alias: DefinedUseQueryResult\<TData, TError\>
-
 ```ts
 type DefinedUseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/preact/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesOptions.md
@@ -3,8 +3,6 @@ id: QueriesOptions
 title: QueriesOptions
 ---
 
-# Type Alias: QueriesOptions\<T, TResults, TDepth\>
-
 ```ts
 type QueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryOptionsForUseQueries[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryOptionsForUseQueries<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesOptions<[...Tails], [...TResults, GetUseQueryOptionsForUseQueries<Head>], [...TDepth, 1]> : ReadonlyArray<unknown> extends T ? T : T extends UseQueryOptionsForUseQueries<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData, TQueryKey>[] : UseQueryOptionsForUseQueries[];
 ```

--- a/docs/framework/preact/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesResults.md
@@ -3,8 +3,6 @@ id: QueriesResults
 title: QueriesResults
 ---
 
-# Type Alias: QueriesResults\<T, TResults, TDepth\>
-
 ```ts
 type QueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesResults<[...Tails], [...TResults, GetUseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseQueryResult<T[K]> };
 ```

--- a/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
@@ -3,8 +3,6 @@ id: QueryClientProviderProps
 title: QueryClientProviderProps
 ---
 
-# Type Alias: QueryClientProviderProps
-
 ```ts
 type QueryClientProviderProps = object;
 ```

--- a/docs/framework/preact/reference/type-aliases/QueryErrorClearResetFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorClearResetFunction.md
@@ -3,8 +3,6 @@ id: QueryErrorClearResetFunction
 title: QueryErrorClearResetFunction
 ---
 
-# Type Alias: QueryErrorClearResetFunction()
-
 ```ts
 type QueryErrorClearResetFunction = () => void;
 ```

--- a/docs/framework/preact/reference/type-aliases/QueryErrorIsResetFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorIsResetFunction.md
@@ -3,8 +3,6 @@ id: QueryErrorIsResetFunction
 title: QueryErrorIsResetFunction
 ---
 
-# Type Alias: QueryErrorIsResetFunction()
-
 ```ts
 type QueryErrorIsResetFunction = () => boolean;
 ```

--- a/docs/framework/preact/reference/type-aliases/QueryErrorResetBoundaryFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorResetBoundaryFunction.md
@@ -3,8 +3,6 @@ id: QueryErrorResetBoundaryFunction
 title: QueryErrorResetBoundaryFunction
 ---
 
-# Type Alias: QueryErrorResetBoundaryFunction()
-
 ```ts
 type QueryErrorResetBoundaryFunction = (value) => ComponentChildren;
 ```

--- a/docs/framework/preact/reference/type-aliases/QueryErrorResetFunction.md
+++ b/docs/framework/preact/reference/type-aliases/QueryErrorResetFunction.md
@@ -3,8 +3,6 @@ id: QueryErrorResetFunction
 title: QueryErrorResetFunction
 ---
 
-# Type Alias: QueryErrorResetFunction()
-
 ```ts
 type QueryErrorResetFunction = () => void;
 ```

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
@@ -3,8 +3,6 @@ id: SuspenseQueriesOptions
 title: SuspenseQueriesOptions
 ---
 
-# Type Alias: SuspenseQueriesOptions\<T, TResults, TDepth\>
-
 ```ts
 type SuspenseQueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryOptions[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryOptions<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesOptions<[...Tails], [...TResults, GetUseSuspenseQueryOptions<Head>], [...TDepth, 1]> : unknown[] extends T ? T : T extends UseSuspenseQueryOptions<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[] : UseSuspenseQueryOptions[];
 ```

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
@@ -3,8 +3,6 @@ id: SuspenseQueriesResults
 title: SuspenseQueriesResults
 ---
 
-# Type Alias: SuspenseQueriesResults\<T, TResults, TDepth\>
-
 ```ts
 type SuspenseQueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesResults<[...Tails], [...TResults, GetUseSuspenseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseSuspenseQueryResult<T[K]> };
 ```

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
@@ -3,8 +3,6 @@ id: UndefinedInitialDataInfiniteOptions
 title: UndefinedInitialDataInfiniteOptions
 ---
 
-# Type Alias: UndefinedInitialDataInfiniteOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type UndefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: UndefinedInitialDataOptions
 title: UndefinedInitialDataOptions
 ---
 
-# Type Alias: UndefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object;
 ```

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
@@ -3,8 +3,6 @@ id: UnusedSkipTokenInfiniteOptions
 title: UnusedSkipTokenInfiniteOptions
 ---
 
-# Type Alias: UnusedSkipTokenInfiniteOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type UnusedSkipTokenInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
@@ -3,8 +3,6 @@ id: UnusedSkipTokenOptions
 title: UnusedSkipTokenOptions
 ---
 
-# Type Alias: UnusedSkipTokenOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> = OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
@@ -3,8 +3,6 @@ id: UseBaseMutationResult
 title: UseBaseMutationResult
 ---
 
-# Type Alias: UseBaseMutationResult\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Override<MutationObserverResult<TData, TError, TVariables, TOnMutateResult>, {
   mutate: UseMutateFunction<TData, TError, TVariables, TOnMutateResult>;

--- a/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
@@ -3,8 +3,6 @@ id: UseBaseQueryResult
 title: UseBaseQueryResult
 ---
 
-# Type Alias: UseBaseQueryResult\<TData, TError\>
-
 ```ts
 type UseBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
@@ -3,8 +3,6 @@ id: UseInfiniteQueryResult
 title: UseInfiniteQueryResult
 ---
 
-# Type Alias: UseInfiniteQueryResult\<TData, TError\>
-
 ```ts
 type UseInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
@@ -3,8 +3,6 @@ id: UseMutateAsyncFunction
 title: UseMutateAsyncFunction
 ---
 
-# Type Alias: UseMutateAsyncFunction\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type UseMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
@@ -3,8 +3,6 @@ id: UseMutateFunction
 title: UseMutateFunction
 ---
 
-# Type Alias: UseMutateFunction()\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type UseMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutationResult.md
@@ -3,8 +3,6 @@ id: UseMutationResult
 title: UseMutationResult
 ---
 
-# Type Alias: UseMutationResult\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type UseMutationResult<TData, TError, TVariables, TOnMutateResult> = UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseQueryResult.md
@@ -3,8 +3,6 @@ id: UseQueryResult
 title: UseQueryResult
 ---
 
-# Type Alias: UseQueryResult\<TData, TError\>
-
 ```ts
 type UseQueryResult<TData, TError> = UseBaseQueryResult<TData, TError>;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
@@ -3,8 +3,6 @@ id: UseSuspenseInfiniteQueryResult
 title: UseSuspenseInfiniteQueryResult
 ---
 
-# Type Alias: UseSuspenseInfiniteQueryResult\<TData, TError\>
-
 ```ts
 type UseSuspenseInfiniteQueryResult<TData, TError> = OmitKeyof<DefinedInfiniteQueryObserverResult<TData, TError>, "isPlaceholderData" | "promise">;
 ```

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
@@ -3,8 +3,6 @@ id: UseSuspenseQueryResult
 title: UseSuspenseQueryResult
 ---
 
-# Type Alias: UseSuspenseQueryResult\<TData, TError\>
-
 ```ts
 type UseSuspenseQueryResult<TData, TError> = DistributiveOmit<DefinedQueryObserverResult<TData, TError>, "isPlaceholderData" | "promise">;
 ```

--- a/docs/framework/preact/reference/variables/IsRestoringProvider.md
+++ b/docs/framework/preact/reference/variables/IsRestoringProvider.md
@@ -3,8 +3,6 @@ id: IsRestoringProvider
 title: IsRestoringProvider
 ---
 
-# Variable: IsRestoringProvider
-
 ```ts
 const IsRestoringProvider: Provider<boolean> = IsRestoringContext.Provider;
 ```

--- a/docs/framework/preact/reference/variables/QueryClientContext.md
+++ b/docs/framework/preact/reference/variables/QueryClientContext.md
@@ -3,8 +3,6 @@ id: QueryClientContext
 title: QueryClientContext
 ---
 
-# Variable: QueryClientContext
-
 ```ts
 const QueryClientContext: Context<QueryClient | undefined>;
 ```

--- a/docs/framework/svelte/reference/functions/createInfiniteQuery.md
+++ b/docs/framework/svelte/reference/functions/createInfiniteQuery.md
@@ -3,8 +3,6 @@ id: createInfiniteQuery
 title: createInfiniteQuery
 ---
 
-# Function: createInfiniteQuery()
-
 ```ts
 function createInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): CreateInfiniteQueryResult<TData, TError>;
 ```

--- a/docs/framework/svelte/reference/functions/createMutation.md
+++ b/docs/framework/svelte/reference/functions/createMutation.md
@@ -3,8 +3,6 @@ id: createMutation
 title: createMutation
 ---
 
-# Function: createMutation()
-
 ```ts
 function createMutation<TData, TError, TVariables, TContext>(options, queryClient?): CreateMutationResult<TData, TError, TVariables, TContext>;
 ```

--- a/docs/framework/svelte/reference/functions/createQueries.md
+++ b/docs/framework/svelte/reference/functions/createQueries.md
@@ -3,8 +3,6 @@ id: createQueries
 title: createQueries
 ---
 
-# Function: createQueries()
-
 ```ts
 function createQueries<T, TCombinedResult>(createQueriesOptions, queryClient?): TCombinedResult;
 ```

--- a/docs/framework/svelte/reference/functions/createQuery.md
+++ b/docs/framework/svelte/reference/functions/createQuery.md
@@ -3,8 +3,6 @@ id: createQuery
 title: createQuery
 ---
 
-# Function: createQuery()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/svelte/reference/functions/getIsRestoringContext.md
+++ b/docs/framework/svelte/reference/functions/getIsRestoringContext.md
@@ -3,8 +3,6 @@ id: getIsRestoringContext
 title: getIsRestoringContext
 ---
 
-# Function: getIsRestoringContext()
-
 ```ts
 function getIsRestoringContext(): Box<boolean>;
 ```

--- a/docs/framework/svelte/reference/functions/getQueryClientContext.md
+++ b/docs/framework/svelte/reference/functions/getQueryClientContext.md
@@ -3,8 +3,6 @@ id: getQueryClientContext
 title: getQueryClientContext
 ---
 
-# Function: getQueryClientContext()
-
 ```ts
 function getQueryClientContext(): QueryClient;
 ```

--- a/docs/framework/svelte/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/svelte/reference/functions/infiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: infiniteQueryOptions
 title: infiniteQueryOptions
 ---
 
-# Function: infiniteQueryOptions()
-
 ```ts
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```

--- a/docs/framework/svelte/reference/functions/mutationOptions.md
+++ b/docs/framework/svelte/reference/functions/mutationOptions.md
@@ -3,8 +3,6 @@ id: mutationOptions
 title: mutationOptions
 ---
 
-# Function: mutationOptions()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/svelte/reference/functions/queryOptions.md
+++ b/docs/framework/svelte/reference/functions/queryOptions.md
@@ -3,8 +3,6 @@ id: queryOptions
 title: queryOptions
 ---
 
-# Function: queryOptions()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/svelte/reference/functions/setIsRestoringContext.md
+++ b/docs/framework/svelte/reference/functions/setIsRestoringContext.md
@@ -3,8 +3,6 @@ id: setIsRestoringContext
 title: setIsRestoringContext
 ---
 
-# Function: setIsRestoringContext()
-
 ```ts
 function setIsRestoringContext(isRestoring): void;
 ```

--- a/docs/framework/svelte/reference/functions/setQueryClientContext.md
+++ b/docs/framework/svelte/reference/functions/setQueryClientContext.md
@@ -3,8 +3,6 @@ id: setQueryClientContext
 title: setQueryClientContext
 ---
 
-# Function: setQueryClientContext()
-
 ```ts
 function setQueryClientContext(client): void;
 ```

--- a/docs/framework/svelte/reference/functions/useHydrate.md
+++ b/docs/framework/svelte/reference/functions/useHydrate.md
@@ -3,8 +3,6 @@ id: useHydrate
 title: useHydrate
 ---
 
-# Function: useHydrate()
-
 ```ts
 function useHydrate(
    state?, 

--- a/docs/framework/svelte/reference/functions/useIsFetching.md
+++ b/docs/framework/svelte/reference/functions/useIsFetching.md
@@ -3,8 +3,6 @@ id: useIsFetching
 title: useIsFetching
 ---
 
-# Function: useIsFetching()
-
 ```ts
 function useIsFetching(filters?, queryClient?): ReactiveValue<number>;
 ```

--- a/docs/framework/svelte/reference/functions/useIsMutating.md
+++ b/docs/framework/svelte/reference/functions/useIsMutating.md
@@ -3,8 +3,6 @@ id: useIsMutating
 title: useIsMutating
 ---
 
-# Function: useIsMutating()
-
 ```ts
 function useIsMutating(filters?, queryClient?): ReactiveValue<number>;
 ```

--- a/docs/framework/svelte/reference/functions/useIsRestoring.md
+++ b/docs/framework/svelte/reference/functions/useIsRestoring.md
@@ -3,8 +3,6 @@ id: useIsRestoring
 title: useIsRestoring
 ---
 
-# Function: useIsRestoring()
-
 ```ts
 function useIsRestoring(): Box<boolean>;
 ```

--- a/docs/framework/svelte/reference/functions/useMutationState.md
+++ b/docs/framework/svelte/reference/functions/useMutationState.md
@@ -3,8 +3,6 @@ id: useMutationState
 title: useMutationState
 ---
 
-# Function: useMutationState()
-
 ```ts
 function useMutationState<TResult>(options, queryClient?): TResult[];
 ```

--- a/docs/framework/svelte/reference/functions/useQueryClient.md
+++ b/docs/framework/svelte/reference/functions/useQueryClient.md
@@ -3,8 +3,6 @@ id: useQueryClient
 title: useQueryClient
 ---
 
-# Function: useQueryClient()
-
 ```ts
 function useQueryClient(queryClient?): QueryClient;
 ```

--- a/docs/framework/svelte/reference/index.md
+++ b/docs/framework/svelte/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/svelte-query"
 title: "@tanstack/svelte-query"
 ---
 
-# @tanstack/svelte-query
-
 ## Type Aliases
 
 - [Accessor](type-aliases/Accessor.md)

--- a/docs/framework/svelte/reference/type-aliases/Accessor.md
+++ b/docs/framework/svelte/reference/type-aliases/Accessor.md
@@ -3,8 +3,6 @@ id: Accessor
 title: Accessor
 ---
 
-# Type Alias: Accessor()\<T\>
-
 ```ts
 type Accessor<T> = () => T;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateBaseMutationResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateBaseMutationResult.md
@@ -3,8 +3,6 @@ id: CreateBaseMutationResult
 title: CreateBaseMutationResult
 ---
 
-# Type Alias: CreateBaseMutationResult\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Override<MutationObserverResult<TData, TError, TVariables, TOnMutateResult>, {
   mutate: CreateMutateFunction<TData, TError, TVariables, TOnMutateResult>;

--- a/docs/framework/svelte/reference/type-aliases/CreateBaseQueryOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateBaseQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateBaseQueryOptions
 title: CreateBaseQueryOptions
 ---
 
-# Type Alias: CreateBaseQueryOptions\<TQueryFnData, TError, TData, TQueryData, TQueryKey\>
-
 ```ts
 type CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateBaseQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateBaseQueryResult.md
@@ -3,8 +3,6 @@ id: CreateBaseQueryResult
 title: CreateBaseQueryResult
 ---
 
-# Type Alias: CreateBaseQueryResult\<TData, TError\>
-
 ```ts
 type CreateBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateInfiniteQueryOptions
 title: CreateInfiniteQueryOptions
 ---
 
-# Type Alias: CreateInfiniteQueryOptions\<TQueryFnData, TError, TData, TQueryKey, TPageParam\>
-
 ```ts
 type CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryResult.md
@@ -3,8 +3,6 @@ id: CreateInfiniteQueryResult
 title: CreateInfiniteQueryResult
 ---
 
-# Type Alias: CreateInfiniteQueryResult\<TData, TError\>
-
 ```ts
 type CreateInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateMutateAsyncFunction.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutateAsyncFunction.md
@@ -3,8 +3,6 @@ id: CreateMutateAsyncFunction
 title: CreateMutateAsyncFunction
 ---
 
-# Type Alias: CreateMutateAsyncFunction\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateMutateFunction.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutateFunction.md
@@ -3,8 +3,6 @@ id: CreateMutateFunction
 title: CreateMutateFunction
 ---
 
-# Type Alias: CreateMutateFunction()\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateMutationOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutationOptions.md
@@ -3,8 +3,6 @@ id: CreateMutationOptions
 title: CreateMutationOptions
 ---
 
-# Type Alias: CreateMutationOptions\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateMutationOptions<TData, TError, TVariables, TOnMutateResult> = OmitKeyof<MutationObserverOptions<TData, TError, TVariables, TOnMutateResult>, "_defaulted">;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateMutationResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutationResult.md
@@ -3,8 +3,6 @@ id: CreateMutationResult
 title: CreateMutationResult
 ---
 
-# Type Alias: CreateMutationResult\<TData, TError, TVariables, TOnMutateResult\>
-
 ```ts
 type CreateMutationResult<TData, TError, TVariables, TOnMutateResult> = CreateBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateQueryOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateQueryOptions.md
@@ -3,8 +3,6 @@ id: CreateQueryOptions
 title: CreateQueryOptions
 ---
 
-# Type Alias: CreateQueryOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> = CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/CreateQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateQueryResult.md
@@ -3,8 +3,6 @@ id: CreateQueryResult
 title: CreateQueryResult
 ---
 
-# Type Alias: CreateQueryResult\<TData, TError\>
-
 ```ts
 type CreateQueryResult<TData, TError> = CreateBaseQueryResult<TData, TError>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/DefinedCreateBaseQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/DefinedCreateBaseQueryResult.md
@@ -3,8 +3,6 @@ id: DefinedCreateBaseQueryResult
 title: DefinedCreateBaseQueryResult
 ---
 
-# Type Alias: DefinedCreateBaseQueryResult\<TData, TError\>
-
 ```ts
 type DefinedCreateBaseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/DefinedCreateQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/DefinedCreateQueryResult.md
@@ -3,8 +3,6 @@ id: DefinedCreateQueryResult
 title: DefinedCreateQueryResult
 ---
 
-# Type Alias: DefinedCreateQueryResult\<TData, TError\>
-
 ```ts
 type DefinedCreateQueryResult<TData, TError> = DefinedCreateBaseQueryResult<TData, TError>;
 ```

--- a/docs/framework/svelte/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/DefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: DefinedInitialDataOptions
 title: DefinedInitialDataOptions
 ---
 
-# Type Alias: DefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object;
 ```

--- a/docs/framework/svelte/reference/type-aliases/HydrationBoundary.md
+++ b/docs/framework/svelte/reference/type-aliases/HydrationBoundary.md
@@ -3,8 +3,6 @@ id: HydrationBoundary
 title: HydrationBoundary
 ---
 
-# Type Alias: HydrationBoundary
-
 ```ts
 type HydrationBoundary = SvelteComponent;
 ```

--- a/docs/framework/svelte/reference/type-aliases/MutationStateOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/MutationStateOptions.md
@@ -3,8 +3,6 @@ id: MutationStateOptions
 title: MutationStateOptions
 ---
 
-# Type Alias: MutationStateOptions\<TResult\>
-
 ```ts
 type MutationStateOptions<TResult> = object;
 ```

--- a/docs/framework/svelte/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/QueriesOptions.md
@@ -3,8 +3,6 @@ id: QueriesOptions
 title: QueriesOptions
 ---
 
-# Type Alias: QueriesOptions\<T, TResults, TDepth\>
-
 ```ts
 type QueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? CreateQueryOptionsForCreateQueries[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetCreateQueryOptionsForCreateQueries<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesOptions<[...Tails], [...TResults, GetCreateQueryOptionsForCreateQueries<Head>], [...TDepth, 1]> : ReadonlyArray<unknown> extends T ? T : T extends CreateQueryOptionsForCreateQueries<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? CreateQueryOptionsForCreateQueries<TQueryFnData, TError, TData, TQueryKey>[] : CreateQueryOptionsForCreateQueries[];
 ```

--- a/docs/framework/svelte/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/svelte/reference/type-aliases/QueriesResults.md
@@ -3,8 +3,6 @@ id: QueriesResults
 title: QueriesResults
 ---
 
-# Type Alias: QueriesResults\<T, TResults, TDepth\>
-
 ```ts
 type QueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? CreateQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetCreateQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesResults<[...Tails], [...TResults, GetCreateQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetCreateQueryResult<T[K]> };
 ```

--- a/docs/framework/svelte/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/svelte/reference/type-aliases/QueryClientProviderProps.md
@@ -3,8 +3,6 @@ id: QueryClientProviderProps
 title: QueryClientProviderProps
 ---
 
-# Type Alias: QueryClientProviderProps
-
 ```ts
 type QueryClientProviderProps = object;
 ```

--- a/docs/framework/svelte/reference/type-aliases/UndefinedInitialDataOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/UndefinedInitialDataOptions.md
@@ -3,8 +3,6 @@ id: UndefinedInitialDataOptions
 title: UndefinedInitialDataOptions
 ---
 
-# Type Alias: UndefinedInitialDataOptions\<TQueryFnData, TError, TData, TQueryKey\>
-
 ```ts
 type UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object;
 ```

--- a/docs/framework/svelte/reference/variables/HydrationBoundary.md
+++ b/docs/framework/svelte/reference/variables/HydrationBoundary.md
@@ -3,8 +3,6 @@ id: HydrationBoundary
 title: HydrationBoundary
 ---
 
-# Variable: HydrationBoundary
-
 ```ts
 const HydrationBoundary: LegacyComponentType;
 ```


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11194, which added `hidePageTitle: true` to `scripts/generate-docs.ts`. This PR is the regenerated output of `pnpm run generate-docs` on top of that change.

- Removes the redundant `# Function: X()`-style heading from all 197 TypeDoc-generated reference pages (Angular, Svelte, Preact, Lit) — the same name was previously repeated in the sidebar entry, the page's `title` frontmatter, and this in-body heading
- Every file loses exactly 2 lines (the heading + its trailing blank line); no other content changed
- Verified locally that re-running `pnpm run generate-docs` against this diff produces no further changes (idempotent), and that pages with `@deprecated` functions (`injectQueryClient`, `provideAngularQuery`) still show their `## Deprecated` body section — only the struck-through page title heading is removed

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (docs-only change, no code/tests affected)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API reference formatting across Angular, Lit, Preact, and Svelte documentation.
  * Removed redundant generated headings for functions, interfaces, classes, type aliases, variables, and reference indexes.
  * Preserved all API signatures, definitions, parameters, examples, links, and descriptive content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->