### PR TITLE
docs(preact-query): use function declarations instead of arrow functions in example code

### DIFF
--- a/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
@@ -7,7 +7,7 @@ title: QueryErrorResetBoundary
 function QueryErrorResetBoundary(__namedParameters): Element;
 ```
 
-Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:157](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L157)
+Defined in: [preact-query/src/QueryErrorResetBoundary.tsx:159](https://github.com/TanStack/query/blob/main/packages/preact-query/src/QueryErrorResetBoundary.tsx#L159)
 
 When using `suspense` or `throwOnError` in your queries, you need a way to let queries know that you want to
 try again when re-rendering after some error occurred. With the `QueryErrorResetBoundary` component you can
@@ -54,13 +54,15 @@ function ErrorBoundary({
   return children
 }
 
-const App = () => (
-  <QueryErrorResetBoundary>
-    {({ reset }) => (
-      <ErrorBoundary reset={reset}>
-        <Page />
-      </ErrorBoundary>
-    )}
-  </QueryErrorResetBoundary>
-)
+function App() {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary reset={reset}>
+          <Page />
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}
 ```

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -162,7 +162,7 @@ function AddTodos() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   })
 
-  const handleAddAll = async (todos: Array<string>) => {
+  async function handleAddAll(todos: Array<string>) {
     try {
       await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
     } catch (error) {
@@ -192,7 +192,7 @@ function AddTodos() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   })
 
-  const handleAddAll = async (todos: Array<string>) => {
+  async function handleAddAll(todos: Array<string>) {
     const results = await Promise.allSettled(
       todos.map((todo) => addMutation.mutateAsync(todo)),
     )

--- a/packages/preact-query/src/QueryErrorResetBoundary.tsx
+++ b/packages/preact-query/src/QueryErrorResetBoundary.tsx
@@ -143,15 +143,17 @@ export interface QueryErrorResetBoundaryProps {
  *   return children
  * }
  *
- * const App = () => (
- *   <QueryErrorResetBoundary>
- *     {({ reset }) => (
- *       <ErrorBoundary reset={reset}>
- *         <Page />
- *       </ErrorBoundary>
- *     )}
- *   </QueryErrorResetBoundary>
- * )
+ * function App() {
+ *   return (
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary reset={reset}>
+ *           <Page />
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
+ *   )
+ * }
  * ```
  */
 export const QueryErrorResetBoundary = ({

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -136,7 +136,7 @@ import { useSyncExternalStore } from './utils'
  *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
  *   })
  *
- *   const handleAddAll = async (todos: Array<string>) => {
+ *   async function handleAddAll(todos: Array<string>) {
  *     try {
  *       await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
  *     } catch (error) {
@@ -167,7 +167,7 @@ import { useSyncExternalStore } from './utils'
  *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
  *   })
  *
- *   const handleAddAll = async (todos: Array<string>) => {
+ *   async function handleAddAll(todos: Array<string>) {
  *     const results = await Promise.allSettled(
  *       todos.map((todo) => addMutation.mutateAsync(todo)),
  *     )


### PR DESCRIPTION
## 🎯 Changes

Two `@example` blocks in preact-query used arrow functions assigned to local variables where the rest of the file (and the surrounding example itself) already used function declarations:

- `useMutation.ts`: `const handleAddAll = async (todos) => {...}` → `async function handleAddAll(todos) {...}` (two examples: `Promise.all` and `Promise.allSettled`)
- `QueryErrorResetBoundary.tsx`: `const App = () => (...)` → `function App() { return (...) }` — the same example already declares `ErrorBoundary` and `Page` as function declarations, so `App` was the odd one out

Regenerated the corresponding reference docs with `pnpm run generate-docs`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Preact examples to use clearer named function declarations.
  * Corrected a documentation source link.
  * Kept mutation execution, error handling, and runtime behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->