### PR TITLE
docs(preact-query): expand JSDoc @example coverage across hooks

### DIFF
--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -95,7 +95,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:113](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L113)
+Defined in: [preact-query/src/useInfiniteQuery.ts:117](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L117)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -168,15 +168,19 @@ const projectsOptions = infiniteQueryOptions({
 })
 
 function Projects() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
     useInfiniteQuery(projectsOptions)
 
   return (
     <button
       onClick={() => fetchNextPage()}
-      disabled={!hasNextPage || isFetchingNextPage}
+      disabled={!hasNextPage || isFetching}
     >
-      Load More
+      {isFetchingNextPage
+        ? 'Loading more...'
+        : hasNextPage
+          ? 'Load More'
+          : 'Nothing more to load'}
     </button>
   )
 }
@@ -188,7 +192,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:171](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L171)
+Defined in: [preact-query/src/useInfiniteQuery.ts:179](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L179)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -261,15 +265,19 @@ const projectsOptions = infiniteQueryOptions({
 })
 
 function Projects() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
     useInfiniteQuery(projectsOptions)
 
   return (
     <button
       onClick={() => fetchNextPage()}
-      disabled={!hasNextPage || isFetchingNextPage}
+      disabled={!hasNextPage || isFetching}
     >
-      Load More
+      {isFetchingNextPage
+        ? 'Loading more...'
+        : hasNextPage
+          ? 'Load More'
+          : 'Nothing more to load'}
     </button>
   )
 }

--- a/docs/framework/preact/reference/functions/useIsFetching.md
+++ b/docs/framework/preact/reference/functions/useIsFetching.md
@@ -7,7 +7,7 @@ title: useIsFetching
 function useIsFetching(filters?, queryClient?): number;
 ```
 
-Defined in: [preact-query/src/useIsFetching.ts:28](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useIsFetching.ts#L28)
+Defined in: [preact-query/src/useIsFetching.ts:42](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useIsFetching.ts#L42)
 
 `useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or
 fetching in the background (useful for app-wide loading indicators).
@@ -34,7 +34,7 @@ be used.
 Will be the `number` of the queries that your application is currently loading or fetching in the
 background.
 
-## Example
+## Examples
 
 ```tsx
 import { useIsFetching } from '@tanstack/preact-query'
@@ -43,4 +43,17 @@ import { useIsFetching } from '@tanstack/preact-query'
 const isFetching = useIsFetching()
 // How many queries matching the posts prefix are fetching?
 const isFetchingPosts = useIsFetching({ queryKey: ['posts'] })
+```
+
+A global loading indicator for any query fetching in the background, not just the ones on screen:
+```tsx
+import { useIsFetching } from '@tanstack/preact-query'
+
+function GlobalLoadingIndicator() {
+  const isFetching = useIsFetching()
+
+  return isFetching ? (
+    <div>Queries are fetching in the background...</div>
+  ) : null
+}
 ```

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -141,8 +141,8 @@ function AddTodo() {
 }
 ```
 
-Adding several todos in a row with `mutate` only fires `onSuccess` once, for the last call —
-`mutateAsync` gives you a promise per call instead, so you can wait for all of them:
+Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
+promise per call instead, so you can wait for all of them:
 ```tsx
 import { useMutation, useQueryClient } from '@tanstack/preact-query'
 

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -7,7 +7,7 @@ title: useMutation
 function useMutation<TData, TError, TVariables, TOnMutateResult>(options, queryClient?): UseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/useMutation.ts:182](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutation.ts#L182)
+Defined in: [preact-query/src/useMutation.ts:190](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutation.ts#L190)
 
 Unlike queries, mutations are typically used to create/update/delete data or perform server side-effects.
 `useMutation` is the hook for that.
@@ -72,7 +72,15 @@ function AddTodo() {
   })
 
   return (
-    <button onClick={() => addMutation.mutate('Item')}>Add</button>
+    <button
+      onClick={() =>
+        addMutation.mutate('Item', {
+          onError: (error) => console.error('Failed to add item:', error),
+        })
+      }
+    >
+      Add
+    </button>
   )
 }
 ```

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -7,7 +7,7 @@ title: useMutation
 function useMutation<TData, TError, TVariables, TOnMutateResult>(options, queryClient?): UseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/useMutation.ts:87](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutation.ts#L87)
+Defined in: [preact-query/src/useMutation.ts:182](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutation.ts#L182)
 
 Unlike queries, mutations are typically used to create/update/delete data or perform server side-effects.
 `useMutation` is the hook for that.
@@ -77,6 +77,35 @@ function AddTodo() {
 }
 ```
 
+Rendering the mutation's own state, rather than just firing it off:
+```tsx
+import { useMutation, useQueryClient } from '@tanstack/preact-query'
+
+function AddTodo() {
+  const queryClient = useQueryClient()
+
+  const addMutation = useMutation({
+    mutationFn: addTodo,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  })
+
+  return (
+    <div>
+      {addMutation.isPending ? (
+        'Adding todo...'
+      ) : (
+        <>
+          {addMutation.isError ? (
+            <div>An error occurred: {addMutation.error.message}</div>
+          ) : null}
+          <button onClick={() => addMutation.mutate('Item')}>Add</button>
+        </>
+      )}
+    </div>
+  )
+}
+```
+
 Optimistic update via `onMutate`, rolling back on `onError`:
 ```tsx
 import { useMutation, useQueryClient } from '@tanstack/preact-query'
@@ -108,6 +137,69 @@ function AddTodo() {
 
   return (
     <button onClick={() => addMutation.mutate('Item')}>Add</button>
+  )
+}
+```
+
+Adding several todos in a row with `mutate` only fires `onSuccess` once, for the last call —
+`mutateAsync` gives you a promise per call instead, so you can wait for all of them:
+```tsx
+import { useMutation, useQueryClient } from '@tanstack/preact-query'
+
+function AddTodos() {
+  const queryClient = useQueryClient()
+
+  const addMutation = useMutation({
+    mutationFn: addTodo,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  })
+
+  const handleAddAll = async (todos: Array<string>) => {
+    try {
+      await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  return (
+    <button onClick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+      Add all
+    </button>
+  )
+}
+```
+
+If some of the mutations above can fail independently of the others, and you want to know which ones
+did — rather than losing that information the moment the first one rejects — swap `Promise.all` for
+`Promise.allSettled`:
+```tsx
+import { useMutation, useQueryClient } from '@tanstack/preact-query'
+
+function AddTodos() {
+  const queryClient = useQueryClient()
+
+  const addMutation = useMutation({
+    mutationFn: addTodo,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  })
+
+  const handleAddAll = async (todos: Array<string>) => {
+    const results = await Promise.allSettled(
+      todos.map((todo) => addMutation.mutateAsync(todo)),
+    )
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        console.error(`Failed to add "${todos[index]}":`, result.reason)
+      }
+    })
+  }
+
+  return (
+    <button onClick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+      Add all
+    </button>
   )
 }
 ```

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -166,7 +166,7 @@ function AddTodos() {
     try {
       await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
     } catch (error) {
-      console.error(error)
+      console.error('Failed to add todos:', error)
     }
   }
 

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -178,7 +178,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:187](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L187)
+Defined in: [preact-query/src/useQuery.ts:192](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L192)
 
 ### Type Parameters
 
@@ -252,16 +252,21 @@ function Posts() {
 }
 ```
 
-A dependent query, only enabled once `postId` is set:
+A dependent query, only enabled once `postId` is set — use `isLoading`, not `isPending`, so the
+loading state doesn't show while the query is disabled:
 ```tsx
 import { useQuery } from '@tanstack/preact-query'
 
 function Post({ postId }: { postId: number | undefined }) {
-  const { data } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: ['post', postId],
     queryFn: () => fetchPost(postId!),
     enabled: postId != null,
   })
+
+  if (postId == null) return 'Select a post'
+  if (isLoading) return 'Loading...'
+  if (isError) return <span>Error: {error.message}</span>
 
   return <h1>{data?.title}</h1>
 }

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -81,7 +81,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:87](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L87)
+Defined in: [preact-query/src/useQuery.ts:105](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L105)
 
 ### Type Parameters
 
@@ -128,7 +128,7 @@ display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
 
 [queryOptions](queryOptions.md) to share these options between `useQuery` and imperative APIs like `queryClient.query`.
 
-### Example
+### Examples
 
 ```tsx
 import { queryOptions, useQuery } from '@tanstack/preact-query'
@@ -155,13 +155,30 @@ function Posts() {
 }
 ```
 
+The same query, checking `isPending`/`isError` instead of `status` — pick whichever reads better to you:
+```tsx
+import { useQuery } from '@tanstack/preact-query'
+
+function Posts() {
+  const { isPending, isError, data, error } = useQuery({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+  })
+
+  if (isPending) return 'Loading...'
+  if (isError) return <span>Error: {error.message}</span>
+
+  return <>{data.map((post) => <p key={post.id}>{post.title}</p>)}</>
+}
+```
+
 ## Call Signature
 
 ```ts
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:169](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L169)
+Defined in: [preact-query/src/useQuery.ts:187](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L187)
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -178,7 +178,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:192](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L192)
+Defined in: [preact-query/src/useQuery.ts:221](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L221)
 
 ### Type Parameters
 
@@ -289,5 +289,33 @@ function Post({ postId }: { postId: number }) {
   })
 
   return <h1>{data?.title}</h1>
+}
+```
+
+Paginated data, keeping the previous page's data visible while the next page loads:
+```tsx
+import { keepPreviousData, useQuery } from '@tanstack/preact-query'
+import { useState } from 'preact/hooks'
+
+function Posts() {
+  const [page, setPage] = useState(0)
+
+  const { data, isPlaceholderData } = useQuery({
+    queryKey: ['posts', page],
+    queryFn: () => fetchPosts(page),
+    placeholderData: keepPreviousData,
+  })
+
+  return (
+    <div>
+      {data?.map((post) => <p key={post.id}>{post.title}</p>)}
+      <button
+        disabled={isPlaceholderData}
+        onClick={() => setPage((old) => old + 1)}
+      >
+        Next Page
+      </button>
+    </div>
+  )
 }
 ```

--- a/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
@@ -7,7 +7,7 @@ title: useSuspenseInfiniteQuery
 function useSuspenseInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseSuspenseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:66](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L66)
+Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:74](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L74)
 
 The options for `useSuspenseInfiniteQuery` are the same as for `useInfiniteQuery`, except for `throwOnError`,
 `enabled`, and `placeholderData`.
@@ -67,20 +67,28 @@ import { useSuspenseInfiniteQuery } from '@tanstack/preact-query'
 
 function Projects() {
   // `data` is guaranteed to be defined here — no `isPending` check needed.
-  const { data, fetchNextPage, hasNextPage } = useSuspenseInfiniteQuery({
-    queryKey: ['projects'],
-    queryFn: ({ pageParam }) => fetchProjects(pageParam),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => lastPage.nextId,
-  })
+  const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
+    useSuspenseInfiniteQuery({
+      queryKey: ['projects'],
+      queryFn: ({ pageParam }) => fetchProjects(pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextId,
+    })
 
   return (
     <div>
       {data.pages.map((page) =>
         page.projects.map((project) => <p key={project.id}>{project.name}</p>),
       )}
-      <button onClick={() => fetchNextPage()} disabled={!hasNextPage}>
-        Load More
+      <button
+        onClick={() => fetchNextPage()}
+        disabled={!hasNextPage || isFetching}
+      >
+        {isFetchingNextPage
+          ? 'Loading more...'
+          : hasNextPage
+            ? 'Load More'
+            : 'Nothing more to load'}
       </button>
     </div>
   )

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -96,15 +96,19 @@ export function useInfiniteQuery<
  * })
  *
  * function Projects() {
- *   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+ *   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
  *     useInfiniteQuery(projectsOptions)
  *
  *   return (
  *     <button
  *       onClick={() => fetchNextPage()}
- *       disabled={!hasNextPage || isFetchingNextPage}
+ *       disabled={!hasNextPage || isFetching}
  *     >
- *       Load More
+ *       {isFetchingNextPage
+ *         ? 'Loading more...'
+ *         : hasNextPage
+ *           ? 'Load More'
+ *           : 'Nothing more to load'}
  *     </button>
  *   )
  * }
@@ -154,15 +158,19 @@ export function useInfiniteQuery<
  * })
  *
  * function Projects() {
- *   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+ *   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
  *     useInfiniteQuery(projectsOptions)
  *
  *   return (
  *     <button
  *       onClick={() => fetchNextPage()}
- *       disabled={!hasNextPage || isFetchingNextPage}
+ *       disabled={!hasNextPage || isFetching}
  *     >
- *       Load More
+ *       {isFetchingNextPage
+ *         ? 'Loading more...'
+ *         : hasNextPage
+ *           ? 'Load More'
+ *           : 'Nothing more to load'}
  *     </button>
  *   )
  * }

--- a/packages/preact-query/src/useIsFetching.ts
+++ b/packages/preact-query/src/useIsFetching.ts
@@ -24,6 +24,20 @@ import { useSyncExternalStore } from './utils'
  * // How many queries matching the posts prefix are fetching?
  * const isFetchingPosts = useIsFetching({ queryKey: ['posts'] })
  * ```
+ *
+ * @example
+ * A global loading indicator for any query fetching in the background, not just the ones on screen:
+ * ```tsx
+ * import { useIsFetching } from '@tanstack/preact-query'
+ *
+ * function GlobalLoadingIndicator() {
+ *   const isFetching = useIsFetching()
+ *
+ *   return isFetching ? (
+ *     <div>Queries are fetching in the background...</div>
+ *   ) : null
+ * }
+ * ```
  */
 export function useIsFetching(
   filters?: QueryFilters,

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -49,6 +49,36 @@ import { useSyncExternalStore } from './utils'
  * ```
  *
  * @example
+ * Rendering the mutation's own state, rather than just firing it off:
+ * ```tsx
+ * import { useMutation, useQueryClient } from '@tanstack/preact-query'
+ *
+ * function AddTodo() {
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = useMutation({
+ *     mutationFn: addTodo,
+ *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+ *   })
+ *
+ *   return (
+ *     <div>
+ *       {addMutation.isPending ? (
+ *         'Adding todo...'
+ *       ) : (
+ *         <>
+ *           {addMutation.isError ? (
+ *             <div>An error occurred: {addMutation.error.message}</div>
+ *           ) : null}
+ *           <button onClick={() => addMutation.mutate('Item')}>Add</button>
+ *         </>
+ *       )}
+ *     </div>
+ *   )
+ * }
+ * ```
+ *
+ * @example
  * Optimistic update via `onMutate`, rolling back on `onError`:
  * ```tsx
  * import { useMutation, useQueryClient } from '@tanstack/preact-query'
@@ -80,6 +110,71 @@ import { useSyncExternalStore } from './utils'
  *
  *   return (
  *     <button onClick={() => addMutation.mutate('Item')}>Add</button>
+ *   )
+ * }
+ * ```
+ *
+ * @example
+ * Adding several todos in a row with `mutate` only fires `onSuccess` once, for the last call —
+ * `mutateAsync` gives you a promise per call instead, so you can wait for all of them:
+ * ```tsx
+ * import { useMutation, useQueryClient } from '@tanstack/preact-query'
+ *
+ * function AddTodos() {
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = useMutation({
+ *     mutationFn: addTodo,
+ *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+ *   })
+ *
+ *   const handleAddAll = async (todos: Array<string>) => {
+ *     try {
+ *       await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
+ *     } catch (error) {
+ *       console.error(error)
+ *     }
+ *   }
+ *
+ *   return (
+ *     <button onClick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+ *       Add all
+ *     </button>
+ *   )
+ * }
+ * ```
+ *
+ * @example
+ * If some of the mutations above can fail independently of the others, and you want to know which ones
+ * did — rather than losing that information the moment the first one rejects — swap `Promise.all` for
+ * `Promise.allSettled`:
+ * ```tsx
+ * import { useMutation, useQueryClient } from '@tanstack/preact-query'
+ *
+ * function AddTodos() {
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = useMutation({
+ *     mutationFn: addTodo,
+ *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+ *   })
+ *
+ *   const handleAddAll = async (todos: Array<string>) => {
+ *     const results = await Promise.allSettled(
+ *       todos.map((todo) => addMutation.mutateAsync(todo)),
+ *     )
+ *
+ *     results.forEach((result, index) => {
+ *       if (result.status === 'rejected') {
+ *         console.error(`Failed to add "${todos[index]}":`, result.reason)
+ *       }
+ *     })
+ *   }
+ *
+ *   return (
+ *     <button onClick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+ *       Add all
+ *     </button>
  *   )
  * }
  * ```

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -140,7 +140,7 @@ import { useSyncExternalStore } from './utils'
  *     try {
  *       await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
  *     } catch (error) {
- *       console.error(error)
+ *       console.error('Failed to add todos:', error)
  *     }
  *   }
  *

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -115,8 +115,8 @@ import { useSyncExternalStore } from './utils'
  * ```
  *
  * @example
- * Adding several todos in a row with `mutate` only fires `onSuccess` once, for the last call —
- * `mutateAsync` gives you a promise per call instead, so you can wait for all of them:
+ * Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
+ * promise per call instead, so you can wait for all of them:
  * ```tsx
  * import { useMutation, useQueryClient } from '@tanstack/preact-query'
  *

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -43,7 +43,15 @@ import { useSyncExternalStore } from './utils'
  *   })
  *
  *   return (
- *     <button onClick={() => addMutation.mutate('Item')}>Add</button>
+ *     <button
+ *       onClick={() =>
+ *         addMutation.mutate('Item', {
+ *           onError: (error) => console.error('Failed to add item:', error),
+ *         })
+ *       }
+ *     >
+ *       Add
+ *     </button>
  *   )
  * }
  * ```

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -188,6 +188,35 @@ export function useQuery<
  *   return <h1>{data?.title}</h1>
  * }
  * ```
+ *
+ * @example
+ * Paginated data, keeping the previous page's data visible while the next page loads:
+ * ```tsx
+ * import { keepPreviousData, useQuery } from '@tanstack/preact-query'
+ * import { useState } from 'preact/hooks'
+ *
+ * function Posts() {
+ *   const [page, setPage] = useState(0)
+ *
+ *   const { data, isPlaceholderData } = useQuery({
+ *     queryKey: ['posts', page],
+ *     queryFn: () => fetchPosts(page),
+ *     placeholderData: keepPreviousData,
+ *   })
+ *
+ *   return (
+ *     <div>
+ *       {data?.map((post) => <p key={post.id}>{post.title}</p>)}
+ *       <button
+ *         disabled={isPlaceholderData}
+ *         onClick={() => setPage((old) => old + 1)}
+ *       >
+ *         Next Page
+ *       </button>
+ *     </div>
+ *   )
+ * }
+ * ```
  */
 export function useQuery<
   TQueryFnData = unknown,

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -83,6 +83,24 @@ export function useQuery<
  *   )
  * }
  * ```
+ *
+ * @example
+ * The same query, checking `isPending`/`isError` instead of `status` — pick whichever reads better to you:
+ * ```tsx
+ * import { useQuery } from '@tanstack/preact-query'
+ *
+ * function Posts() {
+ *   const { isPending, isError, data, error } = useQuery({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *   })
+ *
+ *   if (isPending) return 'Loading...'
+ *   if (isError) return <span>Error: {error.message}</span>
+ *
+ *   return <>{data.map((post) => <p key={post.id}>{post.title}</p>)}</>
+ * }
+ * ```
  */
 export function useQuery<
   TQueryFnData = unknown,

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -148,16 +148,21 @@ export function useQuery<
  * ```
  *
  * @example
- * A dependent query, only enabled once `postId` is set:
+ * A dependent query, only enabled once `postId` is set — use `isLoading`, not `isPending`, so the
+ * loading state doesn't show while the query is disabled:
  * ```tsx
  * import { useQuery } from '@tanstack/preact-query'
  *
  * function Post({ postId }: { postId: number | undefined }) {
- *   const { data } = useQuery({
+ *   const { data, isLoading, isError, error } = useQuery({
  *     queryKey: ['post', postId],
  *     queryFn: () => fetchPost(postId!),
  *     enabled: postId != null,
  *   })
+ *
+ *   if (postId == null) return 'Select a post'
+ *   if (isLoading) return 'Loading...'
+ *   if (isError) return <span>Error: {error.message}</span>
  *
  *   return <h1>{data?.title}</h1>
  * }

--- a/packages/preact-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/preact-query/src/useSuspenseInfiniteQuery.ts
@@ -35,20 +35,28 @@ import { useBaseQuery } from './useBaseQuery'
  *
  * function Projects() {
  *   // `data` is guaranteed to be defined here — no `isPending` check needed.
- *   const { data, fetchNextPage, hasNextPage } = useSuspenseInfiniteQuery({
- *     queryKey: ['projects'],
- *     queryFn: ({ pageParam }) => fetchProjects(pageParam),
- *     initialPageParam: 0,
- *     getNextPageParam: (lastPage) => lastPage.nextId,
- *   })
+ *   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
+ *     useSuspenseInfiniteQuery({
+ *       queryKey: ['projects'],
+ *       queryFn: ({ pageParam }) => fetchProjects(pageParam),
+ *       initialPageParam: 0,
+ *       getNextPageParam: (lastPage) => lastPage.nextId,
+ *     })
  *
  *   return (
  *     <div>
  *       {data.pages.map((page) =>
  *         page.projects.map((project) => <p key={project.id}>{project.name}</p>),
  *       )}
- *       <button onClick={() => fetchNextPage()} disabled={!hasNextPage}>
- *         Load More
+ *       <button
+ *         onClick={() => fetchNextPage()}
+ *         disabled={!hasNextPage || isFetching}
+ *       >
+ *         {isFetchingNextPage
+ *           ? 'Loading more...'
+ *           : hasNextPage
+ *             ? 'Load More'
+ *             : 'Nothing more to load'}
  *       </button>
  *     </div>
  *   )


### PR DESCRIPTION
## 🎯 Changes

Adds and fixes `@example` blocks in `preact-query` JSDoc, cross-checked against the official TanStack Query guides (`docs/framework/react/guides/`) for patterns not yet covered:

- `useQuery`: add an `isPending`/`isError` boolean-style example alongside the existing `status` example; fix the dependent-query example to use `isLoading` (not `isPending`) so the loading state doesn't show while disabled; add a pagination example with `keepPreviousData`
- `useInfiniteQuery`/`useSuspenseInfiniteQuery`: fix the `fetchNextPage` example's `disabled` condition, which used `isFetchingNextPage` instead of `isFetching` — contradicting the function's own `@remarks` guidance
- `useMutation`: add an example rendering the mutation's own state (`isPending`/`isError`); add `Promise.all` and `Promise.allSettled` examples for firing several mutations at once; reorder examples so state-rendering comes before the more advanced optimistic-update example
- `useIsFetching`: add a global loading indicator example

All new example code was verified with `tsc --noEmit` against the package's `tsconfig.json`. Generated reference docs (`docs/framework/preact/reference/`) were regenerated via `pnpm run generate-docs`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Preact Query examples with clearer loading, pending, error, and fetching states.
  - Added infinite-query examples showing disabled controls and labels for loading, more pages, or no remaining pages.
  - Added global background-fetch status guidance with `useIsFetching`.
  - Expanded mutation examples covering per-call errors, pending/error states, parallel mutations, and independent failure handling.
  - Added query examples for dependent queries, pagination, retained previous data, and placeholder states.
  - Refreshed documentation source references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->