### PR TITLE
fix(query-core): Keep observer notifications stable

### DIFF
--- a/.changeset/stable-observers-notify.md
+++ b/.changeset/stable-observers-notify.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Notify every query observer when another observer unsubscribes synchronously during the same query update.

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -824,6 +824,27 @@ describe('query', () => {
     notifySpy.mockRestore()
   })
 
+  it('should notify remaining observers when one unsubscribes during an update', () => {
+    const key = queryKey()
+    const options = { queryKey: key, enabled: false }
+    const firstObserver = new QueryObserver(queryClient, options)
+    const secondObserver = new QueryObserver(queryClient, options)
+    const secondListener = vi.fn()
+
+    let unsubscribeFirst: () => void = () => undefined
+    unsubscribeFirst = firstObserver.subscribe(() => {
+      unsubscribeFirst()
+    })
+    const unsubscribeSecond = secondObserver.subscribe(secondListener)
+
+    queryClient.setQueryData(key, 'data')
+
+    expect(secondListener).toHaveBeenCalledTimes(1)
+    expect(secondObserver.getCurrentResult().data).toBe('data')
+
+    unsubscribeSecond()
+  })
+
   it('should not change state on invalidate() if already invalidated', async () => {
     const key = queryKey()
 

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -704,7 +704,9 @@ export class Query<
     this.state = reducer(this.state)
 
     notifyManager.batch(() => {
-      this.observers.forEach((observer) => {
+      // Keep the current iteration stable if an observer unsubscribes
+      // synchronously while it is being notified.
+      this.observers.slice().forEach((observer) => {
         observer.onQueryUpdate()
       })
 


### PR DESCRIPTION
PR #11214 changed observer removal from `filter()` to `splice()`. That made removing lots of observers much faster, but it also allowed an observer to change the same array while a query was notifying it. If an observer unsubscribed synchronously, the next observer could be skipped and left with stale data.

This notifies a shallow copy of the observer array. The removal path still uses `splice()`, so the performance improvement from #11214 stays.

I ran a local Vitest benchmark that calls `setQueryData` on one query with all observers subscribed:

| Observers | Before | After |
|---:|---:|---:|
| 10 | 0.0027 ms | 0.0027 ms |
| 50 | 0.0096 ms | 0.0101 ms |
| 10,000 | 2.6049 ms | 2.6032 ms |

There isn't a meaningful change in notification time. The key change and unmount paths measured in #11214 are unchanged because this does not change observer removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query updates so all remaining observers are notified correctly when another observer unsubscribes during notification.
  * Ensured observers receive the latest query data consistently during synchronous updates.

* **Tests**
  * Added regression coverage for observer notifications during unsubscribe scenarios.

* **Release**
  * Included in a patch release of `@tanstack/query-core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->