### PR TITLE
docs(react-query/reference): remove stale 'suspense' references left over from the v5 suspense split

### DIFF
--- a/docs/framework/react/reference/useQuery.md
+++ b/docs/framework/react/reference/useQuery.md
@@ -175,7 +175,6 @@ const {
   - Optional
   - Defaults to `false`
   - Set this to `true` if you want errors to be thrown in the render phase and propagate to the nearest error boundary
-  - Set this to `false` to disable `suspense`'s default behavior of throwing errors to the error boundary.
   - If set to a function, it will be passed the error and the query, and it should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)
 - `meta: Record<string, unknown>`
   - Optional

--- a/docs/framework/react/reference/useSuspenseInfiniteQuery.md
+++ b/docs/framework/react/reference/useSuspenseInfiniteQuery.md
@@ -11,7 +11,6 @@ const result = useSuspenseInfiniteQuery(options)
 
 The same as for [useInfiniteQuery](./useInfiniteQuery.md), except for:
 
-- `suspense`
 - `throwOnError`
 - `enabled`
 - `placeholderData`

--- a/docs/framework/react/reference/useSuspenseQueries.md
+++ b/docs/framework/react/reference/useSuspenseQueries.md
@@ -11,7 +11,6 @@ const result = useSuspenseQueries(options)
 
 The same as for [useQueries](./useQueries.md), except that each `query` can't have:
 
-- `suspense`
 - `throwOnError`
 - `enabled`
 - `placeholderData`


### PR DESCRIPTION
## 🎯 Changes

Removes `suspense` from the "except for" option lists in `useSuspenseInfiniteQuery.md` and `useSuspenseQueries.md`, and removes a stale sentence about `suspense`'s default behavior from `useQuery.md`'s `throwOnError` description.

`suspense` was already omitted from `UseInfiniteQueryOptions` and `UseQueryOptions` (`OmitKeyof<..., 'suspense'>` in `packages/react-query/src/types.ts`), and `DefaultOptions['queries']` omits it too — so it can never reach a plain `useQuery`/`useInfiniteQuery`/`useQueries` call. Listing it as something `useSuspenseInfiniteQuery`/`useSuspenseQueries` additionally excludes, or describing it as a behavior `throwOnError: false` disables, describes an unreachable state. `useSuspenseQuery.md` (the correct reference) never listed `suspense` for the same reason.

All three changes are pure removals — no new prose added, since `useQuery.md` and `hydration.md` are reused by Vue via `ref:` and unreviewed prose there risks being wrong for Vue's suspense model.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated React query documentation to reflect current suspense behavior.
  - Clarified supported and restricted options for suspense-based infinite queries and query collections.
  - Removed outdated references to disabling suspense error-boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->