### PR TITLE
fix(query-core): notify sibling observers when one unsubscribes during dispatch

### DIFF
--- a/.changeset/fix-query-dispatch-observer-skip.md
+++ b/.changeset/fix-query-dispatch-observer-skip.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Fix an observer being skipped during query notification when another observer on the same query unsubscribes mid-dispatch. `Query.#dispatch` iterated the live `observers` array while `onQueryUpdate()` could splice it, so a still-subscribed sibling could be left with a stale `pending` result after the query resolved. The notification now iterates over a snapshot of the observers.

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -33,7 +33,9 @@ describe('queryObserver', () => {
 
   it('should notify a sibling observer when another observer on the same query unsubscribes during dispatch', async () => {
     const key = queryKey()
-    const queryFn = vi.fn().mockImplementation(() => sleep(10).then(() => 'data'))
+    const queryFn = vi
+      .fn()
+      .mockImplementation(() => sleep(10).then(() => 'data'))
 
     const observerA = new QueryObserver(queryClient, {
       queryKey: key,

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -31,6 +31,37 @@ describe('queryObserver', () => {
     vi.useRealTimers()
   })
 
+  it('should notify a sibling observer when another observer on the same query unsubscribes during dispatch', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn().mockImplementation(() => sleep(10).then(() => 'data'))
+
+    const observerA = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn,
+      staleTime: Infinity,
+    })
+    const observerB = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn,
+      staleTime: Infinity,
+    })
+
+    let unsubscribeA = () => {}
+    unsubscribeA = observerA.subscribe((result) => {
+      if (result.status === 'success') {
+        unsubscribeA()
+      }
+    })
+    const unsubscribeB = observerB.subscribe(() => undefined)
+
+    await vi.advanceTimersByTimeAsync(15)
+
+    expect(observerB.getCurrentResult().status).toBe('success')
+    expect(observerB.getCurrentResult().data).toBe('data')
+
+    unsubscribeB()
+  })
+
   it('should trigger a fetch when subscribed', () => {
     const key = queryKey()
     const queryFn = vi

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -704,7 +704,9 @@ export class Query<
     this.state = reducer(this.state)
 
     notifyManager.batch(() => {
-      this.observers.forEach((observer) => {
+      // Iterate over a snapshot so that an observer unsubscribing during
+      // notification cannot cause a sibling observer to be skipped.
+      ;[...this.observers].forEach((observer) => {
         observer.onQueryUpdate()
       })
 


### PR DESCRIPTION
## Summary

`Query.#dispatch` can skip a still-subscribed observer when another observer on the same query unsubscribes during notification, leaving it with a stale `pending` result after the query has already resolved.

## Root cause

`removeObserver` mutates the observer array in place (`this.observers.splice(index, 1)`). `#dispatch` iterates that same live array with `this.observers.forEach(...)` and calls `onQueryUpdate()` synchronously inside the open `notifyManager` batch. If a listener unsubscribes a same-query observer during that loop, an element is spliced out mid-iteration and `forEach` skips the next observer.

## Fix

Iterate over a snapshot (`[...this.observers]`) so an observer unsubscribing during notification can't cause a sibling to be skipped.

## Test

Added a regression test in `queryObserver.test.tsx`: two observers subscribe to the same query; observer A unsubscribes itself when it first sees `success`, and the test asserts observer B still receives the resolved `success` data. It fails on `main` (`expected 'pending' to be 'success'`) and passes with this change. A changeset is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed query updates being skipped for some observers when another observer unsubscribes during notification.
  - Ensured all still-subscribed observers receive successful query results reliably, including when subscriptions change during an update.

- **Tests**
  - Added regression coverage for observer notifications during subscription changes and asynchronous query completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->