### PR TITLE
fix(preact-query): propagate falsy errors to the error boundary

### DIFF
--- a/.changeset/tame-otters-relax.md
+++ b/.changeset/tame-otters-relax.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query': patch
+---
+
+fix(preact-query): propagate falsy errors to the error boundary

--- a/packages/preact-query/src/__tests__/useQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useQueries.test.tsx
@@ -246,6 +246,43 @@ describe('useQueries', () => {
     consoleMock.mockRestore()
   })
 
+  it("should throw error if in one of queries' queryFn rejects with a falsy error and throwOnError is in use", async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const key = queryKey()
+
+    function Page() {
+      useQueries({
+        queries: [
+          {
+            queryKey: key,
+            // Preact's error path dereferences the thrown value (`if (e.then)`), so a
+            // literal `undefined` error crashes the framework. `0` is just an arbitrary
+            // falsy value that's safe to dereference (`(0).then` is `undefined`, not a
+            // crash) — any falsy primitive other than `null`/`undefined` would do.
+            queryFn: () => Promise.reject(0),
+            retry: false,
+            throwOnError: true,
+          },
+        ],
+      })
+
+      return null
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('error boundary')).toBeInTheDocument()
+    consoleMock.mockRestore()
+  })
+
   it('should use provided custom queryClient', async () => {
     const key = queryKey()
     const queryFn = async () => {

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -2781,6 +2781,39 @@ describe('useQuery', () => {
     consoleMock.mockRestore()
   })
 
+  it('should throw error if queryFn rejects with a falsy error and throwOnError is in use', async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const key = queryKey()
+
+    function Page() {
+      const { status } = useQuery({
+        queryKey: key,
+        // Preact's error path dereferences the thrown value (`if (e.then)`), so a
+        // literal `undefined` error crashes the framework. `0` is just an arbitrary
+        // falsy value that's safe to dereference (`(0).then` is `undefined`, not a
+        // crash) — any falsy primitive other than `null`/`undefined` would do.
+        queryFn: () => Promise.reject(0),
+        retry: false,
+        throwOnError: true,
+      })
+
+      return <h1>{status}</h1>
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered.getByText('error boundary')).toBeInTheDocument()
+    consoleMock.mockRestore()
+  })
+
   it('should update with data if we observe no properties and throwOnError', async () => {
     const key = queryKey()
 

--- a/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useSuspenseQueries.test.tsx
@@ -523,6 +523,46 @@ describe('useSuspenseQueries', () => {
     expect(rendered.getByText('Data 1')).toBeInTheDocument()
   })
 
+  it('should throw error when a queryFn rejects with a falsy error', async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const key = queryKey()
+
+    function Page() {
+      const [query] = useSuspenseQueries({
+        queries: [
+          {
+            queryKey: key,
+            // Preact's error path dereferences the thrown value (`if (e.then)`), so a
+            // literal `undefined` error crashes the framework. `0` is just an arbitrary
+            // falsy value that's safe to dereference (`(0).then` is `undefined`, not a
+            // crash) — any falsy primitive other than `null`/`undefined` would do.
+            queryFn: () => sleep(10).then(() => Promise.reject(0)),
+            retry: false,
+          },
+        ],
+      })
+
+      return <div>data: {String(query.data)}</div>
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </ErrorBoundary>,
+    )
+
+    expect(rendered.getByText('loading')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('error boundary')).toBeInTheDocument()
+    consoleMock.mockRestore()
+  })
+
   it('should throw error when queryKey changes and new query fails', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -402,7 +402,7 @@ export function useQueries<
     },
   )
 
-  if (firstSingleResultWhichShouldThrow?.error) {
+  if (firstSingleResultWhichShouldThrow) {
     throw firstSingleResultWhichShouldThrow.error
   }
 


### PR DESCRIPTION
## 🎯 Changes

`useQueries`/`useSuspenseQueries` used `firstSingleResultWhichShouldThrow?.error` to both find and throw the errored result, which meant a falsy error value (e.g. rejecting with `undefined` or `0`) was silently swallowed instead of being propagated to the error boundary. Same defect as `@tanstack/react-query`'s #11305 — `@tanstack/preact-query`'s `useQueries.ts` copied the same pattern and needed the same fix.

Regression tests added for `useQuery`, `useQueries`, and `useSuspenseQueries` use `Promise.reject(0)` rather than `Promise.reject()` — Preact's error path dereferences the thrown value (`if (e.then)`), so a literal `undefined` error crashes the framework itself; `0` is falsy too and safe to dereference.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in `useQuery`, `useQueries`, and `useSuspenseQueries` so falsy errors, such as `0`, are correctly routed to error boundaries.
  * Prevented failed queries with falsy error values from being silently ignored when configured to throw on error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->