### PR TITLE
fix(solid-query): don't re-trigger Suspense on background refetches

### DIFF
--- a/.changeset/solid-suspense-background-refetch.md
+++ b/.changeset/solid-suspense-background-refetch.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Stop background refetches and cached-data mounts from re-triggering enclosing `<Suspense>` boundaries. Every observer update used to pass through the resource's Promise path, suspending the boundary for a microtask — which detached and re-inserted its DOM, restarting CSS animations and resetting focus/scroll/iframe state even though no fallback was ever painted. Queries now resolve synchronously when data is available, so Suspense only triggers on genuine initial loads.

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -384,7 +384,9 @@ describe("useQuery's in Suspense mode", () => {
     expect(rendered.getByText('show')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByText('show'))
-    expect(rendered.getByText('loading')).toBeInTheDocument()
+    // Cached data renders immediately without suspending; the mount refetch
+    // happens in the background
+    expect(rendered.getByText('data: 1')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(0)
     expect(rendered.getByText('fetching: true')).toBeInTheDocument()
     await vi.advanceTimersByTimeAsync(100)
@@ -894,5 +896,88 @@ describe("useQuery's in Suspense mode", () => {
     })
     expect(renders).toBe(2)
     expect(rendered.queryByText('rendered')).toBeInTheDocument()
+  })
+
+  it('should not trigger Suspense when mounting with cached data, even while a background refetch runs', async () => {
+    const key = queryKey()
+    let fetches = 0
+    let fallbackRenders = 0
+
+    queryClient.setQueryData(key, 'cached')
+
+    function Fallback() {
+      fallbackRenders++
+      return <div>loading</div>
+    }
+
+    function Page() {
+      const query = useQuery(() => ({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => `data${++fetches}`),
+        staleTime: 0,
+      }))
+
+      return <div>content: {query.data}</div>
+    }
+
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback={<Fallback />}>
+        <Page />
+      </Suspense>
+    ))
+
+    // Cached data renders immediately without suspending
+    expect(rendered.getByText('content: cached')).toBeInTheDocument()
+    const contentElement = rendered.getByText('content: cached')
+
+    // staleTime: 0 kicks off a background refetch on mount; it must not
+    // suspend the boundary (a suspended boundary detaches its DOM, which
+    // restarts CSS animations even if the fallback is never painted)
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('content: data1')).toBeInTheDocument()
+
+    // Same DOM node throughout — no remount, no detach/re-insert
+    expect(rendered.getByText('content: data1')).toBe(contentElement)
+    expect(fallbackRenders).toBe(0)
+  })
+
+  it('should not re-trigger Suspense when an invalidation refetches a mounted query', async () => {
+    const key = queryKey()
+    let fetches = 0
+    let fallbackRenders = 0
+
+    function Fallback() {
+      fallbackRenders++
+      return <div>loading</div>
+    }
+
+    function Page() {
+      const query = useQuery(() => ({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => `data${++fetches}`),
+      }))
+
+      return <div>content: {query.data}</div>
+    }
+
+    const rendered = renderWithClient(queryClient, () => (
+      <Suspense fallback={<Fallback />}>
+        <Page />
+      </Suspense>
+    ))
+
+    // Initial load has no data and should suspend exactly once
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('content: data1')).toBeInTheDocument()
+    expect(fallbackRenders).toBe(1)
+    const contentElement = rendered.getByText('content: data1')
+
+    // A background refetch of a mounted query must not suspend again
+    queryClient.invalidateQueries({ queryKey: key })
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('content: data2')).toBeInTheDocument()
+
+    expect(rendered.getByText('content: data2')).toBe(contentElement)
+    expect(fallbackRenders).toBe(1)
   })
 })

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -240,34 +240,78 @@ export function useBaseQuery<
   const [queryResource, { refetch }] = createResource<ResourceData | undefined>(
     () => {
       const obs = observer()
-      return new Promise((resolve, reject) => {
-        resolver = resolve
-        if (isServer) {
+      const shouldThrowCurrentError = () =>
+        observerResult.isError &&
+        !observerResult.isFetching &&
+        !isRestoring() &&
+        shouldThrowError(obs.options.throwOnError, [
+          observerResult.error,
+          obs.getCurrentQuery(),
+        ])
+
+      if (isServer) {
+        return new Promise((resolve, reject) => {
+          resolver = resolve
           unsubscribe = createServerSubscriber(resolve, reject)
-        } else if (!unsubscribe && !isRestoring()) {
-          unsubscribe = createClientSubscriber()
-        }
-        obs.updateResult()
+          obs.updateResult()
 
-        if (
-          observerResult.isError &&
-          !observerResult.isFetching &&
-          !isRestoring() &&
-          shouldThrowError(obs.options.throwOnError, [
-            observerResult.error,
-            obs.getCurrentQuery(),
-          ])
-        ) {
+          if (shouldThrowCurrentError()) {
+            setStateWithReconciliation(observerResult)
+            return reject(observerResult.error)
+          }
+          if (!observerResult.isLoading) {
+            resolver = null
+            return resolve(
+              hydratableObserverResult(obs.getCurrentQuery(), observerResult),
+            )
+          }
+
           setStateWithReconciliation(observerResult)
-          return reject(observerResult.error)
-        }
-        if (!observerResult.isLoading) {
-          resolver = null
-          return resolve(
-            hydratableObserverResult(obs.getCurrentQuery(), observerResult),
-          )
-        }
+        })
+      }
 
+      if (!unsubscribe && !isRestoring()) {
+        unsubscribe = createClientSubscriber()
+      }
+      obs.updateResult()
+
+      if (shouldThrowCurrentError()) {
+        setStateWithReconciliation(observerResult)
+        throw observerResult.error
+      }
+      /**
+       * When data is available and the observer is not in an initial loading
+       * state, we return the result synchronously (a non-thenable) instead of
+       * a resolved Promise. A Promise — even one that resolves within the same
+       * tick — leaves the resource in a pending/refreshing state for at least
+       * a microtask, which makes every enclosing <Suspense> boundary flip to
+       * its fallback and back. That flip detaches and re-inserts the
+       * boundary's DOM, restarting CSS animations and resetting
+       * focus/scroll/iframe state on every background refetch, even though no
+       * fallback is ever painted. Returning a plain value keeps the resource
+       * in its ready state, so Suspense is only triggered by genuine initial
+       * loads.
+       *
+       * The exception is when a previous fetcher promise is still pending
+       * (`resolver` is set): the boundary is already suspended — possibly
+       * inside a transition — and completing through the Promise path keeps
+       * Solid's Suspense/Transition bookkeeping intact.
+       */
+      if (!observerResult.isLoading && observerResult.data !== undefined) {
+        const result = observerResult
+        if (resolver) {
+          resolver = null
+          return new Promise((resolve) => resolve(result))
+        }
+        return result
+      }
+      if (!observerResult.isLoading) {
+        resolver = null
+        return new Promise((resolve) => resolve(observerResult))
+      }
+
+      return new Promise((resolve) => {
+        resolver = resolve
         setStateWithReconciliation(observerResult)
       })
     },


### PR DESCRIPTION
## Summary

Background refetches (and mounts with cached data) no longer flip enclosing `<Suspense>` boundaries. This fixes CSS animations restarting, and focus/scroll/iframe state resetting, on every query update.

Fixes #9955
Related: #9883, and the downstream report TanStack/router#8000 (solid-router wraps every route match in `<Suspense>`, so route components can't escape a boundary — which made this present as a router bug).

## Root cause

`useBaseQuery`'s client subscriber calls the resource's `refetch()` on **every** observer notification, and the fetcher always returned a Promise — even when it resolved within the same tick (`!isLoading` → `resolve()` called synchronously in the executor). A native Promise's `.then` fires a microtask later, so the resource spent at least one microtask in a pending/refreshing state with `pr` set.

Any `query.data` read that ever registered with a `SuspenseContext` while `pr` was set leaves behind a tracking computed that re-runs on every `trigger()` and increments the boundary again (the `.latest` fast path can't prevent this: on mount with cached data, `resolved` is still false during that first microtask, so the initial read registers anyway — and structural sharing keeps `data` referentially stable, so the reading memo never re-runs and never disposes the computed).

The boundary flips to fallback and back within one microtask. That's never painted, but Suspense detaches and re-inserts the children's DOM — and reconnecting an element restarts its CSS animations. Verified in the router#8000 repro with a MutationObserver: the exact same DOM node is removed and re-inserted 1 ms apart precisely when a background refetch settles.

The existing mitigations in #10053 / #10592 gate on `isFetching === false`, so the stale-mount case (refetch already in flight at mount) still flips.

## Fix

When the observer result has data and is not in an initial loading state, the fetcher returns the result **synchronously** (a non-thenable). Solid's `load()` completes non-Promise results immediately without ever setting a pending promise, so Suspense is only triggered by genuine initial loads. Two exceptions preserve existing semantics:

- If a previous fetcher promise is still pending (`resolver` set — an in-flight initial load, where the boundary is already suspended and possibly inside a transition), completion goes through the Promise path so Suspense/Transition bookkeeping resolves correctly.
- No-data results (e.g. disabled queries) keep the previous Promise behavior; there is no rendered content to protect and existing tests rely on the fallback window.

## Behavior change

`should refetch when re-mounting` previously asserted that the Suspense fallback shows when re-mounting a component whose query has cached data. That expectation codified the reported bug; the test now expects cached data to render immediately while the mount refetch runs in the background (matching React `useSuspenseQuery` semantics). The refetch itself still happens and is still asserted.

## Validation

- 2 new regression tests: mounting with cached data during a background refetch, and invalidation-triggered refetch of a mounted query — both assert the fallback never renders and DOM node identity is preserved
- Full solid-query runtime suite: 322 passed (baseline on main: 320), no new failures; transition test passes
- End-to-end: built package swapped into the router#8000 repro — the same-node detach/re-insert at refetch completion is gone and the animation plays once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Suspense behavior when displaying cached data.
  * Background refetches and query invalidations no longer unnecessarily re-trigger Suspense or detach and remount content.
  * Initial loads without available data continue to suspend as expected.
  * Improved error handling and hydration behavior across server and client rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->