### PR TITLE
perf(query-core): Reduce observer removal overhead

### DIFF
--- a/.changeset/faster-query-observer-churn.md
+++ b/.changeset/faster-query-observer-churn.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Reduce observer churn overhead by removing observers in place instead of copying the observer list for every unsubscribe.

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -360,8 +360,9 @@ export class Query<
   }
 
   removeObserver(observer: QueryObserver<any, any, any, any, any>): void {
-    if (this.observers.includes(observer)) {
-      this.observers = this.observers.filter((x) => x !== observer)
+    const index = this.observers.indexOf(observer)
+    if (index !== -1) {
+      this.observers.splice(index, 1)
 
       if (!this.observers.length) {
         // If the transport layer does not support cancellation


### PR DESCRIPTION
Removing observers currently allocates a new observer array for every unsubscribe. This removes the observer in place instead, which avoids repeated copies when lots of components share a query.

The hot case is many observers sharing one query. In a local jsdom benchmark with 10,000 disabled `useQuery` components on the same query:

| Operation | Before | After |
|---|---:|---:|
| Change every query key | 190 ms | 81 ms |
| Unmount | 163 ms | 15 ms |

10,000 different queries are effectively unchanged because each query only has one observer:

| Operation | Before | After |
|---|---:|---:|
| Mount | 65.9 ms | 66.9 ms |
| Parent rerender | 52.9 ms | 54.0 ms |
| Unmount | 8.8 ms | 7.8 ms |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary observer churn when subscriptions are removed.
  * Preserved existing cancellation, garbage-collection, and cache notification behavior.

* **Release**
  * Included in a patch release of the query core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->