### PR TITLE
fix(query-core): re-attach MutationObserver to its in-flight mutation on resubscribe

### DIFF
--- a/packages/query-core/src/__tests__/mutationObserver.test.tsx
+++ b/packages/query-core/src/__tests__/mutationObserver.test.tsx
@@ -499,4 +499,54 @@ describe('mutationObserver', () => {
 
     unsubscribe()
   })
+
+  it('should track an in-flight mutation again after unsubscribing and resubscribing', async () => {
+    const mutationObserver = new MutationObserver(queryClient, {
+      mutationFn: (text: string) => sleep(20).then(() => text),
+    })
+
+    const unsubscribe = mutationObserver.subscribe(() => undefined)
+    mutationObserver.mutate('input')
+    await vi.advanceTimersByTimeAsync(0)
+
+    // React tears down and re-establishes subscriptions while keeping the
+    // component state (StrictMode, <Activity>, re-suspending boundaries)
+    unsubscribe()
+    const subscriptionHandler = vi.fn()
+    mutationObserver.subscribe(subscriptionHandler)
+
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(mutationObserver.getCurrentResult()).toMatchObject({
+      status: 'success',
+      data: 'input',
+    })
+    expect(subscriptionHandler).toHaveBeenCalledTimes(1)
+    expect(subscriptionHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'success', data: 'input' }),
+    )
+  })
+
+  it('should report the final state of a mutation that settled while unsubscribed', async () => {
+    const mutationObserver = new MutationObserver(queryClient, {
+      mutationFn: (text: string) => sleep(20).then(() => text),
+    })
+
+    const unsubscribe = mutationObserver.subscribe(() => undefined)
+    mutationObserver.mutate('input')
+    await vi.advanceTimersByTimeAsync(0)
+
+    unsubscribe()
+
+    // mutation settles while no one is subscribed
+    await vi.advanceTimersByTimeAsync(20)
+    expect(mutationObserver.getCurrentResult().status).toBe('pending')
+
+    mutationObserver.subscribe(() => undefined)
+
+    expect(mutationObserver.getCurrentResult()).toMatchObject({
+      status: 'success',
+      data: 'input',
+    })
+  })
 })

--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -93,6 +93,16 @@ export class MutationObserver<
     }
   }
 
+  protected onSubscribe(): void {
+    if (this.listeners.size === 1 && this.#currentMutation) {
+      // re-attach to the mutation the first listener unsubscribing detached us
+      // from, and refresh the result in case the mutation settled while we
+      // were not watching it
+      this.#currentMutation.addObserver(this)
+      this.#updateResult()
+    }
+  }
+
   protected onUnsubscribe(): void {
     if (!this.hasListeners()) {
       this.#currentMutation?.removeObserver(this)


### PR DESCRIPTION
Fixes #11171

## Problem

When the last listener unsubscribes, `MutationObserver.onUnsubscribe()` removes the observer from its current mutation — but resubscribing never adds it back. React legitimately tears down and re-establishes the store subscription of a mounted component that keeps its state (`<Activity mode="hidden">`, re-suspending `<Suspense>` boundaries, StrictMode in dev).

If that happens while a mutation is in flight, the mutation settles against an empty observer list, and the observer keeps serving its frozen `pending` snapshot from `getCurrentResult()` forever:

- `isPending` stays `true` → submit buttons using `disabled={isPending}` stay disabled until remount
- callbacks passed to `mutate(vars, { onSuccess })` never fire
- devtools/`MutationCache` show `success` while the hook shows `pending`

## Fix

Mirror `QueryObserver.onSubscribe()`: when the first listener subscribes, re-attach the observer to its current mutation (`Mutation.addObserver` is already idempotent) and refresh the result snapshot in case the mutation settled while detached.

## Tests

Two regression tests in `mutationObserver.test.tsx`, driving `subscribe`/`unsubscribe` the way `useSyncExternalStore` does:

1. unsubscribe + resubscribe while the mutation is in flight → observer reaches `success` and notifies the new listener
2. mutation settles while fully unsubscribed → resubscribing refreshes the snapshot to the final state

Both fail on `main` and pass with the fix. Full `query-core` (627) and `react-query` (577) suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mutation status and results now refresh correctly when listeners unsubscribe and later resubscribe.
  - In-progress mutations remain tracked across subscription changes.
  - Mutations that finish while no listeners are present now report their final success state when observed again.

- **Tests**
  - Added coverage for mutation observer behavior across unsubscribe and resubscribe cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->