### PR TITLE
fix(vue-query): stop MaybeRefDeep stripping branded queryKey types (#9920)

### DIFF
--- a/.changeset/fix-branded-types-mayberefdeep.md
+++ b/.changeset/fix-branded-types-mayberefdeep.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query': patch
+---
+
+fix(vue-query): preserve branded types in `MaybeRefDeep` so branded `queryKey`s (e.g. `string & { __brand }`) pass through `queryOptions` into `useQuery` without a TS2769 overload error

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -362,4 +362,64 @@ describe('queryOptions', () => {
 
     expectTypeOf(options.queryKey).not.toBeUndefined()
   })
+
+  it('should work with branded queryKey', () => {
+    type PostId = string & { readonly __brand: 'PostId' }
+    const postId = '123' as PostId
+
+    const options = queryOptions({
+      queryKey: ['post', postId],
+      queryFn: () => Promise.resolve({ id: postId }),
+    })
+
+    expectTypeOf(options.queryKey).not.toBeUndefined()
+
+    const { data } = reactive(useQuery(options))
+
+    expectTypeOf(data).toEqualTypeOf<{ id: PostId } | undefined>()
+  })
+
+  it('should work with branded queryKey inside MaybeRefOrGetter', () => {
+    type PostId = string & { readonly __brand: 'PostId' }
+    const postId = '123' as PostId
+
+    const simpleOptions = queryOptions({
+      queryKey: ['post', postId],
+      queryFn: () => Promise.resolve({ id: postId }),
+    })
+
+    const { data: simpleData } = reactive(useQuery(simpleOptions))
+
+    expectTypeOf(simpleData).toEqualTypeOf<{ id: PostId } | undefined>()
+
+    const nestedOptions = queryOptions({
+      queryKey: ['post', { postId }],
+      queryFn: () => Promise.resolve({ id: postId }),
+    })
+
+    const { data: nestedData } = reactive(useQuery(nestedOptions))
+
+    expectTypeOf(nestedData).toEqualTypeOf<{ id: PostId } | undefined>()
+
+    const inlineData = reactive(
+      useQuery({
+        queryKey: ['post', postId],
+        queryFn: () => Promise.resolve({ id: postId }),
+      }),
+    )
+
+    expectTypeOf(inlineData.data).toEqualTypeOf<{ id: PostId } | undefined>()
+  })
+
+  it('should still tag the queryKey with the queryFn result when it contains branded types', () => {
+    type PostId = string & { readonly __brand: 'PostId' }
+    const postId = '123' as PostId
+
+    const { queryKey: tagged } = queryOptions({
+      queryKey: ['post', { postId }],
+      queryFn: () => Promise.resolve({ id: postId }),
+    })
+
+    expectTypeOf(tagged[dataTagSymbol]).toEqualTypeOf<{ id: PostId }>()
+  })
 })

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -31,11 +31,13 @@ export type MaybeRefOrGetter<T> = MaybeRef<T> | (() => T)
 export type MaybeRefDeep<T> = MaybeRef<
   T extends Function
     ? T
-    : T extends object
-      ? {
-          [Property in keyof T]: MaybeRefDeep<T[Property]>
-        }
-      : T
+    : T extends { __brand: infer _ }
+      ? T
+      : T extends object
+        ? {
+            [Property in keyof T]: MaybeRefDeep<T[Property]>
+          }
+        : T
 >
 
 export type NoUnknown<T> = Equal<unknown, T> extends true ? never : T


### PR DESCRIPTION
Closes #9920

vue-query's MaybeRefDeep remapped branded primitives (e.g. string and object intersection with __brand) into bare objects, stripping the string base. Options built by queryOptions() then failed useQuery overloads with TS2769, while inline calls - which skip the mapping - worked.

- Short-circuit types carrying a __brand property in MaybeRefDeep so they pass through untouched
- Regression type-tests: branded key through queryOptions into useQuery compiles; nested-branded keys compile; DataTag inference preserved for plain keys
- Patch changeset included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript errors when using branded types with `queryOptions` and `useQuery`.
  * Preserved branded types in deeply referenced query options, including nested values.
  * Ensured branded query keys and query data retain their type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->