### PR TITLE
docs(config.json): add 'Preact Reference' index entry to API Reference sidebar

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1403,6 +1403,10 @@
           "label": "preact",
           "children": [
             {
+              "label": "Preact Reference",
+              "to": "framework/preact/reference/index"
+            },
+            {
               "label": "useQuery",
               "to": "framework/preact/reference/functions/useQuery"
             },


### PR DESCRIPTION
## 🎯 Changes

Adds a `Preact Reference` sidebar entry linking to `framework/preact/reference/index`, matching the existing `Angular Reference` / `Svelte Reference` / `Lit Reference` entries.

Without it, Preact's `interfaces/`, `type-aliases/`, and `variables/` reference pages (e.g. `QueriesOptions`, `UseQueryOptions`, `QueryClientContext`) are unreachable from the docs site — they aren't listed in the sidebar and aren't linked from any `functions/` page. The `reference/index.md` page (auto-generated by TypeDoc) already lists all of them, so adding this one entry restores the same reachable path Angular/Svelte/Lit already have.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Preact Reference entry to the documentation navigation.
  * Linked the new entry to the Preact reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->