### PR TITLE
test(query-broadcast-client-experimental): replace inline query key literals with 'queryKey' from 'query-test-utils'

### DIFF
--- a/packages/query-broadcast-client-experimental/package.json
+++ b/packages/query-broadcast-client-experimental/package.json
@@ -59,6 +59,7 @@
     "broadcast-channel": "^7.0.0"
   },
   "devDependencies": {
+    "@tanstack/query-test-utils": "workspace:*",
     "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react": "^4.3.4",
     "npm-run-all2": "^5.0.0"

--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from '@tanstack/query-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { queryKey } from '@tanstack/query-test-utils'
 import { broadcastQueryClient } from '..'
 import type { BroadcastErrorEvent } from '..'
 import type { QueryCache } from '@tanstack/query-core'
@@ -59,6 +60,7 @@ describe('broadcastQueryClient', () => {
     })
 
     it('should not cause an unhandled rejection when onBroadcastError itself throws', async () => {
+      const key = queryKey()
       const cloneError = new DOMException('DataCloneError', 'DataCloneError')
       mockPostMessage.mockRejectedValueOnce(cloneError)
 
@@ -79,7 +81,7 @@ describe('broadcastQueryClient', () => {
           onBroadcastError,
         })
 
-        queryClient.setQueryData(['test'], { value: 1 })
+        queryClient.setQueryData(key, { value: 1 })
 
         await new Promise((r) => setTimeout(r, 0))
 
@@ -88,7 +90,7 @@ describe('broadcastQueryClient', () => {
           expect.objectContaining<BroadcastErrorEvent>({
             type: 'added',
             queryHash: expect.any(String) as string,
-            queryKey: ['test'],
+            queryKey: key,
           }),
         )
         expect(unhandledRejections).toHaveLength(0)
@@ -98,6 +100,7 @@ describe('broadcastQueryClient', () => {
     })
 
     it('should warn in dev when onBroadcastError itself throws', async () => {
+      const key = queryKey()
       process.env['NODE_ENV'] = 'development'
       const cloneError = new DOMException('DataCloneError', 'DataCloneError')
       const callbackError = new Error('boom')
@@ -114,7 +117,7 @@ describe('broadcastQueryClient', () => {
           },
         })
 
-        queryClient.setQueryData(['test'], { value: 1 })
+        queryClient.setQueryData(key, { value: 1 })
 
         await new Promise((r) => setTimeout(r, 0))
 
@@ -128,6 +131,7 @@ describe('broadcastQueryClient', () => {
     })
 
     it('should not cause an unhandled rejection when async onBroadcastError rejects', async () => {
+      const key = queryKey()
       const cloneError = new DOMException('DataCloneError', 'DataCloneError')
       mockPostMessage.mockRejectedValueOnce(cloneError)
 
@@ -148,7 +152,7 @@ describe('broadcastQueryClient', () => {
           onBroadcastError,
         })
 
-        queryClient.setQueryData(['test'], { value: 1 })
+        queryClient.setQueryData(key, { value: 1 })
 
         await new Promise((r) => setTimeout(r, 10))
 
@@ -157,7 +161,7 @@ describe('broadcastQueryClient', () => {
           expect.objectContaining<BroadcastErrorEvent>({
             type: 'added',
             queryHash: expect.any(String) as string,
-            queryKey: ['test'],
+            queryKey: key,
           }),
         )
         expect(unhandledRejections).toHaveLength(0)
@@ -167,6 +171,7 @@ describe('broadcastQueryClient', () => {
     })
 
     it('should warn in dev when async onBroadcastError rejects', async () => {
+      const key = queryKey()
       process.env['NODE_ENV'] = 'development'
       const cloneError = new DOMException('DataCloneError', 'DataCloneError')
       const asyncError = new Error('async boom')
@@ -181,7 +186,7 @@ describe('broadcastQueryClient', () => {
           onBroadcastError: () => Promise.reject(asyncError),
         })
 
-        queryClient.setQueryData(['test'], { value: 1 })
+        queryClient.setQueryData(key, { value: 1 })
 
         await new Promise((r) => setTimeout(r, 10))
 
@@ -195,6 +200,7 @@ describe('broadcastQueryClient', () => {
     })
 
     it('should call onBroadcastError when postMessage fails', async () => {
+      const key = queryKey()
       const cloneError = new DOMException('DataCloneError', 'DataCloneError')
       mockPostMessage.mockRejectedValueOnce(cloneError)
 
@@ -205,7 +211,7 @@ describe('broadcastQueryClient', () => {
         onBroadcastError,
       })
 
-      queryClient.setQueryData(['test'], { value: 1 })
+      queryClient.setQueryData(key, { value: 1 })
 
       await new Promise((r) => setTimeout(r, 0))
       expect(onBroadcastError).toHaveBeenCalledWith(
@@ -213,12 +219,13 @@ describe('broadcastQueryClient', () => {
         expect.objectContaining<BroadcastErrorEvent>({
           type: 'added',
           queryHash: expect.any(String) as string,
-          queryKey: ['test'],
+          queryKey: key,
         }),
       )
     })
 
     it('should warn in dev when postMessage fails and onBroadcastError is not provided', async () => {
+      const key = queryKey()
       process.env['NODE_ENV'] = 'development'
       const cloneError = new DOMException('DataCloneError', 'DataCloneError')
       mockPostMessage.mockRejectedValueOnce(cloneError)
@@ -231,7 +238,7 @@ describe('broadcastQueryClient', () => {
           broadcastChannel: 'test_channel',
         })
 
-        queryClient.setQueryData(['test'], { value: 1 })
+        queryClient.setQueryData(key, { value: 1 })
 
         await new Promise((r) => setTimeout(r, 0))
         expect(warnSpy).toHaveBeenCalledWith(
@@ -244,6 +251,7 @@ describe('broadcastQueryClient', () => {
     })
 
     it('should not warn in production when postMessage fails', async () => {
+      const key = queryKey()
       process.env['NODE_ENV'] = 'production'
       const cloneError = new DOMException('DataCloneError', 'DataCloneError')
       mockPostMessage.mockRejectedValueOnce(cloneError)
@@ -256,7 +264,7 @@ describe('broadcastQueryClient', () => {
           broadcastChannel: 'test_channel',
         })
 
-        queryClient.setQueryData(['test'], { value: 1 })
+        queryClient.setQueryData(key, { value: 1 })
 
         await new Promise((r) => setTimeout(r, 0))
         expect(warnSpy).not.toHaveBeenCalled()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2718,6 +2718,9 @@ importers:
         specifier: ^7.0.0
         version: 7.3.0
     devDependencies:
+      '@tanstack/query-test-utils':
+        specifier: workspace:*
+        version: link:../query-test-utils
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10645,6 +10648,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
## 🎯 Changes

`packages/query-broadcast-client-experimental/src/__tests__/index.test.ts` was the only remaining runtime test file using an inline `['test']` query key literal instead of the shared `queryKey()` helper from `@tanstack/query-test-utils` that other adapter packages' tests already use. Added `@tanstack/query-test-utils` as a devDependency and replaced all 7 occurrences (across `setQueryData` calls and their matching `queryKey` assertions) with a per-`it`-block `const key = queryKey()`. No behavior change — each test still exercises a single query key, just no longer hardcoded.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for broadcast query error handling by using unique query keys in each test scenario.
  * Expanded coverage to help ensure reliable behavior when multiple queries are processed independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->