### PR TITLE
perf(query-core): skip no-op hydration callbacks and export dehydrateQuery

### DIFF
--- a/.changeset/fast-pandas-hydrate.md
+++ b/.changeset/fast-pandas-hydrate.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/query-core': patch
+---
+
+Improve hydration performance by skipping no-op data transforms and default error-redaction callbacks.
+Export dehydrateQuery.

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -22,6 +22,8 @@ describe('dehydration and rehydration', () => {
       const queryClient = new QueryClient()
       queryClient.setQueryData(key, 'data')
       const query = queryClient.getQueryCache().find({ queryKey: key })!
+      const dehydratedAt = new Date('2024-01-01T00:00:00.000Z')
+      vi.setSystemTime(dehydratedAt)
 
       const dehydrated = dehydrateQuery(query)
 
@@ -30,7 +32,7 @@ describe('dehydration and rehydration', () => {
         queryKey: key,
         state: query.state,
       })
-      expect(dehydrated.dehydratedAt).toBe(Date.now())
+      expect(dehydrated.dehydratedAt).toBe(dehydratedAt.getTime())
       expect(dehydrated.state).not.toBe(query.state)
       expect(dehydrated.promise).toBeUndefined()
 

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -3,6 +3,7 @@ import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { QueryCache } from '../queryCache'
 import { dehydrate, hydrate } from '../hydration'
+import { dehydrateQuery } from '../index'
 import { MutationCache } from '../mutationCache'
 import { executeMutation, mockOnlineManagerIsOnline } from './utils'
 
@@ -13,6 +14,68 @@ describe('dehydration and rehydration', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  describe('dehydrateQuery', () => {
+    it('should dehydrate a query directly without optional callbacks', () => {
+      const key = queryKey()
+      const queryClient = new QueryClient()
+      queryClient.setQueryData(key, 'data')
+      const query = queryClient.getQueryCache().find({ queryKey: key })!
+
+      const dehydrated = dehydrateQuery(query)
+
+      expect(dehydrated).toMatchObject({
+        queryHash: query.queryHash,
+        queryKey: key,
+        state: query.state,
+      })
+      expect(dehydrated.dehydratedAt).toBe(Date.now())
+      expect(dehydrated.state).not.toBe(query.state)
+      expect(dehydrated.promise).toBeUndefined()
+
+      queryClient.clear()
+    })
+
+    it('should serialize data when dehydrating a query directly', () => {
+      const key = queryKey()
+      const data = new Date('2024-01-01T00:00:00.000Z')
+      const serializeData = vi.fn((value: Date) => value.toISOString())
+      const queryClient = new QueryClient()
+      queryClient.setQueryData(key, data)
+      const query = queryClient.getQueryCache().find({ queryKey: key })!
+
+      const dehydrated = dehydrateQuery(query, serializeData)
+
+      expect(dehydrated.state.data).toBe('2024-01-01T00:00:00.000Z')
+      expect(serializeData).toHaveBeenCalledExactlyOnceWith(data)
+      expect(query.state.data).toBe(data)
+
+      queryClient.clear()
+    })
+
+    it('should use shouldRedactErrors when dehydrating a query directly', async () => {
+      const key = queryKey()
+      const testError = new Error('original error')
+      const shouldRedactErrors = vi.fn(() => false)
+      const queryClient = new QueryClient()
+      const promise = queryClient
+        .prefetchQuery({
+          queryKey: key,
+          queryFn: () => Promise.reject(testError),
+          retry: false,
+        })
+        .catch(() => undefined)
+      const query = queryClient.getQueryCache().find({ queryKey: key })!
+
+      const dehydrated = dehydrateQuery(query, undefined, shouldRedactErrors)
+
+      await expect(dehydrated.promise).rejects.toBe(testError)
+      expect(shouldRedactErrors).toHaveBeenCalledExactlyOnceWith(testError)
+      await promise
+
+      queryClient.clear()
+    })
   })
 
   it('should work with serializable values', async () => {
@@ -1266,7 +1329,7 @@ describe('dehydration and rehydration', () => {
     await promise
   })
 
-  it('should handle errors in promises for pending queries', async () => {
+  it('should redact errors by default when shouldRedactErrors is not set', async () => {
     const key = queryKey()
     const consoleMock = vi.spyOn(console, 'error')
     consoleMock.mockImplementation(() => undefined)

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -15,9 +15,6 @@ import type { Mutation, MutationState } from './mutation'
 
 // TYPES
 type TransformerFn = (data: any) => any
-function defaultTransformerFn(data: any): any {
-  return data
-}
 
 function tryResolveSync(promise: PromiseLike<unknown>) {
   let data: unknown
@@ -89,51 +86,57 @@ function dehydrateMutation(mutation: Mutation): DehydratedMutation {
   }
 }
 
+function dehydratePromise(
+  query: Query,
+  serializeData?: TransformerFn,
+  shouldRedactErrors?: (error: unknown) => boolean,
+): Promise<unknown> | undefined {
+  const promise = query.promise?.then(serializeData).catch((error) => {
+    if (shouldRedactErrors?.(error) === false) {
+      // Reject original error if it should not be redacted
+      return Promise.reject(error)
+    }
+    // If not in production, log original error before rejecting redacted error
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(
+        `A query that was dehydrated as pending ended up rejecting. [${query.queryHash}]: ${error}; The error will be redacted in production builds`,
+      )
+    }
+    return Promise.reject(new Error('redacted'))
+  })
+
+  // Avoid unhandled promise rejections
+  // We need the promise we dehydrate to reject to get the correct result into
+  // the query cache, but we also want to avoid unhandled promise rejections
+  // in whatever environment the prefetches are happening in.
+  promise?.catch(noop)
+
+  return promise
+}
+
 // Most config is not dehydrated but instead meant to configure again when
 // consuming the de/rehydrated data, typically with useQuery on the client.
 // Sometimes it might make sense to prefetch data on the server and include
 // in the html-payload, but not consume it on the initial render.
-function dehydrateQuery(
+export function dehydrateQuery(
   query: Query,
-  serializeData: TransformerFn,
-  shouldRedactErrors: (error: unknown) => boolean,
+  serializeData?: TransformerFn,
+  shouldRedactErrors?: (error: unknown) => boolean,
 ): DehydratedQuery {
-  const dehydratePromise = () => {
-    const promise = query.promise?.then(serializeData).catch((error) => {
-      if (!shouldRedactErrors(error)) {
-        // Reject original error if it should not be redacted
-        return Promise.reject(error)
-      }
-      // If not in production, log original error before rejecting redacted error
-      if (process.env.NODE_ENV !== 'production') {
-        console.error(
-          `A query that was dehydrated as pending ended up rejecting. [${query.queryHash}]: ${error}; The error will be redacted in production builds`,
-        )
-      }
-      return Promise.reject(new Error('redacted'))
-    })
-
-    // Avoid unhandled promise rejections
-    // We need the promise we dehydrate to reject to get the correct result into
-    // the query cache, but we also want to avoid unhandled promise rejections
-    // in whatever environment the prefetches are happening in.
-    promise?.catch(noop)
-
-    return promise
-  }
-
   return {
     dehydratedAt: Date.now(),
     state: {
       ...query.state,
       ...(query.state.data !== undefined && {
-        data: serializeData(query.state.data),
+        data: serializeData
+          ? serializeData(query.state.data)
+          : query.state.data,
       }),
     },
     queryKey: query.queryKey,
     queryHash: query.queryHash,
     ...(query.state.status === 'pending' && {
-      promise: dehydratePromise(),
+      promise: dehydratePromise(query, serializeData, shouldRedactErrors),
     }),
     ...(query.meta && { meta: query.meta }),
     ...(query.queryType && { queryType: query.queryType }),
@@ -146,10 +149,6 @@ export function defaultShouldDehydrateMutation(mutation: Mutation) {
 
 export function defaultShouldDehydrateQuery(query: Query) {
   return query.state.status === 'success'
-}
-
-function defaultShouldRedactErrors(_: unknown) {
-  return true
 }
 
 export function dehydrate(
@@ -175,13 +174,10 @@ export function dehydrate(
 
   const shouldRedactErrors =
     options.shouldRedactErrors ??
-    client.getDefaultOptions().dehydrate?.shouldRedactErrors ??
-    defaultShouldRedactErrors
+    client.getDefaultOptions().dehydrate?.shouldRedactErrors
 
   const serializeData =
-    options.serializeData ??
-    client.getDefaultOptions().dehydrate?.serializeData ??
-    defaultTransformerFn
+    options.serializeData ?? client.getDefaultOptions().dehydrate?.serializeData
 
   const queries = client
     .getQueryCache()
@@ -208,8 +204,7 @@ export function hydrate(
   const queryCache = client.getQueryCache()
   const deserializeData =
     options?.defaultOptions?.deserializeData ??
-    client.getDefaultOptions().hydrate?.deserializeData ??
-    defaultTransformerFn
+    client.getDefaultOptions().hydrate?.deserializeData
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const mutations = (dehydratedState as DehydratedState).mutations || []
@@ -240,7 +235,12 @@ export function hydrate(
     }) => {
       const syncData = promise ? tryResolveSync(promise) : undefined
       const rawData = state.data === undefined ? syncData?.data : state.data
-      const data = rawData === undefined ? rawData : deserializeData(rawData)
+      const data =
+        rawData === undefined
+          ? rawData
+          : deserializeData
+            ? deserializeData(rawData)
+            : rawData
 
       let query = queryCache.get(queryHash)
       const existingQueryIsPending = query?.state.status === 'pending'

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -6,6 +6,7 @@ export {
   defaultShouldDehydrateMutation,
   defaultShouldDehydrateQuery,
   dehydrate,
+  dehydrateQuery,
   hydrate,
 } from './hydration'
 export { InfiniteQueryObserver } from './infiniteQueryObserver'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported `dehydrateQuery` for direct use.
  * Made data serialization and deserialization optional during hydration.
  * Improved hydration performance by avoiding unnecessary transformations.
  * Added flexible error-redaction handling with secure defaults.

* **Bug Fixes**
  * Preserved data correctly when no serialization or deserialization callback is provided.

* **Chores**
  * Prepared a patch release for `@tanstack/query-core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->