### PR TITLE
chore(scripts/create-github-release): fix release-notes diff range after 'Version Packages' PR is squash-merged

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -54,10 +54,10 @@ async function resolveAuthorForPR(prNumber) {
 }
 
 // Get the previous release commit to diff against.
-// This script runs right after the "ci: changeset release" commit is pushed,
+// This script runs right after the "ci: Version Packages" PR is merged,
 // so HEAD is the release commit.
 const releaseLogs = execSync(
-  'git log --oneline --grep="ci: changeset release" --format=%H',
+  'git log --oneline --grep="^ci: Version Packages" --grep="^ci: changeset release" --format=%H',
 )
   .toString()
   .trim()
@@ -159,7 +159,11 @@ for (const line of commits) {
   const [, hash, email, subject] = match
 
   // Skip release commits
-  if (subject.startsWith('ci: changeset release')) continue
+  if (
+    subject.startsWith('ci: Version Packages') ||
+    subject.startsWith('ci: changeset release')
+  )
+    continue
 
   // Parse conventional commit: type(scope)!: message
   const conventionalMatch = subject.match(/^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.*)$/)


### PR DESCRIPTION
## 🎯 Changes

The GitHub Release published today (`release-2026-08-24-1925`) listed three unrelated svelte-query fixes from the *previous* release instead of the two commits actually included ([#11274](https://github.com/TanStack/query/pull/11274), [#11275](https://github.com/TanStack/query/pull/11275)). npm publishing and package versions were unaffected — only the "## Changes" summary on the GitHub Release was wrong.

Root cause: `scripts/create-github-release.mjs` finds the previous release commit by grepping the full commit message for the substring `ci: changeset release` (the commit message `changesets/action` writes on its `changeset-release/main` branch). When the "Version Packages" PR carries a single commit, GitHub's squash-merge copies that commit's message into the squash commit body, so the substring survives and the grep works. When the PR is updated multiple times before merge (as happened today, after both #11274 and #11275 landed in quick succession), the PR has multiple commits, and GitHub's squash-merge instead uses the PR title only — so the squash commit body no longer contains `ci: changeset release`, the grep silently skips the actual release commit, and the script's "previous release" pointer shifts back by one release.

`TanStack/router` hit and fixed this exact bug in [#7456](https://github.com/TanStack/router/pull/7456) — this PR ports that fix:
- `git log --grep` now anchors both patterns with `^` and additionally matches `^ci: Version Packages` (the squash commit's title), so the release commit is found regardless of how GitHub composed the squash message.
- The changelog-commit skip filter also recognizes `ci: Version Packages` as a release commit to exclude.

Verified locally by re-running the (patched) diff-range logic against today's actual history — it now resolves `previousRelease` to `96f2da635` (#11271) instead of `388bbaf18`, and correctly yields exactly the #11274/#11275 commits for the changelog.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release detection to recognize both supported release commit formats.
  * Prevented automated changelogs from including internal release commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->