### PR TITLE
fix(preact-query/usePrefetchQuery): replace deprecated 'queryClient.fetchQuery' with 'queryClient.query'

### DIFF
--- a/.changeset/khaki-donkeys-clap.md
+++ b/.changeset/khaki-donkeys-clap.md
@@ -2,4 +2,4 @@
 '@tanstack/preact-query': patch
 ---
 
-Replace deprecated `queryClient.fetchQuery` with `queryClient.query` inside `usePrefetchQuery`
+fix(preact-query/usePrefetchQuery): replace deprecated `queryClient.fetchQuery` with `queryClient.query`

--- a/.changeset/khaki-donkeys-clap.md
+++ b/.changeset/khaki-donkeys-clap.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query': patch
+---
+
+Replace deprecated `queryClient.fetchQuery` with `queryClient.query` inside `usePrefetchQuery`

--- a/packages/preact-query/src/usePrefetchQuery.tsx
+++ b/packages/preact-query/src/usePrefetchQuery.tsx
@@ -23,6 +23,6 @@ export function usePrefetchQuery<
   const client = useQueryClient(queryClient)
 
   if (!client.getQueryState(options.queryKey)) {
-    void client.fetchQuery(options).catch(noop)
+    void client.query(options).catch(noop)
   }
 }


### PR DESCRIPTION
## 🎯 Changes

`usePrefetchQuery` in `@tanstack/preact-query` still called `queryClient.fetchQuery`, which is `@deprecated` in favor of `queryClient.query`. `react-query`'s `usePrefetchQuery` already uses `client.query`, and preact-query's own `usePrefetchInfiniteQuery` already uses `client.infiniteQuery` — this closes the last remaining spot using the deprecated method.

Swaps the call from `client.fetchQuery(options)` to `client.query(options)`. No behavior change: `query()` performs the same staleness check, retry default, and cache build as `fetchQuery()`; its only addition is running `select` on the returned promise, which prefetch discards.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query prefetching so missing data is loaded using the supported query approach.
  - Preserved handling for intentionally ignored promise rejections, helping prevent unnecessary errors during prefetching.
  - Updated prefetch behavior for greater compatibility with current query management practices.

- **Documentation**
  - Added release notes describing the query prefetching improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->