### PR TITLE
fix/11018

### DIFF
--- a/.changeset/dull-masks-melt.md
+++ b/.changeset/dull-masks-melt.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/preact-query': patch
+'@tanstack/react-query': patch
+---
+
+revert: remove NoInfer from useQuery return types

--- a/packages/preact-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test-d.tsx
@@ -288,6 +288,23 @@ describe('useQuery', () => {
       })
     })
 
+    it('should preserve discriminated-union narrowing', () => {
+      type Result =
+        | { type: 'first'; first: string }
+        | { type: 'second'; second: string }
+
+      const query = useQuery({
+        queryKey: queryKey(),
+        queryFn: (): Result => ({ type: 'first', first: 'a' }),
+      })
+
+      const second = query.data?.type === 'first' ? undefined : query.data
+
+      expectTypeOf(second).toEqualTypeOf<
+        { type: 'second'; second: string } | undefined
+      >()
+    })
+
     describe('custom hook', () => {
       it('should allow custom hooks using UseQueryOptions', () => {
         type Data = string

--- a/packages/preact-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test-d.tsx
@@ -278,23 +278,6 @@ describe('useQuery', () => {
         }
       })
 
-      // eslint-disable-next-line vitest/expect-expect
-      it('TData should depend from only arguments, not the result', () => {
-        // @ts-expect-error
-        // eslint-disable-next-line
-        const result: UseQueryResult<{ wow: string }> = useQuery({
-          queryKey: queryKey(),
-          queryFn: () => {
-            return {
-              wow: true,
-            }
-          },
-          initialData: () => undefined as { wow: boolean } | undefined,
-        })
-
-        void result
-      })
-
       it('data should not have undefined when initialData is provided', () => {
         const { data } = useQuery({
           queryKey: queryKey(),

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -20,7 +20,7 @@ export function useQuery<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): DefinedUseQueryResult<NoInfer<TData>, TError>
+): DefinedUseQueryResult<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -30,7 +30,7 @@ export function useQuery<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<NoInfer<TData>, TError>
+): UseQueryResult<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -40,7 +40,7 @@ export function useQuery<
 >(
   options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<NoInfer<TData>, TError>
+): UseQueryResult<TData, TError>
 
 export function useQuery(options: UseQueryOptions, queryClient?: QueryClient) {
   return useBaseQuery(options, QueryObserver, queryClient)

--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -277,22 +277,6 @@ describe('useQuery', () => {
         }
       })
 
-      // eslint-disable-next-line vitest/expect-expect
-      it('TData should depend from only arguments, not the result', () => {
-        // @ts-expect-error
-        const result: UseQueryResult<{ wow: string }> = useQuery({
-          queryKey: queryKey(),
-          queryFn: () => {
-            return {
-              wow: true,
-            }
-          },
-          initialData: () => undefined as { wow: boolean } | undefined,
-        })
-
-        void result
-      })
-
       it('data should not have undefined when initialData is provided', () => {
         const { data } = useQuery({
           queryKey: queryKey(),

--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -277,6 +277,23 @@ describe('useQuery', () => {
         }
       })
 
+      it('should preserve discriminated-union narrowing', () => {
+        type Result =
+          | { type: 'first'; first: string }
+          | { type: 'second'; second: string }
+
+        const query = useQuery({
+          queryKey: queryKey(),
+          queryFn: (): Result => ({ type: 'first', first: 'a' }),
+        })
+
+        const second = query.data?.type === 'first' ? undefined : query.data
+
+        expectTypeOf(second).toEqualTypeOf<
+          { type: 'second'; second: string } | undefined
+        >()
+      })
+
       it('data should not have undefined when initialData is provided', () => {
         const { data } = useQuery({
           queryKey: queryKey(),

--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -20,7 +20,7 @@ export function useQuery<
 >(
   options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): DefinedUseQueryResult<NoInfer<TData>, TError>
+): DefinedUseQueryResult<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -30,7 +30,7 @@ export function useQuery<
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<NoInfer<TData>, TError>
+): UseQueryResult<TData, TError>
 
 export function useQuery<
   TQueryFnData = unknown,
@@ -40,7 +40,7 @@ export function useQuery<
 >(
   options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): UseQueryResult<NoInfer<TData>, TError>
+): UseQueryResult<TData, TError>
 
 export function useQuery(options: UseQueryOptions, queryClient?: QueryClient) {
   return useBaseQuery(options, QueryObserver, queryClient)


### PR DESCRIPTION
fixes #11018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored expected TypeScript inference behavior for `useQuery` results in React Query and Preact Query.
  * Improved discriminated-union narrowing for `query.data`, enabling more accurate type-safe access.

* **Tests**
  * Updated type coverage to verify correct union narrowing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->