### PR TITLE
fix(query-core): resetQueries now preserves the queries matched before query.reset() changes their state.

### DIFF
--- a/.changeset/swift-actors-brush.md
+++ b/.changeset/swift-actors-brush.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+fix: resetQueries now preserves the queries matched before query.reset() changes their state.

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -1662,6 +1662,39 @@ describe('queryClient', () => {
       expect(state?.data).toEqual('initial')
     })
 
+    it('should refetch queries matched by a state-dependent predicate', async () => {
+      const key = queryKey()
+      const queryFn = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(new Error('error'))
+        .mockResolvedValue('data')
+
+      await expect(
+        queryClient.fetchQuery({
+          queryKey: key,
+          queryFn,
+          retry: false,
+        }),
+      ).rejects.toThrow('error')
+
+      const observer = new QueryObserver(queryClient, {
+        queryKey: key,
+        queryFn,
+        retry: false,
+        retryOnMount: false,
+      })
+      const unsubscribe = observer.subscribe(() => undefined)
+
+      await queryClient.resetQueries({
+        predicate: (query) => query.state.status === 'error',
+      })
+
+      expect(queryFn).toHaveBeenCalledTimes(2)
+      expect(queryClient.getQueryData(key)).toBe('data')
+
+      unsubscribe()
+    })
+
     it('should refetch all active queries', async () => {
       const key1 = queryKey()
       const key2 = queryKey()

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -260,13 +260,15 @@ export class QueryClient {
     const queryCache = this.#queryCache
 
     return notifyManager.batch(() => {
-      queryCache.findAll(filters).forEach((query) => {
+      const matched = queryCache.findAll(filters)
+      const queriesToRefetch = new Set(matched)
+      matched.forEach((query) => {
         query.reset()
       })
       return this.refetchQueries(
         {
           type: 'active',
-          ...filters,
+          predicate: (query) => queriesToRefetch.has(query),
         },
         options,
       )


### PR DESCRIPTION
closes #10705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `resetQueries` so it consistently resets and refetches the queries originally selected, even when their state changes during the reset.
  * Ensured active queries with errors are correctly refetched and updated with fresh data.

* **Tests**
  * Added coverage for state-dependent query selection, resetting, and refetching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->