### PR TITLE
docs(preact-query): backtick bare code-symbol references in JSDoc ('QueryClient', 'suspense', 'throwOnError')

### DIFF
--- a/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
@@ -9,7 +9,7 @@ function QueryErrorResetBoundary(__namedParameters): Element;
 
 Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:157](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L157)
 
-When using **suspense** or **throwOnError** in your queries, you need a way to let queries know that you want to
+When using `suspense` or `throwOnError` in your queries, you need a way to let queries know that you want to
 try again when re-rendering after some error occurred. With the `QueryErrorResetBoundary` component you can
 reset any query errors within the boundaries of the component.
 

--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -50,7 +50,7 @@ The [DefinedInitialDataInfiniteOptions](../type-aliases/DefinedInitialDataInfini
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ### Returns
@@ -134,7 +134,7 @@ The [UndefinedInitialDataInfiniteOptions](../type-aliases/UndefinedInitialDataIn
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ### Returns
@@ -227,7 +227,7 @@ The [UseInfiniteQueryOptions](../interfaces/UseInfiniteQueryOptions.md) to use â
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ### Returns

--- a/docs/framework/preact/reference/functions/useIsFetching.md
+++ b/docs/framework/preact/reference/functions/useIsFetching.md
@@ -24,7 +24,7 @@ The QueryFilters to narrow down the matched queries.
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/useIsMutating.md
+++ b/docs/framework/preact/reference/functions/useIsMutating.md
@@ -24,7 +24,7 @@ The MutationFilters to narrow down the matched mutations.
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -42,7 +42,7 @@ The [UseMutationOptions](../interfaces/UseMutationOptions.md) to use — everyth
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/useMutationState.md
+++ b/docs/framework/preact/reference/functions/useMutationState.md
@@ -36,7 +36,7 @@ mutation state.
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchInfiniteQuery.md
@@ -57,7 +57,7 @@ The [UsePrefetchInfiniteQueryOptions](../type-aliases/UsePrefetchInfiniteQueryOp
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/usePrefetchQuery.md
+++ b/docs/framework/preact/reference/functions/usePrefetchQuery.md
@@ -52,7 +52,7 @@ The [UsePrefetchQueryOptions](../type-aliases/UsePrefetchQueryOptions.md) to use
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -68,7 +68,7 @@ true
 
 `QueryClient`
 
-Use this to provide a custom QueryClient. Otherwise, the one from the nearest context
+Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context
 will be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -43,7 +43,7 @@ The [DefinedInitialDataOptions](../type-aliases/DefinedInitialDataOptions.md) to
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ### Returns
@@ -113,7 +113,7 @@ The [UndefinedInitialDataOptions](../type-aliases/UndefinedInitialDataOptions.md
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ### Returns
@@ -193,7 +193,7 @@ The [UseQueryOptions](../interfaces/UseQueryOptions.md) to use — everything yo
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ### Returns

--- a/docs/framework/preact/reference/functions/useQueryClient.md
+++ b/docs/framework/preact/reference/functions/useQueryClient.md
@@ -17,7 +17,7 @@ The `useQueryClient` hook returns the current `QueryClient` instance.
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
@@ -48,7 +48,7 @@ The [UseSuspenseInfiniteQueryOptions](../interfaces/UseSuspenseInfiniteQueryOpti
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -48,7 +48,7 @@ An array with query option objects identical to `useSuspenseQuery`.
 
 `QueryClient`
 
-Use this to provide a custom QueryClient. Otherwise, the one from the nearest context
+Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context
 will be used.
 
 ### Returns
@@ -140,7 +140,7 @@ An array with query option objects identical to `useSuspenseQuery`.
 
 `QueryClient`
 
-Use this to provide a custom QueryClient. Otherwise, the one from the nearest context
+Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context
 will be used.
 
 ### Returns

--- a/docs/framework/preact/reference/functions/useSuspenseQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQuery.md
@@ -44,7 +44,7 @@ The [UseSuspenseQueryOptions](../interfaces/UseSuspenseQueryOptions.md) to use â
 
 `QueryClient`
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
 be used.
 
 ## Returns

--- a/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
+++ b/docs/framework/preact/reference/interfaces/HydrationBoundaryProps.md
@@ -53,7 +53,7 @@ optional queryClient: QueryClient;
 
 Defined in: [preact-query/src/HydrationBoundary.tsx:41](https://github.com/TanStack/query/blob/main/packages/preact-query/src/HydrationBoundary.tsx#L41)
 
-Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will be used.
 
 ***
 

--- a/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
@@ -35,4 +35,4 @@ Defined in: [preact-query/src/QueryClientProvider.tsx:44](https://github.com/Tan
 
 **Required**
 
-The QueryClient instance to provide.
+The `QueryClient` instance to provide.

--- a/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/preact/reference/type-aliases/QueryClientProviderProps.md
@@ -21,7 +21,7 @@ optional children: ComponentChildren;
 
 Defined in: [preact-query/src/QueryClientProvider.tsx:48](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryClientProvider.tsx#L48)
 
-The components that get access to the provided QueryClient.
+The components that get access to the provided `QueryClient`.
 
 ***
 

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -36,7 +36,7 @@ export interface HydrationBoundaryProps {
    */
   children?: ComponentChildren
   /**
-   * Use this to use a custom QueryClient. Otherwise, the one from the nearest context will be used.
+   * Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will be used.
    */
   queryClient?: QueryClient
 }

--- a/packages/preact-query/src/QueryClientProvider.tsx
+++ b/packages/preact-query/src/QueryClientProvider.tsx
@@ -43,7 +43,7 @@ export type QueryClientProviderProps = {
    */
   client: QueryClient
   /**
-   * The components that get access to the provided QueryClient.
+   * The components that get access to the provided `QueryClient`.
    */
   children?: ComponentChildren
 }

--- a/packages/preact-query/src/QueryClientProvider.tsx
+++ b/packages/preact-query/src/QueryClientProvider.tsx
@@ -13,7 +13,7 @@ export const QueryClientContext = createContext<QueryClient | undefined>(
 /**
  * The `useQueryClient` hook returns the current `QueryClient` instance.
  *
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The current `QueryClient` instance.
  * @throws If no `queryClient` argument is passed and no `QueryClientProvider` is found in the component tree.
@@ -39,7 +39,7 @@ export type QueryClientProviderProps = {
   /**
    * **Required**
    *
-   * The QueryClient instance to provide.
+   * The `QueryClient` instance to provide.
    */
   client: QueryClient
   /**

--- a/packages/preact-query/src/QueryErrorResetBoundary.tsx
+++ b/packages/preact-query/src/QueryErrorResetBoundary.tsx
@@ -109,7 +109,7 @@ export interface QueryErrorResetBoundaryProps {
 }
 
 /**
- * When using **suspense** or **throwOnError** in your queries, you need a way to let queries know that you want to
+ * When using `suspense` or `throwOnError` in your queries, you need a way to let queries know that you want to
  * try again when re-rendering after some error occurred. With the `QueryErrorResetBoundary` component you can
  * reset any query errors within the boundaries of the component.
  *

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -29,7 +29,7 @@ import { useBaseQuery } from './useBaseQuery'
  * actions, or add conditions like `hasNextPage && !isFetching`.
  * @see {@link infiniteQueryOptions} to share these options between `useInfiniteQuery` and imperative APIs like `queryClient.infiniteQuery`.
  * @param options - The {@link DefinedInitialDataInfiniteOptions} to use — everything you can pass to `useInfiniteQuery`, with `initialData` set.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
  * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
@@ -78,7 +78,7 @@ export function useInfiniteQuery<
  * actions, or add conditions like `hasNextPage && !isFetching`.
  * @see {@link infiniteQueryOptions} to share these options between `useInfiniteQuery` and imperative APIs like `queryClient.infiniteQuery`.
  * @param options - The {@link UndefinedInitialDataInfiniteOptions} to use — everything you can pass to `useInfiniteQuery`.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
  * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
@@ -136,7 +136,7 @@ export function useInfiniteQuery<
  * actions, or add conditions like `hasNextPage && !isFetching`.
  * @see {@link infiniteQueryOptions} to share these options between `useInfiniteQuery` and imperative APIs like `queryClient.infiniteQuery`.
  * @param options - The {@link UseInfiniteQueryOptions} to use — everything you can pass to `useInfiniteQuery`.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
  * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and

--- a/packages/preact-query/src/useIsFetching.ts
+++ b/packages/preact-query/src/useIsFetching.ts
@@ -10,7 +10,7 @@ import { useSyncExternalStore } from './utils'
  * fetching in the background (useful for app-wide loading indicators).
  *
  * @param filters - The {@link QueryFilters} to narrow down the matched queries.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns Will be the `number` of the queries that your application is currently loading or fetching in the
  * background.

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -23,7 +23,7 @@ import { useSyncExternalStore } from './utils'
  *
  * @see {@link mutationOptions} to share these options across multiple `useMutation` call sites.
  * @param options - The {@link UseMutationOptions} to use — everything you can pass to `useMutation`.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns `mutate`/`mutateAsync` also accept per-call `onSuccess`/`onError`/`onSettled` callbacks as a second
  * argument, useful for triggering call-site side effects (e.g. navigation) without coupling them to the shared

--- a/packages/preact-query/src/useMutationState.ts
+++ b/packages/preact-query/src/useMutationState.ts
@@ -16,7 +16,7 @@ import { useSyncExternalStore } from './utils'
  * (useful for app-wide loading indicators).
  *
  * @param filters - The {@link MutationFilters} to narrow down the matched mutations.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns Will be the `number` of the mutations that your application is currently fetching.
  *
@@ -86,7 +86,7 @@ function getResult<
  *
  * @param options - The `filters` to narrow down matched mutations, and an optional `select` to transform the
  * mutation state.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns Will be an Array of whatever `select` returns for each matching mutation.
  *

--- a/packages/preact-query/src/usePrefetchInfiniteQuery.tsx
+++ b/packages/preact-query/src/usePrefetchInfiniteQuery.tsx
@@ -20,7 +20,7 @@ import type { UsePrefetchInfiniteQueryOptions } from './types'
  * already there or already in flight.
  *
  * @param options - The {@link UsePrefetchInfiniteQueryOptions} to use — everything you can pass to `queryClient.infiniteQuery`.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns `void` — nothing is returned.
  *

--- a/packages/preact-query/src/usePrefetchQuery.tsx
+++ b/packages/preact-query/src/usePrefetchQuery.tsx
@@ -15,7 +15,7 @@ import type { UsePrefetchQueryOptions } from './types'
  * already there or already in flight.
  *
  * @param options - The {@link UsePrefetchQueryOptions} to use — everything you can pass to `queryClient.query`.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns `void` — nothing is returned.
  *

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -235,7 +235,7 @@ export type QueriesResults<
  * The `combine` option can be used to combine the results of the queries into a single value. The result will
  * be structurally shared to be as referentially stable as possible.
  *
- * @param queryClient - Use this to provide a custom QueryClient. Otherwise, the one from the nearest context
+ * @param queryClient - Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context
  * will be used.
  * @returns The combined result. Without `combine`, this is an array with all the query results, in the same
  * order as the input. When `combine` is provided, this is the value returned by `combine` instead.

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -17,7 +17,7 @@ import { useBaseQuery } from './useBaseQuery'
  *
  * @see {@link queryOptions} to share these options between `useQuery` and imperative APIs like `queryClient.query`.
  * @param options - The {@link DefinedInitialDataOptions} to use — everything you can pass to `useQuery`, with `initialData` set.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The current query result, typed so that `status` is `success` — or `error` if a fetch attempt
  * fails while keeping the existing data (`status` never resolves to `pending` in this overload's type,
@@ -52,7 +52,7 @@ export function useQuery<
 /**
  * @see {@link queryOptions} to share these options between `useQuery` and imperative APIs like `queryClient.query`.
  * @param options - The {@link UndefinedInitialDataOptions} to use — everything you can pass to `useQuery`.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
  * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
@@ -97,7 +97,7 @@ export function useQuery<
 /**
  * @see {@link queryOptions} to share these options between `useQuery` and imperative APIs like `queryClient.query`.
  * @param options - The {@link UseQueryOptions} to use — everything you can pass to `useQuery`.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
  * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to

--- a/packages/preact-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/preact-query/src/useSuspenseInfiniteQuery.ts
@@ -22,7 +22,7 @@ import { useBaseQuery } from './useBaseQuery'
  * Caveat: cancellation does not work.
  *
  * @param options - The {@link UseSuspenseInfiniteQueryOptions} to use — the same options as `useInfiniteQuery`, minus the ones listed above.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The same object as `useInfiniteQuery`, except that `data` is guaranteed to be defined,
  * `isPlaceholderData` is missing, and `status` is either `success` or `error` (with the derived flags set

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -185,7 +185,7 @@ export type SuspenseQueriesResults<
  * `throwOnError`, `enabled`, or `placeholderData`.
  *
  * @param options - The `queries` array to run in Suspense, and an optional `combine` function.
- * @param queryClient - Use this to provide a custom QueryClient. Otherwise, the one from the nearest context
+ * @param queryClient - Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context
  * will be used.
  * @returns The same structure as `useQueries`, except that for each `query`, `data` is guaranteed to be
  * defined, `isPlaceholderData` is missing, and `status` is either `success` or `error` (with the derived
@@ -252,7 +252,7 @@ export function useSuspenseQueries<
  * `throwOnError`, `enabled`, or `placeholderData`.
  *
  * @param options - The `queries` array to run in Suspense, and an optional `combine` function.
- * @param queryClient - Use this to provide a custom QueryClient. Otherwise, the one from the nearest context
+ * @param queryClient - Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context
  * will be used.
  * @returns The same structure as `useQueries`, except that for each `query`, `data` is guaranteed to be
  * defined, `isPlaceholderData` is missing, and `status` is either `success` or `error` (with the derived

--- a/packages/preact-query/src/useSuspenseQuery.ts
+++ b/packages/preact-query/src/useSuspenseQuery.ts
@@ -12,7 +12,7 @@ import { useBaseQuery } from './useBaseQuery'
  * Caveat: cancellation does not work.
  *
  * @param options - The {@link UseSuspenseQueryOptions} to use — the same options as `useQuery`, minus the ones listed above.
- * @param queryClient - Use this to use a custom QueryClient. Otherwise, the one from the nearest context will
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
  * @returns The same object as `useQuery`, except that `data` is guaranteed to be defined, `isPlaceholderData`
  * is missing, and `status` is either `success` or `error` (with the derived flags set accordingly).


### PR DESCRIPTION
## 🎯 Changes

Wraps bare code-symbol references in backticks across the package's JSDoc, found via a systematic audit against the codebase's existing backtick convention for types, fields, and literal values:

- The `QueryClient` type name was bare in the `@param queryClient` description used throughout the package ("Use this to use/provide a custom QueryClient...") and in `QueryClientProviderProps`'s `client`/`children` field docs. This wording was introduced verbatim in #11204 and repeated in every hook that accepts an optional `queryClient` argument — a single consistent fix across 13 source files (21 occurrences).
- `suspense` and `throwOnError` — actual option field names from `QueryObserverOptions` — were bolded (`**suspense**`/`**throwOnError**`) instead of backticked in `QueryErrorResetBoundary`'s summary.

Every other code-symbol reference in the package's JSDoc (types, fields, literals, package names) is already backtick-wrapped or `{@link}`-linked — these were the only gaps. Verified with `pnpm run generate-docs` and `pnpm --filter @tanstack/preact-query run test:types`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).