### PR TITLE
docs(reference): remove redundant page title heading from InfiniteQueryObserver, QueriesObserver, and QueryClient

### DIFF
--- a/docs/reference/InfiniteQueryObserver.md
+++ b/docs/reference/InfiniteQueryObserver.md
@@ -3,8 +3,6 @@ id: InfiniteQueryObserver
 title: InfiniteQueryObserver
 ---
 
-## `InfiniteQueryObserver`
-
 The `InfiniteQueryObserver` can be used to observe and switch between infinite queries.
 
 ```tsx

--- a/docs/reference/QueriesObserver.md
+++ b/docs/reference/QueriesObserver.md
@@ -3,8 +3,6 @@ id: QueriesObserver
 title: QueriesObserver
 ---
 
-## `QueriesObserver`
-
 The `QueriesObserver` can be used to observe multiple queries.
 
 ```tsx

--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -3,8 +3,6 @@ id: QueryClient
 title: QueryClient
 ---
 
-## `QueryClient`
-
 The `QueryClient` can be used to interact with a cache:
 
 ```tsx


### PR DESCRIPTION
## 🎯 Changes

Related in spirit to #11194/#11196 (which removed the same kind of redundant title heading from the TypeDoc-generated reference docs), this fixes the same issue in 3 of the 12 hand-written `docs/reference/*.md` files.

Every page's `title` frontmatter already renders as the page heading in the sidebar/breadcrumb, so a `## \`X\`` heading repeating the same name in the body is redundant. 9 of the 12 files in `docs/reference/` already start directly with the description sentence (no such heading); only `InfiniteQueryObserver.md`, `QueriesObserver.md`, and `QueryClient.md` still had it.

- Remove the `## \`InfiniteQueryObserver\``, `## \`QueriesObserver\``, and `## \`QueryClient\`` headings (2 lines each: heading + trailing blank line)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`. (docs-only change, no code/tests affected)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed redundant section headings from the Infinite Query Observer, Queries Observer, and Query Client reference documentation.
  * Existing descriptions and usage guidance remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->