### PR TITLE
test(vue-query): add regression tests for suspense release on programmatic 'setQueryData'

### DIFF
--- a/packages/vue-query/src/__tests__/suspense.test.ts
+++ b/packages/vue-query/src/__tests__/suspense.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { experimental_streamedQuery } from '@tanstack/query-core'
+import { queryKey, sleep } from '@tanstack/query-test-utils'
+import { useQuery } from '../useQuery'
+import { useQueryClient } from '../useQueryClient'
+
+vi.mock('../useQueryClient')
+
+describe('suspense()', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should release suspense when setQueryData is called while fetch is in-flight', async () => {
+    const key = queryKey()
+
+    const query = useQuery({
+      queryKey: key,
+      queryFn: () => sleep(10000).then(() => 'fetched'),
+    })
+
+    const suspensePromise = query.suspense()
+
+    const queryClient = useQueryClient()
+    queryClient.setQueryData(key, 'manual data')
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    const result = await suspensePromise
+    expect(result.data).toBe('manual data')
+  })
+
+  it('should release suspense when streamedQuery receives first chunk', async () => {
+    const key = queryKey()
+
+    async function* numberGenerator() {
+      await sleep(10)
+      yield 'chunk1'
+      await sleep(10)
+      yield 'chunk2'
+    }
+
+    const query = useQuery({
+      queryKey: key,
+      queryFn: experimental_streamedQuery({
+        streamFn: () => numberGenerator(),
+      }),
+    })
+
+    const suspensePromise = query.suspense()
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    const result = await suspensePromise
+    expect(result.data).toStrictEqual(['chunk1'])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Port the vue-query counterpart of the regression tests added in #11036 (react-query). The underlying fix lives in `packages/query-core/src/queryObserver.ts` (`fetchOptimistic`), and `vue-query`'s `.suspense()` helper (`useBaseQuery.ts`) calls `observer.fetchOptimistic(...)` directly, so it already gets the runtime behavior for free — this PR only adds test coverage:

- `should release suspense when setQueryData is called while fetch is in-flight`
- `should release suspense when streamedQuery receives first chunk`

Two scenarios from the react-query version were deliberately **not** ported:
- **"setQueryData before component mounts"**: in vue-query, `.suspense()` only calls `fetchOptimistic` when `optimisticResult.isStale` is true; with data already cached and fresh, it resolves via a different branch and never reaches the fixed code path, so the test would pass regardless of the fix.
- **"should NOT release suspense when setQueryData is called with undefined"**: verified locally that this assertion still passed even with the `query.state.data !== undefined` guard removed from `fetchOptimistic`, i.e. it doesn't actually exercise the guard in vue's `.suspense()` shape. Left out rather than shipping a test that doesn't test anything.

Both included tests were verified against a reverted (pre-#11036) `fetchOptimistic` locally and failed as expected (timeout) before being confirmed passing against the current code.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for suspense behavior after query data updates.
  * Added coverage for suspense resolution when streamed queries receive their first data chunk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->