### PR TITLE
chore(examples,docs): replace deprecated 'prefetchQuery'/'fetchQuery' calls with 'query'

### DIFF
--- a/docs/framework/lit/guides/ssr.md
+++ b/docs/framework/lit/guides/ssr.md
@@ -23,7 +23,7 @@ Never share one server `QueryClient` between users or requests.
 import { render } from '@lit-labs/ssr'
 import { collectResult } from '@lit-labs/ssr/lib/render-result.js'
 import { html } from 'lit'
-import { QueryClient, dehydrate } from '@tanstack/lit-query'
+import { QueryClient, dehydrate, noop } from '@tanstack/lit-query'
 import { createDataQueryOptions } from './api.js'
 import './app.js'
 
@@ -37,7 +37,7 @@ async function renderPage() {
     },
   })
 
-  await queryClient.prefetchQuery(createDataQueryOptions(apiBaseUrl))
+  await queryClient.query(createDataQueryOptions(apiBaseUrl)).catch(noop)
 
   const appHtml = await collectResult(
     render(

--- a/docs/framework/lit/typescript.md
+++ b/docs/framework/lit/typescript.md
@@ -90,6 +90,7 @@ import { LitElement } from 'lit'
 import {
   QueryClient,
   createQueryController,
+  noop,
   queryOptions,
 } from '@tanstack/lit-query'
 
@@ -107,7 +108,7 @@ class TodosView extends LitElement {
   private readonly todos = createQueryController(this, todosOptions())
 }
 
-void queryClient.prefetchQuery(todosOptions())
+void queryClient.query(todosOptions()).catch(noop)
 ```
 
 The branded `queryKey` returned from `queryOptions` also helps APIs like `queryClient.getQueryData` understand the data type.

--- a/examples/angular/pagination/src/app/components/example.component.ts
+++ b/examples/angular/pagination/src/app/components/example.component.ts
@@ -10,6 +10,7 @@ import {
   QueryClient,
   injectQuery,
   keepPreviousData,
+  noop,
 } from '@tanstack/angular-query-experimental'
 import { lastValueFrom } from 'rxjs'
 import { ProjectsService } from '../services/projects.service'
@@ -40,11 +41,13 @@ export class ExampleComponent {
 
     untracked(() => {
       if (!isPlaceholderData && data?.hasMore) {
-        void this.queryClient.prefetchQuery({
-          queryKey: ['projects', newPage],
-          queryFn: () =>
-            lastValueFrom(this.projectsService.getProjects(newPage)),
-        })
+        void this.queryClient
+          .query({
+            queryKey: ['projects', newPage],
+            queryFn: () =>
+              lastValueFrom(this.projectsService.getProjects(newPage)),
+          })
+          .catch(noop)
       }
     })
   })

--- a/examples/lit/pagination/src/main.ts
+++ b/examples/lit/pagination/src/main.ts
@@ -5,6 +5,7 @@ import {
   createMutationController,
   createQueryController,
   keepPreviousData,
+  noop,
 } from '@tanstack/lit-query'
 import {
   armNextProjectMutationFailureOnServer,
@@ -272,15 +273,17 @@ class PaginationDemo extends LitElement {
     this.prefetchStatus = `pending:${targetPage}`
 
     try {
-      await queryClient.prefetchQuery({
-        queryKey: projectsQueryKey(
-          targetPage,
-          this.delayMs,
-          this.forceErrorMode,
-        ),
-        queryFn: () =>
-          fetchProjectsPage(targetPage, this.delayMs, this.forceErrorMode),
-      })
+      await queryClient
+        .query({
+          queryKey: projectsQueryKey(
+            targetPage,
+            this.delayMs,
+            this.forceErrorMode,
+          ),
+          queryFn: () =>
+            fetchProjectsPage(targetPage, this.delayMs, this.forceErrorMode),
+        })
+        .catch(noop)
       this.prefetchStatus = `ready:${targetPage}`
     } catch (error) {
       this.prefetchStatus = `error:${String(error)}`

--- a/examples/react/nextjs-app-optimistic-updates/app/page.tsx
+++ b/examples/react/nextjs-app-optimistic-updates/app/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import { HydrationBoundary, dehydrate, noop } from '@tanstack/react-query'
 import { getQueryClient } from '@/app/get-query-client'
 import { getTodos } from '@/app/api/todos/data'
 import ApproachTabs from '@/components/ApproachTabs'
@@ -7,10 +7,12 @@ import ApproachTabs from '@/components/ApproachTabs'
 export default function Home() {
   const queryClient = getQueryClient()
 
-  void queryClient.prefetchQuery({
-    queryKey: ['todos'],
-    queryFn: getTodos,
-  })
+  void queryClient
+    .query({
+      queryKey: ['todos'],
+      queryFn: getTodos,
+    })
+    .catch(noop)
 
   return (
     <main style={{ maxWidth: 600, margin: '0 auto', padding: '2rem 1rem' }}>

--- a/examples/react/nextjs-app-prefetching/app/page.tsx
+++ b/examples/react/nextjs-app-prefetching/app/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import { HydrationBoundary, dehydrate, noop } from '@tanstack/react-query'
 import { pokemonOptions } from '@/app/pokemon'
 import { getQueryClient } from '@/app/get-query-client'
 import { PokemonInfo } from './pokemon-info'
@@ -7,7 +7,7 @@ import { PokemonInfo } from './pokemon-info'
 export default function Home() {
   const queryClient = getQueryClient()
 
-  void queryClient.prefetchQuery(pokemonOptions)
+  void queryClient.query(pokemonOptions).catch(noop)
 
   return (
     <main>

--- a/examples/react/nextjs/src/pages/index.tsx
+++ b/examples/react/nextjs/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { QueryClient, dehydrate } from '@tanstack/react-query'
+import { QueryClient, dehydrate, noop } from '@tanstack/react-query'
 import { Header, InfoBox, Layout, PostList } from '../components'
 import { fetchPosts } from '../hooks/usePosts'
 
@@ -16,10 +16,12 @@ const Home = () => {
 export async function getStaticProps() {
   const queryClient = new QueryClient()
 
-  await queryClient.prefetchQuery({
-    queryKey: ['posts', 10],
-    queryFn: () => fetchPosts(10),
-  })
+  await queryClient
+    .query({
+      queryKey: ['posts', 10],
+      queryFn: () => fetchPosts(10),
+    })
+    .catch(noop)
 
   return {
     props: {

--- a/examples/react/offline/src/App.tsx
+++ b/examples/react/offline/src/App.tsx
@@ -92,7 +92,7 @@ function Movies() {
             // do not load if we are offline or hydrating because it returns a promise that is pending until we go online again
             // we just let the Detail component handle it
             (onlineManager.isOnline() && !isRestoring
-              ? queryClient.fetchQuery({
+              ? queryClient.query({
                   queryKey: movieKeys.detail(movieId),
                   queryFn: () => api.fetchMovie(movieId),
                 })

--- a/examples/react/pagination/src/pages/index.tsx
+++ b/examples/react/pagination/src/pages/index.tsx
@@ -3,6 +3,7 @@ import {
   QueryClient,
   QueryClientProvider,
   keepPreviousData,
+  noop,
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
@@ -42,10 +43,12 @@ function Example() {
   // Prefetch the next page!
   React.useEffect(() => {
     if (!isPlaceholderData && data?.hasMore) {
-      queryClient.prefetchQuery({
-        queryKey: ['projects', page + 1],
-        queryFn: () => fetchProjects(page + 1),
-      })
+      queryClient
+        .query({
+          queryKey: ['projects', page + 1],
+          queryFn: () => fetchProjects(page + 1),
+        })
+        .catch(noop)
     }
   }, [data, isPlaceholderData, page, queryClient])
 

--- a/examples/react/prefetching/src/pages/index.tsx
+++ b/examples/react/prefetching/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { noop, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 const getCharacters = async (): Promise<{
@@ -53,11 +53,13 @@ export default function Example() {
                   setSelectedChar(char.id)
                 }}
                 onMouseEnter={async () => {
-                  await queryClient.prefetchQuery({
-                    queryKey: ['character', char.id],
-                    queryFn: () => getCharacter(char.id),
-                    staleTime: 10 * 1000, // only prefetch if older than 10 seconds
-                  })
+                  await queryClient
+                    .query({
+                      queryKey: ['character', char.id],
+                      queryFn: () => getCharacter(char.id),
+                      staleTime: 10 * 1000, // only prefetch if older than 10 seconds
+                    })
+                    .catch(noop)
 
                   setTimeout(() => {
                     rerender({})

--- a/examples/react/suspense/src/components/Projects.tsx
+++ b/examples/react/suspense/src/components/Projects.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { noop, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { fetchProject, fetchProjects } from '../queries'
 import Button from './Button'
 import Spinner from './Spinner'
@@ -23,10 +23,12 @@ export default function Projects({
           <Button
             onClick={() => {
               // Prefetch the project query
-              queryClient.prefetchQuery({
-                queryKey: ['project', project.full_name],
-                queryFn: () => fetchProject(project.full_name),
-              })
+              queryClient
+                .query({
+                  queryKey: ['project', project.full_name],
+                  queryFn: () => fetchProject(project.full_name),
+                })
+                .catch(noop)
               setActiveProject(project.full_name)
             }}
           >

--- a/examples/react/suspense/src/index.tsx
+++ b/examples/react/suspense/src/index.tsx
@@ -5,6 +5,7 @@ import {
   QueryClient,
   QueryClientProvider,
   QueryErrorResetBoundary,
+  noop,
   useQueryClient,
 } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
@@ -44,10 +45,12 @@ function Example() {
         onClick={() => {
           setShowProjects((old) => {
             if (!old) {
-              queryClient.prefetchQuery({
-                queryKey: ['projects'],
-                queryFn: fetchProjects,
-              })
+              queryClient
+                .query({
+                  queryKey: ['projects'],
+                  queryFn: fetchProjects,
+                })
+                .catch(noop)
             }
             return !old
           })

--- a/examples/solid/solid-start-streaming/src/routes/prefetch.tsx
+++ b/examples/solid/solid-start-streaming/src/routes/prefetch.tsx
@@ -1,4 +1,4 @@
-import { useQueryClient } from '@tanstack/solid-query'
+import { noop, useQueryClient } from '@tanstack/solid-query'
 import { isServer } from 'solid-js/web'
 import { Title } from '@solidjs/meta'
 import { UserInfo, userInfoQueryOpts } from '~/components/user-info'
@@ -7,7 +7,9 @@ export const route = {
   load: () => {
     const queryClient = useQueryClient()
     // Prefetching the user info and caching it for 15 seconds.
-    queryClient.prefetchQuery(userInfoQueryOpts({ sleep: 500, gcTime: 15000 }))
+    queryClient
+      .query(userInfoQueryOpts({ sleep: 500, gcTime: 15000 }))
+      .catch(noop)
   },
 }
 

--- a/examples/svelte/ssr/src/routes/+page.ts
+++ b/examples/svelte/ssr/src/routes/+page.ts
@@ -1,11 +1,14 @@
+import { noop } from '@tanstack/svelte-query'
 import type { PageLoad } from './$types'
 import { api } from '$lib/api'
 
 export const load: PageLoad = async ({ parent, fetch }) => {
   const { queryClient } = await parent()
 
-  await queryClient.prefetchQuery({
-    queryKey: ['posts', 10],
-    queryFn: () => api(fetch).getPosts(10),
-  })
+  await queryClient
+    .query({
+      queryKey: ['posts', 10],
+      queryFn: () => api(fetch).getPosts(10),
+    })
+    .catch(noop)
 }

--- a/examples/svelte/ssr/src/routes/[postId]/+page.ts
+++ b/examples/svelte/ssr/src/routes/[postId]/+page.ts
@@ -1,3 +1,4 @@
+import { noop } from '@tanstack/svelte-query'
 import type { PageLoad } from './$types'
 import { api } from '$lib/api'
 
@@ -6,10 +7,12 @@ export const load: PageLoad = async ({ parent, fetch, params }) => {
 
   const postId = parseInt(params.postId)
 
-  await queryClient.prefetchQuery({
-    queryKey: ['post', postId],
-    queryFn: () => api(fetch).getPostById(postId),
-  })
+  await queryClient
+    .query({
+      queryKey: ['post', postId],
+      queryFn: () => api(fetch).getPostById(postId),
+    })
+    .catch(noop)
 
   return { postId }
 }


### PR DESCRIPTION
## 🎯 Changes

`queryClient.fetchQuery` and `queryClient.prefetchQuery` are `@deprecated` in favor of `queryClient.query` (see [RFC: Unified Imperative Query Methods](https://github.com/TanStack/query/discussions/9135)). A repo-wide search turned up 13 examples and 2 docs pages across react, svelte, lit, angular, and solid still calling the deprecated methods.

- `queryClient.fetchQuery(options)` → `queryClient.query(options)` (`examples/react/offline/src/App.tsx`) — no `.catch`, since the return value feeds a router loader and errors should propagate to `errorElement`, exactly as `fetchQuery` did.
- `queryClient.prefetchQuery(options)` → `queryClient.query(options).catch(noop)` everywhere else — `prefetchQuery` is literally `fetchQuery(options).then(noop).catch(noop)` under the hood, so `.catch(noop)` preserves the exact same "never rejects" behavior for both `await`ed and fire-and-forget call sites. `noop` is imported from each example's own framework package (e.g. `@tanstack/react-query`), which re-exports it from `@tanstack/query-core`.

Migration guides (`migrating-to-v5.md`, `migrating-to-react-query-3.md`) were left untouched — they intentionally show the deprecated calls as historical/instructional content.

Verified with `tsc --noEmit` (react, lit, angular examples), `svelte-check` (svelte example), and by diffing each example's pre-existing type errors against `main` to confirm no new errors were introduced. The solid example's `tsc` run fails on a pre-existing, unrelated `vinxi/client` type-resolution error present on `main` as well.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SSR and TypeScript guidance with the current query-loading pattern.
  - Examples across Angular, Lit, React, Solid, and Svelte now demonstrate consistent data loading and error handling.

- **Bug Fixes**
  - Improved reliability during preloading, pagination, navigation, and server-side rendering by safely handling rejected data requests.
  - Updated offline route loading to use the supported query execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->