### PR TITLE
fix(query-core): release mutation retryer after execute() settles

### DIFF
--- a/.changeset/release-mutation-retryer.md
+++ b/.changeset/release-mutation-retryer.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Release a mutation's retryer once `execute()` settles, so the settled promise no longer keeps the raw mutation result in memory alongside `state.data` for the mutation's lifetime. Mirrors the same fix applied to `Query.fetch()` in #11163.

--- a/packages/query-core/src/__tests__/mutations.test.tsx
+++ b/packages/query-core/src/__tests__/mutations.test.tsx
@@ -1191,4 +1191,50 @@ describe('mutations', () => {
 
     expect(queryClient.getMutationCache().getAll()).toHaveLength(1)
   })
+
+  it('should release the retryer once execute() has settled', async () => {
+    // Regression: Mutation.execute() left #retryer set after settling, so the
+    // retryer's resolved promise kept the raw mutation result in memory for the
+    // mutation's lifetime — a second copy alongside state.data. Mirrors the fix
+    // applied to Query.fetch() in #11163.
+    let secondExecute: Promise<unknown> | undefined
+    const testCache = new MutationCache({
+      onSuccess: (_data, _variables, _context, mutation) => {
+        // On the first success, kick off a second execute().
+        // The identity guard (this.#retryer === retryer) must keep the NEW
+        // retryer alive while clearing the OLD one.
+        secondExecute ??= mutation.execute(undefined as any)
+      },
+    })
+    const testClient = new QueryClient({ mutationCache: testCache })
+
+    const observer = new MutationObserver(testClient, {
+      mutationFn: () => sleep(10).then(() => 'data'),
+    })
+
+    const firstExecutePromise = observer.mutate()
+    const mutation = testCache.getAll()[0]!
+
+    // While the first execute is in-flight the promise must be defined.
+    expect(mutation.promise).toBeDefined()
+    const firstPromise = mutation.promise
+
+    // Let the first execute settle and the cache onSuccess callback fire,
+    // which starts the second execute synchronously.
+    await vi.advanceTimersByTimeAsync(10)
+    await firstExecutePromise.catch(() => undefined)
+
+    // A new retryer was installed by the second execute; its promise is a
+    // different object from the first one.
+    expect(mutation.promise).toBeDefined()
+    expect(mutation.promise).not.toBe(firstPromise)
+
+    // Let the second execute settle.
+    await vi.advanceTimersByTimeAsync(10)
+    await secondExecute
+
+    // After everything has settled the retryer must be released.
+    expect(mutation.state.data).toBe('data')
+    expect(mutation.promise).toBeUndefined()
+  })
 })

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -121,6 +121,11 @@ export class Mutation<
     this.updateGcTime(this.options.gcTime)
   }
 
+  /** The active retryer's promise, or `undefined` once `execute()` has settled. */
+  get promise(): Promise<TData> | undefined {
+    return this.#retryer?.promise
+  }
+
   get meta(): MutationMeta | undefined {
     return this.options.meta
   }
@@ -181,7 +186,7 @@ export class Mutation<
       mutationKey: this.options.mutationKey,
     } satisfies MutationFunctionContext
 
-    this.#retryer = createRetryer({
+    const retryer = (this.#retryer = createRetryer({
       fn: () => {
         if (!this.options.mutationFn) {
           return Promise.reject(new Error('No mutationFn found'))
@@ -200,10 +205,10 @@ export class Mutation<
       retryDelay: this.options.retryDelay,
       networkMode: this.options.networkMode,
       canRun: () => this.#mutationCache.canRun(this),
-    })
+    }))
 
     const restored = this.state.status === 'pending'
-    const isPaused = !this.#retryer.canStart()
+    const isPaused = !retryer.canStart()
 
     try {
       if (restored) {
@@ -232,7 +237,7 @@ export class Mutation<
           })
         }
       }
-      const data = await this.#retryer.start()
+      const data = await retryer.start()
 
       // Notify cache callback
       await this.#mutationCache.config.onSuccess?.(
@@ -324,6 +329,14 @@ export class Mutation<
       this.#dispatch({ type: 'error', error: error as TError })
       throw error
     } finally {
+      // The settled retryer's promise would otherwise pin this mutation's raw
+      // result for the mutation's lifetime. Clear it once execute() settles,
+      // mirroring the same fix applied to Query.fetch() in #11163.
+      // The identity check guards against a re-entrant execute() call (e.g. from
+      // a cache onSuccess callback) having already installed a new retryer.
+      if (this.#retryer === retryer) {
+        this.#retryer = undefined
+      }
       this.#mutationCache.runNext(this)
     }
   }


### PR DESCRIPTION
## Summary

`Mutation.execute()` leaves `#retryer` set after the mutation settles. The retryer's resolved promise keeps the raw mutation result in memory for the mutation's entire lifetime — a second copy alongside the structurally-shared `state.data`, and persisting even after the mutation is removed from the cache.

This is the direct parallel to the `Query.fetch()` memory leak fixed in #11163. The fix is identical in structure.

Closes #11216

## Root cause

```js
// Before: #retryer stays set after execute() returns
this.#retryer = createRetryer({ ... })
try {
  const data = await this.#retryer.start()
  // ... callbacks ...
} finally {
  this.#mutationCache.runNext(this)  // ← #retryer is never cleared
}
```

## Fix

```js
// After: mirrors Query.fetch() from #11163
const retryer = (this.#retryer = createRetryer({ ... }))
try {
  const data = await retryer.start()
  // ... callbacks ...
} finally {
  if (this.#retryer === retryer) {  // identity guard for re-entrant execute()
    this.#retryer = undefined
  }
  this.#mutationCache.runNext(this)
}
```

The identity guard is the same as in `query.ts` — it prevents a re-entrant `execute()` call (e.g. from a `MutationCache.onSuccess` callback) from having its fresh retryer cleared by the outer `finally`.

## Changes

- **`mutation.ts`**: apply the same 3-line fix as `query.ts` line 593-595
- **`mutation.ts`**: add `get promise()` to match `Query`'s public API, enabling a parallel regression test
- **`mutations.test.tsx`**: add regression test that verifies `mutation.promise` is `undefined` after `execute()` settles (including re-entrant case)

All 25 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mutation cleanup after execution completes, preventing settled operations from retaining unnecessary result data.
  * Preserved mutation results while ensuring active retry operations are correctly released.
  * Fixed handling of new mutation executions started during a success callback.

* **New Features**
  * Added access to the currently active mutation promise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->