### PR TITLE
test(query-broadcast-client-experimental): replace inline 'new Promise' timeouts with 'sleep' from 'query-test-utils'

### DIFF
--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/query-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { queryKey } from '@tanstack/query-test-utils'
+import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { broadcastQueryClient } from '..'
 import type { BroadcastErrorEvent } from '..'
 import type { QueryCache } from '@tanstack/query-core'
@@ -83,7 +83,7 @@ describe('broadcastQueryClient', () => {
 
         queryClient.setQueryData(key, { value: 1 })
 
-        await new Promise((r) => setTimeout(r, 0))
+        await sleep(0)
 
         expect(onBroadcastError).toHaveBeenCalledWith(
           cloneError,
@@ -119,7 +119,7 @@ describe('broadcastQueryClient', () => {
 
         queryClient.setQueryData(key, { value: 1 })
 
-        await new Promise((r) => setTimeout(r, 0))
+        await sleep(0)
 
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('onBroadcastError threw while handling'),
@@ -154,7 +154,7 @@ describe('broadcastQueryClient', () => {
 
         queryClient.setQueryData(key, { value: 1 })
 
-        await new Promise((r) => setTimeout(r, 10))
+        await sleep(10)
 
         expect(onBroadcastError).toHaveBeenCalledWith(
           cloneError,
@@ -188,7 +188,7 @@ describe('broadcastQueryClient', () => {
 
         queryClient.setQueryData(key, { value: 1 })
 
-        await new Promise((r) => setTimeout(r, 10))
+        await sleep(10)
 
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('onBroadcastError threw while handling'),
@@ -213,7 +213,7 @@ describe('broadcastQueryClient', () => {
 
       queryClient.setQueryData(key, { value: 1 })
 
-      await new Promise((r) => setTimeout(r, 0))
+      await sleep(0)
       expect(onBroadcastError).toHaveBeenCalledWith(
         cloneError,
         expect.objectContaining<BroadcastErrorEvent>({
@@ -240,7 +240,7 @@ describe('broadcastQueryClient', () => {
 
         queryClient.setQueryData(key, { value: 1 })
 
-        await new Promise((r) => setTimeout(r, 0))
+        await sleep(0)
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('cross-tab sync for this query was skipped'),
           cloneError,
@@ -266,7 +266,7 @@ describe('broadcastQueryClient', () => {
 
         queryClient.setQueryData(key, { value: 1 })
 
-        await new Promise((r) => setTimeout(r, 0))
+        await sleep(0)
         expect(warnSpy).not.toHaveBeenCalled()
       } finally {
         warnSpy.mockRestore()


### PR DESCRIPTION
## 🎯 Changes

`packages/query-broadcast-client-experimental/src/__tests__/index.test.ts` was still writing `new Promise((r) => setTimeout(r, N))` inline instead of using the shared `sleep(N)` helper from `@tanstack/query-test-utils` (already a devDependency since #11240). Replaced all 7 occurrences. No behavior change — `sleep` is implemented identically to the inlined promise.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated asynchronous test waits to use a shared timing utility, improving consistency and readability without changing end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->