### PR TITLE
fix: declaration emit

### DIFF
--- a/.changeset/fix-query-options-declaration-emit.md
+++ b/.changeset/fix-query-options-declaration-emit.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/query-core': patch
+'@tanstack/angular-query-experimental': patch
+'@tanstack/preact-query': patch
+'@tanstack/react-query': patch
+'@tanstack/solid-query': patch
+'@tanstack/svelte-query': patch
+'@tanstack/vue-query': patch
+---
+
+Fix `queryOptions` and `infiniteQueryOptions` return types so exported inferred options can be emitted in declaration files without leaking internal data tag symbols.

--- a/integrations/vue-declaration-emit/consumer/query-options.ts
+++ b/integrations/vue-declaration-emit/consumer/query-options.ts
@@ -1,0 +1,9 @@
+import {
+  definedInitialDataOptions,
+  undefinedInitialDataOptions,
+} from '../dist/query-options.js'
+
+export const options = {
+  definedInitialDataOptions,
+  undefinedInitialDataOptions,
+}

--- a/integrations/vue-declaration-emit/package.json
+++ b/integrations/vue-declaration-emit/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "vue-declaration-emit",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:types": "pnpm run test:types:ts6 && pnpm run test:types:ts7",
+    "test:types:ts6": "node ../../node_modules/typescript/lib/tsc.js --pretty false --project tsconfig.emit.json && node ../../node_modules/typescript/lib/tsc.js --pretty false --project tsconfig.consume.json",
+    "test:types:ts7": "node ../../node_modules/typescript70/lib/tsc.js --pretty false --project tsconfig.emit.json && node ../../node_modules/typescript70/lib/tsc.js --pretty false --project tsconfig.consume.json"
+  },
+  "dependencies": {
+    "@tanstack/vue-query": "workspace:*",
+    "vue": "^3.4.27"
+  },
+  "devDependencies": {
+    "typescript": "5.8.3"
+  },
+  "nx": {
+    "targets": {
+      "test:types": {
+        "dependsOn": [
+          "^build"
+        ]
+      }
+    }
+  }
+}

--- a/integrations/vue-declaration-emit/src/query-options.ts
+++ b/integrations/vue-declaration-emit/src/query-options.ts
@@ -1,0 +1,14 @@
+import { queryOptions } from '@tanstack/vue-query'
+
+/** @public */
+export const undefinedInitialDataOptions = queryOptions({
+  queryKey: ['undefined-initial-data'],
+  queryFn: async () => ({ value: 'data' }),
+})
+
+/** @public */
+export const definedInitialDataOptions = queryOptions({
+  queryKey: ['defined-initial-data'],
+  queryFn: async () => ({ value: 'data' }),
+  initialData: { value: 'initial data' },
+})

--- a/integrations/vue-declaration-emit/tsconfig.consume.json
+++ b/integrations/vue-declaration-emit/tsconfig.consume.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true
+  },
+  "include": ["./consumer"]
+}

--- a/integrations/vue-declaration-emit/tsconfig.emit.json
+++ b/integrations/vue-declaration-emit/tsconfig.emit.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "strict": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["./src"]
+}

--- a/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
@@ -10,6 +10,15 @@ import type {
   InitialDataFunction,
 } from '@tanstack/query-core'
 
+// Regression test for exported infiniteQueryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedInfiniteQueryOptions = infiniteQueryOptions({
+  queryKey: ['invalid'],
+  getNextPageParam: () => 1,
+  initialPageParam: 1,
+})
+
 describe('infiniteQueryOptions', () => {
   it('should not allow excess properties', () => {
     const key = queryKey()

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -9,6 +9,13 @@ import {
 } from '..'
 import type { Signal } from '@angular/core'
 
+// Regression test for exported queryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedQueryOptions = queryOptions({
+  queryKey: ['invalid'],
+})
+
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
     expectTypeOf(queryOptions).parameter(0).not.toHaveProperty('stallTime')

--- a/packages/angular-query-experimental/src/infinite-query-options.ts
+++ b/packages/angular-query-experimental/src/infinite-query-options.ts
@@ -1,11 +1,11 @@
 import type {
-  DataTag,
   DefaultError,
   InfiniteData,
   InitialDataFunction,
   NonUndefinedGuard,
   OmitKeyof,
   QueryKey,
+  QueryKeyWithDataTag,
   SkipToken,
 } from '@tanstack/query-core'
 import type { CreateInfiniteQueryOptions } from './types'
@@ -105,9 +105,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 /**
  * Allows sharing and re-using infinite query options in a type-safe way.
@@ -136,9 +135,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 /**
  * Allows sharing and re-using infinite query options in a type-safe way.
@@ -167,9 +165,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 /**
  * Allows sharing and re-using infinite query options in a type-safe way.

--- a/packages/angular-query-experimental/src/query-options.ts
+++ b/packages/angular-query-experimental/src/query-options.ts
@@ -1,11 +1,11 @@
 import type {
-  DataTag,
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
   OmitKeyof,
   QueryFunction,
   QueryKey,
+  QueryKeyWithDataTag,
   SkipToken,
 } from '@tanstack/query-core'
 import type { CreateQueryOptions } from './types'
@@ -80,9 +80,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 /**
  * Allows sharing and re-using query options in a type-safe way.
@@ -112,9 +111,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 /**
  * Allows sharing and re-using query options in a type-safe way.
@@ -144,9 +142,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 /**
  * Allows sharing and re-using query options in a type-safe way.

--- a/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -12,6 +12,15 @@ import { useInfiniteQuery } from '../useInfiniteQuery'
 import { useQuery } from '../useQuery'
 import { useSuspenseInfiniteQuery } from '../useSuspenseInfiniteQuery'
 
+// Regression test for exported infiniteQueryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedInfiniteQueryOptions = infiniteQueryOptions({
+  queryKey: ['invalid'],
+  getNextPageParam: () => 1,
+  initialPageParam: 1,
+})
+
 describe('infiniteQueryOptions', () => {
   it('should not allow excess properties', () => {
     assertType(

--- a/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
@@ -18,6 +18,13 @@ import { useQueries } from '../useQueries'
 import { useQuery } from '../useQuery'
 import { useSuspenseQuery } from '../useSuspenseQuery'
 
+// Regression test for exported queryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedQueryOptions = queryOptions({
+  queryKey: ['invalid'],
+})
+
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
     assertType(

--- a/packages/preact-query/src/infiniteQueryOptions.ts
+++ b/packages/preact-query/src/infiniteQueryOptions.ts
@@ -1,11 +1,11 @@
 import type {
-  DataTag,
   DefaultError,
   InfiniteData,
   InitialDataFunction,
   NonUndefinedGuard,
   OmitKeyof,
   QueryKey,
+  QueryKeyWithDataTag,
   SkipToken,
 } from '@tanstack/query-core'
 
@@ -93,9 +93,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions<
   TQueryFnData,
@@ -117,9 +116,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions<
   TQueryFnData,
@@ -141,9 +139,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions(options: unknown) {
   return options

--- a/packages/preact-query/src/queryOptions.ts
+++ b/packages/preact-query/src/queryOptions.ts
@@ -1,11 +1,11 @@
 import type {
-  DataTag,
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
   OmitKeyof,
   QueryFunction,
   QueryKey,
+  QueryKeyWithDataTag,
   SkipToken,
 } from '@tanstack/query-core'
 
@@ -57,9 +57,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -68,9 +67,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -79,9 +77,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions(options: unknown) {
   return options

--- a/packages/query-core/src/types.ts
+++ b/packages/query-core/src/types.ts
@@ -79,6 +79,14 @@ export type DataTag<
       [dataTagErrorSymbol]: TError
     }
 
+export type QueryKeyWithDataTag<
+  TQueryKey extends QueryKey = QueryKey,
+  TQueryFnData = unknown,
+  TError = DefaultError,
+> = {
+  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
+}
+
 export type InferDataFromTag<TQueryFnData, TTaggedQueryKey extends QueryKey> =
   TTaggedQueryKey extends DataTag<unknown, infer TaggedValue, unknown>
     ? TaggedValue

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -11,6 +11,15 @@ import type {
   InitialDataFunction,
 } from '@tanstack/query-core'
 
+// Regression test for exported infiniteQueryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedInfiniteQueryOptions = infiniteQueryOptions({
+  queryKey: ['invalid'],
+  getNextPageParam: () => 1,
+  initialPageParam: 1,
+})
+
 describe('infiniteQueryOptions', () => {
   it('should not allow excess properties', () => {
     assertType(

--- a/packages/react-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.test-d.tsx
@@ -18,6 +18,13 @@ import type {
   QueryPersister,
 } from '@tanstack/query-core'
 
+// Regression test for exported queryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedQueryOptions = queryOptions({
+  queryKey: ['invalid'],
+})
+
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
     assertType(

--- a/packages/react-query/src/infiniteQueryOptions.ts
+++ b/packages/react-query/src/infiniteQueryOptions.ts
@@ -1,11 +1,11 @@
 import type {
-  DataTag,
   DefaultError,
   InfiniteData,
   InitialDataFunction,
   NonUndefinedGuard,
   OmitKeyof,
   QueryKey,
+  QueryKeyWithDataTag,
   SkipToken,
 } from '@tanstack/query-core'
 import type { UseInfiniteQueryOptions } from './types'
@@ -92,9 +92,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions<
   TQueryFnData,
@@ -116,9 +115,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions<
   TQueryFnData,
@@ -140,9 +138,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions(options: unknown) {
   return options

--- a/packages/react-query/src/queryOptions.ts
+++ b/packages/react-query/src/queryOptions.ts
@@ -1,11 +1,11 @@
 import type {
-  DataTag,
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
   OmitKeyof,
   QueryFunction,
   QueryKey,
+  QueryKeyWithDataTag,
   SkipToken,
 } from '@tanstack/query-core'
 import type { UseQueryOptions } from './types'
@@ -56,9 +56,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -67,9 +66,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -78,9 +76,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions(options: unknown) {
   return options

--- a/packages/solid-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -9,6 +9,15 @@ import type {
   UndefinedInitialDataInfiniteOptions,
 } from '../infiniteQueryOptions'
 
+// Regression test for exported infiniteQueryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedInfiniteQueryOptions = infiniteQueryOptions({
+  queryKey: ['invalid'],
+  getNextPageParam: () => 1,
+  initialPageParam: 1,
+})
+
 describe('infiniteQueryOptions', () => {
   it('should work when passed to infiniteQuery', async () => {
     const options = infiniteQueryOptions({

--- a/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
@@ -9,6 +9,13 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { useQuery } from '../useQuery'
 import { queryOptions } from '../queryOptions'
 
+// Regression test for exported queryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedQueryOptions = queryOptions({
+  queryKey: ['invalid'],
+})
+
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
     assertType(

--- a/packages/solid-query/src/infiniteQueryOptions.ts
+++ b/packages/solid-query/src/infiniteQueryOptions.ts
@@ -1,9 +1,9 @@
 import type {
-  DataTag,
   DefaultError,
   InfiniteData,
   NonUndefinedGuard,
   QueryKey,
+  QueryKeyWithDataTag,
 } from '@tanstack/query-core'
 import type { InfiniteQueryOptions } from './types'
 import type { Accessor } from 'solid-js'
@@ -58,9 +58,8 @@ export function infiniteQueryOptions<
     TQueryKey,
     TPageParam
   >
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 export function infiniteQueryOptions<
   TQueryFnData,
   TError = DefaultError,
@@ -85,9 +84,8 @@ export function infiniteQueryOptions<
     TQueryKey,
     TPageParam
   >
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions(options: unknown) {
   return options

--- a/packages/solid-query/src/queryOptions.ts
+++ b/packages/solid-query/src/queryOptions.ts
@@ -1,4 +1,8 @@
-import type { DataTag, DefaultError, QueryKey } from '@tanstack/query-core'
+import type {
+  DefaultError,
+  QueryKey,
+  QueryKeyWithDataTag,
+} from '@tanstack/query-core'
 import type { QueryOptions } from './types'
 import type { Accessor } from 'solid-js'
 
@@ -35,9 +39,8 @@ export function queryOptions<
   >,
 ): ReturnType<
   UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
-> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -50,9 +53,8 @@ export function queryOptions<
   >,
 ): ReturnType<
   DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
-> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions(options: unknown) {
   return options

--- a/packages/svelte-query/src/queryOptions.ts
+++ b/packages/svelte-query/src/queryOptions.ts
@@ -1,9 +1,9 @@
 import type {
-  DataTag,
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
   QueryKey,
+  QueryKeyWithDataTag,
 } from '@tanstack/query-core'
 import type { CreateQueryOptions } from './types.js'
 
@@ -34,9 +34,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData>
-}
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -45,9 +44,8 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData>
-}
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData>
 
 export function queryOptions(options: unknown) {
   return options

--- a/packages/svelte-query/src/queryOptions.ts
+++ b/packages/svelte-query/src/queryOptions.ts
@@ -35,7 +35,7 @@ export function queryOptions<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
-  QueryKeyWithDataTag<TQueryKey, TQueryFnData>
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -45,7 +45,7 @@ export function queryOptions<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
-  QueryKeyWithDataTag<TQueryKey, TQueryFnData>
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions(options: unknown) {
   return options

--- a/packages/svelte-query/tests/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions.test-d.ts
@@ -9,6 +9,13 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { createQueries, queryOptions } from '../src/index.js'
 import type { QueryObserverResult } from '@tanstack/query-core'
 
+// Regression test for exported queryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedQueryOptions = queryOptions({
+  queryKey: ['invalid'],
+})
+
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
     const key = queryKey()

--- a/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
@@ -7,6 +7,15 @@ import { QueryClient } from '../queryClient'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import type { InfiniteData } from '@tanstack/query-core'
 
+// Regression test for exported infiniteQueryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedInfiniteQueryOptions = infiniteQueryOptions({
+  queryKey: ['invalid'],
+  getNextPageParam: () => 1,
+  initialPageParam: 1,
+})
+
 describe('infiniteQueryOptions', () => {
   it('should not allow excess properties', () => {
     const key = queryKey()

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -6,6 +6,17 @@ import { QueryClient } from '../queryClient'
 import { queryOptions } from '../queryOptions'
 import { useQuery } from '../useQuery'
 
+// Regression test for exported queryOptions inference under declaration emit.
+// TypeScript should be able to name the return type without expanding the
+// internal data tag symbols into the consumer's .d.ts output.
+export const exportedQueryOptions = queryOptions({
+  queryKey: ['invalid'],
+})
+
+export const exportedQueryOptionsGetter = queryOptions(() => ({
+  queryKey: ['invalid'],
+}))
+
 describe('queryOptions', () => {
   it('should not allow excess properties', () => {
     const key = queryKey()

--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -6,7 +6,11 @@ export { VueQueryPlugin } from './vueQueryPlugin'
 export { QueryClient } from './queryClient'
 export { QueryCache } from './queryCache'
 export { queryOptions } from './queryOptions'
-export { type QueryOptions } from './queryOptions'
+export type {
+  QueryOptions,
+  UndefinedInitialQueryOptionsWithDataTag,
+  DefinedInitialQueryOptionsWithDataTag,
+} from './queryOptions'
 export { infiniteQueryOptions } from './infiniteQueryOptions'
 export type {
   DefinedInitialDataInfiniteOptions,

--- a/packages/vue-query/src/infiniteQueryOptions.ts
+++ b/packages/vue-query/src/infiniteQueryOptions.ts
@@ -1,9 +1,9 @@
 import type {
-  DataTag,
   DefaultError,
   InfiniteData,
   NonUndefinedGuard,
   QueryKey,
+  QueryKeyWithDataTag,
 } from '@tanstack/query-core'
 import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
 
@@ -61,9 +61,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions<
   TQueryFnData,
@@ -85,9 +84,8 @@ export function infiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
-> & {
-  queryKey: DataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
-}
+> &
+  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions(options: unknown) {
   return options

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -1,11 +1,11 @@
 import type { DeepUnwrapRef, MaybeRefOrGetter, ShallowOption } from './types'
 import type {
-  DataTag,
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
   QueryBooleanOption,
   QueryKey,
+  QueryKeyWithDataTag,
   QueryObserverOptions,
 } from '@tanstack/query-core'
 
@@ -65,6 +65,22 @@ export type DefinedInitialQueryOptions<
     | (() => NonUndefinedGuard<TQueryFnData>)
 }
 
+export type UndefinedInitialQueryOptionsWithDataTag<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
+
+export type DefinedInitialQueryOptionsWithDataTag<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> &
+  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
+
 export function queryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -72,9 +88,7 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): DefinedInitialQueryOptionsWithDataTag<TQueryFnData, TError, TData, TQueryKey>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -88,9 +102,12 @@ export function queryOptions<
     TData,
     TQueryKey
   >,
-): () => DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): () => DefinedInitialQueryOptionsWithDataTag<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryKey
+>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -99,9 +116,12 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+): UndefinedInitialQueryOptionsWithDataTag<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryKey
+>
 
 export function queryOptions<
   TQueryFnData = unknown,
@@ -115,14 +135,12 @@ export function queryOptions<
     TData,
     TQueryKey
   >,
-): () => UndefinedInitialQueryOptions<
+): () => UndefinedInitialQueryOptionsWithDataTag<
   TQueryFnData,
   TError,
   TData,
   TQueryKey
-> & {
-  queryKey: DataTag<TQueryKey, TQueryFnData, TError>
-}
+>
 
 export function queryOptions(options: unknown) {
   return options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2381,6 +2381,19 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  integrations/vue-declaration-emit:
+    dependencies:
+      '@tanstack/vue-query':
+        specifier: workspace:*
+        version: link:../../packages/vue-query
+      vue:
+        specifier: ^3.4.27
+        version: 3.5.31(typescript@5.8.3)
+    devDependencies:
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   integrations/vue-vite:
     dependencies:
       '@tanstack/vue-query':


### PR DESCRIPTION
fixes https://github.com/TanStack/query/issues/8453

based on work by @artemxknpv in https://github.com/TanStack/query/pull/10583 🙏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated TypeScript declarations for `queryOptions` and infinite query options across supported frameworks.
  * Prevented internal type details from appearing in consumer-facing declarations.
  * Preserved type inference for query keys, data, errors, initial data, and pagination options.

* **Tests**
  * Added declaration-generation coverage across Angular, Preact, React, Solid, Svelte, and Vue.
  * Added Vue integration checks for consuming emitted declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->