### PR TITLE
chore(preact-query): remove eslint-disable comments for rules already off at the package level

### DIFF
--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -61,7 +61,6 @@ export const HydrationBoundary = ({
       // State is supplied from the outside and we might as well fail
       // gracefully if it has the wrong shape, so while we type `queries`
       // as required, we still provide a fallback.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const queries = state.queries || []
 
       const newQueries: DehydratedState['queries'] = []

--- a/packages/preact-query/src/utils.ts
+++ b/packages/preact-query/src/utils.ts
@@ -56,7 +56,6 @@ function didSnapshotChange(inst: {
   try {
     const nextValue = latestGetSnapshot()
     return !Object.is(prevValue, nextValue)
-    // eslint-disable-next-line no-unused-vars
   } catch (_error) {
     return true
   }


### PR DESCRIPTION
## 🎯 Changes

`packages/preact-query/eslint.config.js` already sets `no-unused-vars` and `@typescript-eslint/no-unnecessary-condition` to `'off'` at the package level, which makes the corresponding `eslint-disable-next-line` comments in `HydrationBoundary.tsx` and `utils.ts` dead — `eslint --skip-nx-cache` reported both as "Unused eslint-disable directive". Removed both.

Left the two `react-hooks/exhaustive-deps` warnings in `utils.ts` untouched — that file is a direct port of React's `use-sync-external-store` shim, and adding `_instance` to those effect dependency arrays would introduce a feedback loop.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete linting suppressions.
  * No changes to hydration, snapshot comparison, error handling, or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->