### PR TITLE
docs(config): register all TypeDoc-generated reference pages with category-prefixed labels

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1212,52 +1212,164 @@
               "to": "framework/svelte/reference/index"
             },
             {
-              "label": "createQuery",
+              "label": "Functions / createQuery",
               "to": "framework/svelte/reference/functions/createQuery"
             },
             {
-              "label": "createQueries",
+              "label": "Functions / createQueries",
               "to": "framework/svelte/reference/functions/createQueries"
             },
             {
-              "label": "createInfiniteQuery",
+              "label": "Functions / createInfiniteQuery",
               "to": "framework/svelte/reference/functions/createInfiniteQuery"
             },
             {
-              "label": "createMutation",
+              "label": "Functions / createMutation",
               "to": "framework/svelte/reference/functions/createMutation"
             },
             {
-              "label": "useIsFetching",
+              "label": "Functions / useIsFetching",
               "to": "framework/svelte/reference/functions/useIsFetching"
             },
             {
-              "label": "useIsMutating",
+              "label": "Functions / useIsMutating",
               "to": "framework/svelte/reference/functions/useIsMutating"
             },
             {
-              "label": "useMutationState",
+              "label": "Functions / useMutationState",
               "to": "framework/svelte/reference/functions/useMutationState"
             },
             {
-              "label": "useQueryClient",
+              "label": "Functions / useQueryClient",
               "to": "framework/svelte/reference/functions/useQueryClient"
             },
             {
-              "label": "queryOptions",
+              "label": "Functions / queryOptions",
               "to": "framework/svelte/reference/functions/queryOptions"
             },
             {
-              "label": "infiniteQueryOptions",
+              "label": "Functions / infiniteQueryOptions",
               "to": "framework/svelte/reference/functions/infiniteQueryOptions"
             },
             {
-              "label": "mutationOptions",
+              "label": "Functions / mutationOptions",
               "to": "framework/svelte/reference/functions/mutationOptions"
             },
             {
-              "label": "useHydrate",
+              "label": "Functions / useHydrate",
               "to": "framework/svelte/reference/functions/useHydrate"
+            },
+            {
+              "label": "Functions / getIsRestoringContext",
+              "to": "framework/svelte/reference/functions/getIsRestoringContext"
+            },
+            {
+              "label": "Functions / getQueryClientContext",
+              "to": "framework/svelte/reference/functions/getQueryClientContext"
+            },
+            {
+              "label": "Functions / setIsRestoringContext",
+              "to": "framework/svelte/reference/functions/setIsRestoringContext"
+            },
+            {
+              "label": "Functions / setQueryClientContext",
+              "to": "framework/svelte/reference/functions/setQueryClientContext"
+            },
+            {
+              "label": "Functions / useIsRestoring",
+              "to": "framework/svelte/reference/functions/useIsRestoring"
+            },
+            {
+              "label": "Types / Accessor",
+              "to": "framework/svelte/reference/type-aliases/Accessor"
+            },
+            {
+              "label": "Types / CreateBaseMutationResult",
+              "to": "framework/svelte/reference/type-aliases/CreateBaseMutationResult"
+            },
+            {
+              "label": "Types / CreateBaseQueryOptions",
+              "to": "framework/svelte/reference/type-aliases/CreateBaseQueryOptions"
+            },
+            {
+              "label": "Types / CreateBaseQueryResult",
+              "to": "framework/svelte/reference/type-aliases/CreateBaseQueryResult"
+            },
+            {
+              "label": "Types / CreateInfiniteQueryOptions",
+              "to": "framework/svelte/reference/type-aliases/CreateInfiniteQueryOptions"
+            },
+            {
+              "label": "Types / CreateInfiniteQueryResult",
+              "to": "framework/svelte/reference/type-aliases/CreateInfiniteQueryResult"
+            },
+            {
+              "label": "Types / CreateMutateAsyncFunction",
+              "to": "framework/svelte/reference/type-aliases/CreateMutateAsyncFunction"
+            },
+            {
+              "label": "Types / CreateMutateFunction",
+              "to": "framework/svelte/reference/type-aliases/CreateMutateFunction"
+            },
+            {
+              "label": "Types / CreateMutationOptions",
+              "to": "framework/svelte/reference/type-aliases/CreateMutationOptions"
+            },
+            {
+              "label": "Types / CreateMutationResult",
+              "to": "framework/svelte/reference/type-aliases/CreateMutationResult"
+            },
+            {
+              "label": "Types / CreateQueryOptions",
+              "to": "framework/svelte/reference/type-aliases/CreateQueryOptions"
+            },
+            {
+              "label": "Types / CreateQueryResult",
+              "to": "framework/svelte/reference/type-aliases/CreateQueryResult"
+            },
+            {
+              "label": "Types / DefinedCreateBaseQueryResult",
+              "to": "framework/svelte/reference/type-aliases/DefinedCreateBaseQueryResult"
+            },
+            {
+              "label": "Types / DefinedCreateQueryResult",
+              "to": "framework/svelte/reference/type-aliases/DefinedCreateQueryResult"
+            },
+            {
+              "label": "Types / DefinedInitialDataOptions",
+              "to": "framework/svelte/reference/type-aliases/DefinedInitialDataOptions"
+            },
+            {
+              "label": "Types / HydrationBoundary",
+              "to": "framework/svelte/reference/type-aliases/HydrationBoundary"
+            },
+            {
+              "label": "Types / MutationStateOptions",
+              "to": "framework/svelte/reference/type-aliases/MutationStateOptions"
+            },
+            {
+              "label": "Types / MutationTypeFromResult",
+              "to": "framework/svelte/reference/type-aliases/MutationTypeFromResult"
+            },
+            {
+              "label": "Types / QueriesOptions",
+              "to": "framework/svelte/reference/type-aliases/QueriesOptions"
+            },
+            {
+              "label": "Types / QueriesResults",
+              "to": "framework/svelte/reference/type-aliases/QueriesResults"
+            },
+            {
+              "label": "Types / QueryClientProviderProps",
+              "to": "framework/svelte/reference/type-aliases/QueryClientProviderProps"
+            },
+            {
+              "label": "Types / UndefinedInitialDataOptions",
+              "to": "framework/svelte/reference/type-aliases/UndefinedInitialDataOptions"
+            },
+            {
+              "label": "Variables / HydrationBoundary",
+              "to": "framework/svelte/reference/variables/HydrationBoundary"
             }
           ]
         },
@@ -1269,7 +1381,7 @@
               "to": "framework/lit/reference/index"
             },
             {
-              "label": "QueryClientProvider",
+              "label": "Classes / QueryClientProvider",
               "to": "framework/lit/reference/classes/QueryClientProvider"
             },
             {
@@ -1335,6 +1447,102 @@
             {
               "label": "Context / resolveQueryClient",
               "to": "framework/lit/reference/functions/resolveQueryClient"
+            },
+            {
+              "label": "Types / Accessor",
+              "to": "framework/lit/reference/type-aliases/Accessor"
+            },
+            {
+              "label": "Types / CreateInfiniteQueryOptions",
+              "to": "framework/lit/reference/type-aliases/CreateInfiniteQueryOptions"
+            },
+            {
+              "label": "Types / CreateMutationOptions",
+              "to": "framework/lit/reference/type-aliases/CreateMutationOptions"
+            },
+            {
+              "label": "Types / CreateQueriesControllerOptions",
+              "to": "framework/lit/reference/type-aliases/CreateQueriesControllerOptions"
+            },
+            {
+              "label": "Types / CreateQueriesInput",
+              "to": "framework/lit/reference/type-aliases/CreateQueriesInput"
+            },
+            {
+              "label": "Types / CreateQueryOptions",
+              "to": "framework/lit/reference/type-aliases/CreateQueryOptions"
+            },
+            {
+              "label": "Types / DefinedInitialDataOptions",
+              "to": "framework/lit/reference/type-aliases/DefinedInitialDataOptions"
+            },
+            {
+              "label": "Types / InfiniteQueryControllerOptions",
+              "to": "framework/lit/reference/type-aliases/InfiniteQueryControllerOptions"
+            },
+            {
+              "label": "Types / InfiniteQueryResultAccessor",
+              "to": "framework/lit/reference/type-aliases/InfiniteQueryResultAccessor"
+            },
+            {
+              "label": "Types / IsFetchingAccessor",
+              "to": "framework/lit/reference/type-aliases/IsFetchingAccessor"
+            },
+            {
+              "label": "Types / IsMutatingAccessor",
+              "to": "framework/lit/reference/type-aliases/IsMutatingAccessor"
+            },
+            {
+              "label": "Types / MutationControllerOptions",
+              "to": "framework/lit/reference/type-aliases/MutationControllerOptions"
+            },
+            {
+              "label": "Types / MutationControllerResult",
+              "to": "framework/lit/reference/type-aliases/MutationControllerResult"
+            },
+            {
+              "label": "Types / MutationResultAccessor",
+              "to": "framework/lit/reference/type-aliases/MutationResultAccessor"
+            },
+            {
+              "label": "Types / MutationStateAccessor",
+              "to": "framework/lit/reference/type-aliases/MutationStateAccessor"
+            },
+            {
+              "label": "Types / MutationStateOptions",
+              "to": "framework/lit/reference/type-aliases/MutationStateOptions"
+            },
+            {
+              "label": "Types / QueriesControllerOptions",
+              "to": "framework/lit/reference/type-aliases/QueriesControllerOptions"
+            },
+            {
+              "label": "Types / QueriesResultAccessor",
+              "to": "framework/lit/reference/type-aliases/QueriesResultAccessor"
+            },
+            {
+              "label": "Types / QueryControllerOptions",
+              "to": "framework/lit/reference/type-aliases/QueryControllerOptions"
+            },
+            {
+              "label": "Types / QueryControllerResult",
+              "to": "framework/lit/reference/type-aliases/QueryControllerResult"
+            },
+            {
+              "label": "Types / QueryResultAccessor",
+              "to": "framework/lit/reference/type-aliases/QueryResultAccessor"
+            },
+            {
+              "label": "Types / UndefinedInitialDataOptions",
+              "to": "framework/lit/reference/type-aliases/UndefinedInitialDataOptions"
+            },
+            {
+              "label": "Types / UnusedSkipTokenOptions",
+              "to": "framework/lit/reference/type-aliases/UnusedSkipTokenOptions"
+            },
+            {
+              "label": "Types / ValueAccessor",
+              "to": "framework/lit/reference/type-aliases/ValueAccessor"
             }
           ]
         },
@@ -1346,60 +1554,200 @@
               "to": "framework/angular/reference/index"
             },
             {
-              "label": "infiniteQueryOptions",
+              "label": "Functions / infiniteQueryOptions",
               "to": "framework/angular/reference/functions/infiniteQueryOptions"
             },
             {
-              "label": "injectInfiniteQuery",
+              "label": "Functions / injectInfiniteQuery",
               "to": "framework/angular/reference/functions/injectInfiniteQuery"
             },
             {
-              "label": "injectIsFetching",
+              "label": "Functions / injectIsFetching",
               "to": "framework/angular/reference/functions/injectIsFetching"
             },
             {
-              "label": "injectIsMutating",
+              "label": "Functions / injectIsMutating",
               "to": "framework/angular/reference/functions/injectIsMutating"
             },
             {
-              "label": "injectIsRestoring",
+              "label": "Functions / injectIsRestoring",
               "to": "framework/angular/reference/functions/injectIsRestoring"
             },
             {
-              "label": "injectMutation",
+              "label": "Functions / injectMutation",
               "to": "framework/angular/reference/functions/injectMutation"
             },
             {
-              "label": "injectMutationState",
+              "label": "Functions / injectMutationState",
               "to": "framework/angular/reference/functions/injectMutationState"
             },
             {
-              "label": "injectQuery",
+              "label": "Functions / injectQuery",
               "to": "framework/angular/reference/functions/injectQuery"
             },
             {
-              "label": "mutationOptions",
+              "label": "Functions / mutationOptions",
               "to": "framework/angular/reference/functions/mutationOptions"
             },
             {
-              "label": "provideIsRestoring",
+              "label": "Functions / provideIsRestoring",
               "to": "framework/angular/reference/functions/provideIsRestoring"
             },
             {
-              "label": "provideQueryClient",
+              "label": "Functions / provideQueryClient",
               "to": "framework/angular/reference/functions/provideQueryClient"
             },
             {
-              "label": "provideTanStackQuery",
+              "label": "Functions / provideTanStackQuery",
               "to": "framework/angular/reference/functions/provideTanStackQuery"
             },
             {
-              "label": "queryFeature",
+              "label": "Functions / queryFeature",
               "to": "framework/angular/reference/functions/queryFeature"
             },
             {
-              "label": "queryOptions",
+              "label": "Functions / queryOptions",
               "to": "framework/angular/reference/functions/queryOptions"
+            },
+            {
+              "label": "Functions / injectQueryClient",
+              "to": "framework/angular/reference/functions/injectQueryClient"
+            },
+            {
+              "label": "Functions / provideAngularQuery",
+              "to": "framework/angular/reference/functions/provideAngularQuery"
+            },
+            {
+              "label": "Interfaces / BaseMutationNarrowing",
+              "to": "framework/angular/reference/interfaces/BaseMutationNarrowing"
+            },
+            {
+              "label": "Interfaces / BaseQueryNarrowing",
+              "to": "framework/angular/reference/interfaces/BaseQueryNarrowing"
+            },
+            {
+              "label": "Interfaces / CreateBaseQueryOptions",
+              "to": "framework/angular/reference/interfaces/CreateBaseQueryOptions"
+            },
+            {
+              "label": "Interfaces / CreateInfiniteQueryOptions",
+              "to": "framework/angular/reference/interfaces/CreateInfiniteQueryOptions"
+            },
+            {
+              "label": "Interfaces / CreateMutationOptions",
+              "to": "framework/angular/reference/interfaces/CreateMutationOptions"
+            },
+            {
+              "label": "Interfaces / CreateQueryOptions",
+              "to": "framework/angular/reference/interfaces/CreateQueryOptions"
+            },
+            {
+              "label": "Interfaces / InjectInfiniteQueryOptions",
+              "to": "framework/angular/reference/interfaces/InjectInfiniteQueryOptions"
+            },
+            {
+              "label": "Interfaces / InjectIsFetchingOptions",
+              "to": "framework/angular/reference/interfaces/InjectIsFetchingOptions"
+            },
+            {
+              "label": "Interfaces / InjectIsMutatingOptions",
+              "to": "framework/angular/reference/interfaces/InjectIsMutatingOptions"
+            },
+            {
+              "label": "Interfaces / InjectMutationOptions",
+              "to": "framework/angular/reference/interfaces/InjectMutationOptions"
+            },
+            {
+              "label": "Interfaces / InjectMutationStateOptions",
+              "to": "framework/angular/reference/interfaces/InjectMutationStateOptions"
+            },
+            {
+              "label": "Interfaces / InjectQueryOptions",
+              "to": "framework/angular/reference/interfaces/InjectQueryOptions"
+            },
+            {
+              "label": "Interfaces / QueryFeature",
+              "to": "framework/angular/reference/interfaces/QueryFeature"
+            },
+            {
+              "label": "Types / CreateBaseMutationResult",
+              "to": "framework/angular/reference/type-aliases/CreateBaseMutationResult"
+            },
+            {
+              "label": "Types / CreateBaseQueryResult",
+              "to": "framework/angular/reference/type-aliases/CreateBaseQueryResult"
+            },
+            {
+              "label": "Types / CreateInfiniteQueryResult",
+              "to": "framework/angular/reference/type-aliases/CreateInfiniteQueryResult"
+            },
+            {
+              "label": "Types / CreateMutateAsyncFunction",
+              "to": "framework/angular/reference/type-aliases/CreateMutateAsyncFunction"
+            },
+            {
+              "label": "Types / CreateMutateFunction",
+              "to": "framework/angular/reference/type-aliases/CreateMutateFunction"
+            },
+            {
+              "label": "Types / CreateMutationResult",
+              "to": "framework/angular/reference/type-aliases/CreateMutationResult"
+            },
+            {
+              "label": "Types / CreateQueryResult",
+              "to": "framework/angular/reference/type-aliases/CreateQueryResult"
+            },
+            {
+              "label": "Types / DefinedCreateInfiniteQueryResult",
+              "to": "framework/angular/reference/type-aliases/DefinedCreateInfiniteQueryResult"
+            },
+            {
+              "label": "Types / DefinedCreateQueryResult",
+              "to": "framework/angular/reference/type-aliases/DefinedCreateQueryResult"
+            },
+            {
+              "label": "Types / DefinedInitialDataInfiniteOptions",
+              "to": "framework/angular/reference/type-aliases/DefinedInitialDataInfiniteOptions"
+            },
+            {
+              "label": "Types / DefinedInitialDataOptions",
+              "to": "framework/angular/reference/type-aliases/DefinedInitialDataOptions"
+            },
+            {
+              "label": "Types / DevtoolsFeature",
+              "to": "framework/angular/reference/type-aliases/DevtoolsFeature"
+            },
+            {
+              "label": "Types / PersistQueryClientFeature",
+              "to": "framework/angular/reference/type-aliases/PersistQueryClientFeature"
+            },
+            {
+              "label": "Types / QueriesOptions",
+              "to": "framework/angular/reference/type-aliases/QueriesOptions"
+            },
+            {
+              "label": "Types / QueriesResults",
+              "to": "framework/angular/reference/type-aliases/QueriesResults"
+            },
+            {
+              "label": "Types / QueryFeatures",
+              "to": "framework/angular/reference/type-aliases/QueryFeatures"
+            },
+            {
+              "label": "Types / UndefinedInitialDataInfiniteOptions",
+              "to": "framework/angular/reference/type-aliases/UndefinedInitialDataInfiniteOptions"
+            },
+            {
+              "label": "Types / UndefinedInitialDataOptions",
+              "to": "framework/angular/reference/type-aliases/UndefinedInitialDataOptions"
+            },
+            {
+              "label": "Types / UnusedSkipTokenInfiniteOptions",
+              "to": "framework/angular/reference/type-aliases/UnusedSkipTokenInfiniteOptions"
+            },
+            {
+              "label": "Types / UnusedSkipTokenOptions",
+              "to": "framework/angular/reference/type-aliases/UnusedSkipTokenOptions"
             }
           ]
         },
@@ -1411,84 +1759,264 @@
               "to": "framework/preact/reference/index"
             },
             {
-              "label": "useQuery",
+              "label": "Functions / useQuery",
               "to": "framework/preact/reference/functions/useQuery"
             },
             {
-              "label": "useQueries",
+              "label": "Functions / useQueries",
               "to": "framework/preact/reference/functions/useQueries"
             },
             {
-              "label": "useInfiniteQuery",
+              "label": "Functions / useInfiniteQuery",
               "to": "framework/preact/reference/functions/useInfiniteQuery"
             },
             {
-              "label": "useMutation",
+              "label": "Functions / useMutation",
               "to": "framework/preact/reference/functions/useMutation"
             },
             {
-              "label": "useIsFetching",
+              "label": "Functions / useIsFetching",
               "to": "framework/preact/reference/functions/useIsFetching"
             },
             {
-              "label": "useIsMutating",
+              "label": "Functions / useIsMutating",
               "to": "framework/preact/reference/functions/useIsMutating"
             },
             {
-              "label": "useMutationState",
+              "label": "Functions / useMutationState",
               "to": "framework/preact/reference/functions/useMutationState"
             },
             {
-              "label": "useSuspenseQuery",
+              "label": "Functions / useSuspenseQuery",
               "to": "framework/preact/reference/functions/useSuspenseQuery"
             },
             {
-              "label": "useSuspenseInfiniteQuery",
+              "label": "Functions / useSuspenseInfiniteQuery",
               "to": "framework/preact/reference/functions/useSuspenseInfiniteQuery"
             },
             {
-              "label": "useSuspenseQueries",
+              "label": "Functions / useSuspenseQueries",
               "to": "framework/preact/reference/functions/useSuspenseQueries"
             },
             {
-              "label": "QueryClientProvider",
+              "label": "Functions / QueryClientProvider",
               "to": "framework/preact/reference/functions/QueryClientProvider"
             },
             {
-              "label": "useQueryClient",
+              "label": "Functions / useQueryClient",
               "to": "framework/preact/reference/functions/useQueryClient"
             },
             {
-              "label": "queryOptions",
+              "label": "Functions / queryOptions",
               "to": "framework/preact/reference/functions/queryOptions"
             },
             {
-              "label": "infiniteQueryOptions",
+              "label": "Functions / infiniteQueryOptions",
               "to": "framework/preact/reference/functions/infiniteQueryOptions"
             },
             {
-              "label": "mutationOptions",
+              "label": "Functions / mutationOptions",
               "to": "framework/preact/reference/functions/mutationOptions"
             },
             {
-              "label": "usePrefetchQuery",
+              "label": "Functions / usePrefetchQuery",
               "to": "framework/preact/reference/functions/usePrefetchQuery"
             },
             {
-              "label": "usePrefetchInfiniteQuery",
+              "label": "Functions / usePrefetchInfiniteQuery",
               "to": "framework/preact/reference/functions/usePrefetchInfiniteQuery"
             },
             {
-              "label": "QueryErrorResetBoundary",
+              "label": "Functions / QueryErrorResetBoundary",
               "to": "framework/preact/reference/functions/QueryErrorResetBoundary"
             },
             {
-              "label": "useQueryErrorResetBoundary",
+              "label": "Functions / useQueryErrorResetBoundary",
               "to": "framework/preact/reference/functions/useQueryErrorResetBoundary"
             },
             {
-              "label": "hydration",
+              "label": "Functions / HydrationBoundary",
               "to": "framework/preact/reference/functions/HydrationBoundary"
+            },
+            {
+              "label": "Functions / useIsRestoring",
+              "to": "framework/preact/reference/functions/useIsRestoring"
+            },
+            {
+              "label": "Interfaces / HydrationBoundaryProps",
+              "to": "framework/preact/reference/interfaces/HydrationBoundaryProps"
+            },
+            {
+              "label": "Interfaces / QueryErrorResetBoundaryProps",
+              "to": "framework/preact/reference/interfaces/QueryErrorResetBoundaryProps"
+            },
+            {
+              "label": "Interfaces / UseBaseQueryOptions",
+              "to": "framework/preact/reference/interfaces/UseBaseQueryOptions"
+            },
+            {
+              "label": "Interfaces / UseInfiniteQueryOptions",
+              "to": "framework/preact/reference/interfaces/UseInfiniteQueryOptions"
+            },
+            {
+              "label": "Interfaces / UseMutationOptions",
+              "to": "framework/preact/reference/interfaces/UseMutationOptions"
+            },
+            {
+              "label": "Interfaces / UseQueryOptions",
+              "to": "framework/preact/reference/interfaces/UseQueryOptions"
+            },
+            {
+              "label": "Interfaces / UseSuspenseInfiniteQueryOptions",
+              "to": "framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions"
+            },
+            {
+              "label": "Interfaces / UseSuspenseQueryOptions",
+              "to": "framework/preact/reference/interfaces/UseSuspenseQueryOptions"
+            },
+            {
+              "label": "Types / AnyUseBaseQueryOptions",
+              "to": "framework/preact/reference/type-aliases/AnyUseBaseQueryOptions"
+            },
+            {
+              "label": "Types / AnyUseInfiniteQueryOptions",
+              "to": "framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions"
+            },
+            {
+              "label": "Types / AnyUseMutationOptions",
+              "to": "framework/preact/reference/type-aliases/AnyUseMutationOptions"
+            },
+            {
+              "label": "Types / AnyUseQueryOptions",
+              "to": "framework/preact/reference/type-aliases/AnyUseQueryOptions"
+            },
+            {
+              "label": "Types / AnyUseSuspenseInfiniteQueryOptions",
+              "to": "framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions"
+            },
+            {
+              "label": "Types / AnyUseSuspenseQueryOptions",
+              "to": "framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions"
+            },
+            {
+              "label": "Types / DefinedInitialDataInfiniteOptions",
+              "to": "framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions"
+            },
+            {
+              "label": "Types / DefinedInitialDataOptions",
+              "to": "framework/preact/reference/type-aliases/DefinedInitialDataOptions"
+            },
+            {
+              "label": "Types / DefinedUseInfiniteQueryResult",
+              "to": "framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult"
+            },
+            {
+              "label": "Types / DefinedUseQueryResult",
+              "to": "framework/preact/reference/type-aliases/DefinedUseQueryResult"
+            },
+            {
+              "label": "Types / QueriesOptions",
+              "to": "framework/preact/reference/type-aliases/QueriesOptions"
+            },
+            {
+              "label": "Types / QueriesResults",
+              "to": "framework/preact/reference/type-aliases/QueriesResults"
+            },
+            {
+              "label": "Types / QueryClientProviderProps",
+              "to": "framework/preact/reference/type-aliases/QueryClientProviderProps"
+            },
+            {
+              "label": "Types / QueryErrorClearResetFunction",
+              "to": "framework/preact/reference/type-aliases/QueryErrorClearResetFunction"
+            },
+            {
+              "label": "Types / QueryErrorIsResetFunction",
+              "to": "framework/preact/reference/type-aliases/QueryErrorIsResetFunction"
+            },
+            {
+              "label": "Types / QueryErrorResetBoundaryFunction",
+              "to": "framework/preact/reference/type-aliases/QueryErrorResetBoundaryFunction"
+            },
+            {
+              "label": "Types / QueryErrorResetFunction",
+              "to": "framework/preact/reference/type-aliases/QueryErrorResetFunction"
+            },
+            {
+              "label": "Types / SuspenseQueriesOptions",
+              "to": "framework/preact/reference/type-aliases/SuspenseQueriesOptions"
+            },
+            {
+              "label": "Types / SuspenseQueriesResults",
+              "to": "framework/preact/reference/type-aliases/SuspenseQueriesResults"
+            },
+            {
+              "label": "Types / UndefinedInitialDataInfiniteOptions",
+              "to": "framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions"
+            },
+            {
+              "label": "Types / UndefinedInitialDataOptions",
+              "to": "framework/preact/reference/type-aliases/UndefinedInitialDataOptions"
+            },
+            {
+              "label": "Types / UnusedSkipTokenInfiniteOptions",
+              "to": "framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions"
+            },
+            {
+              "label": "Types / UnusedSkipTokenOptions",
+              "to": "framework/preact/reference/type-aliases/UnusedSkipTokenOptions"
+            },
+            {
+              "label": "Types / UseBaseMutationResult",
+              "to": "framework/preact/reference/type-aliases/UseBaseMutationResult"
+            },
+            {
+              "label": "Types / UseBaseQueryResult",
+              "to": "framework/preact/reference/type-aliases/UseBaseQueryResult"
+            },
+            {
+              "label": "Types / UseInfiniteQueryResult",
+              "to": "framework/preact/reference/type-aliases/UseInfiniteQueryResult"
+            },
+            {
+              "label": "Types / UseMutateAsyncFunction",
+              "to": "framework/preact/reference/type-aliases/UseMutateAsyncFunction"
+            },
+            {
+              "label": "Types / UseMutateFunction",
+              "to": "framework/preact/reference/type-aliases/UseMutateFunction"
+            },
+            {
+              "label": "Types / UseMutationResult",
+              "to": "framework/preact/reference/type-aliases/UseMutationResult"
+            },
+            {
+              "label": "Types / UsePrefetchInfiniteQueryOptions",
+              "to": "framework/preact/reference/type-aliases/UsePrefetchInfiniteQueryOptions"
+            },
+            {
+              "label": "Types / UsePrefetchQueryOptions",
+              "to": "framework/preact/reference/type-aliases/UsePrefetchQueryOptions"
+            },
+            {
+              "label": "Types / UseQueryResult",
+              "to": "framework/preact/reference/type-aliases/UseQueryResult"
+            },
+            {
+              "label": "Types / UseSuspenseInfiniteQueryResult",
+              "to": "framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult"
+            },
+            {
+              "label": "Types / UseSuspenseQueryResult",
+              "to": "framework/preact/reference/type-aliases/UseSuspenseQueryResult"
+            },
+            {
+              "label": "Variables / IsRestoringProvider",
+              "to": "framework/preact/reference/variables/IsRestoringProvider"
+            },
+            {
+              "label": "Variables / QueryClientContext",
+              "to": "framework/preact/reference/variables/QueryClientContext"
             }
           ]
         }


### PR DESCRIPTION
## 🎯 Changes

The sidebar (`docs/config.json`) for the 4 TypeDoc-generated frameworks (angular, svelte, preact, lit) only registered `functions/` pages, leaving every `classes/`, `interfaces/`, and `type-aliases/` page (and one `variables/` page in svelte/preact/lit) unreachable from the sidebar tree. This matches TanStack Form's convention, where every generated category is registered with a `<Category> / <Name>` label.

This PR:

- Registers all 195 currently-generated reference pages across the 4 frameworks (132 newly added) with `Classes / X`, `Functions / X`, `Interfaces / X`, `Types / X`, `Variables / X` labels.
- Normalizes the 47 pre-existing bare-label `Functions` entries (e.g. `useQuery` → `Functions / useQuery`) to the same convention for consistency, using the actual file name as the source of truth for the name half of the label (fixes one label/file-name mismatch: preact's `hydration` entry pointed at `HydrationBoundary.md`, now labeled `Functions / HydrationBoundary`).
- Leaves Lit's hand-curated `Context / X` grouping (5 entries covering `queryClientContext` and related functions) and other multi-word labels untouched — only bare, unprefixed labels were normalized.

Verified: every entry's `to` resolves to an existing file (0 missing, 0 pointing at nonexistent pages) across all 4 frameworks, valid JSON, `prettier --check` passes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API-reference navigation for Svelte, Lit, Angular, and Preact.
  * Added category labels and expanded listings for available functions, interfaces, types, variables, and classes.
  * Improved consistency and coverage across framework-specific documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->