### PR TITLE
docs(preact-query): document type parameters with '@template' and add 'useQueryClient' throws note

### DIFF
--- a/docs/framework/preact/reference/functions/QueryClientProvider.md
+++ b/docs/framework/preact/reference/functions/QueryClientProvider.md
@@ -7,7 +7,7 @@ title: QueryClientProvider
 function QueryClientProvider(__namedParameters): VNode;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:69](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L69)
+Defined in: [preact-query/src/QueryClientProvider.tsx:70](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L70)
 
 Use the `QueryClientProvider` component to connect and provide a `QueryClient` to your application. Also
 calls `client.mount()`/`client.unmount()` as this component mounts/unmounts, which subscribes the client to

--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -9,7 +9,7 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:135](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L135)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:156](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L156)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -76,7 +76,7 @@ function Projects() {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:210](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L210)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:231](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L231)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -165,7 +165,7 @@ queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:285](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L285)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:306](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L306)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.

--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -9,7 +9,7 @@ title: queryOptions
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:115](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L115)
+Defined in: [preact-query/src/queryOptions.ts:130](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L130)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -71,7 +71,7 @@ function Posts() {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:184](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L184)
+Defined in: [preact-query/src/queryOptions.ts:199](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L199)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -163,7 +163,7 @@ queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefi
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:253](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L253)
+Defined in: [preact-query/src/queryOptions.ts:268](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L268)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -7,7 +7,7 @@ title: useQueries
 function useQueries<T, TCombinedResult>(__namedParameters, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useQueries.ts:263](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L263)
+Defined in: [preact-query/src/useQueries.ts:275](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L275)
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 

--- a/docs/framework/preact/reference/functions/useQueryClient.md
+++ b/docs/framework/preact/reference/functions/useQueryClient.md
@@ -7,7 +7,7 @@ title: useQueryClient
 function useQueryClient(queryClient?): QueryClient;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:20](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L20)
+Defined in: [preact-query/src/QueryClientProvider.tsx:21](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L21)
 
 The `useQueryClient` hook returns the current `QueryClient` instance.
 
@@ -25,3 +25,7 @@ be used.
 `QueryClient`
 
 The current `QueryClient` instance.
+
+## Throws
+
+If no `queryClient` argument is passed and no `QueryClientProvider` is found in the component tree.

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -9,7 +9,7 @@ title: useSuspenseQueries
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:218](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L218)
+Defined in: [preact-query/src/useSuspenseQueries.ts:230](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L230)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -102,7 +102,7 @@ function App() {
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:285](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L285)
+Defined in: [preact-query/src/useSuspenseQueries.ts:297](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L297)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.

--- a/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
@@ -3,7 +3,7 @@ id: UseBaseQueryOptions
 title: UseBaseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:38](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L38)
+Defined in: [preact-query/src/types.ts:46](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L46)
 
 The options shared by `useQuery` and `useSuspenseQuery`. Extends QueryObserverOptions from
 `@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
@@ -18,21 +18,33 @@ The options shared by `useQuery` and `useSuspenseQuery`. Extends QueryObserverOp
 
 `TQueryFnData` = `unknown`
 
+The type your `queryFn` resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+`select` is used.
+
 ### TQueryData
 
 `TQueryData` = `TQueryFnData`
 
+The type `select` receives as input — usually the same as `TQueryFnData`, unless a
+`queryFn` has been shared across queries with different `select` functions.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
+
+The type of your `queryKey`.
 
 ## Properties
 
@@ -42,7 +54,7 @@ The options shared by `useQuery` and `useSuspenseQuery`. Extends QueryObserverOp
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L55)
+Defined in: [preact-query/src/types.ts:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L63)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
@@ -37,8 +37,8 @@ The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when 
 
 `TQueryData` = `TQueryFnData`
 
-The type `select` receives as input — usually the same as `TQueryFnData`, unless a
-`queryFn` has been shared across queries with different `select` functions.
+The type of the data actually held in the query cache — the input to `select` and
+`placeholderData`. Defaults to, and is usually the same as, `TQueryFnData`.
 
 ### TQueryKey
 

--- a/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
@@ -3,7 +3,7 @@ id: UseInfiniteQueryOptions
 title: UseInfiniteQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:193](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L193)
+Defined in: [preact-query/src/types.ts:236](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L236)
 
 The options accepted by `useInfiniteQuery`. Extends InfiniteQueryObserverOptions from
 `@tanstack/query-core` with the `preact-query`-specific `subscribed` option, minus `suspense` (which
@@ -19,21 +19,32 @@ The options accepted by `useInfiniteQuery`. Extends InfiniteQueryObserverOptions
 
 `TQueryFnData` = `unknown`
 
+The type of a single page, as your `queryFn` resolves it.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `InfiniteData`\<`TQueryFnData`\>
 
+The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+the shape of all fetched pages plus their page params.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
 
+The type of your `queryKey`.
+
 ### TPageParam
 
 `TPageParam` = `unknown`
+
+The type of the parameter passed to `queryFn` to fetch a given page.
 
 ## Properties
 
@@ -43,7 +54,7 @@ The options accepted by `useInfiniteQuery`. Extends InfiniteQueryObserverOptions
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:213](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L213)
+Defined in: [preact-query/src/types.ts:256](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L256)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseMutationOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseMutationOptions.md
@@ -3,7 +3,7 @@ id: UseMutationOptions
 title: UseMutationOptions
 ---
 
-Defined in: [preact-query/src/types.ts:332](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L332)
+Defined in: [preact-query/src/types.ts:409](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L409)
 
 The options accepted by `useMutation`. Same as MutationObserverOptions from `@tanstack/query-core`,
 minus the internal `_defaulted` flag.
@@ -18,14 +18,23 @@ minus the internal `_defaulted` flag.
 
 `TData` = `unknown`
 
+The type your mutation function resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your mutation function may throw.
 
 ### TVariables
 
 `TVariables` = `void`
 
+The type of the variable passed to `mutate`/`mutateAsync`.
+
 ### TOnMutateResult
 
 `TOnMutateResult` = `unknown`
+
+The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+their `onMutateResult` parameter — useful for optimistic-update rollback data.

--- a/docs/framework/preact/reference/interfaces/UseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseQueryOptions.md
@@ -3,7 +3,7 @@ id: UseQueryOptions
 title: UseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:133](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L133)
+Defined in: [preact-query/src/types.ts:163](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L163)
 
 The options accepted by `useQuery`. Same as [UseBaseQueryOptions](UseBaseQueryOptions.md), minus `suspense` (which
 `preact-query` derives from which hook you call rather than exposing as an option).
@@ -18,17 +18,26 @@ The options accepted by `useQuery`. Same as [UseBaseQueryOptions](UseBaseQueryOp
 
 `TQueryFnData` = `unknown`
 
+The type your `queryFn` resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+`select` is used.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
+
+The type of your `queryKey`.
 
 ## Properties
 
@@ -38,7 +47,7 @@ The options accepted by `useQuery`. Same as [UseBaseQueryOptions](UseBaseQueryOp
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L55)
+Defined in: [preact-query/src/types.ts:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L63)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
@@ -3,7 +3,7 @@ id: UseSuspenseInfiniteQueryOptions
 title: UseSuspenseInfiniteQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:227](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L227)
+Defined in: [preact-query/src/types.ts:277](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L277)
 
 The options accepted by `useSuspenseInfiniteQuery`. Same as [UseInfiniteQueryOptions](UseInfiniteQueryOptions.md), minus `enabled`,
 `throwOnError`, and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so
@@ -19,21 +19,32 @@ those options don't apply.
 
 `TQueryFnData` = `unknown`
 
+The type of a single page, as your `queryFn` resolves it.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `InfiniteData`\<`TQueryFnData`\>
 
+The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+the shape of all fetched pages plus their page params.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
 
+The type of your `queryKey`.
+
 ### TPageParam
 
 `TPageParam` = `unknown`
+
+The type of the parameter passed to `queryFn` to fetch a given page.
 
 ## Properties
 
@@ -43,7 +54,7 @@ those options don't apply.
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [preact-query/src/types.ts:241](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L241)
+Defined in: [preact-query/src/types.ts:291](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L291)
 
 `skipToken` is not allowed here — Suspense hooks cannot render a "disabled" state, so a query function
 must always be provided, unless a default query function has been defined.
@@ -56,7 +67,7 @@ must always be provided, unless a default query function has been defined.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:213](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L213)
+Defined in: [preact-query/src/types.ts:256](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L256)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
@@ -3,7 +3,7 @@ id: UseSuspenseQueryOptions
 title: UseSuspenseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:158](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L158)
+Defined in: [preact-query/src/types.ts:194](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L194)
 
 The options accepted by `useSuspenseQuery`. Same as [UseQueryOptions](UseQueryOptions.md), minus `enabled`, `throwOnError`,
 and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so those options
@@ -19,17 +19,26 @@ don't apply.
 
 `TQueryFnData` = `unknown`
 
+The type your `queryFn` resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+`select` is used.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
+
+The type of your `queryKey`.
 
 ## Properties
 
@@ -39,7 +48,7 @@ don't apply.
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, never>;
 ```
 
-Defined in: [preact-query/src/types.ts:171](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L171)
+Defined in: [preact-query/src/types.ts:207](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L207)
 
 `skipToken` is not allowed here — Suspense hooks cannot render a "disabled" state, so a query function
 must always be provided, unless a default query function has been defined.
@@ -52,7 +61,7 @@ must always be provided, unless a default query function has been defined.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L55)
+Defined in: [preact-query/src/types.ts:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L63)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
 Defaults to `true`.

--- a/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseInfiniteQueryOptions
 type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:181](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L181)
+Defined in: [preact-query/src/types.ts:217](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L217)
 
 [UseInfiniteQueryOptions](../interfaces/UseInfiniteQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
@@ -7,7 +7,7 @@ title: AnyUseMutationOptions
 type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:327](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L327)
+Defined in: [preact-query/src/types.ts:398](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L398)
 
 [UseMutationOptions](../interfaces/UseMutationOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any mutation in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseQueryOptions
 type AnyUseQueryOptions = UseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:128](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L128)
+Defined in: [preact-query/src/types.ts:152](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L152)
 
 [UseQueryOptions](../interfaces/UseQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseSuspenseInfiniteQueryOptions
 type AnyUseSuspenseInfiniteQueryOptions = UseSuspenseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:220](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L220)
+Defined in: [preact-query/src/types.ts:263](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L263)
 
 [UseSuspenseInfiniteQueryOptions](../interfaces/UseSuspenseInfiniteQueryOptions.md) with all type parameters set to `any`, useful when the specific types
 aren't relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseSuspenseQueryOptions
 type AnyUseSuspenseQueryOptions = UseSuspenseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:147](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L147)
+Defined in: [preact-query/src/types.ts:177](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L177)
 
 [UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -7,7 +7,7 @@ title: DefinedInitialDataInfiniteOptions
 type DefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:81](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L81)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:102](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L102)
 
 The options accepted by the `infiniteQueryOptions` overload selected when `initialData` is set — `data` is
 never `undefined`.
@@ -35,18 +35,29 @@ cache.
 
 `TQueryFnData`
 
+The type of a single page, as your `queryFn` resolves it.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `InfiniteData`\<`TQueryFnData`\>
 
+The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+the shape of all fetched pages plus their page params.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
 
+The type of your `queryKey`.
+
 ### TPageParam
 
 `TPageParam` = `unknown`
+
+The type of the parameter passed to `queryFn` to fetch a given page.

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
@@ -7,7 +7,7 @@ title: DefinedInitialDataOptions
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L64)
+Defined in: [preact-query/src/queryOptions.ts:79](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L79)
 
 The options accepted by the `queryOptions` overload selected when `initialData` is set — `data` is never
 `undefined`.
@@ -44,14 +44,22 @@ Optional here, but omitting it is only safe when no fetch will be attempted — 
 
 `TQueryFnData` = `unknown`
 
+The type your `queryFn` resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
+
+The type of your `queryKey`.

--- a/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedUseInfiniteQueryResult
 type DefinedUseInfiniteQueryResult<TData, TError> = DefinedInfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:306](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L306)
+Defined in: [preact-query/src/types.ts:374](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L374)
 
 The result of `useInfiniteQuery` when `initialData` is set — `data` is never `undefined`. Re-exports
 DefinedInfiniteQueryObserverResult from `@tanstack/query-core`.
@@ -18,6 +18,10 @@ DefinedInfiniteQueryObserverResult from `@tanstack/query-core`.
 
 `TData` = `unknown`
 
+The type `data` ends up as after `select` runs.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.

--- a/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedUseQueryResult
 type DefinedUseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:288](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L288)
+Defined in: [preact-query/src/types.ts:350](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L350)
 
 The result of `useQuery` when `initialData` is set, or of `useSuspenseQuery` before the `isPlaceholderData`
 omission — `data` is never `undefined`. Re-exports DefinedQueryObserverResult from
@@ -19,6 +19,10 @@ omission — `data` is never `undefined`. Re-exports DefinedQueryObserverResult 
 
 `TData` = `unknown`
 
+The type `data` ends up as after `select` runs.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.

--- a/docs/framework/preact/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesOptions.md
@@ -26,12 +26,12 @@ The type of the `queries` array as written at the call site.
 
 `TResults` *extends* `any`[] = \[\]
 
-Internal accumulator this type builds up during recursion. Not meant to be set
-explicitly.
+The internal accumulator that this type builds during recursion. It is not meant
+to be set explicitly.
 
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
 
-Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
-set explicitly.
+The internal recursion-depth counter, checked against the 20-element limit. It is not
+meant to be set explicitly.

--- a/docs/framework/preact/reference/type-aliases/QueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesOptions.md
@@ -7,7 +7,7 @@ title: QueriesOptions
 type QueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryOptionsForUseQueries[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryOptionsForUseQueries<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesOptions<[...Tails], [...TResults, GetUseQueryOptionsForUseQueries<Head>], [...TDepth, 1]> : ReadonlyArray<unknown> extends T ? T : T extends UseQueryOptionsForUseQueries<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData, TQueryKey>[] : UseQueryOptionsForUseQueries[];
 ```
 
-Defined in: [preact-query/src/useQueries.ts:150](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L150)
+Defined in: [preact-query/src/useQueries.ts:156](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L156)
 
 The `queries` array accepted by `useQueries`. Recursively unwraps each tuple element so every entry's
 `queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements. An opaque array (e.g.
@@ -20,10 +20,18 @@ back to a single homogeneous options type.
 
 `T` *extends* `any`[]
 
+The type of the `queries` array as written at the call site.
+
 ### TResults
 
 `TResults` *extends* `any`[] = \[\]
 
+Internal accumulator this type builds up during recursion. Not meant to be set
+explicitly.
+
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
+
+Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+set explicitly.

--- a/docs/framework/preact/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesResults.md
@@ -7,7 +7,7 @@ title: QueriesResults
 type QueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? QueriesResults<[...Tails], [...TResults, GetUseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useQueries.ts:195](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L195)
+Defined in: [preact-query/src/useQueries.ts:207](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L207)
 
 The result type returned by `useQueries`, when no `combine` is provided. Mirrors [QueriesOptions](QueriesOptions.md): each
 tuple element's result type is inferred individually, up to 20 elements. A non-tuple array is mapped
@@ -20,10 +20,18 @@ single homogeneous [UseQueryResult](UseQueryResult.md) type.
 
 `T` *extends* `any`[]
 
+The type of the `queries` array, as inferred by [QueriesOptions](QueriesOptions.md).
+
 ### TResults
 
 `TResults` *extends* `any`[] = \[\]
 
+Internal accumulator this type builds up during recursion. Not meant to be set
+explicitly.
+
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
+
+Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+set explicitly.

--- a/docs/framework/preact/reference/type-aliases/QueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/QueriesResults.md
@@ -26,12 +26,12 @@ The type of the `queries` array, as inferred by [QueriesOptions](QueriesOptions.
 
 `TResults` *extends* `any`[] = \[\]
 
-Internal accumulator this type builds up during recursion. Not meant to be set
-explicitly.
+The internal accumulator that this type builds during recursion. It is not meant
+to be set explicitly.
 
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
 
-Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
-set explicitly.
+The internal recursion-depth counter, checked against the 20-element limit. It is not
+meant to be set explicitly.

--- a/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
@@ -7,7 +7,7 @@ title: QueryClientProviderProps
 type QueryClientProviderProps = object;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:37](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L37)
+Defined in: [preact-query/src/QueryClientProvider.tsx:38](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L38)
 
 The props accepted by `QueryClientProvider`.
 
@@ -19,7 +19,7 @@ The props accepted by `QueryClientProvider`.
 optional children: ComponentChildren;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:47](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L47)
+Defined in: [preact-query/src/QueryClientProvider.tsx:48](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L48)
 
 The components that get access to the provided QueryClient.
 
@@ -31,7 +31,7 @@ The components that get access to the provided QueryClient.
 client: QueryClient;
 ```
 
-Defined in: [preact-query/src/QueryClientProvider.tsx:43](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L43)
+Defined in: [preact-query/src/QueryClientProvider.tsx:44](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L44)
 
 **Required**
 

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
@@ -7,7 +7,7 @@ title: SuspenseQueriesOptions
 type SuspenseQueriesOptions<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryOptions[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryOptions<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesOptions<[...Tails], [...TResults, GetUseSuspenseQueryOptions<Head>], [...TDepth, 1]> : unknown[] extends T ? T : T extends UseSuspenseQueryOptions<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[] ? UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[] : UseSuspenseQueryOptions[];
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:113](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L113)
+Defined in: [preact-query/src/useSuspenseQueries.ts:119](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L119)
 
 The `queries` array accepted by `useSuspenseQueries`. Recursively unwraps each tuple element so every
 entry's `queryFn`/`select` are inferred individually, up to 20 elements. An opaque array (e.g. `unknown[]`)
@@ -20,10 +20,18 @@ single homogeneous [UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptio
 
 `T` *extends* `any`[]
 
+The type of the `queries` array as written at the call site.
+
 ### TResults
 
 `TResults` *extends* `any`[] = \[\]
 
+Internal accumulator this type builds up during recursion. Not meant to be set
+explicitly.
+
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
+
+Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+set explicitly.

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesOptions.md
@@ -26,12 +26,12 @@ The type of the `queries` array as written at the call site.
 
 `TResults` *extends* `any`[] = \[\]
 
-Internal accumulator this type builds up during recursion. Not meant to be set
-explicitly.
+The internal accumulator that this type builds during recursion. It is not meant
+to be set explicitly.
 
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
 
-Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
-set explicitly.
+The internal recursion-depth counter, checked against the 20-element limit. It is not
+meant to be set explicitly.

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
@@ -26,12 +26,12 @@ The type of the `queries` array, as inferred by [SuspenseQueriesOptions](Suspens
 
 `TResults` *extends* `any`[] = \[\]
 
-Internal accumulator this type builds up during recursion. Not meant to be set
-explicitly.
+The internal accumulator that this type builds during recursion. It is not meant
+to be set explicitly.
 
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
 
-Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
-set explicitly.
+The internal recursion-depth counter, checked against the 20-element limit. It is not
+meant to be set explicitly.

--- a/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
+++ b/docs/framework/preact/reference/type-aliases/SuspenseQueriesResults.md
@@ -7,7 +7,7 @@ title: SuspenseQueriesResults
 type SuspenseQueriesResults<T, TResults, TDepth> = TDepth["length"] extends MAXIMUM_DEPTH ? UseSuspenseQueryResult[] : T extends [] ? [] : T extends [infer Head] ? [...TResults, GetUseSuspenseQueryResult<Head>] : T extends [infer Head, ...(infer Tails)] ? SuspenseQueriesResults<[...Tails], [...TResults, GetUseSuspenseQueryResult<Head>], [...TDepth, 1]> : { [K in keyof T]: GetUseSuspenseQueryResult<T[K]> };
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:153](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L153)
+Defined in: [preact-query/src/useSuspenseQueries.ts:165](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L165)
 
 The result type returned by `useSuspenseQueries`, when no `combine` is provided. Mirrors
 [SuspenseQueriesOptions](SuspenseQueriesOptions.md): each tuple element's result type is inferred individually, up to 20 elements.
@@ -20,10 +20,18 @@ elements does this fall back to a single homogeneous [UseSuspenseQueryResult](Us
 
 `T` *extends* `any`[]
 
+The type of the `queries` array, as inferred by [SuspenseQueriesOptions](SuspenseQueriesOptions.md).
+
 ### TResults
 
 `TResults` *extends* `any`[] = \[\]
 
+Internal accumulator this type builds up during recursion. Not meant to be set
+explicitly.
+
 ### TDepth
 
 `TDepth` *extends* `ReadonlyArray`\<`number`\> = \[\]
+
+Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+set explicitly.

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataInfiniteOptions.md
@@ -7,7 +7,7 @@ title: UndefinedInitialDataInfiniteOptions
 type UndefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:18](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L18)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:25](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L25)
 
 The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set — `data`
 may be `undefined` while the query is `pending`.
@@ -34,18 +34,29 @@ cache.
 
 `TQueryFnData`
 
+The type of a single page, as your `queryFn` resolves it.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `InfiniteData`\<`TQueryFnData`\>
 
+The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+the shape of all fetched pages plus their page params.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
 
+The type of your `queryKey`.
+
 ### TPageParam
 
 `TPageParam` = `unknown`
+
+The type of the parameter passed to `queryFn` to fetch a given page.

--- a/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UndefinedInitialDataOptions.md
@@ -7,7 +7,7 @@ title: UndefinedInitialDataOptions
 type UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:18](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L18)
+Defined in: [preact-query/src/queryOptions.ts:23](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L23)
 
 The options accepted by the `queryOptions` overload selected when no `initialData` is set — `data` may be
 `undefined` while the query is `pending`.
@@ -34,14 +34,22 @@ cache.
 
 `TQueryFnData` = `unknown`
 
+The type your `queryFn` resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
+
+The type of your `queryKey`.

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
@@ -7,7 +7,7 @@ title: UnusedSkipTokenInfiniteOptions
 type UnusedSkipTokenInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:51](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L51)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:65](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L65)
 
 The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set and
 `queryFn` is not `skipToken` — same as [UndefinedInitialDataInfiniteOptions](UndefinedInitialDataInfiniteOptions.md), but `queryFn` may not be
@@ -30,18 +30,29 @@ you don't intend to run the query yet, omit `queryFn` or use a default query fun
 
 `TQueryFnData`
 
+The type of a single page, as your `queryFn` resolves it.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `InfiniteData`\<`TQueryFnData`\>
 
+The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+the shape of all fetched pages plus their page params.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
 
+The type of your `queryKey`.
+
 ### TPageParam
 
 `TPageParam` = `unknown`
+
+The type of the parameter passed to `queryFn` to fetch a given page.

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
@@ -7,7 +7,7 @@ title: UnusedSkipTokenOptions
 type UnusedSkipTokenOptions<TQueryFnData, TError, TData, TQueryKey> = OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:41](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L41)
+Defined in: [preact-query/src/queryOptions.ts:51](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L51)
 
 The options accepted by the `queryOptions` overload selected when no `initialData` is set and `queryFn` is
 not `skipToken` — same as [UndefinedInitialDataOptions](UndefinedInitialDataOptions.md), but `queryFn` may not be `skipToken`.
@@ -29,14 +29,22 @@ you don't intend to run the query yet, omit `queryFn` or use a default query fun
 
 `TQueryFnData` = `unknown`
 
+The type your `queryFn` resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
+
+The type of your `queryKey`.

--- a/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
@@ -9,7 +9,7 @@ type UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Overrid
 }> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:373](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L373)
+Defined in: [preact-query/src/types.ts:468](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L468)
 
 The result of `useMutation`. Same as MutationObserverResult from `@tanstack/query-core`, with
 `mutate` narrowed to the fire-and-forget [UseMutateFunction](UseMutateFunction.md) signature, plus the added `mutateAsync`.
@@ -30,14 +30,23 @@ Similar to `mutate`, but returns a promise which can be awaited.
 
 `TData` = `unknown`
 
+The type your mutation function resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your mutation function may throw.
 
 ### TVariables
 
 `TVariables` = `unknown`
 
+The type of the variable passed to `mutate`/`mutateAsync`.
+
 ### TOnMutateResult
 
 `TOnMutateResult` = `unknown`
+
+The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+their `onMutateResult` parameter — useful for optimistic-update rollback data.

--- a/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
@@ -7,7 +7,7 @@ title: UseBaseQueryResult
 type UseBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:258](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L258)
+Defined in: [preact-query/src/types.ts:311](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L311)
 
 The result of `useQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
 `pending`. Re-exports QueryObserverResult from `@tanstack/query-core`. `useInfiniteQuery` returns
@@ -19,6 +19,10 @@ The result of `useQuery` when `initialData` isn't set — `data` may be `undefin
 
 `TData` = `unknown`
 
+The type `data` ends up as after `select` runs.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.

--- a/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: UseInfiniteQueryResult
 type UseInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:297](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L297)
+Defined in: [preact-query/src/types.ts:362](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L362)
 
 The result of `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
 `pending`. Re-exports InfiniteQueryObserverResult from `@tanstack/query-core`.
@@ -18,6 +18,10 @@ The result of `useInfiniteQuery` when `initialData` isn't set — `data` may be 
 
 `TData` = `unknown`
 
+The type `data` ends up as after `select` runs.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.

--- a/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
@@ -7,7 +7,7 @@ title: UseMutateAsyncFunction
 type UseMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:362](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L362)
+Defined in: [preact-query/src/types.ts:451](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L451)
 
 The type of `mutateAsync`, as returned by `useMutation`. Similar to [UseMutateFunction](UseMutateFunction.md), but returns a
 promise which can be awaited.
@@ -18,14 +18,23 @@ promise which can be awaited.
 
 `TData` = `unknown`
 
+The type your mutation function resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your mutation function may throw.
 
 ### TVariables
 
 `TVariables` = `void`
 
+The type of the variable passed to `mutateAsync`.
+
 ### TOnMutateResult
 
 `TOnMutateResult` = `unknown`
+
+The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+their `onMutateResult` parameter — useful for optimistic-update rollback data.

--- a/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
@@ -7,7 +7,7 @@ title: UseMutateFunction
 type UseMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```
 
-Defined in: [preact-query/src/types.ts:347](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L347)
+Defined in: [preact-query/src/types.ts:430](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L430)
 
 The type of `mutate`, as returned by `useMutation`. Forwards the variables (and an optional per-call
 `onSuccess`/`onError`/`onSettled`) to the underlying `mutate` call. Fire-and-forget — errors are surfaced
@@ -19,17 +19,26 @@ through the mutation result, not thrown.
 
 `TData` = `unknown`
 
+The type your mutation function resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your mutation function may throw.
 
 ### TVariables
 
 `TVariables` = `void`
 
+The type of the variable passed to `mutate`.
+
 ### TOnMutateResult
 
 `TOnMutateResult` = `unknown`
+
+The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+their `onMutateResult` parameter — useful for optimistic-update rollback data.
 
 ## Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutationResult.md
@@ -7,7 +7,7 @@ title: UseMutationResult
 type UseMutationResult<TData, TError, TVariables, TOnMutateResult> = UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:396](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L396)
+Defined in: [preact-query/src/types.ts:497](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L497)
 
 The result of `useMutation`. Same as [UseBaseMutationResult](UseBaseMutationResult.md).
 
@@ -17,14 +17,23 @@ The result of `useMutation`. Same as [UseBaseMutationResult](UseBaseMutationResu
 
 `TData` = `unknown`
 
+The type your mutation function resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your mutation function may throw.
 
 ### TVariables
 
 `TVariables` = `unknown`
 
+The type of the variable passed to `mutate`/`mutateAsync`.
+
 ### TOnMutateResult
 
 `TOnMutateResult` = `unknown`
+
+The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+their `onMutateResult` parameter — useful for optimistic-update rollback data.

--- a/docs/framework/preact/reference/type-aliases/UsePrefetchInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UsePrefetchInfiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: UsePrefetchInfiniteQueryOptions
 type UsePrefetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = DistributiveOmit<InfiniteQueryExecuteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:92](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L92)
+Defined in: [preact-query/src/types.ts:116](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L116)
 
 The options accepted by `usePrefetchInfiniteQuery` — everything you can pass to `queryClient.infiniteQuery`,
 except `queryFn` is required unless a default query function has been defined.
@@ -29,18 +29,30 @@ unless a default query function has been defined.
 
 `TQueryFnData` = `unknown`
 
+The type of a single page, as your `queryFn` resolves it.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` (a single page)
+here, since a prefetch never reads `data` back out — this parameter only matters if you reuse these options
+elsewhere with `select` applied.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
 
+The type of your `queryKey`.
+
 ### TPageParam
 
 `TPageParam` = `unknown`
+
+The type of the parameter passed to `queryFn` to fetch a given page.

--- a/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
@@ -7,7 +7,7 @@ title: UsePrefetchQueryOptions
 type UsePrefetchQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = DistributiveOmit<QueryExecuteOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:62](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L62)
+Defined in: [preact-query/src/types.ts:78](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L78)
 
 The options accepted by `usePrefetchQuery` — everything you can pass to `queryClient.query`, except `queryFn`
 is required unless a default query function has been defined.
@@ -29,18 +29,30 @@ unless a default query function has been defined.
 
 `TQueryFnData` = `unknown`
 
+The type your `queryFn` resolves to.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.
 
 ### TData
 
 `TData` = `TQueryFnData`
 
+The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+`select` is used.
+
 ### TQueryData
 
 `TQueryData` = `TQueryFnData`
 
+The type `select` receives as input — usually the same as `TQueryFnData`, unless a
+`queryFn` has been shared across queries with different `select` functions.
+
 ### TQueryKey
 
 `TQueryKey` *extends* `QueryKey` = `QueryKey`
+
+The type of your `queryKey`.

--- a/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
@@ -48,8 +48,8 @@ The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when 
 
 `TQueryData` = `TQueryFnData`
 
-The type `select` receives as input — usually the same as `TQueryFnData`, unless a
-`queryFn` has been shared across queries with different `select` functions.
+The type of the data actually held in the query cache — the input to `select` and
+`placeholderData`. Defaults to, and is usually the same as, `TQueryFnData`.
 
 ### TQueryKey
 

--- a/docs/framework/preact/reference/type-aliases/UseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseQueryResult.md
@@ -7,7 +7,7 @@ title: UseQueryResult
 type UseQueryResult<TData, TError> = UseBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:266](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L266)
+Defined in: [preact-query/src/types.ts:322](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L322)
 
 The result of `useQuery`. Same as [UseBaseQueryResult](UseBaseQueryResult.md).
 
@@ -17,6 +17,10 @@ The result of `useQuery`. Same as [UseBaseQueryResult](UseBaseQueryResult.md).
 
 `TData` = `unknown`
 
+The type `data` ends up as after `select` runs.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: UseSuspenseInfiniteQueryResult
 type UseSuspenseInfiniteQueryResult<TData, TError> = OmitKeyof<DefinedInfiniteQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:315](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L315)
+Defined in: [preact-query/src/types.ts:386](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L386)
 
 The result of `useSuspenseInfiniteQuery`. Same as [DefinedUseInfiniteQueryResult](DefinedUseInfiniteQueryResult.md), minus
 `isPlaceholderData` — Suspense hooks never render placeholder data.
@@ -18,6 +18,10 @@ The result of `useSuspenseInfiniteQuery`. Same as [DefinedUseInfiniteQueryResult
 
 `TData` = `unknown`
 
+The type `data` ends up as after `select` runs.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
@@ -7,7 +7,7 @@ title: UseSuspenseQueryResult
 type UseSuspenseQueryResult<TData, TError> = DistributiveOmit<DefinedQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:275](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L275)
+Defined in: [preact-query/src/types.ts:334](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L334)
 
 The result of `useSuspenseQuery`. Same as [DefinedUseQueryResult](DefinedUseQueryResult.md), minus `isPlaceholderData` — always
 `false` on that type, so this drops the dead field rather than an active state.
@@ -18,6 +18,10 @@ The result of `useSuspenseQuery`. Same as [DefinedUseQueryResult](DefinedUseQuer
 
 `TData` = `unknown`
 
+The type `data` ends up as after `select` runs.
+
 ### TError
 
 `TError` = `DefaultError`
+
+The type of errors your `queryFn` may throw.

--- a/packages/preact-query/src/QueryClientProvider.tsx
+++ b/packages/preact-query/src/QueryClientProvider.tsx
@@ -16,6 +16,7 @@ export const QueryClientContext = createContext<QueryClient | undefined>(
  * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
  * be used.
  * @returns The current `QueryClient` instance.
+ * @throws If no `queryClient` argument is passed and no `QueryClientProvider` is found in the component tree.
  */
 export const useQueryClient = (queryClient?: QueryClient) => {
   const client = useContext(QueryClientContext)

--- a/packages/preact-query/src/infiniteQueryOptions.ts
+++ b/packages/preact-query/src/infiniteQueryOptions.ts
@@ -14,6 +14,13 @@ import type { UseInfiniteQueryOptions } from './types'
 /**
  * The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set — `data`
  * may be `undefined` while the query is `pending`.
+ *
+ * @template TQueryFnData - The type of a single page, as your `queryFn` resolves it.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+ * the shape of all fetched pages plus their page params.
+ * @template TQueryKey - The type of your `queryKey`.
+ * @template TPageParam - The type of the parameter passed to `queryFn` to fetch a given page.
  */
 export type UndefinedInitialDataInfiniteOptions<
   TQueryFnData,
@@ -47,6 +54,13 @@ export type UndefinedInitialDataInfiniteOptions<
  * The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set and
  * `queryFn` is not `skipToken` — same as {@link UndefinedInitialDataInfiniteOptions}, but `queryFn` may not be
  * `skipToken`.
+ *
+ * @template TQueryFnData - The type of a single page, as your `queryFn` resolves it.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+ * the shape of all fetched pages plus their page params.
+ * @template TQueryKey - The type of your `queryKey`.
+ * @template TPageParam - The type of the parameter passed to `queryFn` to fetch a given page.
  */
 export type UnusedSkipTokenInfiniteOptions<
   TQueryFnData,
@@ -77,6 +91,13 @@ export type UnusedSkipTokenInfiniteOptions<
 /**
  * The options accepted by the `infiniteQueryOptions` overload selected when `initialData` is set — `data` is
  * never `undefined`.
+ *
+ * @template TQueryFnData - The type of a single page, as your `queryFn` resolves it.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+ * the shape of all fetched pages plus their page params.
+ * @template TQueryKey - The type of your `queryKey`.
+ * @template TPageParam - The type of the parameter passed to `queryFn` to fetch a given page.
  */
 export type DefinedInitialDataInfiniteOptions<
   TQueryFnData,

--- a/packages/preact-query/src/queryOptions.ts
+++ b/packages/preact-query/src/queryOptions.ts
@@ -14,6 +14,11 @@ import type { UseQueryOptions } from './types'
 /**
  * The options accepted by the `queryOptions` overload selected when no `initialData` is set — `data` may be
  * `undefined` while the query is `pending`.
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TQueryKey - The type of your `queryKey`.
  */
 export type UndefinedInitialDataOptions<
   TQueryFnData = unknown,
@@ -37,6 +42,11 @@ export type UndefinedInitialDataOptions<
 /**
  * The options accepted by the `queryOptions` overload selected when no `initialData` is set and `queryFn` is
  * not `skipToken` — same as {@link UndefinedInitialDataOptions}, but `queryFn` may not be `skipToken`.
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TQueryKey - The type of your `queryKey`.
  */
 export type UnusedSkipTokenOptions<
   TQueryFnData = unknown,
@@ -60,6 +70,11 @@ export type UnusedSkipTokenOptions<
 /**
  * The options accepted by the `queryOptions` overload selected when `initialData` is set — `data` is never
  * `undefined`.
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TQueryKey - The type of your `queryKey`.
  */
 export type DefinedInitialDataOptions<
   TQueryFnData = unknown,

--- a/packages/preact-query/src/types.ts
+++ b/packages/preact-query/src/types.ts
@@ -39,8 +39,8 @@ export type AnyUseBaseQueryOptions = UseBaseQueryOptions<
  * @template TError - The type of errors your `queryFn` may throw.
  * @template TData - The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
  * `select` is used.
- * @template TQueryData - The type `select` receives as input — usually the same as `TQueryFnData`, unless a
- * `queryFn` has been shared across queries with different `select` functions.
+ * @template TQueryData - The type of the data actually held in the query cache — the input to `select` and
+ * `placeholderData`. Defaults to, and is usually the same as, `TQueryFnData`.
  * @template TQueryKey - The type of your `queryKey`.
  */
 export interface UseBaseQueryOptions<
@@ -71,8 +71,8 @@ export interface UseBaseQueryOptions<
  * @template TError - The type of errors your `queryFn` may throw.
  * @template TData - The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
  * `select` is used.
- * @template TQueryData - The type `select` receives as input — usually the same as `TQueryFnData`, unless a
- * `queryFn` has been shared across queries with different `select` functions.
+ * @template TQueryData - The type of the data actually held in the query cache — the input to `select` and
+ * `placeholderData`. Defaults to, and is usually the same as, `TQueryFnData`.
  * @template TQueryKey - The type of your `queryKey`.
  */
 export type UsePrefetchQueryOptions<

--- a/packages/preact-query/src/types.ts
+++ b/packages/preact-query/src/types.ts
@@ -34,6 +34,14 @@ export type AnyUseBaseQueryOptions = UseBaseQueryOptions<
 /**
  * The options shared by `useQuery` and `useSuspenseQuery`. Extends {@link QueryObserverOptions} from
  * `@tanstack/query-core` with the `preact-query`-specific `subscribed` option.
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+ * `select` is used.
+ * @template TQueryData - The type `select` receives as input — usually the same as `TQueryFnData`, unless a
+ * `queryFn` has been shared across queries with different `select` functions.
+ * @template TQueryKey - The type of your `queryKey`.
  */
 export interface UseBaseQueryOptions<
   TQueryFnData = unknown,
@@ -58,6 +66,14 @@ export interface UseBaseQueryOptions<
 /**
  * The options accepted by `usePrefetchQuery` — everything you can pass to `queryClient.query`, except `queryFn`
  * is required unless a default query function has been defined.
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+ * `select` is used.
+ * @template TQueryData - The type `select` receives as input — usually the same as `TQueryFnData`, unless a
+ * `queryFn` has been shared across queries with different `select` functions.
+ * @template TQueryKey - The type of your `queryKey`.
  */
 export type UsePrefetchQueryOptions<
   TQueryFnData = unknown,
@@ -88,6 +104,14 @@ export type UsePrefetchQueryOptions<
 /**
  * The options accepted by `usePrefetchInfiniteQuery` — everything you can pass to `queryClient.infiniteQuery`,
  * except `queryFn` is required unless a default query function has been defined.
+ *
+ * @template TQueryFnData - The type of a single page, as your `queryFn` resolves it.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` (a single page)
+ * here, since a prefetch never reads `data` back out — this parameter only matters if you reuse these options
+ * elsewhere with `select` applied.
+ * @template TQueryKey - The type of your `queryKey`.
+ * @template TPageParam - The type of the parameter passed to `queryFn` to fetch a given page.
  */
 export type UsePrefetchInfiniteQueryOptions<
   TQueryFnData = unknown,
@@ -129,6 +153,12 @@ export type AnyUseQueryOptions = UseQueryOptions<any, any, any, any>
 /**
  * The options accepted by `useQuery`. Same as {@link UseBaseQueryOptions}, minus `suspense` (which
  * `preact-query` derives from which hook you call rather than exposing as an option).
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+ * `select` is used.
+ * @template TQueryKey - The type of your `queryKey`.
  */
 export interface UseQueryOptions<
   TQueryFnData = unknown,
@@ -154,6 +184,12 @@ export type AnyUseSuspenseQueryOptions = UseSuspenseQueryOptions<
  * The options accepted by `useSuspenseQuery`. Same as {@link UseQueryOptions}, minus `enabled`, `throwOnError`,
  * and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so those options
  * don't apply.
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs. Defaults to `TQueryFnData` when no
+ * `select` is used.
+ * @template TQueryKey - The type of your `queryKey`.
  */
 export interface UseSuspenseQueryOptions<
   TQueryFnData = unknown,
@@ -189,6 +225,13 @@ export type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<
  * The options accepted by `useInfiniteQuery`. Extends {@link InfiniteQueryObserverOptions} from
  * `@tanstack/query-core` with the `preact-query`-specific `subscribed` option, minus `suspense` (which
  * `preact-query` derives from which hook you call rather than exposing as an option).
+ *
+ * @template TQueryFnData - The type of a single page, as your `queryFn` resolves it.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+ * the shape of all fetched pages plus their page params.
+ * @template TQueryKey - The type of your `queryKey`.
+ * @template TPageParam - The type of the parameter passed to `queryFn` to fetch a given page.
  */
 export interface UseInfiniteQueryOptions<
   TQueryFnData = unknown,
@@ -223,6 +266,13 @@ export type AnyUseSuspenseInfiniteQueryOptions =
  * The options accepted by `useSuspenseInfiniteQuery`. Same as {@link UseInfiniteQueryOptions}, minus `enabled`,
  * `throwOnError`, and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so
  * those options don't apply.
+ *
+ * @template TQueryFnData - The type of a single page, as your `queryFn` resolves it.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+ * the shape of all fetched pages plus their page params.
+ * @template TQueryKey - The type of your `queryKey`.
+ * @template TPageParam - The type of the parameter passed to `queryFn` to fetch a given page.
  */
 export interface UseSuspenseInfiniteQueryOptions<
   TQueryFnData = unknown,
@@ -254,6 +304,9 @@ export interface UseSuspenseInfiniteQueryOptions<
  * The result of `useQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
  * `pending`. Re-exports {@link QueryObserverResult} from `@tanstack/query-core`. `useInfiniteQuery` returns
  * {@link UseInfiniteQueryResult} instead.
+ *
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TError - The type of errors your `queryFn` may throw.
  */
 export type UseBaseQueryResult<
   TData = unknown,
@@ -262,6 +315,9 @@ export type UseBaseQueryResult<
 
 /**
  * The result of `useQuery`. Same as {@link UseBaseQueryResult}.
+ *
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TError - The type of errors your `queryFn` may throw.
  */
 export type UseQueryResult<
   TData = unknown,
@@ -271,6 +327,9 @@ export type UseQueryResult<
 /**
  * The result of `useSuspenseQuery`. Same as {@link DefinedUseQueryResult}, minus `isPlaceholderData` — always
  * `false` on that type, so this drops the dead field rather than an active state.
+ *
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TError - The type of errors your `queryFn` may throw.
  */
 export type UseSuspenseQueryResult<
   TData = unknown,
@@ -284,6 +343,9 @@ export type UseSuspenseQueryResult<
  * The result of `useQuery` when `initialData` is set, or of `useSuspenseQuery` before the `isPlaceholderData`
  * omission — `data` is never `undefined`. Re-exports {@link DefinedQueryObserverResult} from
  * `@tanstack/query-core`.
+ *
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TError - The type of errors your `queryFn` may throw.
  */
 export type DefinedUseQueryResult<
   TData = unknown,
@@ -293,6 +355,9 @@ export type DefinedUseQueryResult<
 /**
  * The result of `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
  * `pending`. Re-exports {@link InfiniteQueryObserverResult} from `@tanstack/query-core`.
+ *
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TError - The type of errors your `queryFn` may throw.
  */
 export type UseInfiniteQueryResult<
   TData = unknown,
@@ -302,6 +367,9 @@ export type UseInfiniteQueryResult<
 /**
  * The result of `useInfiniteQuery` when `initialData` is set — `data` is never `undefined`. Re-exports
  * {@link DefinedInfiniteQueryObserverResult} from `@tanstack/query-core`.
+ *
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TError - The type of errors your `queryFn` may throw.
  */
 export type DefinedUseInfiniteQueryResult<
   TData = unknown,
@@ -311,6 +379,9 @@ export type DefinedUseInfiniteQueryResult<
 /**
  * The result of `useSuspenseInfiniteQuery`. Same as {@link DefinedUseInfiniteQueryResult}, minus
  * `isPlaceholderData` — Suspense hooks never render placeholder data.
+ *
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TError - The type of errors your `queryFn` may throw.
  */
 export type UseSuspenseInfiniteQueryResult<
   TData = unknown,
@@ -328,6 +399,12 @@ export type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>
 /**
  * The options accepted by `useMutation`. Same as {@link MutationObserverOptions} from `@tanstack/query-core`,
  * minus the internal `_defaulted` flag.
+ *
+ * @template TData - The type your mutation function resolves to.
+ * @template TError - The type of errors your mutation function may throw.
+ * @template TVariables - The type of the variable passed to `mutate`/`mutateAsync`.
+ * @template TOnMutateResult - The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+ * their `onMutateResult` parameter — useful for optimistic-update rollback data.
  */
 export interface UseMutationOptions<
   TData = unknown,
@@ -343,6 +420,12 @@ export interface UseMutationOptions<
  * The type of `mutate`, as returned by `useMutation`. Forwards the variables (and an optional per-call
  * `onSuccess`/`onError`/`onSettled`) to the underlying `mutate` call. Fire-and-forget — errors are surfaced
  * through the mutation result, not thrown.
+ *
+ * @template TData - The type your mutation function resolves to.
+ * @template TError - The type of errors your mutation function may throw.
+ * @template TVariables - The type of the variable passed to `mutate`.
+ * @template TOnMutateResult - The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+ * their `onMutateResult` parameter — useful for optimistic-update rollback data.
  */
 export type UseMutateFunction<
   TData = unknown,
@@ -358,6 +441,12 @@ export type UseMutateFunction<
 /**
  * The type of `mutateAsync`, as returned by `useMutation`. Similar to {@link UseMutateFunction}, but returns a
  * promise which can be awaited.
+ *
+ * @template TData - The type your mutation function resolves to.
+ * @template TError - The type of errors your mutation function may throw.
+ * @template TVariables - The type of the variable passed to `mutateAsync`.
+ * @template TOnMutateResult - The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+ * their `onMutateResult` parameter — useful for optimistic-update rollback data.
  */
 export type UseMutateAsyncFunction<
   TData = unknown,
@@ -369,6 +458,12 @@ export type UseMutateAsyncFunction<
 /**
  * The result of `useMutation`. Same as {@link MutationObserverResult} from `@tanstack/query-core`, with
  * `mutate` narrowed to the fire-and-forget {@link UseMutateFunction} signature, plus the added `mutateAsync`.
+ *
+ * @template TData - The type your mutation function resolves to.
+ * @template TError - The type of errors your mutation function may throw.
+ * @template TVariables - The type of the variable passed to `mutate`/`mutateAsync`.
+ * @template TOnMutateResult - The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+ * their `onMutateResult` parameter — useful for optimistic-update rollback data.
  */
 export type UseBaseMutationResult<
   TData = unknown,
@@ -392,6 +487,12 @@ export type UseBaseMutationResult<
 
 /**
  * The result of `useMutation`. Same as {@link UseBaseMutationResult}.
+ *
+ * @template TData - The type your mutation function resolves to.
+ * @template TError - The type of errors your mutation function may throw.
+ * @template TVariables - The type of the variable passed to `mutate`/`mutateAsync`.
+ * @template TOnMutateResult - The type returned by `onMutate`, passed to `onSuccess`/`onError`/`onSettled` as
+ * their `onMutateResult` parameter — useful for optimistic-update rollback data.
  */
 export type UseMutationResult<
   TData = unknown,

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -148,10 +148,10 @@ type GetUseQueryResult<T> =
  * back to a single homogeneous options type.
  *
  * @template T - The type of the `queries` array as written at the call site.
- * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
- * explicitly.
- * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
- * set explicitly.
+ * @template TResults - The internal accumulator that this type builds during recursion. It is not meant
+ * to be set explicitly.
+ * @template TDepth - The internal recursion-depth counter, checked against the 20-element limit. It is not
+ * meant to be set explicitly.
  */
 export type QueriesOptions<
   T extends Array<any>,
@@ -199,10 +199,10 @@ export type QueriesOptions<
  * single homogeneous {@link UseQueryResult} type.
  *
  * @template T - The type of the `queries` array, as inferred by {@link QueriesOptions}.
- * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
- * explicitly.
- * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
- * set explicitly.
+ * @template TResults - The internal accumulator that this type builds during recursion. It is not meant
+ * to be set explicitly.
+ * @template TDepth - The internal recursion-depth counter, checked against the 20-element limit. It is not
+ * meant to be set explicitly.
  */
 export type QueriesResults<
   T extends Array<any>,

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -146,6 +146,12 @@ type GetUseQueryResult<T> =
  * `queryFn`/`select`/`throwOnError` are inferred individually, up to 20 elements. An opaque array (e.g.
  * `unknown[]`) is returned as-is; a non-tuple array of a known element type, or a tuple past 20 elements, falls
  * back to a single homogeneous options type.
+ *
+ * @template T - The type of the `queries` array as written at the call site.
+ * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
+ * explicitly.
+ * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+ * set explicitly.
  */
 export type QueriesOptions<
   T extends Array<any>,
@@ -191,6 +197,12 @@ export type QueriesOptions<
  * tuple element's result type is inferred individually, up to 20 elements. A non-tuple array is mapped
  * per-element instead, still inferring each entry individually; only past 20 elements does this fall back to a
  * single homogeneous {@link UseQueryResult} type.
+ *
+ * @template T - The type of the `queries` array, as inferred by {@link QueriesOptions}.
+ * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
+ * explicitly.
+ * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+ * set explicitly.
  */
 export type QueriesResults<
   T extends Array<any>,

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -111,10 +111,10 @@ type GetUseSuspenseQueryResult<T> =
  * single homogeneous {@link UseSuspenseQueryOptions} type.
  *
  * @template T - The type of the `queries` array as written at the call site.
- * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
- * explicitly.
- * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
- * set explicitly.
+ * @template TResults - The internal accumulator that this type builds during recursion. It is not meant
+ * to be set explicitly.
+ * @template TDepth - The internal recursion-depth counter, checked against the 20-element limit. It is not
+ * meant to be set explicitly.
  */
 export type SuspenseQueriesOptions<
   T extends Array<any>,
@@ -157,10 +157,10 @@ export type SuspenseQueriesOptions<
  * elements does this fall back to a single homogeneous {@link UseSuspenseQueryResult} type.
  *
  * @template T - The type of the `queries` array, as inferred by {@link SuspenseQueriesOptions}.
- * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
- * explicitly.
- * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
- * set explicitly.
+ * @template TResults - The internal accumulator that this type builds during recursion. It is not meant
+ * to be set explicitly.
+ * @template TDepth - The internal recursion-depth counter, checked against the 20-element limit. It is not
+ * meant to be set explicitly.
  */
 export type SuspenseQueriesResults<
   T extends Array<any>,

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -109,6 +109,12 @@ type GetUseSuspenseQueryResult<T> =
  * entry's `queryFn`/`select` are inferred individually, up to 20 elements. An opaque array (e.g. `unknown[]`)
  * is returned as-is; a non-tuple array of a known element type, or a tuple past 20 elements, falls back to a
  * single homogeneous {@link UseSuspenseQueryOptions} type.
+ *
+ * @template T - The type of the `queries` array as written at the call site.
+ * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
+ * explicitly.
+ * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+ * set explicitly.
  */
 export type SuspenseQueriesOptions<
   T extends Array<any>,
@@ -149,6 +155,12 @@ export type SuspenseQueriesOptions<
  * {@link SuspenseQueriesOptions}: each tuple element's result type is inferred individually, up to 20 elements.
  * A non-tuple array is mapped per-element instead, still inferring each entry individually; only past 20
  * elements does this fall back to a single homogeneous {@link UseSuspenseQueryResult} type.
+ *
+ * @template T - The type of the `queries` array, as inferred by {@link SuspenseQueriesOptions}.
+ * @template TResults - Internal accumulator this type builds up during recursion. Not meant to be set
+ * explicitly.
+ * @template TDepth - Internal recursion-depth counter, checked against the 20-element limit. Not meant to be
+ * set explicitly.
  */
 export type SuspenseQueriesResults<
   T extends Array<any>,


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11284. Adds `@template` JSDoc tags to every generic interface/type in `packages/preact-query/src` (`types.ts`, `queryOptions.ts`, `infiniteQueryOptions.ts`, `useQueries.ts`, `useSuspenseQueries.ts`) describing what each type parameter means — e.g. `TQueryFnData` vs `TQueryData` vs `TData`, or why `TResults`/`TDepth` exist on `QueriesOptions`/`QueriesResults` but aren't meant to be set explicitly.

`@template` isn't used anywhere else in the repo yet. Verified TypeDoc actually renders it (under each parameter's name/default in the "Type Parameters" section) before applying it everywhere — see e.g. `docs/framework/preact/reference/interfaces/UseQueryOptions.md`. This is scoped to `preact-query` only; extending the same treatment to the other TypeDoc-generated adapters (angular, svelte, lit) would be a separate follow-up.

Also added a `@throws` note to `useQueryClient`, documenting the "No QueryClient set" error it throws when called with no `queryClient` argument outside a `QueryClientProvider`.

Regenerated `docs/framework/preact/reference/` with `pnpm run generate-docs` to pick up the new JSDoc; no other framework's output changed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Preact API reference links to current source locations.
  * Added clearer descriptions for query, mutation, infinite-query, suspense, and result type parameters.
  * Documented the error thrown when no query client or provider is available.
  * Clarified cached data, selection, placeholder data, and optimistic-update rollback concepts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->