### PR TITLE
fix(vue-query): re-export core filter types

### DIFF
--- a/.changeset/tidy-pandas-fetch.md
+++ b/.changeset/tidy-pandas-fetch.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query': patch
+---
+
+Re-export core query and mutation filter types without shadowing them with Vue-specific filter types.

--- a/packages/vue-query/src/__tests__/filterTypes.test-d.ts
+++ b/packages/vue-query/src/__tests__/filterTypes.test-d.ts
@@ -1,0 +1,22 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  MutationFilters as CoreMutationFilters,
+  QueryFilters as CoreQueryFilters,
+} from '@tanstack/query-core'
+import type { MutationFilters, QueryFilters } from '../index'
+
+describe('filter type exports', () => {
+  it('should re-export core query filters', () => {
+    expectTypeOf<QueryFilters>().toEqualTypeOf<CoreQueryFilters>()
+    expectTypeOf<QueryFilters<readonly ['todos', string]>>().toEqualTypeOf<
+      CoreQueryFilters<readonly ['todos', string]>
+    >()
+  })
+
+  it('should re-export core mutation filters', () => {
+    expectTypeOf<MutationFilters>().toEqualTypeOf<CoreMutationFilters>()
+    expectTypeOf<
+      MutationFilters<string, Error, number, boolean>
+    >().toEqualTypeOf<CoreMutationFilters<string, Error, number, boolean>>()
+  })
+})

--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -44,6 +44,9 @@ export type {
 export type { UseMutationOptions, UseMutationReturnType } from './useMutation'
 export type { MutationOptions } from './types'
 export type { UseQueriesOptions, UseQueriesResults } from './useQueries'
-export type { MutationFilters, MutationStateOptions } from './useMutationState'
-export type { QueryFilters } from './useIsFetching'
+export type {
+  MutationStateOptions,
+  UseIsMutatingFilters,
+} from './useMutationState'
+export type { UseIsFetchingFilters } from './useIsFetching'
 export type { VueQueryPluginOptions } from './vueQueryPlugin'

--- a/packages/vue-query/src/useIsFetching.ts
+++ b/packages/vue-query/src/useIsFetching.ts
@@ -2,14 +2,16 @@ import { getCurrentScope, onScopeDispose, ref, watchEffect } from 'vue-demi'
 import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref } from './utils'
 import type { Ref } from 'vue-demi'
-import type { QueryFilters as QF } from '@tanstack/query-core'
+import type { QueryFilters } from '@tanstack/query-core'
 import type { MaybeRefDeep } from './types'
 import type { QueryClient } from './queryClient'
 
-export type QueryFilters = MaybeRefDeep<QF> | (() => MaybeRefDeep<QF>)
+export type UseIsFetchingFilters =
+  | MaybeRefDeep<QueryFilters>
+  | (() => MaybeRefDeep<QueryFilters>)
 
 export function useIsFetching(
-  fetchingFilters: QueryFilters = {},
+  fetchingFilters: UseIsFetchingFilters = {},
   queryClient?: QueryClient,
 ): Ref<number> {
   if (process.env.NODE_ENV === 'development') {

--- a/packages/vue-query/src/useMutationState.ts
+++ b/packages/vue-query/src/useMutationState.ts
@@ -10,18 +10,22 @@ import { useQueryClient } from './useQueryClient'
 import { cloneDeepUnref } from './utils'
 import type { Ref } from 'vue-demi'
 import type {
-  MutationFilters as MF,
   Mutation,
+  MutationFilters,
   MutationState,
 } from '@tanstack/query-core'
 import type { QueryClient } from './queryClient'
 import type { MaybeRefDeep } from './types'
 import type { MutationCache } from './mutationCache'
 
-export type MutationFilters = MaybeRefDeep<MF>
+type VueMutationFilters = MaybeRefDeep<MutationFilters>
+
+export type UseIsMutatingFilters =
+  | VueMutationFilters
+  | (() => VueMutationFilters)
 
 export function useIsMutating(
-  filters: MutationFilters | (() => MutationFilters) = {},
+  filters: UseIsMutatingFilters = {},
   queryClient?: QueryClient,
 ): Ref<number> {
   if (process.env.NODE_ENV === 'development') {
@@ -64,7 +68,7 @@ export type MutationStateOptions<
   TMutation extends Mutation<any, any, any, any> =
     MutationTypeFromResult<TResult>,
 > = {
-  filters?: MutationFilters
+  filters?: VueMutationFilters
   select?: (mutation: TMutation) => TResult
 }
 


### PR DESCRIPTION
`@tanstack/vue-query` currently shadows query-core’s `QueryFilters` and `MutationFilters` with Vue-specific reactive types. Wrapper libraries that type `QueryClient` operations such as `removeQueries` therefore cannot import the matching filters from the Vue package. This renames the Vue-specific types and restores the core exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer Vue-specific filter types for fetching and mutation state utilities.
  - Filter options now support reactive values and callback-based forms.
  - Added type-level compatibility coverage for core query and mutation filter types.

- **Bug Fixes**
  - Improved type export consistency in Vue Query by avoiding conflicts between core and Vue-specific filter types.

- **Breaking Changes**
  - `QueryFilters` and `MutationFilters` are no longer re-exported directly; use the corresponding utility-specific filter types instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->