### PR TITLE
fix(solid-query): support combine functions returning any object shape

### DIFF
--- a/.changeset/solid-query-combine-result-shape.md
+++ b/.changeset/solid-query-combine-result-shape.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Fix `useQueries`/`createQueries` rejecting a `combine` function that returns a shape other than the results array, which previously failed to type check and threw `state.map is not a function` at runtime.

--- a/packages/solid-query/src/__tests__/useQueries.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test-d.tsx
@@ -296,6 +296,27 @@ describe('useQueries', () => {
     }))
   })
 
+  it('should allow combine to return a shape other than the results array', () => {
+    const result = useQueries(() => ({
+      queries: [
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve(1),
+        },
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve(2),
+        },
+      ],
+      combine: (results) => ({
+        data: results.every((queryResult) => queryResult.data),
+        pending: results.some((queryResult) => queryResult.isPending),
+      }),
+    }))
+
+    expectTypeOf(result).toEqualTypeOf<{ data: boolean; pending: boolean }>()
+  })
+
   describe('type parameters', () => {
     it('should handle type parameter - tuple of tuples', () => {
       const key1 = queryKey()

--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -159,6 +159,92 @@ describe('useQueries', () => {
     expect(rendered.getByText('data: custom client')).toBeInTheDocument()
   })
 
+  it('should support a combine function that returns a shape other than the results array', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    function Page() {
+      const result = useQueries(() => ({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(10).then(() => 1),
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(20).then(() => 2),
+          },
+        ],
+        combine: (results) => ({
+          data: results.map((queryResult) => queryResult.data),
+          pending: results.some((queryResult) => queryResult.isPending),
+        }),
+      }))
+
+      return (
+        <div>
+          <div data-testid="data">{JSON.stringify(result.data)}</div>
+          <div data-testid="pending">{String(result.pending)}</div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByTestId('data')).toHaveTextContent('[null,null]')
+    expect(rendered.getByTestId('pending')).toHaveTextContent('true')
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByTestId('data')).toHaveTextContent('[1,null]')
+    expect(rendered.getByTestId('pending')).toHaveTextContent('true')
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByTestId('data')).toHaveTextContent('[1,2]')
+    expect(rendered.getByTestId('pending')).toHaveTextContent('false')
+  })
+
+  it('should keep a combine function that returns the results array array-like', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    function Page() {
+      const result = useQueries(() => ({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(10).then(() => 1),
+          },
+          {
+            queryKey: key2,
+            queryFn: () => sleep(20).then(() => 2),
+          },
+        ],
+        combine: (results) => results,
+      }))
+
+      return (
+        <div>
+          <div data-testid="isArray">{String(Array.isArray(result))}</div>
+          <div data-testid="length">{result.length}</div>
+          <div data-testid="data">
+            {JSON.stringify(result.map((r) => r.data))}
+          </div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByTestId('isArray')).toHaveTextContent('true')
+    expect(rendered.getByTestId('length')).toHaveTextContent('2')
+    expect(rendered.getByTestId('data')).toHaveTextContent('[null,null]')
+
+    await vi.advanceTimersByTimeAsync(20)
+    expect(rendered.getByTestId('data')).toHaveTextContent('[1,2]')
+  })
+
   it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
     const key1 = queryKey()
     const key2 = queryKey()

--- a/packages/solid-query/src/__tests__/useQueries.test.tsx
+++ b/packages/solid-query/src/__tests__/useQueries.test.tsx
@@ -245,6 +245,54 @@ describe('useQueries', () => {
     expect(rendered.getByTestId('data')).toHaveTextContent('[1,2]')
   })
 
+  it('should not throw when the shape returned by combine changes', async () => {
+    const key1 = queryKey()
+
+    function Page() {
+      const [asArray, setAsArray] = createSignal(true)
+
+      const result = useQueries(() => ({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => sleep(10).then(() => 1),
+          },
+        ],
+        combine: (
+          results,
+        ):
+          | Array<UseQueryResult<number, Error>>
+          | { data: Array<number | undefined> } =>
+          asArray()
+            ? results
+            : { data: results.map((queryResult) => queryResult.data) },
+      }))
+
+      return (
+        <div>
+          <button onClick={() => setAsArray(false)}>to object</button>
+          <div data-testid="keys">{Object.keys(result).join(',')}</div>
+          <div data-testid="data">
+            {JSON.stringify(
+              'data' in result ? result.data : (result[0]?.data ?? null),
+            )}
+          </div>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByTestId('keys')).toHaveTextContent('0')
+    expect(rendered.getByTestId('data')).toHaveTextContent('1')
+
+    fireEvent.click(rendered.getByRole('button', { name: /to object/i }))
+
+    expect(rendered.getByTestId('keys')).toHaveTextContent('data')
+    expect(rendered.getByTestId('data')).toHaveTextContent('[1]')
+  })
+
   it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
     const key1 = queryKey()
     const key2 = queryKey()

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -186,7 +186,7 @@ type QueriesResults<
 
 export function useQueries<
   T extends Array<any>,
-  TCombinedResult extends QueriesResults<T> = QueriesResults<T>,
+  TCombinedResult extends object = QueriesResults<T>,
 >(
   queriesOptions: Accessor<{
     queries:
@@ -223,24 +223,20 @@ export function useQueries<
       : undefined,
   )
 
-  const [state, setState] = createStore<TCombinedResult>(
-    observer.getOptimisticResult(
-      defaultedQueries(),
-      (queriesOptions() as QueriesObserverOptions<TCombinedResult>).combine,
-    )[1](),
-  )
+  // The store always holds the raw, uncombined results, because the resources
+  // and proxies below are keyed by query index. `combine` is applied on top of
+  // it right before the result is handed to the caller, so the combined result
+  // of the observer is not needed here.
+  const optimisticResult = () =>
+    observer.getOptimisticResult(defaultedQueries(), undefined)[0]
+
+  const [state, setState] =
+    createStore<Array<QueryObserverResult>>(optimisticResult())
 
   createRenderEffect(
     on(
       () => queriesOptions().queries.length,
-      () =>
-        setState(
-          observer.getOptimisticResult(
-            defaultedQueries(),
-            (queriesOptions() as QueriesObserverOptions<TCombinedResult>)
-              .combine,
-          )[1](),
-        ),
+      () => setState(optimisticResult()),
     ),
   )
 
@@ -277,7 +273,6 @@ export function useQueries<
           for (let index = 0; index < dataResources_.length; index++) {
             const dataResource = dataResources_[index]!
             const unwrappedResult = { ...unwrap(result[index]) }
-            // @ts-expect-error typescript pedantry regarding the possible range of index
             setState(index, unwrap(unwrappedResult))
             dataResource[1].mutate(() => unwrap(state[index]!.data))
             dataResource[1].refetch()
@@ -340,5 +335,44 @@ export function useQueries<
   const [proxyState, setProxyState] = createStore(getProxies())
   createRenderEffect(() => setProxyState(getProxies()))
 
-  return proxyState as TCombinedResult
+  if (!queriesOptions().combine) {
+    return proxyState as unknown as TCombinedResult
+  }
+
+  // `combine` may return any shape, so the combined result cannot live in a
+  // store. It is derived from the tracked results instead, and read through a
+  // proxy so that consumers stay subscribed to the properties they access.
+  const combinedResult = createMemo(() => {
+    const combine = queriesOptions().combine
+    return combine
+      ? combine(proxyState as unknown as QueriesResults<T>)
+      : (proxyState as unknown as TCombinedResult)
+  })
+
+  // The target is only there to keep `Array.isArray` and friends in sync with
+  // what `combine` returns - every read is forwarded to the memo.
+  const target = (Array.isArray(combinedResult()) ? [] : {}) as TCombinedResult
+
+  return new Proxy(target, {
+    get: (_, property) => Reflect.get(combinedResult(), property),
+    has: (_, property) => Reflect.has(combinedResult(), property),
+    ownKeys: () => Reflect.ownKeys(combinedResult()),
+    getOwnPropertyDescriptor: (_, property) => {
+      const descriptor = Reflect.getOwnPropertyDescriptor(
+        combinedResult(),
+        property,
+      )
+
+      if (descriptor === undefined) {
+        return undefined
+      }
+
+      // Properties the target does not own itself (all of them, unless the
+      // target is an array reporting its `length`) have to stay configurable to
+      // satisfy the proxy invariants.
+      return Reflect.getOwnPropertyDescriptor(target, property)
+        ? descriptor
+        : { ...descriptor, configurable: true }
+    },
+  })
 }

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -335,6 +335,9 @@ export function useQueries<
   const [proxyState, setProxyState] = createStore(getProxies())
   createRenderEffect(() => setProxyState(getProxies()))
 
+  // Whether `combine` is used has to be decided once, because a component
+  // cannot hand out a different value later on. Removing it after the fact is
+  // still handled by the memo below, which falls back to the results array.
   if (!queriesOptions().combine) {
     return proxyState as unknown as TCombinedResult
   }
@@ -349,30 +352,48 @@ export function useQueries<
       : (proxyState as unknown as TCombinedResult)
   })
 
-  // The target is only there to keep `Array.isArray` and friends in sync with
-  // what `combine` returns - every read is forwarded to the memo.
+  // A proxy target cannot be swapped later on, so its kind is taken from the
+  // first combined result to keep `Array.isArray` and `JSON.stringify` in line
+  // with what `combine` returns. Every read is forwarded to the memo, but the
+  // properties the target owns itself - `length`, if it is an array - have to
+  // keep being reported even when a later combined result no longer has them,
+  // because they are non-configurable.
   const target = (Array.isArray(combinedResult()) ? [] : {}) as TCombinedResult
+
+  const getTargetDescriptor = (property: PropertyKey) =>
+    Reflect.getOwnPropertyDescriptor(target, property)
 
   return new Proxy(target, {
     get: (_, property) => Reflect.get(combinedResult(), property),
-    has: (_, property) => Reflect.has(combinedResult(), property),
-    ownKeys: () => Reflect.ownKeys(combinedResult()),
+    has: (_, property) =>
+      Reflect.has(combinedResult(), property) ||
+      getTargetDescriptor(property) !== undefined,
+    ownKeys: () => [
+      ...new Set([
+        ...Reflect.ownKeys(combinedResult()),
+        ...Reflect.ownKeys(target),
+      ]),
+    ],
     getOwnPropertyDescriptor: (_, property) => {
       const descriptor = Reflect.getOwnPropertyDescriptor(
         combinedResult(),
         property,
       )
+      const targetDescriptor = getTargetDescriptor(property)
 
-      if (descriptor === undefined) {
-        return undefined
+      if (targetDescriptor) {
+        // Report the target's own flags, or the proxy invariants are violated.
+        return descriptor
+          ? {
+              ...targetDescriptor,
+              value: Reflect.get(combinedResult(), property),
+            }
+          : targetDescriptor
       }
 
-      // Properties the target does not own itself (all of them, unless the
-      // target is an array reporting its `length`) have to stay configurable to
+      // Properties the target does not own have to stay configurable, again to
       // satisfy the proxy invariants.
-      return Reflect.getOwnPropertyDescriptor(target, property)
-        ? descriptor
-        : { ...descriptor, configurable: true }
+      return descriptor && { ...descriptor, configurable: true }
     },
   })
 }


### PR DESCRIPTION
Fixes #7522

### Problem

`useQueries` (`createQueries`) put whatever `combine` returned into the `createStore` that backs the hook, but everything built around that store — the per-query `createResource`s, the `data` proxies, and the `setState(index, ...)` calls in the observer subscription — is keyed by query index and assumes the store holds the results array.

As a result, a `combine` function that returned any other shape:

1. failed to type check, because `TCombinedResult` was constrained to `QueriesResults<T>` (the React adapter has no such constraint), and
2. threw `TypeError: state.map is not a function` at runtime once the constraint was worked around.

@TkDodo [pinpointed the type constraint](https://github.com/TanStack/query/issues/7522#issuecomment-2755142799) and noted that simply removing it runs into `createStore`'s `T extends object` requirement plus follow-up errors in `createMemo` — those come from the store being asked to hold the combined value in the first place.

### Fix

Keep the store holding the **raw** results (so the resources, proxies and index-keyed updates keep working exactly as before) and derive the combined value from the tracked proxies on top of it, which is how the React adapter separates the two.

- The store is now seeded from `getOptimisticResult(...)[0]` (raw results) instead of `[1]()` (combined result).
- When `combine` is set, the result is a `createMemo` over the result proxies, exposed through a small proxy so consumers stay subscribed to just the properties they read.
- The proxy target is `[]` or `{}` depending on what `combine` returns, so `Array.isArray`, `JSON.stringify`, spreading and `Object.keys` keep behaving as they did for combine functions that return the results array.
- `TCombinedResult` is now constrained to `object` rather than `QueriesResults<T>`. Solid needs an object to stay reactive, so a combined primitive is reported as a type error instead of crashing at runtime.

The `@ts-expect-error` on `setState(index, ...)` is gone as well — with the store typed as the raw results, that index write type checks on its own.

### Tests

- `useQueries.test.tsx`: a combine function returning `{ data, pending }` renders and updates as the queries resolve (this is the failing case from the issue), and a combine function returning the results array stays array-like.
- `useQueries.test-d.tsx`: `useQueries` with a combine function returning `{ data: boolean; pending: boolean }` infers exactly that type.

`pnpm test` for `@tanstack/solid-query` passes (338 tests, type tests included).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useQueries` and `createQueries` so `combine` functions can return custom object shapes, not only result arrays.
  * Prevented type-checking failures and runtime errors when using custom combined results.
  * Preserved array-like behavior when the combined result is the original query results array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->