### PR TITLE
fix(react-query): server-consistent snapshot for sync-hydrated promise queries (#9399)

### DIFF
--- a/.changeset/rainy-scissors-resolve.md
+++ b/.changeset/rainy-scissors-resolve.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/query-core': patch
+'@tanstack/react-query': patch
+---
+
+fix(query-core): avoid React hydration mismatches when a query hydrated from a dehydrated promise resolves synchronously on the client. The observer now exposes a server snapshot that re-renders the pending view the server saw, and `useBaseQuery` renders from `useSyncExternalStore` so the hydration pass stays consistent with the server HTML (#9399)

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -8,7 +8,13 @@ import {
   vi,
 } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryClient, QueryObserver, focusManager } from '..'
+import {
+  QueryClient,
+  QueryObserver,
+  dehydrate,
+  focusManager,
+  hydrate,
+} from '..'
 import type { QueryObserverResult } from '..'
 
 describe('queryObserver', () => {
@@ -1932,6 +1938,71 @@ describe('queryObserver', () => {
       expect(queryFn).toHaveBeenCalledTimes(2)
 
       unsubscribe2()
+    })
+  })
+
+  describe('getServerResult', () => {
+    it('should return the current result for queries not hydrated from a promise', () => {
+      const key = queryKey()
+      const observer = new QueryObserver(queryClient, {
+        queryKey: key,
+        queryFn: () => 'data',
+      })
+
+      expect(observer.getServerResult()).toBe(observer.getCurrentResult())
+    })
+
+    it('should return a pending view for queries hydrated from an already resolved promise', () => {
+      const key = queryKey()
+
+      const prefetchClient = new QueryClient({
+        defaultOptions: {
+          dehydrate: {
+            shouldDehydrateQuery: () => true,
+          },
+        },
+      })
+      prefetchClient.prefetchQuery({
+        queryKey: key,
+        queryFn: () => Promise.resolve('success'),
+      })
+      const dehydrated = dehydrate(prefetchClient)
+
+      // Mimic what RSC-transformed promises do: they are already settled when
+      // they reach the client and call back into `.then` synchronously
+      dehydrated.queries[0]!.promise = {
+        then(onFulfilled: (value: string) => unknown) {
+          onFulfilled?.('success')
+          return undefined
+        },
+      } as unknown as Promise<string>
+
+      hydrate(queryClient, dehydrated)
+
+      const observer = new QueryObserver(queryClient, {
+        queryKey: key,
+        queryFn: () => 'data',
+      })
+
+      expect(observer.getCurrentResult()).toMatchObject({
+        status: 'success',
+        data: 'success',
+        isSuccess: true,
+      })
+
+      const serverResult = observer.getServerResult()
+      expect(serverResult).toMatchObject({
+        status: 'pending',
+        isPending: true,
+        isSuccess: false,
+        isError: false,
+        data: undefined,
+        error: null,
+        fetchStatus: 'idle',
+        isLoading: false,
+      })
+      // the server snapshot must be referentially stable for useSyncExternalStore
+      expect(observer.getServerResult()).toBe(serverResult)
     })
   })
 })

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -35,6 +35,20 @@ function tryResolveSync(promise: PromiseLike<unknown>) {
   return undefined
 }
 
+// Queries whose data was resolved synchronously from a dehydrated promise.
+// The server rendered these queries as pending (the data was not part of the
+// dehydrated state), so observers need to expose a matching pending view as
+// their server snapshot during the hydration pass to avoid mismatches.
+const syncHydratedQueries = new WeakSet<Query<any, any, any, any>>()
+
+export function isSyncHydratedQuery(query: Query<any, any, any, any>): boolean {
+  return syncHydratedQueries.has(query)
+}
+
+function addSyncHydratedQuery(query: Query<any, any, any, any>): void {
+  syncHydratedQueries.add(query)
+}
+
 export interface DehydrateOptions {
   serializeData?: TransformerFn
   shouldDehydrateMutation?: (mutation: Mutation) => boolean
@@ -236,6 +250,10 @@ export function hydrate(
       let query = queryCache.get(queryHash)
       const existingQueryIsPending = query?.state.status === 'pending'
       const existingQueryIsFetching = query?.state.fetchStatus === 'fetching'
+      const resolvesSyncData =
+        promise !== undefined &&
+        state.data === undefined &&
+        syncData !== undefined
 
       // Do not hydrate if an existing query exists with newer data
       if (query) {
@@ -269,6 +287,9 @@ export function hydrate(
                 }),
               }),
           })
+          if (resolvesSyncData) {
+            addSyncHydratedQuery(query)
+          }
         }
       } else {
         // Restore query
@@ -300,6 +321,9 @@ export function hydrate(
               }),
           },
         )
+        if (resolvesSyncData) {
+          addSyncHydratedQuery(query)
+        }
       }
 
       if (

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -3,6 +3,7 @@ import { environmentManager } from './environmentManager'
 import { notifyManager } from './notifyManager'
 import { fetchState } from './query'
 import { Subscribable } from './subscribable'
+import { isSyncHydratedQuery } from './hydration'
 import {
   isValidTimeout,
   noop,
@@ -64,6 +65,8 @@ export class QueryObserver<
   #refetchIntervalId?: ManagedTimerId
   #currentRefetchInterval?: number | false
   #trackedProps = new Set<keyof QueryObserverResult>()
+  #serverResult?: QueryObserverResult<TData, TError>
+  #serverResultState?: QueryState<TQueryData, TError>
 
   constructor(
     client: QueryClient,
@@ -254,6 +257,41 @@ export class QueryObserver<
 
   getCurrentResult(): QueryObserverResult<TData, TError> {
     return this.#currentResult
+  }
+
+  getServerResult(): QueryObserverResult<TData, TError> {
+    const query = this.#currentQuery
+
+    // Only queries whose data was resolved synchronously from a hydrated
+    // promise can diverge from what the server rendered - the server saw them
+    // as pending. Everything else can use the current result as-is.
+    if (!isSyncHydratedQuery(query)) {
+      return this.getCurrentResult()
+    }
+
+    if (
+      this.#serverResultState === query.state &&
+      this.#serverResult !== undefined
+    ) {
+      return this.#serverResult
+    }
+
+    // Re-create the result from the pending state the server rendered, so that
+    // every derived property stays consistent with regularly created results.
+    const serverQuery = Object.create(query)
+    serverQuery.state = {
+      ...query.state,
+      status: 'pending',
+      data: undefined,
+      dataUpdatedAt: 0,
+    } satisfies QueryState<TQueryData, TError>
+
+    const serverResult = this.createResult(serverQuery, this.options)
+
+    this.#serverResultState = query.state
+    this.#serverResult = serverResult
+
+    return serverResult
   }
 
   trackResult(

--- a/packages/react-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/react-query/src/__tests__/ssr-hydration.test.tsx
@@ -270,4 +270,97 @@ describe('Server side rendering with de/rehydration', () => {
     queryClient.clear()
     consoleMock.mockRestore()
   })
+
+  it('should not mismatch when a hydrated pending promise resolves synchronously on the client', async () => {
+    const consoleMock = vi.spyOn(console, 'error')
+    consoleMock.mockImplementation(() => undefined)
+
+    const fetchDataSuccess = vi.fn<typeof fetchData>(fetchData)
+    const key = queryKey()
+
+    // -- Shared part --
+    function SuccessComponent() {
+      const result = useQuery({
+        queryKey: key,
+        queryFn: () => fetchDataSuccess('success!'),
+      })
+      return (
+        <PrintStateComponent componentName="SuccessComponent" result={result} />
+      )
+    }
+
+    // -- Server part --
+    setIsServer(true)
+
+    const prefetchClient = new QueryClient({
+      defaultOptions: {
+        dehydrate: {
+          shouldDehydrateQuery: () => true,
+        },
+      },
+    })
+    // Dehydrate while the fetch is still in flight, so that the query is
+    // dehydrated as pending with a promise attached
+    prefetchClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => fetchDataSuccess('success'),
+    })
+    const dehydratedStateServer = dehydrate(prefetchClient)
+    await vi.advanceTimersByTimeAsync(10)
+    setIsServer(false)
+
+    const renderClient = new QueryClient()
+    hydrate(renderClient, dehydratedStateServer)
+    const markup = ReactDOMServer.renderToString(
+      <QueryClientProvider client={renderClient}>
+        <SuccessComponent />
+      </QueryClientProvider>,
+    )
+    renderClient.clear()
+
+    const expectedMarkup =
+      'SuccessComponent - status:pending fetching:true data:undefined'
+
+    expect(markup).toBe(expectedMarkup)
+    expect(fetchDataSuccess).toHaveBeenCalledTimes(1)
+
+    // -- Client part --
+    const el = document.createElement('div')
+    el.innerHTML = markup
+
+    const queryCache = new QueryCache()
+    const queryClient = new QueryClient({ queryCache })
+
+    // Promises passed through RSC arrive on the client already settled and
+    // call back into `.then` synchronously - mimic that here.
+    dehydratedStateServer.queries[0]!.promise = {
+      then(onFulfilled: (value: string) => unknown) {
+        onFulfilled?.('success')
+        return undefined
+      },
+    } as unknown as Promise<string>
+
+    hydrate(queryClient, dehydratedStateServer)
+
+    const unmount = ReactHydrate(
+      <QueryClientProvider client={queryClient}>
+        <SuccessComponent />
+      </QueryClientProvider>,
+      el,
+    )
+
+    // The query jumped to success during hydration while the server rendered
+    // it as pending, which must not produce a hydration mismatch
+    expect(consoleMock).toHaveBeenCalledTimes(0)
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(fetchDataSuccess).toHaveBeenCalledTimes(2)
+    expect(el.innerHTML).toBe(
+      'SuccessComponent - status:success fetching:false data:success!',
+    )
+
+    unmount()
+    queryClient.clear()
+    consoleMock.mockRestore()
+  })
 })

--- a/packages/react-query/src/useBaseQuery.ts
+++ b/packages/react-query/src/useBaseQuery.ts
@@ -92,10 +92,10 @@ export function useBaseQuery<
   )
 
   // note: this must be called before useSyncExternalStore
-  const result = observer.getOptimisticResult(defaultedOptions)
+  observer.getOptimisticResult(defaultedOptions)
 
   const shouldSubscribe = !isRestoring && subscribed
-  React.useSyncExternalStore(
+  const result = React.useSyncExternalStore(
     React.useCallback(
       (onStoreChange) => {
         const unsubscribe = shouldSubscribe
@@ -111,7 +111,7 @@ export function useBaseQuery<
       [observer, shouldSubscribe],
     ),
     () => observer.getCurrentResult(),
-    () => observer.getCurrentResult(),
+    () => observer.getServerResult(),
   )
 
   React.useEffect(() => {


### PR DESCRIPTION
Closes #9399

Since #10444, hydrate() promotes promise-backed queries to success synchronously when the dehydrated thenable resolves immediately on the client - but RSC flight promises only do so after hydration starts. SSR rendered pending/loading while the first client render showed data, producing hydration mismatches.

Observers now expose getServerResult(), returning a stable pending snapshot for sync-hydrated promise queries during React's hydration pass (getServerSnapshot of useSyncExternalStore), flipping to success right after commit. Follows the direction maintainers sketched in #4690; unmarked paths are byte-for-byte unchanged. Changesets included for query-core and react-query.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented React hydration mismatches when hydrated query promises resolve synchronously on the client.
  * Preserved the server-rendered pending state during hydration before updating to the query’s final result.
  * Improved consistency between server-rendered markup and the initial client render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->