### PR TITLE
fix(react-query): propagate falsy errors from useMutation to the error boundary

### DIFF
--- a/.changeset/quiet-pugs-repeat.md
+++ b/.changeset/quiet-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+fix(react-query): throw falsy errors from `useMutation` to the error boundary

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -1363,6 +1363,46 @@ describe('useMutation', () => {
     consoleMock.mockRestore()
   })
 
+  it('should be able to throw a falsy error when throwOnError is set to true', async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    function Page() {
+      const { mutate } = useMutation<string, undefined>({
+        mutationFn: () => {
+          return Promise.reject(undefined)
+        },
+        throwOnError: true,
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+        </div>
+      )
+    }
+
+    const { getByText, queryByText } = renderWithClient(
+      queryClient,
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div>
+            <span>error boundary</span>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>,
+    )
+
+    fireEvent.click(getByText('mutate'))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryByText('error boundary')).not.toBeNull()
+
+    consoleMock.mockRestore()
+  })
+
   it('should be able to throw an error when throwOnError is a function that returns true', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -63,7 +63,7 @@ export function useMutation<
   )
 
   if (
-    result.error &&
+    result.isError &&
     shouldThrowError(observer.options.throwOnError, [result.error])
   ) {
     throw result.error


### PR DESCRIPTION
`useMutation` decides whether to hand the error to the error boundary with:

```ts
if (
  result.error &&
  shouldThrowError(observer.options.throwOnError, [result.error])
) {
  throw result.error
}
```

The `result.error &&` guard means a `mutationFn` that rejects with a falsy value never reaches the boundary. `Promise.reject()`, `Promise.reject('')` and `Promise.reject(0)` all leave the mutation in the error state, `isError` is `true`, but the component keeps rendering as if nothing went wrong and `throwOnError` is never consulted.

This is the same class of bug as #11305, which fixed it for `useQueries` and `useSuspenseQueries`. `useQuery` was already correct because `getHasError` in `errorBoundaryUtils.ts` gates on `result.isError`. `useMutation` was the one place left.

Solid and Angular already gate their equivalent checks on `state.isError`, so this brings React in line with them too.

## The fix

Gate on `result.isError` instead of on the error value being truthy.

## Test

`packages/react-query/src/__tests__/useMutation.test.tsx` gets a case where the `mutationFn` rejects with `undefined` and `throwOnError: true` is set. It expects the boundary fallback to render. On `main` it fails with `expected null not to be null`; with the change it passes.

Full `@tanstack/react-query` suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useMutation` so errors with falsy values, such as `undefined`, are correctly propagated to the error boundary when `throwOnError` is enabled.

* **Tests**
  * Added coverage confirming rejected falsy values reach the error boundary.

* **Release**
  * Included a patch release for `@tanstack/react-query`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->