### PR TITLE
fix(query-core): refetch resetQueries matches after state-mutating reset

### DIFF
--- a/.changeset/reset-queries-state-predicate.md
+++ b/.changeset/reset-queries-state-predicate.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Fix `resetQueries` so queries matched by a state-dependent filter (for example `predicate: (query) => query.state.status === 'error'`) are still refetched after `reset()` mutates their state.

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1698,6 +1698,55 @@ describe('queryClient', () => {
       expect(queryFn2).toHaveBeenCalledTimes(0)
       expect(didSkipTokenRun).toBe(false)
     })
+
+    it('should refetch queries matched by a state-dependent predicate after reset', async () => {
+      const key1 = queryKey()
+      const key2 = queryKey()
+      const queryFn1 = vi
+        .fn<(...args: Array<unknown>) => string>()
+        .mockReturnValue('data')
+      const queryFn2 = vi
+        .fn<(...args: Array<unknown>) => string>()
+        .mockRejectedValue('error')
+
+      const observer1 = new QueryObserver(queryClient, {
+        queryKey: key1,
+        queryFn: queryFn1,
+      })
+      const observer2 = new QueryObserver(queryClient, {
+        queryKey: key2,
+        queryFn: queryFn2,
+        retry: false,
+      })
+
+      observer1.subscribe(() => undefined)
+      observer2.subscribe(() => undefined)
+
+      await vi.waitFor(() => {
+        expect(queryClient.getQueryState(key1)?.status).toBe('success')
+        expect(queryClient.getQueryState(key2)?.status).toBe('error')
+      })
+
+      expect(queryFn1).toHaveBeenCalledTimes(1)
+      expect(queryFn2).toHaveBeenCalledTimes(1)
+
+      await queryClient.resetQueries({
+        predicate: (query) => query.state.status === 'success',
+      })
+
+      expect(queryFn1).toHaveBeenCalledTimes(2)
+      expect(queryFn2).toHaveBeenCalledTimes(1)
+
+      await queryClient.resetQueries({
+        predicate: (query) => query.state.status === 'error',
+      })
+
+      expect(queryFn1).toHaveBeenCalledTimes(2)
+      expect(queryFn2).toHaveBeenCalledTimes(2)
+
+      observer1.destroy()
+      observer2.destroy()
+    })
   })
 
   describe('focusManager and onlineManager', () => {

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -260,13 +260,18 @@ export class QueryClient {
     const queryCache = this.#queryCache
 
     return notifyManager.batch(() => {
-      queryCache.findAll(filters).forEach((query) => {
+      // Snapshot matches before reset(). reset() mutates query state (e.g.
+      // status 'error' → 'pending'), so re-running the same filters for
+      // refetchQueries would miss state-dependent predicates (#10705).
+      const queries = queryCache.findAll(filters)
+      queries.forEach((query) => {
         query.reset()
       })
+      const matchedQueries = new Set(queries)
       return this.refetchQueries(
         {
-          type: 'active',
-          ...filters,
+          type: filters?.type ?? 'active',
+          predicate: (query) => matchedQueries.has(query),
         },
         options,
       )


### PR DESCRIPTION
## Summary

- Fixes #10705: `resetQueries` with a state-dependent filter (e.g. `predicate: (query) => query.state.status === 'error'`) reset the matched queries but never refetched them.
- `reset()` mutates query state before `refetchQueries` re-ran the same filters, so the intended queries no longer matched and stayed stuck in `pending`.
- Snapshot the matched query set before resetting, then refetch exactly those queries (still respecting `filters.type`, defaulting to `active`).

## Test plan

- [x] Added regression test covering success- and error-status predicates
- [x] `pnpm --filter @tanstack/query-core exec vitest run src/__tests__/queryClient.test.tsx -t resetQueries` (5 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `resetQueries` so state-based filters are evaluated before queries are reset.
  * Ensured only the queries that originally matched the filters are refetched.
  * Preserved the configured refetch behavior, including query type selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->