### PR TITLE
fix(broadcast-client): recover from errors thrown while applying an incoming cross-tab message

### DIFF
--- a/.changeset/broadcast-client-transaction-stuck.md
+++ b/.changeset/broadcast-client-transaction-stuck.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-broadcast-client-experimental': patch
+---
+
+fix(broadcast-client): recover from errors thrown while applying an incoming cross-tab message instead of permanently disabling this tab's own broadcasts

--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -84,6 +84,38 @@ describe('broadcastQueryClient', () => {
 
       expect(mockPostMessage).toHaveBeenCalled()
     })
+
+    it('should keep broadcasting local changes after query.setState throws for an existing query', () => {
+      broadcastQueryClient({
+        queryClient,
+        broadcastChannel: 'test_channel',
+      })
+
+      // Populate the cache with an existing query so the incoming message
+      // below is applied via `query.setState` rather than `queryCache.build`.
+      queryClient.setQueryData(['existing'], { value: 0 })
+      const existingQuery = queryCache.find({ queryKey: ['existing'] })!
+
+      const explodingUnsubscribe = queryCache.subscribe(() => {
+        throw new Error('boom from an unrelated cache listener')
+      })
+
+      expect(() => {
+        lastCreatedChannel.onmessage?.({
+          type: 'updated',
+          queryHash: existingQuery.queryHash,
+          queryKey: ['existing'],
+          state: { data: 2 },
+        })
+      }).toThrow('boom')
+
+      explodingUnsubscribe()
+      mockPostMessage.mockClear()
+
+      queryClient.setQueryData(['local2'], { value: 1 })
+
+      expect(mockPostMessage).toHaveBeenCalled()
+    })
   })
 
   describe('postMessage error handling', () => {

--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import type { QueryCache } from '@tanstack/query-core'
 
 const mockPostMessage = vi.fn().mockResolvedValue(undefined)
 const mockClose = vi.fn()
+let lastCreatedChannel: { onmessage: ((action: any) => void) | null }
 
 vi.mock('broadcast-channel', async (importOriginal) => {
   const actual = await importOriginal()
@@ -16,6 +17,9 @@ vi.mock('broadcast-channel', async (importOriginal) => {
       onmessage = null
       postMessage = mockPostMessage
       close = mockClose
+      constructor() {
+        lastCreatedChannel = this
+      }
     },
   }
 })
@@ -46,6 +50,40 @@ describe('broadcastQueryClient', () => {
     })
     unsubscribe()
     expect(queryCache.hasListeners()).toBe(false)
+  })
+
+  describe('incoming message handling', () => {
+    it('should keep broadcasting local changes after applying an incoming message throws', () => {
+      broadcastQueryClient({
+        queryClient,
+        broadcastChannel: 'test_channel',
+      })
+
+      // Simulate some other part of the app (e.g. another cache subscriber)
+      // throwing synchronously while an incoming cross-tab message is being
+      // applied locally.
+      const explodingUnsubscribe = queryCache.subscribe(() => {
+        throw new Error('boom from an unrelated cache listener')
+      })
+
+      expect(() => {
+        lastCreatedChannel.onmessage?.({
+          type: 'added',
+          queryHash: '["remote"]',
+          queryKey: ['remote'],
+          state: { data: 1 },
+        })
+      }).toThrow('boom')
+
+      explodingUnsubscribe()
+      mockPostMessage.mockClear()
+
+      // A later local change must still be broadcast to other tabs, instead
+      // of being silently swallowed because the transaction flag got stuck.
+      queryClient.setQueryData(['local'], { value: 1 })
+
+      expect(mockPostMessage).toHaveBeenCalled()
+    })
   })
 
   describe('postMessage error handling', () => {

--- a/packages/query-broadcast-client-experimental/src/index.ts
+++ b/packages/query-broadcast-client-experimental/src/index.ts
@@ -55,8 +55,16 @@ export function broadcastQueryClient({
   let transaction = false
   const tx = (cb: () => void) => {
     transaction = true
-    cb()
-    transaction = false
+    try {
+      cb()
+    } finally {
+      // Guard against `cb` throwing (e.g. `query.setState`/`queryCache.build`
+      // triggering a listener that throws while applying an incoming
+      // cross-tab message). Without this, `transaction` would stay `true`
+      // forever, silently disabling this tab's own broadcasts to other tabs
+      // for the rest of the session.
+      transaction = false
+    }
   }
 
   const channel = new BroadcastChannel(broadcastChannel, {


### PR DESCRIPTION
## 🎯 Changes

If applying an incoming cross-tab message inside `broadcastQueryClient`'s `channel.onmessage` handler throws (e.g. `query.setState`/`queryCache.build` notifying an observer/listener that itself throws), the internal `tx()` helper never resets its `transaction` flag back to `false`. From that point on, `queryCache.subscribe`'s `if (transaction) return` guard is permanently tripped, so this tab silently stops broadcasting any of its own local changes to other tabs for the rest of the session.

This is the same class of bug as a boolean/timer guard that only gets reset on the happy path (similar in spirit to stuck-timer issues fixed elsewhere in the persister packages). Fixed by wrapping the callback in `try/finally` so `transaction` is always reset, regardless of whether applying the incoming message succeeded.

Added a regression test that makes an unrelated `queryCache` listener throw while an incoming message is applied, and asserts that a subsequent local `setQueryData` is still broadcast afterward. Confirmed the new test fails against the old code and passes with the fix.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

I ran `pnpm nx run @tanstack/query-broadcast-client-experimental:test:lib` directly via `vitest`, and all 10 tests (9 existing + 1 new) pass, including type-checking. I was not able to run the full `pnpm run test:pr` (which invokes `tsc --build` across the workspace) in my local environment because this checkout has `core.symlinks=false` on native Windows, which breaks the repo's symlinked root config files (`root.eslint.config.js`, `root.tsdown.config.js`) — a known limitation called out in CONTRIBUTING.md as needing Linux/macOS/WSL. This is unrelated to this change; happy to have CI confirm.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cross-tab query updates now continue broadcasting after an error occurs while processing an incoming message.
  - Broadcast processing reliably recovers, preventing a single failed update from disabling future synchronization.

- **Tests**
  - Added regression coverage for errors affecting both new and existing queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->