### PR TITLE
docs(preact-query): document request-waterfall avoidance across 'useSuspenseQuery' and 'useSuspenseQueries'

### DIFF
--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -9,7 +9,7 @@ title: useSuspenseQueries
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:230](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L230)
+Defined in: [preact-query/src/useSuspenseQueries.ts:264](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L264)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -63,7 +63,7 @@ Caveat: the component will only re-mount after all queries have finished loading
 stale in the time it took for all the queries to complete, it will be fetched again at re-mount. To avoid
 this, make sure to set a high enough `staleTime`. Cancellation does not work.
 
-### Example
+### Examples
 
 ```tsx
 import { Suspense } from 'preact/compat'
@@ -96,13 +96,46 @@ function App() {
 }
 ```
 
+Several different queries — use `useSuspenseQueries` instead of multiple `useSuspenseQuery` calls, so
+they fetch in parallel rather than suspending one after another:
+```tsx
+import { Suspense } from 'preact/compat'
+import { useSuspenseQueries } from '@tanstack/preact-query'
+
+function Dashboard() {
+  const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
+    queries: [
+      { queryKey: ['users'], queryFn: fetchUsers },
+      { queryKey: ['teams'], queryFn: fetchTeams },
+      { queryKey: ['projects'], queryFn: fetchProjects },
+    ],
+  })
+
+  return (
+    <div>
+      <UserList users={usersQuery.data} />
+      <TeamList teams={teamsQuery.data} />
+      <ProjectList projects={projectsQuery.data} />
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <Suspense fallback={<h1>Loading dashboard...</h1>}>
+      <Dashboard />
+    </Suspense>
+  )
+}
+```
+
 ## Call Signature
 
 ```ts
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:297](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L297)
+Defined in: [preact-query/src/useSuspenseQueries.ts:365](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L365)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -155,7 +188,7 @@ Caveat: the component will only re-mount after all queries have finished loading
 stale in the time it took for all the queries to complete, it will be fetched again at re-mount. To avoid
 this, make sure to set a high enough `staleTime`. Cancellation does not work.
 
-### Example
+### Examples
 
 ```tsx
 import { Suspense } from 'preact/compat'
@@ -183,6 +216,39 @@ function App() {
   return (
     <Suspense fallback={<h1>Loading posts...</h1>}>
       <Posts ids={[1, 2, 3]} />
+    </Suspense>
+  )
+}
+```
+
+Several different queries — use `useSuspenseQueries` instead of multiple `useSuspenseQuery` calls, so
+they fetch in parallel rather than suspending one after another:
+```tsx
+import { Suspense } from 'preact/compat'
+import { useSuspenseQueries } from '@tanstack/preact-query'
+
+function Dashboard() {
+  const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
+    queries: [
+      { queryKey: ['users'], queryFn: fetchUsers },
+      { queryKey: ['teams'], queryFn: fetchTeams },
+      { queryKey: ['projects'], queryFn: fetchProjects },
+    ],
+  })
+
+  return (
+    <div>
+      <UserList users={usersQuery.data} />
+      <TeamList teams={teamsQuery.data} />
+      <ProjectList projects={projectsQuery.data} />
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <Suspense fallback={<h1>Loading dashboard...</h1>}>
+      <Dashboard />
     </Suspense>
   )
 }

--- a/docs/framework/preact/reference/functions/useSuspenseQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQuery.md
@@ -7,7 +7,7 @@ title: useSuspenseQuery
 function useSuspenseQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseSuspenseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseQuery.ts:51](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L51)
+Defined in: [preact-query/src/useSuspenseQuery.ts:55](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L55)
 
 The options for `useSuspenseQuery` are the same as for `useQuery`, except for `throwOnError`, `enabled`, and
 `placeholderData`.
@@ -53,6 +53,13 @@ be used.
 
 The same object as `useQuery`, except that `data` is guaranteed to be defined, `isPlaceholderData`
 is missing, and `status` is either `success` or `error` (with the derived flags set accordingly).
+
+## Remarks
+
+Multiple `useSuspenseQuery` calls in the same component suspend serially, causing a request
+waterfall — each one blocks rendering until it resolves, so the next doesn't even start fetching until then.
+Use [useSuspenseQueries](useSuspenseQueries.md) instead when you have more than one suspenseful query in a component, so they
+fetch in parallel.
 
 ## Example
 

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -226,6 +226,40 @@ export type SuspenseQueriesResults<
  *   )
  * }
  * ```
+ *
+ * @example
+ * Several different queries — use `useSuspenseQueries` instead of multiple `useSuspenseQuery` calls, so
+ * they fetch in parallel rather than suspending one after another:
+ * ```tsx
+ * import { Suspense } from 'preact/compat'
+ * import { useSuspenseQueries } from '@tanstack/preact-query'
+ *
+ * function Dashboard() {
+ *   const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
+ *     queries: [
+ *       { queryKey: ['users'], queryFn: fetchUsers },
+ *       { queryKey: ['teams'], queryFn: fetchTeams },
+ *       { queryKey: ['projects'], queryFn: fetchProjects },
+ *     ],
+ *   })
+ *
+ *   return (
+ *     <div>
+ *       <UserList users={usersQuery.data} />
+ *       <TeamList teams={teamsQuery.data} />
+ *       <ProjectList projects={projectsQuery.data} />
+ *     </div>
+ *   )
+ * }
+ *
+ * function App() {
+ *   return (
+ *     <Suspense fallback={<h1>Loading dashboard...</h1>}>
+ *       <Dashboard />
+ *     </Suspense>
+ *   )
+ * }
+ * ```
  */
 export function useSuspenseQueries<
   T extends Array<any>,
@@ -289,6 +323,40 @@ export function useSuspenseQueries<
  *   return (
  *     <Suspense fallback={<h1>Loading posts...</h1>}>
  *       <Posts ids={[1, 2, 3]} />
+ *     </Suspense>
+ *   )
+ * }
+ * ```
+ *
+ * @example
+ * Several different queries — use `useSuspenseQueries` instead of multiple `useSuspenseQuery` calls, so
+ * they fetch in parallel rather than suspending one after another:
+ * ```tsx
+ * import { Suspense } from 'preact/compat'
+ * import { useSuspenseQueries } from '@tanstack/preact-query'
+ *
+ * function Dashboard() {
+ *   const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
+ *     queries: [
+ *       { queryKey: ['users'], queryFn: fetchUsers },
+ *       { queryKey: ['teams'], queryFn: fetchTeams },
+ *       { queryKey: ['projects'], queryFn: fetchProjects },
+ *     ],
+ *   })
+ *
+ *   return (
+ *     <div>
+ *       <UserList users={usersQuery.data} />
+ *       <TeamList teams={teamsQuery.data} />
+ *       <ProjectList projects={projectsQuery.data} />
+ *     </div>
+ *   )
+ * }
+ *
+ * function App() {
+ *   return (
+ *     <Suspense fallback={<h1>Loading dashboard...</h1>}>
+ *       <Dashboard />
  *     </Suspense>
  *   )
  * }

--- a/packages/preact-query/src/useSuspenseQuery.ts
+++ b/packages/preact-query/src/useSuspenseQuery.ts
@@ -11,6 +11,10 @@ import { useBaseQuery } from './useBaseQuery'
  *
  * Caveat: cancellation does not work.
  *
+ * @remarks Multiple `useSuspenseQuery` calls in the same component suspend serially, causing a request
+ * waterfall — each one blocks rendering until it resolves, so the next doesn't even start fetching until then.
+ * Use {@link useSuspenseQueries} instead when you have more than one suspenseful query in a component, so they
+ * fetch in parallel.
  * @param options - The {@link UseSuspenseQueryOptions} to use — the same options as `useQuery`, minus the ones listed above.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.


### PR DESCRIPTION
## 🎯 Changes

Multiple `useSuspenseQuery` calls in the same component suspend serially, causing a request waterfall — each one blocks rendering until it resolves before the next even starts fetching. `docs/framework/react/guides/request-waterfalls.md` has a dedicated section for this (`### Single Component Waterfalls / Serial Queries`) with a problem/solution code pair and an explicit recommendation to always use `useSuspenseQueries` instead when there's more than one suspenseful query in a component. Neither hook's JSDoc reflected this.

- `useSuspenseQuery.ts`: added an `@remarks` warning about the waterfall, linking to `useSuspenseQueries`.
- `useSuspenseQueries.ts`: added a second `@example` (both overloads) showing several different queries fetched in parallel — the existing example only covered a single dynamic array of homogeneous queries (`ids.map(...)`), not the heterogeneous multi-query case the guide is about.

Regenerated the corresponding reference docs with `pnpm run generate-docs`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added examples showing how to fetch and display multiple datasets in parallel with `useSuspenseQueries`.
  * Clarified that multiple `useSuspenseQuery` calls may fetch serially and create request waterfalls.
  * Added guidance recommending parallel queries for dashboard-style views.
  * Updated documentation links and example headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->