### PR TITLE
docs(vue-query/guides/ssr): fix 'queryKey' to use array form

### DIFF
--- a/docs/framework/vue/guides/ssr.md
+++ b/docs/framework/vue/guides/ssr.md
@@ -149,7 +149,7 @@ export default defineComponent({
     // This won't be prefetched, it will start fetching on client side
     const { data2 } = useQuery(
       {
-        queryKey: 'todos2',
+        queryKey: ['todos2'],
         queryFn: getTodos,
       },
       queryClient,


### PR DESCRIPTION
## 🎯 Changes

Fixes `queryKey: 'todos2'` (a string) to `queryKey: ['todos2']` (an array) in the second `useQuery` example in the Nuxt 2 SSR guide. `QueryKey` is typed as `ReadonlyArray<unknown>` (`packages/query-core/src/types.ts`), and the first `useQuery` call in the same snippet correctly uses `queryKey: ['todos']`.

This traces back to the v5 migration of this guide (#8001), where the original v4 call `useQuery("todos2", getTodos)` — v4 allowed a bare string key — was converted to v5's object form but the key wasn't wrapped in an array.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Nuxt 2 server-side rendering example to use the recommended array format for query keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->