### PR TITLE
fix(react-query): recompute useMutationState result when filters change

### DIFF
--- a/.changeset/react-query-usemutationstate-stale-filters.md
+++ b/.changeset/react-query-usemutationstate-stale-filters.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+fix(react-query): recompute `useMutationState` result when filters change

--- a/packages/react-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/react-query/src/__tests__/useMutationState.test.tsx
@@ -241,4 +241,55 @@ describe('useMutationState', () => {
 
     expect(variables).toEqual([[], [1], []])
   })
+
+  it('should update the result when mutation filters change without a cache update', async () => {
+    const queryClient = new QueryClient()
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    function Variables({ mutationKey }: { mutationKey?: Array<string> }) {
+      const variables = useMutationState({
+        filters: { mutationKey },
+        select: (mutation) => mutation.state.variables,
+      })
+
+      return <div>variables: {variables.join(',')}</div>
+    }
+
+    function Page({ mutationKey }: { mutationKey?: Array<string> }) {
+      const { mutate: mutate1 } = useMutation({
+        mutationKey: key1,
+        mutationFn: (input: number) => sleep(100).then(() => 'data' + input),
+      })
+      const { mutate: mutate2 } = useMutation({
+        mutationKey: key2,
+        mutationFn: (input: number) => sleep(100).then(() => 'data' + input),
+      })
+
+      React.useEffect(() => {
+        mutate1(1)
+        mutate2(2)
+      }, [mutate1, mutate2])
+
+      return (
+        <div>
+          <Variables mutationKey={mutationKey} />
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <Page mutationKey={undefined} />,
+    )
+
+    // both mutations are pending, and an undefined mutationKey matches both
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('variables: 1,2')).toBeInTheDocument()
+
+    // both mutations stay pending, so only the changed filters can update this
+    rendered.rerender(<Page mutationKey={key1} />)
+
+    expect(rendered.getByText('variables: 1')).toBeInTheDocument()
+  })
 })

--- a/packages/react-query/src/useMutationState.ts
+++ b/packages/react-query/src/useMutationState.ts
@@ -94,7 +94,17 @@ export function useMutationState<
         }),
       [mutationCache],
     ),
-    () => result.current,
+    () => {
+      // recompute here so filter changes apply without a cache notification
+      const nextResult = replaceEqualDeep(
+        result.current,
+        getResult(mutationCache, options),
+      )
+      if (result.current !== nextResult) {
+        result.current = nextResult
+      }
+      return result.current
+    },
     () => result.current,
   )!
 }


### PR DESCRIPTION
## 🎯 Changes

Fixes #11272.

`useMutationState()` only recomputed its result inside the `mutationCache.subscribe()` callback — `getSnapshot` was `() => result.current`. A render with changed `filters` recomputed nothing, so the returned array kept showing the previous filters' results until an unrelated cache notification refreshed it.

Fix: recompute in `getSnapshot`, which runs during render and closes over the current `options`. `replaceEqualDeep` keeps the reference stable so `useSyncExternalStore` doesn't loop.

Includes a regression test that narrows `filters` while both mutations stay pending, so the cache never notifies.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useMutationState` so changing mutation filters immediately updates the returned results, including selected variables, while mutations are still pending.
  * Ensured filter changes are reflected without requiring an additional mutation cache update.

* **Tests**
  * Added regression coverage for updating mutation filters during pending mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->