### PR TITLE
docs(preact-query): remove redundant 'infiniteQueryOptions' usage from 'useInfiniteQuery' examples

### DIFF
--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -95,7 +95,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:117](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L117)
+Defined in: [preact-query/src/useInfiniteQuery.ts:115](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L115)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -158,18 +158,16 @@ actions, or add conditions like `hasNextPage && !isFetching`.
 ### Example
 
 ```tsx
-import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
-
-const projectsOptions = infiniteQueryOptions({
-  queryKey: ['projects'],
-  queryFn: ({ pageParam }) => fetchProjects(pageParam),
-  initialPageParam: 0,
-  getNextPageParam: (lastPage) => lastPage.nextId,
-})
+import { useInfiniteQuery } from '@tanstack/preact-query'
 
 function Projects() {
   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
-    useInfiniteQuery(projectsOptions)
+    useInfiniteQuery({
+      queryKey: ['projects'],
+      queryFn: ({ pageParam }) => fetchProjects(pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextId,
+    })
 
   return (
     <button
@@ -192,7 +190,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:179](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L179)
+Defined in: [preact-query/src/useInfiniteQuery.ts:175](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L175)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -255,18 +253,16 @@ actions, or add conditions like `hasNextPage && !isFetching`.
 ### Example
 
 ```tsx
-import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
-
-const projectsOptions = infiniteQueryOptions({
-  queryKey: ['projects'],
-  queryFn: ({ pageParam }) => fetchProjects(pageParam),
-  initialPageParam: 0,
-  getNextPageParam: (lastPage) => lastPage.nextId,
-})
+import { useInfiniteQuery } from '@tanstack/preact-query'
 
 function Projects() {
   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
-    useInfiniteQuery(projectsOptions)
+    useInfiniteQuery({
+      queryKey: ['projects'],
+      queryFn: ({ pageParam }) => fetchProjects(pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextId,
+    })
 
   return (
     <button

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -86,18 +86,16 @@ export function useInfiniteQuery<
  *
  * @example
  * ```tsx
- * import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
- *
- * const projectsOptions = infiniteQueryOptions({
- *   queryKey: ['projects'],
- *   queryFn: ({ pageParam }) => fetchProjects(pageParam),
- *   initialPageParam: 0,
- *   getNextPageParam: (lastPage) => lastPage.nextId,
- * })
+ * import { useInfiniteQuery } from '@tanstack/preact-query'
  *
  * function Projects() {
  *   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
- *     useInfiniteQuery(projectsOptions)
+ *     useInfiniteQuery({
+ *       queryKey: ['projects'],
+ *       queryFn: ({ pageParam }) => fetchProjects(pageParam),
+ *       initialPageParam: 0,
+ *       getNextPageParam: (lastPage) => lastPage.nextId,
+ *     })
  *
  *   return (
  *     <button
@@ -148,18 +146,16 @@ export function useInfiniteQuery<
  *
  * @example
  * ```tsx
- * import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
- *
- * const projectsOptions = infiniteQueryOptions({
- *   queryKey: ['projects'],
- *   queryFn: ({ pageParam }) => fetchProjects(pageParam),
- *   initialPageParam: 0,
- *   getNextPageParam: (lastPage) => lastPage.nextId,
- * })
+ * import { useInfiniteQuery } from '@tanstack/preact-query'
  *
  * function Projects() {
  *   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
- *     useInfiniteQuery(projectsOptions)
+ *     useInfiniteQuery({
+ *       queryKey: ['projects'],
+ *       queryFn: ({ pageParam }) => fetchProjects(pageParam),
+ *       initialPageParam: 0,
+ *       getNextPageParam: (lastPage) => lastPage.nextId,
+ *     })
  *
  *   return (
  *     <button


### PR DESCRIPTION
## 🎯 Changes

Both non-`initialData` overloads of `useInfiniteQuery` had an `@example` that defined a `projectsOptions` factory with `infiniteQueryOptions` and then passed it to `useInfiniteQuery`. This is already the canonical example for `infiniteQueryOptions` itself (`infiniteQueryOptions.ts`), so the `useInfiniteQuery` examples duplicated it instead of showing the more common case of passing options directly.

Replaced both with an inline options object passed straight to `useInfiniteQuery`, matching the style of the first overload's example (the one with `initialData`).

Regenerated the corresponding reference docs with `pnpm run generate-docs`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated infinite-query examples to pass options directly to `useInfiniteQuery`.
  * Refreshed source links for documented overloads.
  * Clarified usage examples without changing runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->