### PR TITLE
docs(preact-query): import 'noop' from '@tanstack/preact-query' instead of '@tanstack/query-core' in examples

### DIFF
--- a/docs/framework/preact/reference/functions/HydrationBoundary.md
+++ b/docs/framework/preact/reference/functions/HydrationBoundary.md
@@ -7,7 +7,7 @@ title: HydrationBoundary
 function HydrationBoundary(__namedParameters): Element;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:85](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L85)
+Defined in: [preact-query/src/HydrationBoundary.tsx:84](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L84)
 
 `HydrationBoundary` adds a previously dehydrated state into the `queryClient` that would be returned by
 `useQueryClient()`. If the client already contains data, the new queries will be intelligently merged based on
@@ -41,8 +41,7 @@ function App() {
 
 Server-side prefetch handed off to the client via `dehydrate`:
 ```tsx
-import { noop } from '@tanstack/query-core'
-import { HydrationBoundary, dehydrate } from '@tanstack/preact-query'
+import { HydrationBoundary, dehydrate, noop } from '@tanstack/preact-query'
 
 async function ServerComponent() {
   const queryClient = getQueryClient()

--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -76,7 +76,7 @@ function Projects() {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:194](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L194)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:197](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L197)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -131,8 +131,11 @@ export const projectsOptions = infiniteQueryOptions({
 
 A parameterized factory, reused across a hook and an imperative call with the same cache entry:
 ```tsx
-import { noop } from '@tanstack/query-core'
-import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
+import {
+  infiniteQueryOptions,
+  noop,
+  useInfiniteQuery,
+} from '@tanstack/preact-query'
 
 export const commentsOptions = (postId: string) =>
   infiniteQueryOptions({
@@ -162,7 +165,7 @@ queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:266](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L266)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:272](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L272)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -217,8 +220,11 @@ export const projectsOptions = infiniteQueryOptions({
 
 A parameterized factory, reused across a hook and an imperative call with the same cache entry:
 ```tsx
-import { noop } from '@tanstack/query-core'
-import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
+import {
+  infiniteQueryOptions,
+  noop,
+  useInfiniteQuery,
+} from '@tanstack/preact-query'
 
 export const commentsOptions = (postId: string) =>
   infiniteQueryOptions({

--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -71,7 +71,7 @@ function Posts() {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:169](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L169)
+Defined in: [preact-query/src/queryOptions.ts:172](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L172)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -120,8 +120,7 @@ export const postsOptions = queryOptions({
 
 A parameterized factory, reused across a hook and an imperative call with the same cache entry:
 ```tsx
-import { noop } from '@tanstack/query-core'
-import { queryOptions, useQuery } from '@tanstack/preact-query'
+import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
 
 export const postOptions = (id: string) =>
   queryOptions({
@@ -140,8 +139,12 @@ queryClient.query(postOptions(id)).catch(noop)
 
 The same options object works with every API that accepts query options:
 ```tsx
-import { noop } from '@tanstack/query-core'
-import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/preact-query'
+import {
+  noop,
+  queryOptions,
+  useQuery,
+  useSuspenseQuery,
+} from '@tanstack/preact-query'
 
 const todosOptions = queryOptions({
   queryKey: ['todos'],
@@ -160,7 +163,7 @@ queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefi
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:235](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L235)
+Defined in: [preact-query/src/queryOptions.ts:241](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L241)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -209,8 +212,7 @@ export const postsOptions = queryOptions({
 
 A parameterized factory, reused across a hook and an imperative call with the same cache entry:
 ```tsx
-import { noop } from '@tanstack/query-core'
-import { queryOptions, useQuery } from '@tanstack/preact-query'
+import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
 
 export const postOptions = (id: string) =>
   queryOptions({
@@ -229,8 +231,12 @@ queryClient.query(postOptions(id)).catch(noop)
 
 The same options object works with every API that accepts query options:
 ```tsx
-import { noop } from '@tanstack/query-core'
-import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/preact-query'
+import {
+  noop,
+  queryOptions,
+  useQuery,
+  useSuspenseQuery,
+} from '@tanstack/preact-query'
 
 const todosOptions = queryOptions({
   queryKey: ['todos'],

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -61,8 +61,7 @@ export interface HydrationBoundaryProps {
  * @example
  * Server-side prefetch handed off to the client via `dehydrate`:
  * ```tsx
- * import { noop } from '@tanstack/query-core'
- * import { HydrationBoundary, dehydrate } from '@tanstack/preact-query'
+ * import { HydrationBoundary, dehydrate, noop } from '@tanstack/preact-query'
  *
  * async function ServerComponent() {
  *   const queryClient = getQueryClient()

--- a/packages/preact-query/src/infiniteQueryOptions.ts
+++ b/packages/preact-query/src/infiniteQueryOptions.ts
@@ -164,8 +164,11 @@ export function infiniteQueryOptions<
  * @example
  * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
  * ```tsx
- * import { noop } from '@tanstack/query-core'
- * import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
+ * import {
+ *   infiniteQueryOptions,
+ *   noop,
+ *   useInfiniteQuery,
+ * } from '@tanstack/preact-query'
  *
  * export const commentsOptions = (postId: string) =>
  *   infiniteQueryOptions({
@@ -236,8 +239,11 @@ export function infiniteQueryOptions<
  * @example
  * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
  * ```tsx
- * import { noop } from '@tanstack/query-core'
- * import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
+ * import {
+ *   infiniteQueryOptions,
+ *   noop,
+ *   useInfiniteQuery,
+ * } from '@tanstack/preact-query'
  *
  * export const commentsOptions = (postId: string) =>
  *   infiniteQueryOptions({

--- a/packages/preact-query/src/queryOptions.ts
+++ b/packages/preact-query/src/queryOptions.ts
@@ -131,8 +131,7 @@ export function queryOptions<
  * @example
  * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
  * ```tsx
- * import { noop } from '@tanstack/query-core'
- * import { queryOptions, useQuery } from '@tanstack/preact-query'
+ * import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
  *
  * export const postOptions = (id: string) =>
  *   queryOptions({
@@ -152,8 +151,12 @@ export function queryOptions<
  * @example
  * The same options object works with every API that accepts query options:
  * ```tsx
- * import { noop } from '@tanstack/query-core'
- * import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/preact-query'
+ * import {
+ *   noop,
+ *   queryOptions,
+ *   useQuery,
+ *   useSuspenseQuery,
+ * } from '@tanstack/preact-query'
  *
  * const todosOptions = queryOptions({
  *   queryKey: ['todos'],
@@ -197,8 +200,7 @@ export function queryOptions<
  * @example
  * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
  * ```tsx
- * import { noop } from '@tanstack/query-core'
- * import { queryOptions, useQuery } from '@tanstack/preact-query'
+ * import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
  *
  * export const postOptions = (id: string) =>
  *   queryOptions({
@@ -218,8 +220,12 @@ export function queryOptions<
  * @example
  * The same options object works with every API that accepts query options:
  * ```tsx
- * import { noop } from '@tanstack/query-core'
- * import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/preact-query'
+ * import {
+ *   noop,
+ *   queryOptions,
+ *   useQuery,
+ *   useSuspenseQuery,
+ * } from '@tanstack/preact-query'
  *
  * const todosOptions = queryOptions({
  *   queryKey: ['todos'],


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11204. The `@example` blocks in `queryOptions.ts`, `infiniteQueryOptions.ts`, and `HydrationBoundary.tsx` imported `noop` from `@tanstack/query-core`, but `@tanstack/preact-query` re-exports everything from `@tanstack/query-core` (`export * from '@tanstack/query-core'` in `index.ts`), so the examples can import `noop` directly from `@tanstack/preact-query` — the package the example already depends on — instead of adding an extra import from a package the example otherwise never references.

Regenerated `docs/framework/preact/reference/` with `pnpm run generate-docs` to pick up the updated examples.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Preact Query examples to use the recommended package import for `noop`.
  * Corrected source links and line references in API documentation.
  * No runtime behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->