### PR TITLE
fix(preact-query): do not go into optimistic fetching state when not subscribed

### DIFF
--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query': patch
+---
+
+fix(preact-query): do not go into optimistic fetching state when not subscribed

--- a/packages/preact-query/src/__tests__/useQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useQueries.test.tsx
@@ -64,6 +64,34 @@ describe('useQueries', () => {
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
   })
 
+  it('should not optimistically show fetching when unsubscribed', () => {
+    const key = queryKey()
+    const queryFn = vi.fn(() => Promise.resolve('data'))
+
+    function Page() {
+      const [query] = useQueries({
+        queries: [{ queryKey: key, queryFn }],
+        subscribed: false,
+      })
+
+      return (
+        <div>
+          <span>isFetching: {String(query.isFetching)}</span>
+          <span>fetchStatus: {query.fetchStatus}</span>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    expect(queryFn).not.toHaveBeenCalled()
+    expect(
+      queryClient.getQueryCache().find({ queryKey: key })!.observers.length,
+    ).toBe(0)
+    rendered.getByText('isFetching: false')
+    rendered.getByText('fetchStatus: idle')
+  })
+
   it('should track results', async () => {
     const key1 = queryKey()
     const results: Array<Array<UseQueryResult>> = []

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -5895,6 +5895,35 @@ describe('useQuery', () => {
       ).toBe(1)
     })
 
+    it('should not optimistically show fetching when subscribed is false', () => {
+      const key = queryKey()
+      const queryFn = vi.fn(() => Promise.resolve('data'))
+
+      function Page() {
+        const query = useQuery({
+          queryKey: key,
+          queryFn,
+          subscribed: false,
+        })
+
+        return (
+          <div>
+            <span>isFetching: {String(query.isFetching)}</span>
+            <span>fetchStatus: {query.fetchStatus}</span>
+          </div>
+        )
+      }
+
+      const rendered = renderWithClient(queryClient, <Page />)
+
+      expect(queryFn).not.toHaveBeenCalled()
+      expect(
+        queryClient.getQueryCache().find({ queryKey: key })!.observers.length,
+      ).toBe(0)
+      rendered.getByText('isFetching: false')
+      rendered.getByText('fetchStatus: idle')
+    })
+
     it('should not be attached to the query when subscribed is false', async () => {
       const key = queryKey()
       const queryFn = vi.fn(() => Promise.resolve('data'))

--- a/packages/preact-query/src/useBaseQuery.ts
+++ b/packages/preact-query/src/useBaseQuery.ts
@@ -70,10 +70,14 @@ export function useBaseQuery<
     }
   }
 
+  const subscribed = options.subscribed !== false
+
   // Make sure results are optimistically set in fetching state before subscribing or updating options
   defaultedOptions._optimisticResults = isRestoring
     ? 'isRestoring'
-    : 'optimistic'
+    : subscribed
+      ? 'optimistic'
+      : undefined
 
   ensureSuspenseTimers(defaultedOptions)
   ensurePreventErrorBoundaryRetry(defaultedOptions, errorResetBoundary, query)
@@ -91,7 +95,7 @@ export function useBaseQuery<
   // note: this must be called before useSyncExternalStore
   const result = observer.getOptimisticResult(defaultedOptions)
 
-  const shouldSubscribe = !isRestoring && options.subscribed !== false
+  const shouldSubscribe = !isRestoring && subscribed
   useSyncExternalStore(
     useCallback(
       (onStoreChange) => {

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -223,6 +223,7 @@ export function useQueries<
   const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
   const errorResetBoundary = useQueryErrorResetBoundary()
+  const subscribed = options.subscribed !== false
 
   const defaultedQueries = useMemo(
     () =>
@@ -234,11 +235,13 @@ export function useQueries<
         // Make sure the results are already in fetching state before subscribing or updating options
         defaultedOptions._optimisticResults = isRestoring
           ? 'isRestoring'
-          : 'optimistic'
+          : subscribed
+            ? 'optimistic'
+            : undefined
 
         return defaultedOptions
       }),
-    [queries, client, isRestoring],
+    [queries, client, isRestoring, subscribed],
   )
 
   defaultedQueries.forEach((queryOptions) => {
@@ -265,7 +268,7 @@ export function useQueries<
       (options as QueriesObserverOptions<TCombinedResult>).combine,
     )
 
-  const shouldSubscribe = !isRestoring && options.subscribed !== false
+  const shouldSubscribe = !isRestoring && subscribed
   useSyncExternalStore(
     useCallback(
       (onStoreChange) =>


### PR DESCRIPTION
## Problem

`subscribed: false` is broken in `@tanstack/preact-query`. A hook that opts out of subscribing still reports `isFetching: true` / `fetchStatus: 'fetching'` on first render, even though no observer is ever attached and the `queryFn` is never called.

The Preact adapter was forked from React in #9935 (Feb 2026) and then missed two fixes that landed on the React side afterwards:

- #10759 (May 2026) — `useBaseQuery`
- #11130 (Aug 2026) — `useQueries`

Both hooks in `preact-query` still set `_optimisticResults = 'optimistic'` unconditionally. In `createResult`, that branch computes `fetchOnMount = !mounted && shouldFetchOnMount(query, options)`; with no listeners attached, `mounted` is `false` and the result is optimistically flipped into `fetchState` — a fetch that will never happen. `useQueries` additionally left `subscribed` out of the `useMemo` dependency array, so toggling it did not recompute the defaulted options.

## Fix

Port the two upstream changes verbatim: derive `subscribed` once, use it to gate `_optimisticResults` (`undefined` when not subscribed), add it to the `useQueries` dependency array, and reuse it for `shouldSubscribe`. The diff is identical in shape to `react-query`'s current `useBaseQuery.ts` / `useQueries.ts`.

## Tests

Two regression tests, mirroring the ones added upstream:

- `useQuery.test.tsx` — added to the existing `subscribed` describe block
- `useQueries.test.tsx` — the Preact counterpart of the test from #11130

Both are synchronous, so there is no timer race.

## Validation

Run from the repo root with `pnpm nx run @tanstack/preact-query:test:lib --skip-nx-cache`.

- Baseline on `main`: 34 files / 524 tests passing, no type errors.
- With this PR: 34 files / 526 tests passing, no type errors.
- Red/green, each half checked separately: reverting only `useBaseQuery.ts` fails just the `useQuery` test; reverting only `useQueries.ts` fails just the `useQueries` test. Reverting both fails both, with `isFetching: true` / `fetchStatus: fetching` rendered where `false` / `idle` is expected.
- Also ran `test:types`, `test:eslint`, `test:build` and `build` for the package, plus `prettier --check` on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented queries from entering a fetching state when subscription is disabled.
  - Disabled query execution and observer registration for unsubscribed queries.
  - Unsubscribed queries now correctly report `isFetching: false` and an idle fetch status.

- **Tests**
  - Added coverage for unsubscribed behavior in `useQuery` and `useQueries`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->