### PR TITLE
fix(examples/vue/nuxt3): guard hydrate() against a null dehydrated state

### DIFF
--- a/examples/vue/nuxt3/plugins/vue-query.ts
+++ b/examples/vue/nuxt3/plugins/vue-query.ts
@@ -28,9 +28,10 @@ export default defineNuxtPlugin((nuxt) => {
     })
   }
 
-  if (import.meta.client) {
+  if (import.meta.client && vueQueryState.value) {
+    const dehydratedState = vueQueryState.value
     nuxt.hooks.hook('app:created', () => {
-      hydrate(queryClient, vueQueryState.value)
+      hydrate(queryClient, dehydratedState)
     })
   }
 })


### PR DESCRIPTION
## Summary

`packages/query-core`'s `hydrate()` changed behavior in 5.102.1 (#11260, "accept partial dehydrated state"): the second parameter went from `dehydratedState: unknown` to `dehydratedState: Partial<DehydratedState>`, and the function's internal runtime guard was removed along with it:

```diff
 export function hydrate(
   client: QueryClient,
-  dehydratedState: unknown,
+  dehydratedState: Partial<DehydratedState>,
   options?: HydrateOptions,
 ): void {
-  if (typeof dehydratedState !== 'object' || dehydratedState === null) {
-    return
-  }
-
   const mutationCache = client.getMutationCache()
   ...
-  const mutations = (dehydratedState as DehydratedState).mutations || []
+  dehydratedState.mutations?.forEach(...)
```

This `examples/vue/nuxt3` plugin still calls `hydrate()` unconditionally with a value that's typed (and can genuinely be) `DehydratedState | null`:

```ts
const vueQueryState = useState<DehydratedState | null>('vue-query')
// ...
if (import.meta.client) {
  nuxt.hooks.hook('app:created', () => {
    hydrate(queryClient, vueQueryState.value)
  })
}
```

`vueQueryState.value` stays `undefined` (Nuxt's `useState` default with no init) whenever the server-side `app:rendered` hook never ran for the current route — e.g. `ssr: false` routes, or a purely client-rendered page. Previously `hydrate()`'s own guard absorbed that case silently. On `@tanstack/vue-query` ≥ 5.102.1 it now throws:

```
TypeError: Cannot read properties of undefined (reading 'mutations')
```

I ran into this while bumping `@tanstack/vue-query` in a Nuxt 4 project and traced it back to the removed guard — this example (and presumably anyone who copied it, since the example itself is still pinned to `^5.90.2` and hasn't hit this yet) will hit the same crash once bumped past 5.102.1.

## What changed

Restores the equivalent guard at the call site, matching what `hydrate()` used to do internally:

```ts
if (import.meta.client && vueQueryState.value) {
  const dehydratedState = vueQueryState.value
  nuxt.hooks.hook('app:created', () => {
    hydrate(queryClient, dehydratedState)
  })
}
```

(Captured into a local `const` rather than a non-null assertion, since the truthiness narrowing on `vueQueryState.value` doesn't survive into the nested closure passed to `nuxt.hooks.hook`.)

## Notes

- Scoped to this one example/file since that's the concrete case I hit; happy to extend to other framework examples using the same `hydrate(client, state.value)` pattern if that's wanted, just didn't want to guess at conventions across frameworks I haven't verified against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-side hydration in Nuxt 3 integrations.
  * Prevented hydration attempts when no server-generated query state is available.
  * Ensured the correct dehydrated state is used during app initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->