### PR TITLE
ref: remove unused experimental_beforeQuery and experimental_afterQuery

### DIFF
--- a/.changeset/true-cobras-wait.md
+++ b/.changeset/true-cobras-wait.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/preact-query': patch
+'@tanstack/react-query': patch
+---
+
+remove unused experimental_beforeQuery and experimental_afterQuery hooks

--- a/packages/preact-query/src/useBaseQuery.ts
+++ b/packages/preact-query/src/useBaseQuery.ts
@@ -54,10 +54,6 @@ export function useBaseQuery<
   const client = useQueryClient(queryClient)
   const defaultedOptions = client.defaultQueryOptions(options)
 
-  ;(client.getDefaultOptions().queries as any)?._experimental_beforeQuery?.(
-    defaultedOptions,
-  )
-
   if (process.env.NODE_ENV !== 'production') {
     if (!defaultedOptions.queryFn) {
       console.error(
@@ -139,11 +135,6 @@ export function useBaseQuery<
   ) {
     throw result.error
   }
-
-  ;(client.getDefaultOptions().queries as any)?._experimental_afterQuery?.(
-    defaultedOptions,
-    result,
-  )
 
   if (
     defaultedOptions.experimental_prefetchInRender &&

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -53,9 +53,6 @@ export function useBaseQuery<
   const errorResetBoundary = useQueryErrorResetBoundary()
   const client = useQueryClient(queryClient)
   const defaultedOptions = client.defaultQueryOptions(options)
-  ;(client.getDefaultOptions().queries as any)?._experimental_beforeQuery?.(
-    defaultedOptions,
-  )
 
   const query = client
     .getQueryCache()
@@ -144,11 +141,6 @@ export function useBaseQuery<
   ) {
     throw result.error
   }
-
-  ;(client.getDefaultOptions().queries as any)?._experimental_afterQuery?.(
-    defaultedOptions,
-    result,
-  )
 
   if (
     defaultedOptions.experimental_prefetchInRender &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the unused experimental `beforeQuery` and `afterQuery` hooks from React Query and Preact Query.
* **Release**
  * Published patch-level updates for the React Query and Preact Query packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->