### PR TITLE
perf(query-core): Deduplicate tracked query properties

### DIFF
--- a/.changeset/fuzzy-taxis-track.md
+++ b/.changeset/fuzzy-taxis-track.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Avoid repeatedly synchronizing the same tracked property across all observers in `useQueries`.

--- a/packages/query-core/src/__tests__/queriesObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queriesObserver.test.tsx
@@ -770,6 +770,10 @@ describe('queriesObserver', () => {
     expect(trackPropSpy).toHaveBeenCalledWith('status')
     expect(trackPropSpy).toHaveBeenCalledTimes(3)
 
+    void trackedResults[1]!.status
+
+    expect(trackPropSpy).toHaveBeenCalledTimes(4)
+
     trackPropSpy.mockRestore()
   })
 

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -200,14 +200,19 @@ export class QueriesObserver<
     result: Array<QueryObserverResult>,
     matches: Array<QueryObserverMatch>,
   ) {
+    const trackedProps = new Set<keyof QueryObserverResult>()
+
     return matches.map((match, index) => {
       const observerResult = result[index]!
       return !match.defaultedQueryOptions.notifyOnChangeProps
         ? match.observer.trackResult(observerResult, (accessedProp) => {
             // track property on all observers to ensure proper (synchronized) tracking (#7000)
-            matches.forEach((m) => {
-              m.observer.trackProp(accessedProp)
-            })
+            if (!trackedProps.has(accessedProp)) {
+              trackedProps.add(accessedProp)
+              matches.forEach((m) => {
+                m.observer.trackProp(accessedProp)
+              })
+            }
           })
         : observerResult
     })


### PR DESCRIPTION
Multi-query APIs use `QueriesObserver` to track which result properties an app reads. When a property is read from one result, every query needs to track it. This makes early exits like `.some()` work correctly (#7014).

The downside is that normal code like this repeats the same work for every result:

```tsx
const results = useQueries({ queries })
const data = results.map((result) => result.data)
```

With 10,000 results, each `.data` read loops over all 10,000 queries. That produces 100,010,000 `trackProp` calls.

This change remembers that `data` was already tracked. Every query still tracks it, but the loop only runs once and the call count drops to 20,000.

This is shared query-core code, so it also applies to other framework adapters built on `QueriesObserver`. A single `useQuery` is not affected because it does not track across multiple observers.

The benchmark renders the React example above with 10,000 disabled queries, then measures a parent rerender. It includes the real `useQueries` and `.map()` paths. The numbers are medians from five rerenders after one warmup.

| | Before | After | Speedup |
|---|---:|---:|---:|
| Parent rerender | 745.10 ms | 13.41 ms | 56x |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `useQueries` tracking to avoid repeatedly synchronizing the same properties across query observers.
  - Ensured tracked properties are propagated only once per tracking operation, improving efficiency and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->