### PR TITLE
fix(react): switch to export type *

### DIFF
--- a/.changeset/quiet-types-import.md
+++ b/.changeset/quiet-types-import.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Avoid emitting a runtime import for React Query's type-only exports.

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -4,7 +4,7 @@
 export * from '@tanstack/query-core'
 
 // React Query
-export * from './types'
+export type * from './types'
 export { useQueries } from './useQueries'
 export type { QueriesResults, QueriesOptions } from './useQueries'
 export { useQuery } from './useQuery'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected React Query type exports so they no longer create unnecessary runtime imports.
  * Preserved access to the exported TypeScript types without affecting runtime behavior.

* **Documentation**
  * Added a patch release note describing the type-only export improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->