### PR TITLE
perf(query-core): Skip unused query result tracking

### DIFF
--- a/.changeset/fresh-mice-listen.md
+++ b/.changeset/fresh-mice-listen.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Skip unused result tracking when notifying `useQueries` listeners without a `combine` function.

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -256,7 +256,7 @@ export class QueriesObserver<
 
   #shouldSkipCombine(): boolean {
     return (
-      this.#options?.combine !== undefined &&
+      this.#options?.combine === undefined ||
       this.#observers.some((observer, index) => {
         return (
           observer.options.suspense && this.#result[index]?.data === undefined
@@ -310,21 +310,16 @@ export class QueriesObserver<
 
   #notify(): void {
     if (this.hasListeners()) {
-      let shouldNotify = true
-      const combine = this.#options?.combine
+      const shouldSkipCombine = this.#shouldSkipCombine()
+      const previousResult = this.#combinedResult
+      const newResult = shouldSkipCombine
+        ? previousResult
+        : this.#combineResult(
+            this.#trackResult(this.#result, this.#observerMatches),
+            this.#options?.combine,
+          )
 
-      if (combine) {
-        const newTracked = this.#trackResult(this.#result, this.#observerMatches)
-        const shouldSkipCombine = this.#shouldSkipCombine()
-        const previousResult = this.#combinedResult
-        const newResult = shouldSkipCombine
-          ? previousResult
-          : this.#combineResult(newTracked, combine)
-
-        shouldNotify = shouldSkipCombine || previousResult !== newResult
-      }
-
-      if (shouldNotify) {
+      if (shouldSkipCombine || previousResult !== newResult) {
         notifyManager.batch(() => {
           this.listeners.forEach((listener) => {
             listener(this.#result)

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -256,7 +256,7 @@ export class QueriesObserver<
 
   #shouldSkipCombine(): boolean {
     return (
-      this.#options?.combine === undefined ||
+      !this.#options?.combine ||
       this.#observers.some((observer, index) => {
         return (
           observer.options.suspense && this.#result[index]?.data === undefined

--- a/packages/query-core/src/queriesObserver.ts
+++ b/packages/query-core/src/queriesObserver.ts
@@ -310,14 +310,21 @@ export class QueriesObserver<
 
   #notify(): void {
     if (this.hasListeners()) {
-      const newTracked = this.#trackResult(this.#result, this.#observerMatches)
-      const shouldSkipCombine = this.#shouldSkipCombine()
-      const previousResult = this.#combinedResult
-      const newResult = shouldSkipCombine
-        ? previousResult
-        : this.#combineResult(newTracked, this.#options?.combine)
+      let shouldNotify = true
+      const combine = this.#options?.combine
 
-      if (shouldSkipCombine || previousResult !== newResult) {
+      if (combine) {
+        const newTracked = this.#trackResult(this.#result, this.#observerMatches)
+        const shouldSkipCombine = this.#shouldSkipCombine()
+        const previousResult = this.#combinedResult
+        const newResult = shouldSkipCombine
+          ? previousResult
+          : this.#combineResult(newTracked, combine)
+
+        shouldNotify = shouldSkipCombine || previousResult !== newResult
+      }
+
+      if (shouldNotify) {
         notifyManager.batch(() => {
           this.listeners.forEach((listener) => {
             listener(this.#result)


### PR DESCRIPTION
Most `useQueries` calls look like this:

```tsx
useQueries({ queries })
```

During every query update, `QueriesObserver` was still building a tracked version of every result. That tracked version is only used by `combine`; listeners have always received the raw results. For normal `useQueries` calls, we were walking and wrapping the full result list on every update for nothing.

This skips that work when there is no `combine` function. Calls that use `combine` still take the existing path:

```tsx
useQueries({
  queries,
  combine: (results) => results.map((result) => result.data),
})
```

10,000 different disabled queries, each updated once with `setQueryData` inside one batch. Median of five runs:

| Before | After | Speedup |
|---:|---:|---:|
| 1,444 ms | 46 ms | 31x |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `useQueries` listener notifications when no result-combining option is configured.
  * Prevented unnecessary result tracking and combining in this scenario.

* **Documentation**
  * Added a patch release note for the improved notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->