### PR TITLE
docs(preact-query): tag 'subscribed' with '@defaultValue' for structured default-value rendering

### DIFF
--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -56,7 +56,13 @@ and `previousQuery` always `undefined`, rather than `useQuery`'s placeholder fun
 
 `boolean`
 
-Set this to `false` to unsubscribe this observer from updates to the query cache. Defaults to `true`.
+Set this to `false` to unsubscribe this observer from updates to the query cache.
+
+**Default Value**
+
+```ts
+true
+```
 
 ### queryClient?
 

--- a/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseBaseQueryOptions.md
@@ -54,7 +54,12 @@ The type of your `queryKey`.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L63)
+Defined in: [preact-query/src/types.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L64)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
-Defaults to `true`.
+
+#### Default Value
+
+```ts
+true
+```

--- a/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseInfiniteQueryOptions.md
@@ -3,7 +3,7 @@ id: UseInfiniteQueryOptions
 title: UseInfiniteQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:236](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L236)
+Defined in: [preact-query/src/types.ts:237](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L237)
 
 The options accepted by `useInfiniteQuery`. Extends InfiniteQueryObserverOptions from
 `@tanstack/query-core` with the `preact-query`-specific `subscribed` option, minus `suspense` (which
@@ -54,7 +54,12 @@ The type of the parameter passed to `queryFn` to fetch a given page.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:256](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L256)
+Defined in: [preact-query/src/types.ts:258](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L258)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
-Defaults to `true`.
+
+#### Default Value
+
+```ts
+true
+```

--- a/docs/framework/preact/reference/interfaces/UseMutationOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseMutationOptions.md
@@ -3,7 +3,7 @@ id: UseMutationOptions
 title: UseMutationOptions
 ---
 
-Defined in: [preact-query/src/types.ts:409](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L409)
+Defined in: [preact-query/src/types.ts:411](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L411)
 
 The options accepted by `useMutation`. Same as MutationObserverOptions from `@tanstack/query-core`,
 minus the internal `_defaulted` flag.

--- a/docs/framework/preact/reference/interfaces/UseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseQueryOptions.md
@@ -3,7 +3,7 @@ id: UseQueryOptions
 title: UseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:163](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L163)
+Defined in: [preact-query/src/types.ts:164](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L164)
 
 The options accepted by `useQuery`. Same as [UseBaseQueryOptions](UseBaseQueryOptions.md), minus `suspense` (which
 `preact-query` derives from which hook you call rather than exposing as an option).
@@ -47,10 +47,15 @@ The type of your `queryKey`.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L63)
+Defined in: [preact-query/src/types.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L64)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
-Defaults to `true`.
+
+#### Default Value
+
+```ts
+true
+```
 
 #### Inherited from
 

--- a/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseInfiniteQueryOptions.md
@@ -3,7 +3,7 @@ id: UseSuspenseInfiniteQueryOptions
 title: UseSuspenseInfiniteQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:277](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L277)
+Defined in: [preact-query/src/types.ts:279](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L279)
 
 The options accepted by `useSuspenseInfiniteQuery`. Same as [UseInfiniteQueryOptions](UseInfiniteQueryOptions.md), minus `enabled`,
 `throwOnError`, and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so
@@ -54,7 +54,7 @@ The type of the parameter passed to `queryFn` to fetch a given page.
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [preact-query/src/types.ts:291](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L291)
+Defined in: [preact-query/src/types.ts:293](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L293)
 
 `skipToken` is not allowed here — Suspense hooks cannot render a "disabled" state, so a query function
 must always be provided, unless a default query function has been defined.
@@ -67,10 +67,15 @@ must always be provided, unless a default query function has been defined.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:256](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L256)
+Defined in: [preact-query/src/types.ts:258](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L258)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
-Defaults to `true`.
+
+#### Default Value
+
+```ts
+true
+```
 
 #### Inherited from
 

--- a/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSuspenseQueryOptions.md
@@ -3,7 +3,7 @@ id: UseSuspenseQueryOptions
 title: UseSuspenseQueryOptions
 ---
 
-Defined in: [preact-query/src/types.ts:194](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L194)
+Defined in: [preact-query/src/types.ts:195](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L195)
 
 The options accepted by `useSuspenseQuery`. Same as [UseQueryOptions](UseQueryOptions.md), minus `enabled`, `throwOnError`,
 and `placeholderData` — Suspense hooks cannot render a "disabled" or "placeholder" state, so those options
@@ -48,7 +48,7 @@ The type of your `queryKey`.
 optional queryFn: QueryFunction<TQueryFnData, TQueryKey, never>;
 ```
 
-Defined in: [preact-query/src/types.ts:207](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L207)
+Defined in: [preact-query/src/types.ts:208](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L208)
 
 `skipToken` is not allowed here — Suspense hooks cannot render a "disabled" state, so a query function
 must always be provided, unless a default query function has been defined.
@@ -61,10 +61,15 @@ must always be provided, unless a default query function has been defined.
 optional subscribed: boolean;
 ```
 
-Defined in: [preact-query/src/types.ts:63](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L63)
+Defined in: [preact-query/src/types.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L64)
 
 Set this to `false` to unsubscribe this observer from updates to the query cache.
-Defaults to `true`.
+
+#### Default Value
+
+```ts
+true
+```
 
 #### Inherited from
 

--- a/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseInfiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseInfiniteQueryOptions
 type AnyUseInfiniteQueryOptions = UseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:217](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L217)
+Defined in: [preact-query/src/types.ts:218](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L218)
 
 [UseInfiniteQueryOptions](../interfaces/UseInfiniteQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseMutationOptions.md
@@ -7,7 +7,7 @@ title: AnyUseMutationOptions
 type AnyUseMutationOptions = UseMutationOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:398](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L398)
+Defined in: [preact-query/src/types.ts:400](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L400)
 
 [UseMutationOptions](../interfaces/UseMutationOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any mutation in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseQueryOptions
 type AnyUseQueryOptions = UseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:152](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L152)
+Defined in: [preact-query/src/types.ts:153](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L153)
 
 [UseQueryOptions](../interfaces/UseQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseInfiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseSuspenseInfiniteQueryOptions
 type AnyUseSuspenseInfiniteQueryOptions = UseSuspenseInfiniteQueryOptions<any, any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:263](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L263)
+Defined in: [preact-query/src/types.ts:265](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L265)
 
 [UseSuspenseInfiniteQueryOptions](../interfaces/UseSuspenseInfiniteQueryOptions.md) with all type parameters set to `any`, useful when the specific types
 aren't relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/AnyUseSuspenseQueryOptions.md
@@ -7,7 +7,7 @@ title: AnyUseSuspenseQueryOptions
 type AnyUseSuspenseQueryOptions = UseSuspenseQueryOptions<any, any, any, any>;
 ```
 
-Defined in: [preact-query/src/types.ts:177](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L177)
+Defined in: [preact-query/src/types.ts:178](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L178)
 
 [UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptions.md) with all type parameters set to `any`, useful when the specific types aren't
 relevant, e.g. when accepting options for any query in a helper function.

--- a/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedUseInfiniteQueryResult
 type DefinedUseInfiniteQueryResult<TData, TError> = DefinedInfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:374](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L374)
+Defined in: [preact-query/src/types.ts:376](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L376)
 
 The result of `useInfiniteQuery` when `initialData` is set — `data` is never `undefined`. Re-exports
 DefinedInfiniteQueryObserverResult from `@tanstack/query-core`.

--- a/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedUseQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedUseQueryResult
 type DefinedUseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:350](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L350)
+Defined in: [preact-query/src/types.ts:352](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L352)
 
 The result of `useQuery` when `initialData` is set, or of `useSuspenseQuery` before the `isPlaceholderData`
 omission — `data` is never `undefined`. Re-exports DefinedQueryObserverResult from

--- a/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseMutationResult.md
@@ -9,7 +9,7 @@ type UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Overrid
 }> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:468](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L468)
+Defined in: [preact-query/src/types.ts:470](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L470)
 
 The result of `useMutation`. Same as MutationObserverResult from `@tanstack/query-core`, with
 `mutate` narrowed to the fire-and-forget [UseMutateFunction](UseMutateFunction.md) signature, plus the added `mutateAsync`.

--- a/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseBaseQueryResult.md
@@ -7,7 +7,7 @@ title: UseBaseQueryResult
 type UseBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:311](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L311)
+Defined in: [preact-query/src/types.ts:313](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L313)
 
 The result of `useQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
 `pending`. Re-exports QueryObserverResult from `@tanstack/query-core`. `useInfiniteQuery` returns

--- a/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: UseInfiniteQueryResult
 type UseInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:362](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L362)
+Defined in: [preact-query/src/types.ts:364](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L364)
 
 The result of `useInfiniteQuery` when `initialData` isn't set — `data` may be `undefined` while the query is
 `pending`. Re-exports InfiniteQueryObserverResult from `@tanstack/query-core`.

--- a/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateAsyncFunction.md
@@ -7,7 +7,7 @@ title: UseMutateAsyncFunction
 type UseMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:451](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L451)
+Defined in: [preact-query/src/types.ts:453](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L453)
 
 The type of `mutateAsync`, as returned by `useMutation`. Similar to [UseMutateFunction](UseMutateFunction.md), but returns a
 promise which can be awaited.

--- a/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutateFunction.md
@@ -7,7 +7,7 @@ title: UseMutateFunction
 type UseMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```
 
-Defined in: [preact-query/src/types.ts:430](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L430)
+Defined in: [preact-query/src/types.ts:432](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L432)
 
 The type of `mutate`, as returned by `useMutation`. Forwards the variables (and an optional per-call
 `onSuccess`/`onError`/`onSettled`) to the underlying `mutate` call. Fire-and-forget — errors are surfaced

--- a/docs/framework/preact/reference/type-aliases/UseMutationResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseMutationResult.md
@@ -7,7 +7,7 @@ title: UseMutationResult
 type UseMutationResult<TData, TError, TVariables, TOnMutateResult> = UseBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/types.ts:497](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L497)
+Defined in: [preact-query/src/types.ts:499](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L499)
 
 The result of `useMutation`. Same as [UseBaseMutationResult](UseBaseMutationResult.md).
 

--- a/docs/framework/preact/reference/type-aliases/UsePrefetchInfiniteQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UsePrefetchInfiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: UsePrefetchInfiniteQueryOptions
 type UsePrefetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = DistributiveOmit<InfiniteQueryExecuteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:116](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L116)
+Defined in: [preact-query/src/types.ts:117](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L117)
 
 The options accepted by `usePrefetchInfiniteQuery` — everything you can pass to `queryClient.infiniteQuery`,
 except `queryFn` is required unless a default query function has been defined.

--- a/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UsePrefetchQueryOptions.md
@@ -7,7 +7,7 @@ title: UsePrefetchQueryOptions
 type UsePrefetchQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = DistributiveOmit<QueryExecuteOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/types.ts:78](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L78)
+Defined in: [preact-query/src/types.ts:79](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L79)
 
 The options accepted by `usePrefetchQuery` — everything you can pass to `queryClient.query`, except `queryFn`
 is required unless a default query function has been defined.

--- a/docs/framework/preact/reference/type-aliases/UseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseQueryResult.md
@@ -7,7 +7,7 @@ title: UseQueryResult
 type UseQueryResult<TData, TError> = UseBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/types.ts:322](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L322)
+Defined in: [preact-query/src/types.ts:324](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L324)
 
 The result of `useQuery`. Same as [UseBaseQueryResult](UseBaseQueryResult.md).
 

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: UseSuspenseInfiniteQueryResult
 type UseSuspenseInfiniteQueryResult<TData, TError> = OmitKeyof<DefinedInfiniteQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:386](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L386)
+Defined in: [preact-query/src/types.ts:388](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L388)
 
 The result of `useSuspenseInfiniteQuery`. Same as [DefinedUseInfiniteQueryResult](DefinedUseInfiniteQueryResult.md), minus
 `isPlaceholderData` — Suspense hooks never render placeholder data.

--- a/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
+++ b/docs/framework/preact/reference/type-aliases/UseSuspenseQueryResult.md
@@ -7,7 +7,7 @@ title: UseSuspenseQueryResult
 type UseSuspenseQueryResult<TData, TError> = DistributiveOmit<DefinedQueryObserverResult<TData, TError>, "isPlaceholderData">;
 ```
 
-Defined in: [preact-query/src/types.ts:334](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L334)
+Defined in: [preact-query/src/types.ts:336](https://github.com/TanStack/query/blob/main/packages/preact-query/src/types.ts#L336)
 
 The result of `useSuspenseQuery`. Same as [DefinedUseQueryResult](DefinedUseQueryResult.md), minus `isPlaceholderData` — always
 `false` on that type, so this drops the dead field rather than an active state.

--- a/packages/preact-query/src/types.ts
+++ b/packages/preact-query/src/types.ts
@@ -58,7 +58,8 @@ export interface UseBaseQueryOptions<
 > {
   /**
    * Set this to `false` to unsubscribe this observer from updates to the query cache.
-   * Defaults to `true`.
+   *
+   * @defaultValue true
    */
   subscribed?: boolean
 }
@@ -251,7 +252,8 @@ export interface UseInfiniteQueryOptions<
 > {
   /**
    * Set this to `false` to unsubscribe this observer from updates to the query cache.
-   * Defaults to `true`.
+   *
+   * @defaultValue true
    */
   subscribed?: boolean
 }

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -295,7 +295,9 @@ export function useQueries<
      */
     combine?: (result: QueriesResults<T>) => TCombinedResult
     /**
-     * Set this to `false` to unsubscribe this observer from updates to the query cache. Defaults to `true`.
+     * Set this to `false` to unsubscribe this observer from updates to the query cache.
+     *
+     * @defaultValue true
      */
     subscribed?: boolean
   },


### PR DESCRIPTION
## 🎯 Changes

Tags the `subscribed` option's default with TypeDoc's `@defaultValue` tag, in the three places it's declared (`UseBaseQueryOptions`, `UseInfiniteQueryOptions`, and the inline `useQueries` per-query options).

Previously the default was only mentioned as prose inside the description ("Defaults to `true`."). TypeDoc renders `@defaultValue` as a separate, structured "Default Value" section, so this makes the default visually distinct from the description instead of buried in it. Verified with `pnpm run generate-docs` — the rest of the diff in `docs/framework/preact/reference/` is line-number drift in `Defined in:` links from the added JSDoc lines, not content changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for the `subscribed` option by clearly displaying its default value as `true`.
  * Updated source-reference links throughout the Preact API reference to keep them accurate and current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->