### PR TITLE
fix(svelte-query): useMutationState array never shrank when mutations stopped matching filter

### DIFF
--- a/.changeset/fix-svelte-use-mutation-state-shrink.md
+++ b/.changeset/fix-svelte-use-mutation-state-shrink.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/svelte-query": patch
+---
+
+fix(svelte-query): use splice in useMutationState so the result array shrinks when mutations no longer match the filter

--- a/packages/svelte-query/src/useMutationState.svelte.ts
+++ b/packages/svelte-query/src/useMutationState.svelte.ts
@@ -44,7 +44,7 @@ export function useMutationState<
         getResult(mutationCache, options),
       )
       if (result !== nextResult) {
-        Object.assign(result, nextResult)
+        result.splice(0, result.length, ...nextResult)
       }
     })
 

--- a/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
+++ b/packages/svelte-query/tests/useMutationState/useMutationState.svelte.test.ts
@@ -157,3 +157,54 @@ describe('useMutationState', () => {
     expect(rendered.getByText('Data: ["success"]')).toBeInTheDocument()
   })
 })
+
+describe('useMutationState - array shrinks when mutations no longer match filter', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    queryClient = new QueryClient()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+    vi.useRealTimers()
+  })
+
+  it('should remove mutations that no longer match the filter', async () => {
+    const firstKey = queryKey()
+    const secondKey = queryKey()
+    const mutationFn = vi.fn(() => sleep(10).then(() => 'data'))
+
+    const rendered = render(Base, {
+      props: {
+        queryClient,
+        successMutationOpts: () => ({
+          mutationKey: firstKey,
+          mutationFn,
+        }),
+        errorMutationOpts: () => ({
+          mutationKey: secondKey,
+          mutationFn,
+        }),
+        mutationStateOpts: {
+          filters: { status: 'pending' },
+        },
+      },
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: /Success/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /Error/i }))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(
+      rendered.getByText('Data: ["pending","pending"]'),
+    ).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    // Both mutations settled — zero now match status: 'pending'
+    // Previously Object.assign never shrank the array so this stayed ["pending","pending"]
+    expect(rendered.getByText('Data: []')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

`useMutationState()` in `@tanstack/svelte-query` never removed entries from its returned array. Once a mutation stopped matching `filters` (settled, was garbage-collected, or `mutationCache.clear()` was called), the stale entry stayed in the array forever.

## Root cause

The cache-subscription callback updates the reactive `$state` array with:

```ts
Object.assign(result, nextResult)
```

`Object.assign` copies enumerable own properties — the numeric indices of `nextResult` — but never adjusts `Array.length`. When `nextResult` is shorter than `result`, the trailing stale entries are never touched and `result.length` is never updated.

This bug was introduced in the Svelte 5 runes rewrite (#9694) and has been present since.

## Fix

```diff
- Object.assign(result, nextResult)
+ result.splice(0, result.length, ...nextResult)
```

`splice` keeps the `$state` array reference intact (required by Svelte 5 runes — reassigning `result = nextResult` would lose reactivity) while correctly adjusting `length`, replacing all elements, and removing stale trailing entries.

## Test

Added regression test: two mutations started concurrently both match `filters: { status: 'pending' }`. After both settle, the result array must shrink to `[]`. Previously this assertion failed — the array stayed `["pending", "pending"]` indefinitely.

All 7 existing tests continue to pass.

Fixes #11152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mutation state tracking so results are removed when mutations no longer match the selected filter.
  * Ensured filtered mutation lists accurately shrink after mutations finish.

* **Tests**
  * Added coverage verifying pending mutation entries are cleared once mutations settle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->