### PR TITLE
docs(preact-query): document interfaces and type aliases with JSDoc for generated reference docs

### DIFF
--- a/docs/framework/preact/reference/functions/HydrationBoundary.md
+++ b/docs/framework/preact/reference/functions/HydrationBoundary.md
@@ -7,7 +7,7 @@ title: HydrationBoundary
 function HydrationBoundary(__namedParameters): Element;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:84](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L84)
+Defined in: [preact-query/src/HydrationBoundary.tsx:87](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L87)
 
 `HydrationBoundary` adds a previously dehydrated state into the `queryClient` that would be returned by
 `useQueryClient()`. If the client already contains data, the new queries will be intelligently merged based on

--- a/docs/framework/preact/reference/functions/QueryClientProvider.md
+++ b/docs/framework/preact/reference/functions/QueryClientProvider.md
@@ -7,9 +7,12 @@ title: QueryClientProvider
 function QueryClientProvider(__namedParameters): VNode;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L63)
+Defined in: [preact-query/src/QueryClientProvider.tsx:69](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L69)
 
-Use the `QueryClientProvider` component to connect and provide a `QueryClient` to your application.
+Use the `QueryClientProvider` component to connect and provide a `QueryClient` to your application. Also
+calls `client.mount()`/`client.unmount()` as this component mounts/unmounts, which subscribes the client to
+focus/online events (resuming any paused mutations and refetching as needed when the app regains focus or
+comes back online).
 
 ## Parameters
 

--- a/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
@@ -7,7 +7,7 @@ title: QueryErrorResetBoundary
 function QueryErrorResetBoundary(__namedParameters): Element;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:154](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L154)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:157](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L157)
 
 When using **suspense** or **throwOnError** in your queries, you need a way to let queries know that you want to
 try again when re-rendering after some error occurred. With the `QueryErrorResetBoundary` component you can

--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -9,7 +9,7 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:122](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L122)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:135](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L135)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -76,7 +76,7 @@ function Projects() {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:197](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L197)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:210](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L210)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -165,7 +165,7 @@ queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:272](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L272)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:285](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L285)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.

--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -9,7 +9,7 @@ title: queryOptions
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:103](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L103)
+Defined in: [preact-query/src/queryOptions.ts:115](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L115)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -71,7 +71,7 @@ function Posts() {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:172](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L172)
+Defined in: [preact-query/src/queryOptions.ts:184](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L184)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -163,7 +163,7 @@ queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefi
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:241](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L241)
+Defined in: [preact-query/src/queryOptions.ts:253](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L253)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and

--- a/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
@@ -7,7 +7,7 @@ title: usePrefetchInfiniteQuery
 function usePrefetchInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): void;
 ```
 
-Defined in: [preact-query/src/usePrefetchInfiniteQuery.tsx:47](https://github.com/TanStack/query/blob/main/packages/preact-query/src/usePrefetchInfiniteQuery.tsx#L47)
+Defined in: [preact-query/src/usePrefetchInfiniteQuery.tsx:51](https://github.com/TanStack/query/blob/main/packages/preact-query/src/usePrefetchInfiniteQuery.tsx#L51)
 
 `usePrefetchInfiniteQuery` does not return anything, it should be used just to fire a prefetch during render,
 before a suspense boundary that wraps a component that uses `useSuspenseInfiniteQuery`. You can pass
@@ -18,6 +18,10 @@ a default query function has been defined.
 `getNextPageParam` receives both the last page of the infinite list of data and the full array of all pages,
 as well as pageParam information, and should return a single variable that will be passed to your query
 function as `context.pageParam`. Return `undefined` or `null` to indicate there is no next page available.
+
+The prefetch is skipped if the query already has any cached state — including a `pending`/`error` state left
+over from a previous attempt — so calling this on every render is cheap and won't refetch data that's
+already there or already in flight.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/usePrefetchQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchQuery.md
@@ -7,12 +7,16 @@ title: usePrefetchQuery
 function usePrefetchQuery<TQueryFnData, TError, TData, TQueryData, TQueryKey>(options, queryClient?): void;
 ```
 
-Defined in: [preact-query/src/usePrefetchQuery.tsx:38](https://github.com/TanStack/query/blob/main/packages/preact-query/src/usePrefetchQuery.tsx#L38)
+Defined in: [preact-query/src/usePrefetchQuery.tsx:42](https://github.com/TanStack/query/blob/main/packages/preact-query/src/usePrefetchQuery.tsx#L42)
 
 `usePrefetchQuery` does not return anything, it should be used just to fire a prefetch during render, before
 a suspense boundary that wraps a component that uses `useSuspenseQuery`. You can pass everything to
 `usePrefetchQuery` that you can pass to `queryClient.query`, though `queryKey` is always required, and
 `queryFn` is required unless a default query function has been defined.
+
+The prefetch is skipped if the query already has any cached state — including a `pending`/`error` state left
+over from a previous attempt — so calling this on every render is cheap and won't refetch data that's
+already there or already in flight.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -7,7 +7,7 @@ title: useQueries
 function useQueries<T, TCombinedResult>(__namedParameters, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useQueries.ts:262](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L262)
+Defined in: [preact-query/src/useQueries.ts:263](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L263)
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -7,7 +7,7 @@ title: useQueries
 function useQueries<T, TCombinedResult>(__namedParameters, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useQueries.ts:257](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L257)
+Defined in: [preact-query/src/useQueries.ts:262](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L262)
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -9,7 +9,7 @@ title: useSuspenseQueries
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:212](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L212)
+Defined in: [preact-query/src/useSuspenseQueries.ts:217](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L217)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -102,7 +102,7 @@ function App() {
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:279](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L279)
+Defined in: [preact-query/src/useSuspenseQueries.ts:284](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L284)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -9,7 +9,7 @@ title: useSuspenseQueries
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:217](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L217)
+Defined in: [preact-query/src/useSuspenseQueries.ts:218](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L218)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -102,7 +102,7 @@ function App() {
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:284](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L284)
+Defined in: [preact-query/src/useSuspenseQueries.ts:285](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L285)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.

--- a/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
+++ b/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
@@ -3,7 +3,9 @@ id: HydrationBoundaryProps
 title: HydrationBoundaryProps
 ---
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L14)
+Defined in: [preact-query/src/HydrationBoundary.tsx:17](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L17)
+
+The props accepted by `HydrationBoundary`.
 
 ## Properties
 
@@ -13,7 +15,7 @@ Defined in: [preact-query/src/HydrationBoundary.tsx:14](https://github.com/TanSt
 optional children: ComponentChildren;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:34](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L34)
+Defined in: [preact-query/src/HydrationBoundary.tsx:37](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L37)
 
 The components to render — always rendered unconditionally, not gated on hydration. New queries are
 hydrated into the cache during render; for queries that already exist in the cache, only newer dehydrated
@@ -28,7 +30,7 @@ lands.
 optional options: OmitKeyof<HydrateOptions, "defaultOptions"> & object;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:22](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L22)
+Defined in: [preact-query/src/HydrationBoundary.tsx:25](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L25)
 
 Optional. Note: unlike `hydrate`, `mutations` cannot be set here.
 
@@ -49,7 +51,7 @@ optional defaultOptions: OmitKeyof<{
 optional queryClient: QueryClient;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:38](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L38)
+Defined in: [preact-query/src/HydrationBoundary.tsx:41](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L41)
 
 Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
 
@@ -61,6 +63,6 @@ Use this to use a custom QueryClient. Otherwise, the one from the nearest contex
 state: DehydratedState | null | undefined;
 ```
 
-Defined in: [preact-query/src/HydrationBoundary.tsx:18](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L18)
+Defined in: [preact-query/src/HydrationBoundary.tsx:21](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L21)
 
 The state to hydrate.

--- a/docs/framework/preact/reference/interfaces/QueryErrorResetBoundaryProps.md
+++ b/docs/framework/preact/reference/interfaces/QueryErrorResetBoundaryProps.md
@@ -3,7 +3,9 @@ id: QueryErrorResetBoundaryProps
 title: QueryErrorResetBoundaryProps
 ---
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:100](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L100)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:103](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L103)
+
+The props accepted by `QueryErrorResetBoundary`.
 
 ## Properties
 
@@ -15,7 +17,7 @@ children:
   | QueryErrorResetBoundaryFunction;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:105](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L105)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:108](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L108)
 
 Either a plain node, or a function that receives the boundary's QueryErrorResetBoundaryValue and
 returns a node.

--- a/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
@@ -3,7 +3,10 @@ id: UseBaseQueryOptions
 title: UseBaseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:30](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L30)
+Defined in: [preact-query/src/types.ts:38](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L38)
+
+The options shared by `useQuery`, `useSuspenseQuery`, and their infinite counterparts. Extends
+QueryObserverOptions from `@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
 
 ## Extends
 
@@ -39,7 +42,7 @@ Defined in: [preact-query/src/types.ts:30](https://github.com/TanStack/query/blo
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:47](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L47)
+Defined in: [preact-query/src/types.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L55)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
@@ -5,8 +5,8 @@ title: UseBaseQueryOptions
 
 Defined in: [preact-query/src/types.ts:38](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L38)
 
-The options shared by `useQuery`, `useSuspenseQuery`, and their infinite counterparts. Extends
-QueryObserverOptions from `@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
+The options shared by `useQuery` and `useSuspenseQuery`. Extends QueryObserverOptions from
+`@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
 
 ## Extends
 

--- a/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
@@ -3,7 +3,11 @@ id: UseInfiniteQueryOptions
 title: UseInfiniteQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:151](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L151)
+Defined in: [preact-query/src/types.ts:193](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L193)
+
+The options accepted by `useInfiniteQuery`. Extends InfiniteQueryObserverOptions from
+`@tanstack/query-core` with the `preact-query`-specific `subscribed` option, minus `suspense` (which
+`preact-query` derives from which hook you call rather than exposing as an option).
 
 ## Extends
 
@@ -39,7 +43,7 @@ Defined in: [preact-query/src/types.ts:151](https://github.com/TanStack/query/bl
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:171](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L171)
+Defined in: [preact-query/src/types.ts:213](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L213)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseMutationOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseMutationOptions.md
@@ -3,7 +3,10 @@ id: UseMutationOptions
 title: UseMutationOptions
 ---
 
-Defined in: [preact-query/src/types.ts:244](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L244)
+Defined in: [preact-query/src/types.ts:331](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L331)
+
+The options accepted by `useMutation`. Same as MutationObserverOptions from `@tanstack/query-core`,
+minus the internal `_defaulted` flag.
 
 ## Extends
 

--- a/docs/framework/preact/reference/interfaces/UseMutationOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseMutationOptions.md
@@ -3,7 +3,7 @@ id: UseMutationOptions
 title: UseMutationOptions
 ---
 
-Defined in: [preact-query/src/types.ts:331](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L331)
+Defined in: [preact-query/src/types.ts:332](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L332)
 
 The options accepted by `useMutation`. Same as MutationObserverOptions from `@tanstack/query-core`,
 minus the internal `_defaulted` flag.

--- a/docs/framework/preact/reference/interfaces/UseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseQueryOptions.md
@@ -3,7 +3,10 @@ id: UseQueryOptions
 title: UseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:109](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L109)
+Defined in: [preact-query/src/types.ts:133](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L133)
+
+The options accepted by `useQuery`. Same as [UseBaseQueryOptions](UseBaseQueryOptions.md), minus `suspense` (which
+`preact-query` derives from which hook you call rather than exposing as an option).
 
 ## Extends
 
@@ -35,7 +38,7 @@ Defined in: [preact-query/src/types.ts:109](https://github.com/TanStack/query/bl
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:47](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L47)
+Defined in: [preact-query/src/types.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L55)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
@@ -3,7 +3,11 @@ id: UseSuspenseInfiniteQueryOptions
 title: UseSuspenseInfiniteQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:176](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L176)
+Defined in: [preact-query/src/types.ts:227](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L227)
+
+The options accepted by `useSuspenseInfiniteQuery`. Same as [UseInfiniteQueryOptions](UseInfiniteQueryOptions.md), minus `enabled`,
+`throwOnError`, and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so
+those options don't apply.
 
 ## Extends
 
@@ -39,7 +43,7 @@ Defined in: [preact-query/src/types.ts:176](https://github.com/TanStack/query/bl
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [preact-query/src/types.ts:190](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L190)
+Defined in: [preact-query/src/types.ts:241](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L241)
 
 `skipToken` is not allowed here — Suspense hooks cannot render a "disabled" state, so a query function
 must always be provided, unless a default query function has been defined.
@@ -52,7 +56,7 @@ must always be provided, unless a default query function has been defined.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:171](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L171)
+Defined in: [preact-query/src/types.ts:213](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L213)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
@@ -3,7 +3,11 @@ id: UseSuspenseQueryOptions
 title: UseSuspenseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:125](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L125)
+Defined in: [preact-query/src/types.ts:158](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L158)
+
+The options accepted by `useSuspenseQuery`. Same as [UseQueryOptions](UseQueryOptions.md), minus `enabled`, `throwOnError`,
+and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so those options
+don't apply.
 
 ## Extends
 
@@ -35,7 +39,7 @@ Defined in: [preact-query/src/types.ts:125](https://github.com/TanStack/query/bl
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, never>;
 ```
 
-Defined in: [preact-query/src/types.ts:138](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L138)
+Defined in: [preact-query/src/types.ts:171](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L171)
 
 `skipToken` is not allowed here — Suspense hooks cannot render a "disabled" state, so a query function
 must always be provided, unless a default query function has been defined.
@@ -48,7 +52,7 @@ must always be provided, unless a default query function has been defined.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:47](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L47)
+Defined in: [preact-query/src/types.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L55)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/type-aliases/AnyUseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseBaseQueryOptions.md
@@ -7,4 +7,7 @@ title: AnyUseBaseQueryOptions
 type AnyUseBaseQueryOptions = UseBaseQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:23](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L23)
+Defined in: [preact-query/src/types.ts:27](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L27)
+
+[UseBaseQueryOptions](../interfaces/UseBaseQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
+relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
@@ -7,4 +7,7 @@ title: AnyUseInfiniteQueryOptions
 type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:144](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L144)
+Defined in: [preact-query/src/types.ts:181](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L181)
+
+[UseInfiniteQueryOptions](../interfaces/UseInfiniteQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
+relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
@@ -7,4 +7,7 @@ title: AnyUseMutationOptions
 type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:243](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L243)
+Defined in: [preact-query/src/types.ts:326](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L326)
+
+[UseMutationOptions](../interfaces/UseMutationOptions.md) with all type parameters set to `any`, useful when the specific types aren't
+relevant, e.g. when accepting options for any mutation in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
@@ -7,7 +7,7 @@ title: AnyUseMutationOptions
 type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:326](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L326)
+Defined in: [preact-query/src/types.ts:327](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L327)
 
 [UseMutationOptions](../interfaces/UseMutationOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any mutation in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
@@ -7,4 +7,7 @@ title: AnyUseQueryOptions
 type AnyUseQueryOptions = UseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:108](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L108)
+Defined in: [preact-query/src/types.ts:128](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L128)
+
+[UseQueryOptions](../interfaces/UseQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
+relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
@@ -7,4 +7,7 @@ title: AnyUseSuspenseInfiniteQueryOptions
 type AnyUseSuspenseInfiniteQueryOptions = UseSuspenseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:174](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L174)
+Defined in: [preact-query/src/types.ts:220](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L220)
+
+[UseSuspenseInfiniteQueryOptions](../interfaces/UseSuspenseInfiniteQueryOptions.md) with all type parameters set to `any`, useful when the specific types
+aren't relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
@@ -7,4 +7,7 @@ title: AnyUseSuspenseQueryOptions
 type AnyUseSuspenseQueryOptions = UseSuspenseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:119](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L119)
+Defined in: [preact-query/src/types.ts:147](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L147)
+
+[UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
+relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -7,7 +7,10 @@ title: DefinedInitialDataInfiniteOptions
 type DefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:68](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L68)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:81](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L81)
+
+The options accepted by the `infiniteQueryOptions` overload selected when `initialData` is set — `data` is
+never `undefined`.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
@@ -7,7 +7,10 @@ title: DefinedInitialDataOptions
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:52](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L52)
+Defined in: [preact-query/src/queryOptions.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L64)
+
+The options accepted by the `queryOptions` overload selected when `initialData` is set — `data` is never
+`undefined`.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
@@ -7,7 +7,10 @@ title: DefinedUseInfiniteQueryResult
 type DefinedUseInfiniteQueryResult<TData, TError> = DefinedInfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:230](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L230)
+Defined in: [preact-query/src/types.ts:305](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L305)
+
+The result of `useInfiniteQuery` when `initialData` is set — `data` is never `undefined`. Re-exports
+DefinedInfiniteQueryObserverResult from `@tanstack/query-core`.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedUseInfiniteQueryResult
 type DefinedUseInfiniteQueryResult<TData, TError> = DefinedInfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:305](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L305)
+Defined in: [preact-query/src/types.ts:306](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L306)
 
 The result of `useInfiniteQuery` when `initialData` is set — `data` is never `undefined`. Re-exports
 DefinedInfiniteQueryObserverResult from `@tanstack/query-core`.

--- a/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedUseQueryResult
 type DefinedUseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:287](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L287)
+Defined in: [preact-query/src/types.ts:288](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L288)
 
 The result of `useQuery` when `initialData` is set, or of `useSuspenseQuery` before the `isPlaceholderData`
 omission — `data` is never `undefined`. Re-exports DefinedQueryObserverResult from

--- a/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
@@ -7,7 +7,11 @@ title: DefinedUseQueryResult
 type DefinedUseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:220](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L220)
+Defined in: [preact-query/src/types.ts:287](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L287)
+
+The result of `useQuery` when `initialData` is set, or of `useSuspenseQuery` before the `isPlaceholderData`
+omission — `data` is never `undefined`. Re-exports DefinedQueryObserverResult from
+`@tanstack/query-core`.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesOptions.md
@@ -7,9 +7,11 @@ title: QueriesOptions
 type QueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryOptionsForUseQueries[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryOptionsForUseQueries<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesOptions<[...Tails], [...TResults, GetUseQueryOptionsForUseQueries<Head>], [...TDepth, 1]> : ReadonlyArray<unknown> extends T ? T : T extends UseQueryOptionsForUseQueries<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData, TQueryKey>[] : UseQueryOptionsForUseQueries[];
 ```
 
-Defined in: [preact-query/src/useQueries.ts:147](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L147)
+Defined in: [preact-query/src/useQueries.ts:149](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L149)
 
-QueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
+The `queries` array accepted by `useQueries`. Recursively unwraps each tuple element so every entry's
+`queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements — beyond that, or for a
+non-tuple array, falls back to a single homogeneous options type.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesOptions.md
@@ -7,11 +7,12 @@ title: QueriesOptions
 type QueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryOptionsForUseQueries[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryOptionsForUseQueries<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesOptions<[...Tails], [...TResults, GetUseQueryOptionsForUseQueries<Head>], [...TDepth, 1]> : ReadonlyArray<unknown> extends T ? T : T extends UseQueryOptionsForUseQueries<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData, TQueryKey>[] : UseQueryOptionsForUseQueries[];
 ```
 
-Defined in: [preact-query/src/useQueries.ts:149](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L149)
+Defined in: [preact-query/src/useQueries.ts:150](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L150)
 
 The `queries` array accepted by `useQueries`. Recursively unwraps each tuple element so every entry's
-`queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements — beyond that, or for a
-non-tuple array, falls back to a single homogeneous options type.
+`queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements. An opaque array (e.g.
+`unknown[]`) is returned as-is; a non-tuple array of a known element type, or a tuple past 20 elements, falls
+back to a single homogeneous options type.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesResults.md
@@ -7,7 +7,7 @@ title: QueriesResults
 type QueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesResults<[...Tails], [...TResults, GetUseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useQueries.ts:194](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L194)
+Defined in: [preact-query/src/useQueries.ts:195](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L195)
 
 The result type returned by `useQueries`, when no `combine` is provided. Mirrors [QueriesOptions](QueriesOptions.md): each
 tuple element's result type is inferred individually, up to 20 elements. A non-tuple array is mapped

--- a/docs/framework/preact/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesResults.md
@@ -7,9 +7,12 @@ title: QueriesResults
 type QueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesResults<[...Tails], [...TResults, GetUseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useQueries.ts:189](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L189)
+Defined in: [preact-query/src/useQueries.ts:194](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L194)
 
-QueriesResults reducer recursively maps type param to results
+The result type returned by `useQueries`, when no `combine` is provided. Mirrors [QueriesOptions](QueriesOptions.md): each
+tuple element's result type is inferred individually, up to 20 elements. A non-tuple array is mapped
+per-element instead, still inferring each entry individually; only past 20 elements does this fall back to a
+single homogeneous [UseQueryResult](UseQueryResult.md) type.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
@@ -7,7 +7,9 @@ title: QueryClientProviderProps
 type QueryClientProviderProps = object;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:34](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L34)
+Defined in: [preact-query/src/QueryClientProvider.tsx:37](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L37)
+
+The props accepted by `QueryClientProvider`.
 
 ## Properties
 
@@ -17,7 +19,7 @@ Defined in: [preact-query/src/QueryClientProvider.tsx:34](https://github.com/Tan
 optional children: ComponentChildren;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:44](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L44)
+Defined in: [preact-query/src/QueryClientProvider.tsx:47](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L47)
 
 The components that get access to the provided QueryClient.
 
@@ -29,7 +31,7 @@ The components that get access to the provided QueryClient.
 client: QueryClient;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:40](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L40)
+Defined in: [preact-query/src/QueryClientProvider.tsx:43](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L43)
 
 **Required**
 

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
@@ -7,11 +7,12 @@ title: SuspenseQueriesOptions
 type SuspenseQueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryOptions[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryOptions<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesOptions<[...Tails], [...TResults, GetUseSuspenseQueryOptions<Head>], [...TDepth, 1]> : unknown[] extends T ? T : T extends UseSuspenseQueryOptions<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[] : UseSuspenseQueryOptions[];
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:112](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L112)
+Defined in: [preact-query/src/useSuspenseQueries.ts:113](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L113)
 
 The `queries` array accepted by `useSuspenseQueries`. Recursively unwraps each tuple element so every
-entry's `queryFn`/`select` are inferred individually, up to 20 elements — beyond that, or for a non-tuple
-array, falls back to a single homogeneous [UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptions.md) type.
+entry's `queryFn`/`select` are inferred individually, up to 20 elements. An opaque array (e.g. `unknown[]`)
+is returned as-is; a non-tuple array of a known element type, or a tuple past 20 elements, falls back to a
+single homogeneous [UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptions.md) type.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
@@ -7,9 +7,11 @@ title: SuspenseQueriesOptions
 type SuspenseQueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryOptions[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryOptions<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesOptions<[...Tails], [...TResults, GetUseSuspenseQueryOptions<Head>], [...TDepth, 1]> : unknown[] extends T ? T : T extends UseSuspenseQueryOptions<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[] : UseSuspenseQueryOptions[];
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:110](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L110)
+Defined in: [preact-query/src/useSuspenseQueries.ts:112](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L112)
 
-SuspenseQueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
+The `queries` array accepted by `useSuspenseQueries`. Recursively unwraps each tuple element so every
+entry's `queryFn`/`select` are inferred individually, up to 20 elements — beyond that, or for a non-tuple
+array, falls back to a single homogeneous [UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptions.md) type.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
@@ -7,7 +7,7 @@ title: SuspenseQueriesResults
 type SuspenseQueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesResults<[...Tails], [...TResults, GetUseSuspenseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseSuspenseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:152](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L152)
+Defined in: [preact-query/src/useSuspenseQueries.ts:153](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L153)
 
 The result type returned by `useSuspenseQueries`, when no `combine` is provided. Mirrors
 [SuspenseQueriesOptions](SuspenseQueriesOptions.md): each tuple element's result type is inferred individually, up to 20 elements.

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
@@ -7,9 +7,12 @@ title: SuspenseQueriesResults
 type SuspenseQueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesResults<[...Tails], [...TResults, GetUseSuspenseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseSuspenseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:147](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L147)
+Defined in: [preact-query/src/useSuspenseQueries.ts:152](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L152)
 
-SuspenseQueriesResults reducer recursively maps type param to results
+The result type returned by `useSuspenseQueries`, when no `combine` is provided. Mirrors
+[SuspenseQueriesOptions](SuspenseQueriesOptions.md): each tuple element's result type is inferred individually, up to 20 elements.
+A non-tuple array is mapped per-element instead, still inferring each entry individually; only past 20
+elements does this fall back to a single homogeneous [UseSuspenseQueryResult](UseSuspenseQueryResult.md) type.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
@@ -7,7 +7,10 @@ title: UndefinedInitialDataInfiniteOptions
 type UndefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L14)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:18](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L18)
+
+The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set — `data`
+may be `undefined` while the query is `pending`.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
@@ -7,7 +7,10 @@ title: UndefinedInitialDataOptions
 type UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:14](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L14)
+Defined in: [preact-query/src/queryOptions.ts:18](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L18)
+
+The options accepted by the `queryOptions` overload selected when no `initialData` is set — `data` may be
+`undefined` while the query is `pending`.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
@@ -7,7 +7,11 @@ title: UnusedSkipTokenInfiniteOptions
 type UnusedSkipTokenInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:42](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L42)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:51](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L51)
+
+The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set and
+`queryFn` is not `skipToken` — same as [UndefinedInitialDataInfiniteOptions](UndefinedInitialDataInfiniteOptions.md), but `queryFn` may not be
+`skipToken`.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
@@ -7,7 +7,10 @@ title: UnusedSkipTokenOptions
 type UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> = OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:33](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L33)
+Defined in: [preact-query/src/queryOptions.ts:41](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L41)
+
+The options accepted by the `queryOptions` overload selected when no `initialData` is set and `queryFn` is
+not `skipToken` — same as [UndefinedInitialDataOptions](UndefinedInitialDataOptions.md), but `queryFn` may not be `skipToken`.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
@@ -9,7 +9,7 @@ type UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Overrid
 }> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:372](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L372)
+Defined in: [preact-query/src/types.ts:373](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L373)
 
 The result of `useMutation`. Same as MutationObserverResult from `@tanstack/query-core`, with
 `mutate` narrowed to the fire-and-forget [UseMutateFunction](UseMutateFunction.md) signature, plus the added `mutateAsync`.

--- a/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
@@ -9,7 +9,10 @@ type UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Overrid
 }> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:281](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L281)
+Defined in: [preact-query/src/types.ts:372](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L372)
+
+The result of `useMutation`. Same as MutationObserverResult from `@tanstack/query-core`, with
+`mutate` narrowed to the fire-and-forget [UseMutateFunction](UseMutateFunction.md) signature, plus the added `mutateAsync`.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
@@ -7,7 +7,10 @@ title: UseBaseQueryResult
 type UseBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:202](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L202)
+Defined in: [preact-query/src/types.ts:257](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L257)
+
+The result of `useQuery` and `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined`
+while the query is `pending`. Re-exports QueryObserverResult from `@tanstack/query-core`.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
@@ -7,10 +7,11 @@ title: UseBaseQueryResult
 type UseBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:257](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L257)
+Defined in: [preact-query/src/types.ts:258](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L258)
 
-The result of `useQuery` and `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined`
-while the query is `pending`. Re-exports QueryObserverResult from `@tanstack/query-core`.
+The result of `useQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
+`pending`. Re-exports QueryObserverResult from `@tanstack/query-core`. `useInfiniteQuery` returns
+[UseInfiniteQueryResult](UseInfiniteQueryResult.md) instead.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
@@ -7,7 +7,10 @@ title: UseInfiniteQueryResult
 type UseInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:225](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L225)
+Defined in: [preact-query/src/types.ts:296](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L296)
+
+The result of `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
+`pending`. Re-exports InfiniteQueryObserverResult from `@tanstack/query-core`.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: UseInfiniteQueryResult
 type UseInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:296](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L296)
+Defined in: [preact-query/src/types.ts:297](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L297)
 
 The result of `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
 `pending`. Re-exports InfiniteQueryObserverResult from `@tanstack/query-core`.

--- a/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
@@ -7,7 +7,7 @@ title: UseMutateAsyncFunction
 type UseMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:361](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L361)
+Defined in: [preact-query/src/types.ts:362](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L362)
 
 The type of `mutateAsync`, as returned by `useMutation`. Similar to [UseMutateFunction](UseMutateFunction.md), but returns a
 promise which can be awaited.

--- a/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
@@ -7,7 +7,7 @@ title: UseMutateAsyncFunction
 type UseMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:274](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L274)
+Defined in: [preact-query/src/types.ts:361](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L361)
 
 The type of `mutateAsync`, as returned by `useMutation`. Similar to [UseMutateFunction](UseMutateFunction.md), but returns a
 promise which can be awaited.

--- a/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
@@ -7,7 +7,7 @@ title: UseMutateFunction
 type UseMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```
 
-Defined in: [preact-query/src/types.ts:346](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L346)
+Defined in: [preact-query/src/types.ts:347](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L347)
 
 The type of `mutate`, as returned by `useMutation`. Forwards the variables (and an optional per-call
 `onSuccess`/`onError`/`onSettled`) to the underlying `mutate` call. Fire-and-forget — errors are surfaced

--- a/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
@@ -7,7 +7,7 @@ title: UseMutateFunction
 type UseMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```
 
-Defined in: [preact-query/src/types.ts:259](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L259)
+Defined in: [preact-query/src/types.ts:346](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L346)
 
 The type of `mutate`, as returned by `useMutation`. Forwards the variables (and an optional per-call
 `onSuccess`/`onError`/`onSettled`) to the underlying `mutate` call. Fire-and-forget — errors are surfaced

--- a/docs/framework/preact/reference/type-aliases/UseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutationResult.md
@@ -7,7 +7,7 @@ title: UseMutationResult
 type UseMutationResult<TData, TError, TVariables, TOnMutateResult> = UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:395](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L395)
+Defined in: [preact-query/src/types.ts:396](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L396)
 
 The result of `useMutation`. Same as [UseBaseMutationResult](UseBaseMutationResult.md).
 

--- a/docs/framework/preact/reference/type-aliases/UseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutationResult.md
@@ -7,7 +7,9 @@ title: UseMutationResult
 type UseMutationResult<TData, TError, TVariables, TOnMutateResult> = UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:301](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L301)
+Defined in: [preact-query/src/types.ts:395](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L395)
+
+The result of `useMutation`. Same as [UseBaseMutationResult](UseBaseMutationResult.md).
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UsePrefetchInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UsePrefetchInfiniteQueryOptions.md
@@ -7,7 +7,10 @@ title: UsePrefetchInfiniteQueryOptions
 type UsePrefetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = DistributiveOmit<InfiniteQueryExecuteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:76](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L76)
+Defined in: [preact-query/src/types.ts:92](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L92)
+
+The options accepted by `usePrefetchInfiniteQuery` — everything you can pass to `queryClient.infiniteQuery`,
+except `queryFn` is required unless a default query function has been defined.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
@@ -7,7 +7,10 @@ title: UsePrefetchQueryOptions
 type UsePrefetchQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = DistributiveOmit<QueryExecuteOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:50](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L50)
+Defined in: [preact-query/src/types.ts:62](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L62)
+
+The options accepted by `usePrefetchQuery` — everything you can pass to `queryClient.query`, except `queryFn`
+is required unless a default query function has been defined.
 
 ## Type Declaration
 

--- a/docs/framework/preact/reference/type-aliases/UseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseQueryResult.md
@@ -7,7 +7,7 @@ title: UseQueryResult
 type UseQueryResult<TData, TError> = UseBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:265](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L265)
+Defined in: [preact-query/src/types.ts:266](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L266)
 
 The result of `useQuery`. Same as [UseBaseQueryResult](UseBaseQueryResult.md).
 

--- a/docs/framework/preact/reference/type-aliases/UseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseQueryResult.md
@@ -7,7 +7,9 @@ title: UseQueryResult
 type UseQueryResult<TData, TError> = UseBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:207](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L207)
+Defined in: [preact-query/src/types.ts:265](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L265)
+
+The result of `useQuery`. Same as [UseBaseQueryResult](UseBaseQueryResult.md).
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: UseSuspenseInfiniteQueryResult
 type UseSuspenseInfiniteQueryResult<TData, TError> = OmitKeyof<DefinedInfiniteQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:314](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L314)
+Defined in: [preact-query/src/types.ts:315](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L315)
 
 The result of `useSuspenseInfiniteQuery`. Same as [DefinedUseInfiniteQueryResult](DefinedUseInfiniteQueryResult.md), minus
 `isPlaceholderData` — Suspense hooks never render placeholder data.

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
@@ -7,7 +7,10 @@ title: UseSuspenseInfiniteQueryResult
 type UseSuspenseInfiniteQueryResult<TData, TError> = OmitKeyof<DefinedInfiniteQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:235](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L235)
+Defined in: [preact-query/src/types.ts:314](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L314)
+
+The result of `useSuspenseInfiniteQuery`. Same as [DefinedUseInfiniteQueryResult](DefinedUseInfiniteQueryResult.md), minus
+`isPlaceholderData` — Suspense hooks never render placeholder data.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
@@ -7,7 +7,7 @@ title: UseSuspenseQueryResult
 type UseSuspenseQueryResult<TData, TError> = DistributiveOmit<DefinedQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:274](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L274)
+Defined in: [preact-query/src/types.ts:275](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L275)
 
 The result of `useSuspenseQuery`. Same as [DefinedUseQueryResult](DefinedUseQueryResult.md), minus `isPlaceholderData` — always
 `false` on that type, so this drops the dead field rather than an active state.

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
@@ -7,7 +7,10 @@ title: UseSuspenseQueryResult
 type UseSuspenseQueryResult<TData, TError> = DistributiveOmit<DefinedQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:212](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L212)
+Defined in: [preact-query/src/types.ts:274](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L274)
+
+The result of `useSuspenseQuery`. Same as [DefinedUseQueryResult](DefinedUseQueryResult.md), minus `isPlaceholderData` — always
+`false` on that type, so this drops the dead field rather than an active state.
 
 ## Type Parameters
 

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -11,6 +11,9 @@ import { useEffect, useMemo, useRef } from 'preact/hooks'
 
 import { useQueryClient } from './QueryClientProvider'
 
+/**
+ * The props accepted by `HydrationBoundary`.
+ */
 export interface HydrationBoundaryProps {
   /**
    * The state to hydrate.

--- a/packages/preact-query/src/QueryClientProvider.tsx
+++ b/packages/preact-query/src/QueryClientProvider.tsx
@@ -31,6 +31,9 @@ export const useQueryClient = (queryClient?: QueryClient) => {
   return client
 }
 
+/**
+ * The props accepted by `QueryClientProvider`.
+ */
 export type QueryClientProviderProps = {
   /**
    * **Required**
@@ -45,7 +48,10 @@ export type QueryClientProviderProps = {
 }
 
 /**
- * Use the `QueryClientProvider` component to connect and provide a `QueryClient` to your application.
+ * Use the `QueryClientProvider` component to connect and provide a `QueryClient` to your application. Also
+ * calls `client.mount()`/`client.unmount()` as this component mounts/unmounts, which subscribes the client to
+ * focus/online events (resuming any paused mutations and refetching as needed when the app regains focus or
+ * comes back online).
  *
  * @returns The provided `children`, wrapped so they can read the `QueryClient` via `useQueryClient`.
  *

--- a/packages/preact-query/src/QueryErrorResetBoundary.tsx
+++ b/packages/preact-query/src/QueryErrorResetBoundary.tsx
@@ -97,6 +97,9 @@ export type QueryErrorResetBoundaryFunction = (
   value: QueryErrorResetBoundaryValue,
 ) => ComponentChildren
 
+/**
+ * The props accepted by `QueryErrorResetBoundary`.
+ */
 export interface QueryErrorResetBoundaryProps {
   /**
    * Either a plain node, or a function that receives the boundary's {@link QueryErrorResetBoundaryValue} and

--- a/packages/preact-query/src/infiniteQueryOptions.ts
+++ b/packages/preact-query/src/infiniteQueryOptions.ts
@@ -11,6 +11,10 @@ import type {
 
 import type { UseInfiniteQueryOptions } from './types'
 
+/**
+ * The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set — `data`
+ * may be `undefined` while the query is `pending`.
+ */
 export type UndefinedInitialDataInfiniteOptions<
   TQueryFnData,
   TError = DefaultError,
@@ -39,6 +43,11 @@ export type UndefinedInitialDataInfiniteOptions<
       >
 }
 
+/**
+ * The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set and
+ * `queryFn` is not `skipToken` — same as {@link UndefinedInitialDataInfiniteOptions}, but `queryFn` may not be
+ * `skipToken`.
+ */
 export type UnusedSkipTokenInfiniteOptions<
   TQueryFnData,
   TError = DefaultError,
@@ -65,6 +74,10 @@ export type UnusedSkipTokenInfiniteOptions<
   >
 }
 
+/**
+ * The options accepted by the `infiniteQueryOptions` overload selected when `initialData` is set — `data` is
+ * never `undefined`.
+ */
 export type DefinedInitialDataInfiniteOptions<
   TQueryFnData,
   TError = DefaultError,

--- a/packages/preact-query/src/queryOptions.ts
+++ b/packages/preact-query/src/queryOptions.ts
@@ -11,6 +11,10 @@ import type {
 
 import type { UseQueryOptions } from './types'
 
+/**
+ * The options accepted by the `queryOptions` overload selected when no `initialData` is set — `data` may be
+ * `undefined` while the query is `pending`.
+ */
 export type UndefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -30,6 +34,10 @@ export type UndefinedInitialDataOptions<
     | NonUndefinedGuard<TQueryFnData>
 }
 
+/**
+ * The options accepted by the `queryOptions` overload selected when no `initialData` is set and `queryFn` is
+ * not `skipToken` — same as {@link UndefinedInitialDataOptions}, but `queryFn` may not be `skipToken`.
+ */
 export type UnusedSkipTokenOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -49,6 +57,10 @@ export type UnusedSkipTokenOptions<
   >
 }
 
+/**
+ * The options accepted by the `queryOptions` overload selected when `initialData` is set — `data` is never
+ * `undefined`.
+ */
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,
   TError = DefaultError,

--- a/packages/preact-query/src/types.ts
+++ b/packages/preact-query/src/types.ts
@@ -32,8 +32,8 @@ export type AnyUseBaseQueryOptions = UseBaseQueryOptions<
   any
 >
 /**
- * The options shared by `useQuery`, `useSuspenseQuery`, and their infinite counterparts. Extends
- * {@link QueryObserverOptions} from `@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
+ * The options shared by `useQuery` and `useSuspenseQuery`. Extends {@link QueryObserverOptions} from
+ * `@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
  */
 export interface UseBaseQueryOptions<
   TQueryFnData = unknown,
@@ -251,8 +251,9 @@ export interface UseSuspenseInfiniteQueryOptions<
 }
 
 /**
- * The result of `useQuery` and `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined`
- * while the query is `pending`. Re-exports {@link QueryObserverResult} from `@tanstack/query-core`.
+ * The result of `useQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
+ * `pending`. Re-exports {@link QueryObserverResult} from `@tanstack/query-core`. `useInfiniteQuery` returns
+ * {@link UseInfiniteQueryResult} instead.
  */
 export type UseBaseQueryResult<
   TData = unknown,

--- a/packages/preact-query/src/types.ts
+++ b/packages/preact-query/src/types.ts
@@ -20,6 +20,10 @@ import type {
   SkipToken,
 } from '@tanstack/query-core'
 
+/**
+ * {@link UseBaseQueryOptions} with all type parameters set to `any`, useful when the specific types aren't
+ * relevant, e.g. when accepting options for any query in a helper function.
+ */
 export type AnyUseBaseQueryOptions = UseBaseQueryOptions<
   any,
   any,
@@ -27,6 +31,10 @@ export type AnyUseBaseQueryOptions = UseBaseQueryOptions<
   any,
   any
 >
+/**
+ * The options shared by `useQuery`, `useSuspenseQuery`, and their infinite counterparts. Extends
+ * {@link QueryObserverOptions} from `@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
+ */
 export interface UseBaseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -47,6 +55,10 @@ export interface UseBaseQueryOptions<
   subscribed?: boolean
 }
 
+/**
+ * The options accepted by `usePrefetchQuery` — everything you can pass to `queryClient.query`, except `queryFn`
+ * is required unless a default query function has been defined.
+ */
 export type UsePrefetchQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -73,6 +85,10 @@ export type UsePrefetchQueryOptions<
   >
 }
 
+/**
+ * The options accepted by `usePrefetchInfiniteQuery` — everything you can pass to `queryClient.infiniteQuery`,
+ * except `queryFn` is required unless a default query function has been defined.
+ */
 export type UsePrefetchInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -105,7 +121,15 @@ export type UsePrefetchInfiniteQueryOptions<
   >
 }
 
+/**
+ * {@link UseQueryOptions} with all type parameters set to `any`, useful when the specific types aren't
+ * relevant, e.g. when accepting options for any query in a helper function.
+ */
 export type AnyUseQueryOptions = UseQueryOptions<any, any, any, any>
+/**
+ * The options accepted by `useQuery`. Same as {@link UseBaseQueryOptions}, minus `suspense` (which
+ * `preact-query` derives from which hook you call rather than exposing as an option).
+ */
 export interface UseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -116,12 +140,21 @@ export interface UseQueryOptions<
   'suspense'
 > {}
 
+/**
+ * {@link UseSuspenseQueryOptions} with all type parameters set to `any`, useful when the specific types aren't
+ * relevant, e.g. when accepting options for any query in a helper function.
+ */
 export type AnyUseSuspenseQueryOptions = UseSuspenseQueryOptions<
   any,
   any,
   any,
   any
 >
+/**
+ * The options accepted by `useSuspenseQuery`. Same as {@link UseQueryOptions}, minus `enabled`, `throwOnError`,
+ * and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so those options
+ * don't apply.
+ */
 export interface UseSuspenseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -141,6 +174,10 @@ export interface UseSuspenseQueryOptions<
   >
 }
 
+/**
+ * {@link UseInfiniteQueryOptions} with all type parameters set to `any`, useful when the specific types aren't
+ * relevant, e.g. when accepting options for any query in a helper function.
+ */
 export type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<
   any,
   any,
@@ -148,6 +185,11 @@ export type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<
   any,
   any
 >
+/**
+ * The options accepted by `useInfiniteQuery`. Extends {@link InfiniteQueryObserverOptions} from
+ * `@tanstack/query-core` with the `preact-query`-specific `subscribed` option, minus `suspense` (which
+ * `preact-query` derives from which hook you call rather than exposing as an option).
+ */
 export interface UseInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -171,8 +213,17 @@ export interface UseInfiniteQueryOptions<
   subscribed?: boolean
 }
 
+/**
+ * {@link UseSuspenseInfiniteQueryOptions} with all type parameters set to `any`, useful when the specific types
+ * aren't relevant, e.g. when accepting options for any query in a helper function.
+ */
 export type AnyUseSuspenseInfiniteQueryOptions =
   UseSuspenseInfiniteQueryOptions<any, any, any, any, any>
+/**
+ * The options accepted by `useSuspenseInfiniteQuery`. Same as {@link UseInfiniteQueryOptions}, minus `enabled`,
+ * `throwOnError`, and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so
+ * those options don't apply.
+ */
 export interface UseSuspenseInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -199,16 +250,27 @@ export interface UseSuspenseInfiniteQueryOptions<
   >
 }
 
+/**
+ * The result of `useQuery` and `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined`
+ * while the query is `pending`. Re-exports {@link QueryObserverResult} from `@tanstack/query-core`.
+ */
 export type UseBaseQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = QueryObserverResult<TData, TError>
 
+/**
+ * The result of `useQuery`. Same as {@link UseBaseQueryResult}.
+ */
 export type UseQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = UseBaseQueryResult<TData, TError>
 
+/**
+ * The result of `useSuspenseQuery`. Same as {@link DefinedUseQueryResult}, minus `isPlaceholderData` — always
+ * `false` on that type, so this drops the dead field rather than an active state.
+ */
 export type UseSuspenseQueryResult<
   TData = unknown,
   TError = DefaultError,
@@ -217,21 +279,38 @@ export type UseSuspenseQueryResult<
   'isPlaceholderData'
 >
 
+/**
+ * The result of `useQuery` when `initialData` is set, or of `useSuspenseQuery` before the `isPlaceholderData`
+ * omission — `data` is never `undefined`. Re-exports {@link DefinedQueryObserverResult} from
+ * `@tanstack/query-core`.
+ */
 export type DefinedUseQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = DefinedQueryObserverResult<TData, TError>
 
+/**
+ * The result of `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
+ * `pending`. Re-exports {@link InfiniteQueryObserverResult} from `@tanstack/query-core`.
+ */
 export type UseInfiniteQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = InfiniteQueryObserverResult<TData, TError>
 
+/**
+ * The result of `useInfiniteQuery` when `initialData` is set — `data` is never `undefined`. Re-exports
+ * {@link DefinedInfiniteQueryObserverResult} from `@tanstack/query-core`.
+ */
 export type DefinedUseInfiniteQueryResult<
   TData = unknown,
   TError = DefaultError,
 > = DefinedInfiniteQueryObserverResult<TData, TError>
 
+/**
+ * The result of `useSuspenseInfiniteQuery`. Same as {@link DefinedUseInfiniteQueryResult}, minus
+ * `isPlaceholderData` — Suspense hooks never render placeholder data.
+ */
 export type UseSuspenseInfiniteQueryResult<
   TData = unknown,
   TError = DefaultError,
@@ -240,7 +319,15 @@ export type UseSuspenseInfiniteQueryResult<
   'isPlaceholderData'
 >
 
+/**
+ * {@link UseMutationOptions} with all type parameters set to `any`, useful when the specific types aren't
+ * relevant, e.g. when accepting options for any mutation in a helper function.
+ */
 export type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>
+/**
+ * The options accepted by `useMutation`. Same as {@link MutationObserverOptions} from `@tanstack/query-core`,
+ * minus the internal `_defaulted` flag.
+ */
 export interface UseMutationOptions<
   TData = unknown,
   TError = DefaultError,
@@ -278,6 +365,10 @@ export type UseMutateAsyncFunction<
   TOnMutateResult = unknown,
 > = MutateFunction<TData, TError, TVariables, TOnMutateResult>
 
+/**
+ * The result of `useMutation`. Same as {@link MutationObserverResult} from `@tanstack/query-core`, with
+ * `mutate` narrowed to the fire-and-forget {@link UseMutateFunction} signature, plus the added `mutateAsync`.
+ */
 export type UseBaseMutationResult<
   TData = unknown,
   TError = DefaultError,
@@ -298,6 +389,9 @@ export type UseBaseMutationResult<
   >
 }
 
+/**
+ * The result of `useMutation`. Same as {@link UseBaseMutationResult}.
+ */
 export type UseMutationResult<
   TData = unknown,
   TError = DefaultError,

--- a/packages/preact-query/src/usePrefetchInfiniteQuery.tsx
+++ b/packages/preact-query/src/usePrefetchInfiniteQuery.tsx
@@ -15,6 +15,10 @@ import type { UsePrefetchInfiniteQueryOptions } from './types'
  * as well as pageParam information, and should return a single variable that will be passed to your query
  * function as `context.pageParam`. Return `undefined` or `null` to indicate there is no next page available.
  *
+ * The prefetch is skipped if the query already has any cached state — including a `pending`/`error` state left
+ * over from a previous attempt — so calling this on every render is cheap and won't refetch data that's
+ * already there or already in flight.
+ *
  * @param options - The {@link UsePrefetchInfiniteQueryOptions} to use — everything you can pass to `queryClient.infiniteQuery`.
  * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
  * be used.

--- a/packages/preact-query/src/usePrefetchQuery.tsx
+++ b/packages/preact-query/src/usePrefetchQuery.tsx
@@ -10,6 +10,10 @@ import type { UsePrefetchQueryOptions } from './types'
  * `usePrefetchQuery` that you can pass to `queryClient.query`, though `queryKey` is always required, and
  * `queryFn` is required unless a default query function has been defined.
  *
+ * The prefetch is skipped if the query already has any cached state — including a `pending`/`error` state left
+ * over from a previous attempt — so calling this on every render is cheap and won't refetch data that's
+ * already there or already in flight.
+ *
  * @param options - The {@link UsePrefetchQueryOptions} to use — everything you can pass to `queryClient.query`.
  * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
  * be used.

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -142,7 +142,9 @@ type GetUseQueryResult<T> =
                   UseQueryResult
 
 /**
- * QueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
+ * The `queries` array accepted by `useQueries`. Recursively unwraps each tuple element so every entry's
+ * `queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements — beyond that, or for a
+ * non-tuple array, falls back to a single homogeneous options type.
  */
 export type QueriesOptions<
   T extends Array<any>,
@@ -184,7 +186,10 @@ export type QueriesOptions<
               Array<UseQueryOptionsForUseQueries>
 
 /**
- * QueriesResults reducer recursively maps type param to results
+ * The result type returned by `useQueries`, when no `combine` is provided. Mirrors {@link QueriesOptions}: each
+ * tuple element's result type is inferred individually, up to 20 elements. A non-tuple array is mapped
+ * per-element instead, still inferring each entry individually; only past 20 elements does this fall back to a
+ * single homogeneous {@link UseQueryResult} type.
  */
 export type QueriesResults<
   T extends Array<any>,

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -143,8 +143,9 @@ type GetUseQueryResult<T> =
 
 /**
  * The `queries` array accepted by `useQueries`. Recursively unwraps each tuple element so every entry's
- * `queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements — beyond that, or for a
- * non-tuple array, falls back to a single homogeneous options type.
+ * `queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements. An opaque array (e.g.
+ * `unknown[]`) is returned as-is; a non-tuple array of a known element type, or a tuple past 20 elements, falls
+ * back to a single homogeneous options type.
  */
 export type QueriesOptions<
   T extends Array<any>,

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -106,8 +106,9 @@ type GetUseSuspenseQueryResult<T> =
 
 /**
  * The `queries` array accepted by `useSuspenseQueries`. Recursively unwraps each tuple element so every
- * entry's `queryFn`/`select` are inferred individually, up to 20 elements — beyond that, or for a non-tuple
- * array, falls back to a single homogeneous {@link UseSuspenseQueryOptions} type.
+ * entry's `queryFn`/`select` are inferred individually, up to 20 elements. An opaque array (e.g. `unknown[]`)
+ * is returned as-is; a non-tuple array of a known element type, or a tuple past 20 elements, falls back to a
+ * single homogeneous {@link UseSuspenseQueryOptions} type.
  */
 export type SuspenseQueriesOptions<
   T extends Array<any>,

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -105,7 +105,9 @@ type GetUseSuspenseQueryResult<T> =
                     UseSuspenseQueryResult
 
 /**
- * SuspenseQueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
+ * The `queries` array accepted by `useSuspenseQueries`. Recursively unwraps each tuple element so every
+ * entry's `queryFn`/`select` are inferred individually, up to 20 elements — beyond that, or for a non-tuple
+ * array, falls back to a single homogeneous {@link UseSuspenseQueryOptions} type.
  */
 export type SuspenseQueriesOptions<
   T extends Array<any>,
@@ -142,7 +144,10 @@ export type SuspenseQueriesOptions<
               Array<UseSuspenseQueryOptions>
 
 /**
- * SuspenseQueriesResults reducer recursively maps type param to results
+ * The result type returned by `useSuspenseQueries`, when no `combine` is provided. Mirrors
+ * {@link SuspenseQueriesOptions}: each tuple element's result type is inferred individually, up to 20 elements.
+ * A non-tuple array is mapped per-element instead, still inferring each entry individually; only past 20
+ * elements does this fall back to a single homogeneous {@link UseSuspenseQueryResult} type.
  */
 export type SuspenseQueriesResults<
   T extends Array<any>,


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11204, which added JSDoc to `preact-query`'s functions and components. This PR extends the same treatment to the remaining public interfaces and type aliases in `packages/preact-query/src` (`types.ts`, `queryOptions.ts`, `infiniteQueryOptions.ts`, `HydrationBoundary.tsx`, `QueryClientProvider.tsx`, `QueryErrorResetBoundary.tsx`, `useQueries.ts`, `useSuspenseQueries.ts`), so the TypeDoc-generated `interfaces/` and `type-aliases/` pages under `docs/framework/preact/reference/` carry the same level of documentation as the `functions/` pages.

Each declaration's JSDoc focuses on what its type signature alone doesn't say: how it relates to the `@tanstack/query-core` type it extends/omits from, which `queryOptions`/`infiniteQueryOptions` overload it belongs to and why, and — for `QueriesOptions`/`QueriesResults`/`SuspenseQueriesOptions`/`SuspenseQueriesResults` — how the recursive tuple-unwrapping and non-tuple fallback actually behave, verified line-by-line against the conditional types.

While reviewing for accuracy, also folded in a few small clarifications to existing #11204 JSDoc where the actual runtime/type behavior was more specific than what was written:
- `QueryClientProvider`: notes that it calls `client.mount()`/`client.unmount()`, which subscribes to focus/online events and resumes paused mutations.
- `usePrefetchQuery`/`usePrefetchInfiniteQuery`: notes that the prefetch is skipped whenever the query already has any cached state (not just when data is present).
- `SuspenseQueriesOptions`: `select` is inferred per-entry too, not just `queryFn`.

Regenerated `docs/framework/preact/reference/` with `pnpm run generate-docs` to pick up the new JSDoc; no other framework's output changed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded Preact Query API references with clearer descriptions for query, mutation, suspense, infinite-query, and prefetch options and results.
  - Updated source references throughout the documentation.
  - Clarified that repeated prefetch calls skip queries with cached, pending, or error state.
  - Documented provider lifecycle behavior, initial-data guarantees, Suspense constraints, and query-option requirements.
  - Added details about tuple inference and fallback behavior for multi-query APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->