### PR TITLE
fix(query-core): Avoid scheduling stale timeouts for disabled query observers

### DIFF
--- a/.changeset/quiet-timers-rest.md
+++ b/.changeset/quiet-timers-rest.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Avoid scheduling stale timeouts for disabled query observers.

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -8,7 +8,7 @@ import {
   vi,
 } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryClient, QueryObserver, focusManager } from '..'
+import { QueryClient, QueryObserver, focusManager, timeoutManager } from '..'
 import type { QueryObserverResult } from '..'
 
 describe('queryObserver', () => {
@@ -1403,6 +1403,26 @@ describe('queryObserver', () => {
 
     const result = observer.getCurrentResult()
     expect(result.isStale).toBe(false)
+  })
+
+  it('should not schedule a stale timeout for disabled observers', () => {
+    const key = queryKey()
+    queryClient.setQueryData(key, 'data', {
+      updatedAt: Date.now() - 20,
+    })
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      enabled: false,
+      staleTime: 10,
+    })
+    const setTimeoutSpy = vi.spyOn(timeoutManager, 'setTimeout')
+
+    const unsubscribe = observer.subscribe(vi.fn())
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+
+    unsubscribe()
   })
 
   it('should allow staleTime as a function', async () => {

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -415,8 +415,8 @@ export class QueryObserver<
     this.#currentRefetchInterval = nextInterval
 
     if (
-      !this.#shouldScheduleTimer(this.#currentRefetchInterval) ||
-      this.#currentRefetchInterval === 0
+      this.#currentRefetchInterval === 0 ||
+      !this.#shouldScheduleTimer(this.#currentRefetchInterval)
     ) {
       return
     }

--- a/packages/query-core/src/queryObserver.ts
+++ b/packages/query-core/src/queryObserver.ts
@@ -369,6 +369,14 @@ export class QueryObserver<
     return promise
   }
 
+  #shouldScheduleTimer(timeout: unknown): timeout is number {
+    return (
+      !environmentManager.isServer() &&
+      resolveQueryBoolean(this.options.enabled, this.#currentQuery) !== false &&
+      isValidTimeout(timeout)
+    )
+  }
+
   #updateStaleTimeout(): void {
     this.#clearStaleTimeout()
     const staleTime = resolveStaleTime(
@@ -376,11 +384,7 @@ export class QueryObserver<
       this.#currentQuery,
     )
 
-    if (
-      environmentManager.isServer() ||
-      this.#currentResult.isStale ||
-      !isValidTimeout(staleTime)
-    ) {
+    if (this.#currentResult.isStale || !this.#shouldScheduleTimer(staleTime)) {
       return
     }
 
@@ -411,9 +415,7 @@ export class QueryObserver<
     this.#currentRefetchInterval = nextInterval
 
     if (
-      environmentManager.isServer() ||
-      resolveQueryBoolean(this.options.enabled, this.#currentQuery) === false ||
-      !isValidTimeout(this.#currentRefetchInterval) ||
+      !this.#shouldScheduleTimer(this.#currentRefetchInterval) ||
       this.#currentRefetchInterval === 0
     ) {
       return


### PR DESCRIPTION
## 🎯 Changes

Prevent disabled query observers from scheduling stale timeouts for expired cache entries. Add a regression test and a patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where disabled query observers could schedule unnecessary stale-timeout timers.
  - Improved timer handling for stale data and refetch intervals, including cases where cached data is already stale.

- **Tests**
  - Added coverage to verify that disabled observers do not schedule stale-timeout timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->