### PR TITLE
fix(react-query): propagate falsy errors to the error boundary

### DIFF
--- a/.changeset/olive-donuts-shave.md
+++ b/.changeset/olive-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+fix(react-query): throw falsy errors from `useQueries` and `useSuspenseQueries` to the error boundary

--- a/packages/react-query/src/__tests__/useQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useQueries.test.tsx
@@ -273,6 +273,39 @@ describe('useQueries', () => {
     consoleMock.mockRestore()
   })
 
+  it("should throw error if in one of queries' queryFn rejects with a falsy error and throwOnError is in use", async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const key = queryKey()
+
+    function Page() {
+      useQueries({
+        queries: [
+          {
+            queryKey: key,
+            queryFn: () => Promise.reject(),
+            retry: false,
+            throwOnError: true,
+          },
+        ],
+      })
+
+      return null
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('error boundary')).toBeInTheDocument()
+    consoleMock.mockRestore()
+  })
+
   it('should use provided custom queryClient', async () => {
     const key = queryKey()
     const queryFn = async () => {

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -2773,6 +2773,35 @@ describe('useQuery', () => {
     consoleMock.mockRestore()
   })
 
+  it('should throw error if queryFn rejects with a falsy error and throwOnError is in use', async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const key = queryKey()
+
+    function Page() {
+      const { status } = useQuery({
+        queryKey: key,
+        queryFn: () => Promise.reject(),
+        retry: false,
+        throwOnError: true,
+      })
+
+      return <h1>{status}</h1>
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('error boundary')).toBeInTheDocument()
+    consoleMock.mockRestore()
+  })
+
   it('should update with data if we observe no properties and throwOnError', async () => {
     const key = queryKey()
 

--- a/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/react-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -577,6 +577,42 @@ describe('useSuspenseQueries', () => {
     expect(rendered.getByText('Data 1')).toBeInTheDocument()
   })
 
+  it('should throw error when a queryFn rejects with a falsy error', async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const key = queryKey()
+
+    function Page() {
+      const [query] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key,
+            queryFn: () => sleep(10).then(() => Promise.reject()),
+            retry: false,
+          },
+        ],
+      })
+
+      return <div>data: {String(query.data)}</div>
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <React.Suspense fallback="loading">
+          <Page />
+        </React.Suspense>
+      </ErrorBoundary>,
+    )
+
+    expect(rendered.getByText('loading')).toBeInTheDocument()
+
+    await act(() => vi.advanceTimersByTimeAsync(10))
+    expect(rendered.getByText('error boundary')).toBeInTheDocument()
+    consoleMock.mockRestore()
+  })
+
   it('should throw error when queryKey changes and new query fails', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -323,7 +323,7 @@ export function useQueries<
     },
   )
 
-  if (firstSingleResultWhichShouldThrow?.error) {
+  if (firstSingleResultWhichShouldThrow) {
     throw firstSingleResultWhichShouldThrow.error
   }
 


### PR DESCRIPTION
Fixes #11304

## 🎯 Changes

A `queryFn` that rejects with a falsy value (`Promise.reject()`, `null`, `''`, `0`)
reaches the error boundary from `useQuery`, but not from `useQueries` or
`useSuspenseQueries`.

`useQueries` guards its render-phase throw with a truthiness check on the error
*value*:

```diff
-if (firstSingleResultWhichShouldThrow?.error) {
+if (firstSingleResultWhichShouldThrow) {
   throw firstSingleResultWhichShouldThrow.error
 }
```

The optional chain is needed to narrow `Array.prototype.find`'s `T | undefined`,
but `?.error` also skips the throw when the error itself is falsy.
`getHasError()` has already decided the result should throw — it gates on
`result.isError` — so re-checking the value second-guesses it. `useBaseQuery`
has no equivalent check.

`useSuspenseQueries` delegates to `useQueries`, so it was affected too.

### Tests

`useQuery` — reference behaviour, passes before and after:

```tsx
useQuery({
  queryKey: key,
  queryFn: () => Promise.reject(), // rejects with `undefined`
  retry: false,
  throwOnError: true,
})
// ✅ error boundary renders
```

`useQueries` — failed before the fix:

```tsx
useQueries({
  queries: [
    {
      queryKey: key,
      queryFn: () => Promise.reject(),
      retry: false,
      throwOnError: true,
    },
  ],
})
// ❌ was: rendered normally, boundary never appeared
```

`useSuspenseQueries` — failed before the fix:

```tsx
const [query] = useSuspenseQueries({
  queries: [
    { queryKey: key, queryFn: () => sleep(10).then(() => Promise.reject()), retry: false },
  ],
})
return <div>data: {String(query.data)}</div>
// ❌ was: rendered `data: undefined`, though `data` is typed as always defined
```

Reproduction: https://stackblitz.com/edit/github-xu81gzmb?file=src%2Findex.tsx

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error boundary handling for `useQuery`, `useQueries`, and `useSuspenseQueries` when queries reject with falsy error values.
  * Prevented suspense queries from suspending indefinitely in these cases.

* **Tests**
  * Added regression coverage for falsy query errors and error boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->