### PR TITLE
fix(react-query): hydrate existing queries during render on the server

### DIFF
--- a/.changeset/hydration-boundary-server-render.md
+++ b/.changeset/hydration-boundary-server-render.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+fix(react-query): hydrate queries that already exist in the cache during render on the server. `HydrationBoundary` defers those to an effect so an aborted transition cannot overwrite the current page, but effects never run during SSR, so the queue was dropped and children fetched the data a second time (#10145)

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -1,7 +1,7 @@
 'use client'
 import * as React from 'react'
 
-import { hydrate } from '@tanstack/query-core'
+import { environmentManager, hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
   DehydratedState,
@@ -95,7 +95,17 @@ export const HydrationBoundary = ({
           hydrate(client, { queries: newQueries }, optionsRef.current)
         }
         if (existingQueries.length > 0) {
-          return existingQueries
+          // The deferral above only pays off on the client, where a transition
+          // can still be aborted. On the server there is no commit phase, so an
+          // effect never runs and the queue would simply be dropped: children
+          // then render against a cache that is missing the data we just
+          // dehydrated, and fetch it a second time during SSR.
+          if (environmentManager.isServer()) {
+            // eslint-disable-next-line react-hooks/refs
+            hydrate(client, { queries: existingQueries }, optionsRef.current)
+          } else {
+            return existingQueries
+          }
         }
       }
       return undefined

--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -3,9 +3,11 @@ import { renderToString } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
+  HydrationBoundary,
   QueryCache,
   QueryClient,
   QueryClientProvider,
+  dehydrate,
   useInfiniteQuery,
   useIsFetching,
   useMutation,
@@ -30,6 +32,44 @@ describe('Server Side Rendering', () => {
   afterEach(() => {
     queryClient.clear()
     vi.useRealTimers()
+  })
+
+  it('should hydrate a query that an observer above the boundary already built', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn(() => sleep(10).then(() => 'data'))
+
+    const prefetchClient = new QueryClient()
+    prefetchClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'prefetched'),
+    })
+    await vi.advanceTimersByTimeAsync(10)
+    const dehydratedState = dehydrate(prefetchClient)
+
+    // Rendering this before the boundary puts an empty query for the same key
+    // into the cache, which used to make the boundary defer hydration to an
+    // effect that never runs on the server.
+    function Header() {
+      useQuery({ queryKey: key, queryFn })
+      return null
+    }
+
+    function Content() {
+      const query = useQuery({ queryKey: key, queryFn })
+      return <div>{`status ${query.status} data ${query.data}`}</div>
+    }
+
+    const markup = renderToString(
+      <QueryClientProvider client={queryClient}>
+        <Header />
+        <HydrationBoundary state={dehydratedState}>
+          <Content />
+        </HydrationBoundary>
+      </QueryClientProvider>,
+    )
+
+    expect(markup).toContain('status success data prefetched')
+    expect(queryFn).toHaveBeenCalledTimes(0)
   })
 
   it('should not trigger fetch', () => {


### PR DESCRIPTION
## 🎯 Changes

Fixes #10145.

`HydrationBoundary` splits the dehydrated queries into two buckets. Queries that are new to the cache are hydrated during render. Queries that already exist are queued and hydrated in an effect, so that an aborted transition cannot push fresh data onto the page the user is still looking at.

There is no commit phase during SSR, so on the server that effect never runs and the queue is silently dropped. If anything rendered above the boundary observes the same key first, the server-prefetched query is already in the cache, lands in the deferred bucket, and children render without it. `useSuspenseQuery` then fetches the same data a second time during SSR, which is what the issue reports.

Deferring also buys nothing on the server, since there are no transitions to abort there. So when `environmentManager.isServer()` is true, the existing queries are hydrated in render alongside the new ones.

The added test in `ssr.test.tsx` renders a `useQuery` for the key above the boundary and a second one inside it. Before the change the markup is `status pending data undefined`; after it, the prefetched data is there and `queryFn` is never called.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side hydration for queries already present in the cache.
  * Prevented unnecessary duplicate data fetching during server rendering.
  * Ensured hydrated queries display their prefetched data immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->