### PR TITLE
docs(preact-query): rename 'results' to 'postQueries' in 'useSuspenseQueries' example

### DIFF
--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -71,7 +71,7 @@ import { useSuspenseQueries } from '@tanstack/preact-query'
 
 function Posts({ ids }: { ids: Array<number> }) {
   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
-  const results = useSuspenseQueries({
+  const postQueries = useSuspenseQueries({
     queries: ids.map((id) => ({
       queryKey: ['post', id],
       queryFn: () => fetchPost(id),
@@ -80,8 +80,8 @@ function Posts({ ids }: { ids: Array<number> }) {
 
   return (
     <ul>
-      {results.map((result) => (
-        <li key={result.data.id}>{result.data.title}</li>
+      {postQueries.map((query) => (
+        <li key={query.data.id}>{query.data.title}</li>
       ))}
     </ul>
   )
@@ -196,7 +196,7 @@ import { useSuspenseQueries } from '@tanstack/preact-query'
 
 function Posts({ ids }: { ids: Array<number> }) {
   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
-  const results = useSuspenseQueries({
+  const postQueries = useSuspenseQueries({
     queries: ids.map((id) => ({
       queryKey: ['post', id],
       queryFn: () => fetchPost(id),
@@ -205,8 +205,8 @@ function Posts({ ids }: { ids: Array<number> }) {
 
   return (
     <ul>
-      {results.map((result) => (
-        <li key={result.data.id}>{result.data.title}</li>
+      {postQueries.map((query) => (
+        <li key={query.data.id}>{query.data.title}</li>
       ))}
     </ul>
   )

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -202,7 +202,7 @@ export type SuspenseQueriesResults<
  *
  * function Posts({ ids }: { ids: Array<number> }) {
  *   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
- *   const results = useSuspenseQueries({
+ *   const postQueries = useSuspenseQueries({
  *     queries: ids.map((id) => ({
  *       queryKey: ['post', id],
  *       queryFn: () => fetchPost(id),
@@ -211,8 +211,8 @@ export type SuspenseQueriesResults<
  *
  *   return (
  *     <ul>
- *       {results.map((result) => (
- *         <li key={result.data.id}>{result.data.title}</li>
+ *       {postQueries.map((query) => (
+ *         <li key={query.data.id}>{query.data.title}</li>
  *       ))}
  *     </ul>
  *   )
@@ -303,7 +303,7 @@ export function useSuspenseQueries<
  *
  * function Posts({ ids }: { ids: Array<number> }) {
  *   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
- *   const results = useSuspenseQueries({
+ *   const postQueries = useSuspenseQueries({
  *     queries: ids.map((id) => ({
  *       queryKey: ['post', id],
  *       queryFn: () => fetchPost(id),
@@ -312,8 +312,8 @@ export function useSuspenseQueries<
  *
  *   return (
  *     <ul>
- *       {results.map((result) => (
- *         <li key={result.data.id}>{result.data.title}</li>
+ *       {postQueries.map((query) => (
+ *         <li key={query.data.id}>{query.data.title}</li>
  *       ))}
  *     </ul>
  *   )


### PR DESCRIPTION
## 🎯 Changes

Renamed `results` to `postQueries` (and the per-item `result` to `query`) in the array-of-posts `useSuspenseQueries` example, for both overloads. `postQueries` names what the variable actually holds — the array of post query results — consistent with the naming style used in the parallel-queries example added in #11298 (`usersQuery`, `teamsQuery`, `projectsQuery`).

Regenerated the corresponding reference docs with `pnpm run generate-docs`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).