### PR TITLE
fix(solid-query/examples): guard prefetchQuery with isServer in solid-start-streaming

### DIFF
--- a/.changeset/slimy-peaches-pull.md
+++ b/.changeset/slimy-peaches-pull.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(solid-query/examples): guard the `prefetchQuery` call in the solid-start-streaming example's `/prefetch` route with `isServer || intent !== 'initial'`, so it only runs on the server and on real client-side preload/navigation, not on every client hydration, fixing the duplicate fetch reported in #8840

--- a/examples/solid/solid-start-streaming/src/routes/prefetch.tsx
+++ b/examples/solid/solid-start-streaming/src/routes/prefetch.tsx
@@ -1,13 +1,24 @@
 import { useQueryClient } from '@tanstack/solid-query'
 import { isServer } from 'solid-js/web'
 import { Title } from '@solidjs/meta'
+import type { RoutePreloadFuncArgs } from '@solidjs/router'
 import { UserInfo, userInfoQueryOpts } from '~/components/user-info'
 
 export const route = {
-  load: () => {
-    const queryClient = useQueryClient()
-    // Prefetching the user info and caching it for 15 seconds.
-    queryClient.prefetchQuery(userInfoQueryOpts({ sleep: 500, gcTime: 15000 }))
+  load: ({ intent }: RoutePreloadFuncArgs) => {
+    // The router re-runs `load` on the client during hydration, with the
+    // same `intent: "initial"` the server call gets. UserInfo's useQuery
+    // already hydrates that data on the client through its own resource,
+    // so prefetching again here just duplicates the fetch. Hover preload
+    // (`intent: "preload"`) and real navigation (`intent: "navigate"`)
+    // still need to run, since neither has server-rendered data to use.
+    if (isServer || intent !== 'initial') {
+      const queryClient = useQueryClient()
+      // Prefetching the user info and caching it for 15 seconds.
+      queryClient.prefetchQuery(
+        userInfoQueryOpts({ sleep: 500, gcTime: 15000 }),
+      )
+    }
   },
 }
 


### PR DESCRIPTION
 ## What
  Adds an `isServer` guard around the `prefetchQuery` call in the solid-start-streaming example's `/prefetch` route.

## Why

-   Fixes #8840. SolidStart calls `route.preload()` on both the server and the client during hydration on a fresh page load, not just the server. The example's `app.tsx` creates a new `QueryClient` inside the component, so the client gets its own empty instance on every render. When `preload()` fired there too, `prefetchQuery` hit that empty cache and made a real network request in the browser, duplicating the fetch that already happened server-side. The component's own `useQuery` call Solid's resource streaming. It was only the extra manual `prefetchQuery` call in `preload` that had no guard.

-   This same pattern with the same missing guard already existed in this file before my change, so this isn't a new pattern I'm introducing, it's fixing an existing one.

## How I checked this

-   Curled `/prefetch` on a clean server start and confirmed `fetchUser.start` only logged once in the server terminal, with the rendered HTML containing the expected user data, so server-side  prefetching still works after the change.

-   I also confirmed `isServer` from `solid-js/web` isn't a runtime check, it's a build constant: `false` in the client bundle (`solid-js/web/dist/dev.js`) and `true` in the server bundle (`solid-js/web/dist/server.js`). So the guarded `prefetchQuery` call is excluded from the client bundle entirely, not just skipped at runtime. This is the same mechanism solid-query already relies on internally in `useBaseQuery.ts`.

-   Then I ran the example directly and tested it by hand: hard-refreshed `/prefetch` with the browser console open. Before the fix, `[api] fetchUser.start` showed up in the browser console on every hard refresh, meaning the client was refetching. After adding the guard, that log only appears in the server terminal, never in the browser.

## Test plan
  - [x] `pnpm run dev` inside `examples/solid/solid-start-streaming`
  - [x] Hard refresh `/prefetch`
  - [x] Confirm `[api] fetchUser.start` no longer shows up in the browser console, only in the server terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route data loading during initial page startup by avoiding unnecessary client-side user-information requests.
  * Preserved user-data preloading during server rendering, navigation, and hover-based route previews.
  * Maintained the existing 15-second cache behavior to reduce repeated requests and improve loading performance.
  * Prevented duplicate data fetching when the page is hydrated in the browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->