### PR TITLE
test(*): add adapter-level type coverage for optional undefinable mutate variables

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
@@ -72,4 +72,13 @@ describe('injectMutation', () => {
       >()
     })
   })
+
+  it('should allow calling mutate with no arguments when TVariables is optional undefinable', () => {
+    const mutation = injectMutation(() => ({
+      mutationFn: (_variables: number | undefined) => sleep(0).then(() => 1),
+    }))
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith()
+  })
 })

--- a/packages/preact-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test-d.tsx
@@ -79,6 +79,15 @@ describe('useMutation', () => {
     expectTypeOf(mutation.mutate).toBeCallableWith()
   })
 
+  it('should allow calling mutate with no arguments when TVariables is optional undefinable', () => {
+    const mutation = useMutation({
+      mutationFn: (_variables: number | undefined) => Promise.resolve(1),
+    })
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith()
+  })
+
   it('should infer custom TError type', () => {
     class CustomError extends Error {
       code: number

--- a/packages/react-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test-d.tsx
@@ -79,6 +79,15 @@ describe('useMutation', () => {
     expectTypeOf(mutation.mutate).toBeCallableWith()
   })
 
+  it('should allow calling mutate with no arguments when TVariables is optional undefinable', () => {
+    const mutation = useMutation({
+      mutationFn: (_variables: number | undefined) => Promise.resolve(1),
+    })
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith()
+  })
+
   it('should infer custom TError type', () => {
     class CustomError extends Error {
       code: number

--- a/packages/solid-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test-d.tsx
@@ -79,6 +79,15 @@ describe('useMutation', () => {
     expectTypeOf(mutation.mutate).toBeCallableWith()
   })
 
+  it('should allow calling mutate with no arguments when TVariables is optional undefinable', () => {
+    const mutation = useMutation(() => ({
+      mutationFn: (_variables: number | undefined) => Promise.resolve(1),
+    }))
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith()
+  })
+
   it('should infer custom TError type', () => {
     class CustomError extends Error {
       code: number

--- a/packages/svelte-query/tests/createMutation/createMutation.test-d.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.test-d.ts
@@ -79,6 +79,15 @@ describe('createMutation', () => {
     expectTypeOf(mutation.mutate).toBeCallableWith()
   })
 
+  it('should allow calling mutate with no arguments when TVariables is optional undefinable', () => {
+    const mutation = createMutation(() => ({
+      mutationFn: (_variables: number | undefined) => Promise.resolve(1),
+    }))
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith()
+  })
+
   it('should infer custom TError type', () => {
     class CustomError extends Error {
       code: number

--- a/packages/vue-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useMutation.test-d.tsx
@@ -84,3 +84,16 @@ describe('Discriminated union return type', () => {
     expectTypeOf(mutation.variables).toEqualTypeOf<string>()
   })
 })
+
+describe('useMutation', () => {
+  it('should allow calling mutate with no arguments when TVariables is optional undefinable', () => {
+    const mutation = reactive(
+      useMutation({
+        mutationFn: (_variables: number | undefined) => sleep(0).then(() => 1),
+      }),
+    )
+
+    expectTypeOf(mutation.mutate).toBeCallableWith()
+    expectTypeOf(mutation.mutateAsync).toBeCallableWith()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`fix(query-core): make MutateFunction optional undefinable-variables (#8737)` made `MutateFunction`'s variables parameter optional when `TVariables` includes `undefined` (e.g. `number | undefined`), and updated the `mutate` wrapper in every framework adapter (`args[0] as TVariables` cast) to match. That PR added type-level tests for the conditional type itself in `query-core/src/__tests__/mutations.test-d.tsx`, but no adapter exposed an equivalent type-level check for its own exported `mutate`/`mutateAsync` function (`UseMutateFunction`, `CreateMutateFunction`, etc.).

This PR adds one `.test-d` case per adapter asserting that `mutate`/`mutateAsync` can be called with no arguments when `TVariables` is an optional undefinable type:

- `react-query/src/__tests__/useMutation.test-d.tsx`
- `preact-query/src/__tests__/useMutation.test-d.tsx`
- `solid-query/src/__tests__/useMutation.test-d.tsx`
- `svelte-query/tests/createMutation/createMutation.test-d.ts`
- `angular-query-experimental/src/__tests__/inject-mutation.test-d.ts`
- `vue-query/src/__tests__/useMutation.test-d.tsx`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
