### PR TITLE
fix(preact-query): propagate falsy errors from useMutation to the error boundary

### DIFF
--- a/.changeset/spotty-hounds-clap.md
+++ b/.changeset/spotty-hounds-clap.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query': patch
+---
+
+fix(preact-query): throw falsy errors from `useMutation` to the error boundary

--- a/packages/preact-query/src/__tests__/useMutation.test.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test.tsx
@@ -1364,6 +1364,46 @@ describe('useMutation', () => {
     consoleMock.mockRestore()
   })
 
+  it('should be able to throw a falsy error when throwOnError is set to true', async () => {
+    const consoleMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    function Page() {
+      const { mutate } = useMutation<string, string>({
+        mutationFn: () => {
+          return Promise.reject('')
+        },
+        throwOnError: true,
+      })
+
+      return (
+        <div>
+          <button onClick={() => mutate()}>mutate</button>
+        </div>
+      )
+    }
+
+    const { getByText, queryByText } = renderWithClient(
+      queryClient,
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div>
+            <span>error boundary</span>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>,
+    )
+
+    fireEvent.click(getByText('mutate'))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryByText('error boundary')).not.toBeNull()
+
+    consoleMock.mockRestore()
+  })
+
   it('should be able to throw an error when throwOnError is a function that returns true', async () => {
     const consoleMock = vi
       .spyOn(console, 'error')

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -233,7 +233,7 @@ export function useMutation<
   )
 
   if (
-    result.error &&
+    result.isError &&
     shouldThrowError(observer.options.throwOnError, [result.error])
   ) {
     throw result.error


### PR DESCRIPTION
Same bug as #11311, in the Preact adapter.

`useMutation` gates the error boundary throw on the error value itself being truthy:

```ts
if (
  result.error &&
  shouldThrowError(observer.options.throwOnError, [result.error])
) {
  throw result.error
}
```

So a `mutationFn` that rejects with a falsy value leaves the mutation in the error state, with `isError` set to `true`, while the boundary never sees it and `throwOnError` is never consulted.

`useBaseQuery` is already correct here through `getHasError` in `errorBoundaryUtils.ts`, which gates on `result.isError`. #11309 is fixing the matching case in `useQueries`. This is the remaining one.

## The fix

Gate on `result.isError` instead.

## Test

`packages/preact-query/src/__tests__/useMutation.test.tsx` gets a case where the `mutationFn` rejects with `''` and `throwOnError: true` is set, expecting the boundary fallback to render. It fails on `main` and passes with the change.

One note on why the test rejects with `''` rather than `undefined`: Preact's own diff reads `e.then` on the thrown value in `packages/preact/src/diff/index.js` before handing it to `_catchError`, so throwing `undefined` or `null` throws inside Preact itself. That is a Preact limitation and not something this adapter can do anything about, so the test uses a falsy value Preact can actually carry to a boundary.

Full `@tanstack/preact-query` suite passes (385 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `useMutation` so errors with falsy values are correctly propagated to the error boundary when `throwOnError` is enabled.
- **Tests**
  - Added coverage verifying that falsy rejected values reach the error boundary as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->