### PR TITLE
perf(react-query): Batch hydration notifications

### DIFF
--- a/.changeset/faster-react-hydration.md
+++ b/.changeset/faster-react-hydration.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Batch query notifications during hydration to reduce update scheduling overhead.

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -1,7 +1,7 @@
 'use client'
 import * as React from 'react'
 
-import { hydrate } from '@tanstack/query-core'
+import { hydrate, notifyManager } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
   DehydratedState,
@@ -92,7 +92,9 @@ export const HydrationBoundary = ({
           // It's actually fine to call this with queries/state that already exists
           // in the cache, or is older. hydrate() is idempotent for queries.
           // eslint-disable-next-line react-hooks/refs
-          hydrate(client, { queries: newQueries }, optionsRef.current)
+          notifyManager.batch(() => {
+            hydrate(client, { queries: newQueries }, optionsRef.current)
+          })
         }
         if (existingQueries.length > 0) {
           return existingQueries
@@ -103,7 +105,9 @@ export const HydrationBoundary = ({
 
   React.useEffect(() => {
     if (hydrationQueue) {
-      hydrate(client, { queries: hydrationQueue }, optionsRef.current)
+      notifyManager.batch(() => {
+        hydrate(client, { queries: hydrationQueue }, optionsRef.current)
+      })
     }
   }, [client, hydrationQueue])
 


### PR DESCRIPTION
HydrationBoundary is the manual React SSR bridge used by Next.js and custom integrations to merge dehydrated server data into the browser QueryClient. The main case this improves is a later dehydrated payload updating queries that already exist and have active observers, such as a client navigation.

Right now each updated query schedules its own notification flush. Wrapping each HydrationBoundary hydrate pass in notifyManager.batch keeps every observer callback, but flushes the scheduled callbacks together. For N observed queries, scheduled flushes drop from N to 1 without adding another scheduler tick.

This only changes @tanstack/react-query HydrationBoundary. The official @tanstack/react-router-ssr-query integration used by TanStack Start calls the core hydrate API directly, so that path is not affected by this PR.

The benchmark hydrates existing queries with active QueryObserver subscriptions through notifyManager.batchCalls, matching the React subscription path.

## Vitest benchmark

| Observed queries | Before | After | Speedup |
|---|---:|---:|---:|
| 10 | 170,049 ops/s | 182,103 ops/s | 1.07x |
| 25 | 64,924 ops/s | 72,821 ops/s | 1.12x |
| 50 | 33,526 ops/s | 36,224 ops/s | 1.08x |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Batched query notifications during hydration to reduce unnecessary updates and improve rendering efficiency.
  * Applied batching consistently during both initial hydration and follow-up hydration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->