### PR TITLE
docs(vue-query/reference): hide React-only 'React.use()' mention from useInfiniteQuery

### DIFF
--- a/docs/framework/react/reference/useInfiniteQuery.md
+++ b/docs/framework/react/reference/useInfiniteQuery.md
@@ -88,7 +88,9 @@ The returned properties for `useInfiniteQuery` are identical to the [`useQuery` 
   - Will be `true` if the query failed while refetching a page.
 - `promise: Promise<TData>`
   - A stable promise that resolves to the query result.
+  [//]: # 'ReactUse'
   - This can be used with `React.use()` to fetch data
+  [//]: # 'ReactUse'
   - Requires the `experimental_prefetchInRender` feature flag to be enabled on the `QueryClient`.
 
 Keep in mind that imperative fetch calls, such as `fetchNextPage`, may interfere with the default refetch behaviour, resulting in outdated data. Make sure to call these functions only in response to user actions, or add conditions like `hasNextPage && !isFetching`.

--- a/docs/framework/vue/reference/useInfiniteQuery.md
+++ b/docs/framework/vue/reference/useInfiniteQuery.md
@@ -4,3 +4,6 @@ title: useInfiniteQuery
 ref: docs/framework/react/reference/useInfiniteQuery.md
 replace: { '@tanstack/react-query': '@tanstack/vue-query' }
 ---
+
+[//]: # 'ReactUse'
+[//]: # 'ReactUse'


### PR DESCRIPTION
## 🎯 Changes

Wraps the `React.use()` mention in `useInfiniteQuery.md`'s `promise` return-value description in a `[//]: # 'ReactUse'` marker pair (same mechanism already used by `hydration.md` for the `HydrationBoundary` section, and by `initial-query-data.md` for its `Example2`/`Example3`/`Example4` code blocks — including the indented-list-item form).

`useInfiniteQuery.md` is reused by Vue via `ref:`. `React.use()` is a React 19-only API with no Vue equivalent, and this line currently renders verbatim on the live Vue reference page (confirmed at `tanstack.com/query/latest/docs/framework/vue/reference/useInfiniteQuery`). Adding an empty marker pair of the same name to Vue's `useInfiniteQuery.md` strips the line from Vue's rendered page while leaving React's own page unchanged (the marker is a Markdown comment).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation markers to the React and Vue `useInfiniteQuery` reference pages.
  * Clarified integration guidance for handling promise results in React without changing the existing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->