### PR TITLE
fix(solid-query): allow optional initialData in infiniteQueryOptions

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Allow optional `initialData` in `infiniteQueryOptions`, matching react-query

--- a/packages/solid-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -136,4 +136,23 @@ describe('infiniteQueryOptions', () => {
       }>
     >()
   })
+
+  it('should allow optional initialData object', () => {
+    const initialData = { wow: true } as { wow: boolean } | undefined
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => initialData,
+      initialData: initialData
+        ? { pages: [initialData], pageParams: [] }
+        : undefined,
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+    })
+
+    expectTypeOf(options.initialData).toExtend<
+      | InfiniteData<{ wow: boolean } | undefined, number>
+      | (() => InfiniteData<{ wow: boolean } | undefined, number>)
+      | undefined
+    >()
+  })
 })

--- a/packages/solid-query/src/infiniteQueryOptions.ts
+++ b/packages/solid-query/src/infiniteQueryOptions.ts
@@ -16,7 +16,10 @@ export type UndefinedInitialDataInfiniteOptions<
   TPageParam = unknown,
 > = Accessor<
   InfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & {
-    initialData?: undefined
+    initialData?:
+      | undefined
+      | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
+      | (() => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>)
   }
 >
 


### PR DESCRIPTION
## 🎯 Changes

Fixes #11286.

`UndefinedInitialDataInfiniteOptions` typed `initialData` as `?: undefined`, so passing a value that might be undefined matched neither overload. The defined overload rejects `undefined`, and the undefined one rejects the data:

```
Overload 2 of 2, '(options: ... & { initialData?: undefined; })', gave the following error.
  Type '{ pages: { wow: boolean; }[]; pageParams: never[]; } | undefined' is not assignable to type 'undefined'.
```

This widens that union to also accept the data and its function form. `react-query` has had this shape since #8157, and solid's own `DefinedInitialDataInfiniteOptions` already uses the same `T | (() => T)` pair, so this brings the undefined variant in line with both rather than introducing anything new.

Scope note: `vue-query` still has the narrow form in its own `infiniteQueryOptions`. #9088 fixed a different thing there (the `queryOptions` / `useQuery` overloads), so I left vue alone to keep this to one change.

Verification, run against `packages/solid-query`:

- `test:types` on all five pinned compilers, `typescript56/57/58/59/70`, all pass. The issue reports TS 7.0, which is covered.
- `test:eslint` clean.
- `test:lib`: 93 passing, versus 92 on `main`, the difference being the new type test. 11 test files fail to load on both `main` and this branch with `TypeError: ... Received 'file:///@solid-refresh'`, which is a pre-existing Windows path issue unrelated to this change and identical on both sides.
- Reverting only the widened union and rerunning makes the new test fail with the overload error quoted above, and nothing else fails, so the test does pin this regression.

I ran those targets directly rather than through `pnpm run test:pr`, because the repo's symlinked `root.*.config.js` files check out as plain text on Windows without developer mode, which breaks the aggregate script. Worth a CI run to confirm.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `infiniteQueryOptions` now supports optional initial data for infinite queries.
  * Initial data can be provided directly or through a lazy initializer.

* **Bug Fixes**
  * Improved type inference for infinite query initial data, including the possibility of no initial data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->