### PR TITLE
docs(react-query/reference): fix 'queryClient' nesting in 'HydrationBoundary' options

### DIFF
--- a/docs/framework/react/reference/hydration.md
+++ b/docs/framework/react/reference/hydration.md
@@ -122,7 +122,8 @@ function App() {
   - Optional
   - `defaultOptions: QueryOptions`
     - The default query options to use for the hydrated queries.
-  - `queryClient?: QueryClient`
-    - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
+    - Note: unlike `hydrate`, `mutations` cannot be set here.
+- `queryClient?: QueryClient`
+  - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
 [//]: # 'HydrationBoundary'


### PR DESCRIPTION
## 🎯 Changes

Fixes the `HydrationBoundary` options list in `hydration.md`, where `queryClient?` was nested under `options` as if it were a sub-field of `HydrateOptions`. It isn't — `HydrationBoundaryProps` (`packages/react-query/src/HydrationBoundary.tsx`) declares `options` and `queryClient` as separate top-level props, and the component's destructuring (`{ children, options = {}, state, queryClient }`) matches that. Following the previous docs, a caller would have written `options={{ queryClient }}`, which doesn't work.

Also notes that `options.defaultOptions` can't set `mutations` here, since `HydrationBoundaryProps.options.defaultOptions` is typed as `OmitKeyof<..., 'mutations'>`.

`hydration.md` is reused by Vue via `ref:`, so this correction propagates there too.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that mutations cannot be configured through `HydrationBoundary` default options.
  * Updated the documentation to place the `queryClient` option under `HydrateOptions`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->