### PR TITLE
chore(nx.json): drop dead 'dist-cjs' build output entry

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -69,11 +69,7 @@
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
-      "outputs": [
-        "{projectRoot}/build",
-        "{projectRoot}/dist",
-        "{projectRoot}/dist-cjs"
-      ]
+      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"]
     },
     "test:build": {
       "cache": true,


### PR DESCRIPTION
## 🎯 Changes

`targetDefaults.build.outputs` in `nx.json` listed `{projectRoot}/dist-cjs` alongside `{projectRoot}/build` and `{projectRoot}/dist`. This entry was added in #10995 solely because `lit-query` used to build a non-standard `tsc` two-pass output (`dist/` ESM + `dist-cjs/` CJS) — `lit-query` was the only package in the workspace that ever emitted to `dist-cjs`.

#10943 migrated `lit-query` to the standard `tsdown` build (single `build/` directory), so nothing in the workspace emits to `dist-cjs` anymore. This drops the now-dead entry.

No functional change: `pnpm --filter @tanstack/lit-query run build` still produces only `build/modern` and `build/legacy`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build output tracking to include only the supported build and distribution directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->