### PR TITLE
fix(preact-query/useQueries): keep unsubscribed idle

### DIFF
--- a/.changeset/soft-cats-drum.md
+++ b/.changeset/soft-cats-drum.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query': patch
+---
+
+fix(preact-query/useQueries): keep unsubscribed idle

--- a/packages/preact-query/src/__tests__/useQueries.test.tsx
+++ b/packages/preact-query/src/__tests__/useQueries.test.tsx
@@ -64,6 +64,34 @@ describe('useQueries', () => {
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
   })
 
+  it('should not optimistically show fetching when unsubscribed', () => {
+    const key = queryKey()
+    const queryFn = vi.fn(() => Promise.resolve('data'))
+
+    function Page() {
+      const [query] = useQueries({
+        queries: [{ queryKey: key, queryFn }],
+        subscribed: false,
+      })
+
+      return (
+        <div>
+          <span>isFetching: {String(query.isFetching)}</span>
+          <span>fetchStatus: {query.fetchStatus}</span>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    expect(queryFn).not.toHaveBeenCalled()
+    expect(
+      queryClient.getQueryCache().find({ queryKey: key })!.observers.length,
+    ).toBe(0)
+    rendered.getByText('isFetching: false')
+    rendered.getByText('fetchStatus: idle')
+  })
+
   it('should track results', async () => {
     const key1 = queryKey()
     const results: Array<Array<UseQueryResult>> = []

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -306,6 +306,7 @@ export function useQueries<
   const client = useQueryClient(queryClient)
   const isRestoring = useIsRestoring()
   const errorResetBoundary = useQueryErrorResetBoundary()
+  const subscribed = options.subscribed !== false
 
   const defaultedQueries = useMemo(
     () =>
@@ -317,11 +318,13 @@ export function useQueries<
         // Make sure the results are already in fetching state before subscribing or updating options
         defaultedOptions._optimisticResults = isRestoring
           ? 'isRestoring'
-          : 'optimistic'
+          : subscribed
+            ? 'optimistic'
+            : undefined
 
         return defaultedOptions
       }),
-    [queries, client, isRestoring],
+    [queries, client, isRestoring, subscribed],
   )
 
   defaultedQueries.forEach((queryOptions) => {
@@ -348,7 +351,7 @@ export function useQueries<
       (options as QueriesObserverOptions<TCombinedResult>).combine,
     )
 
-  const shouldSubscribe = !isRestoring && options.subscribed !== false
+  const shouldSubscribe = !isRestoring && subscribed
   useSyncExternalStore(
     useCallback(
       (onStoreChange) =>


### PR DESCRIPTION
## 🎯 Changes

`useQueries` unconditionally set `_optimisticResults = 'optimistic'` for every query, ignoring the top-level `subscribed` option. This meant unsubscribed queries showed an optimistic `fetching` state instead of `idle`. Same defect as `@tanstack/react-query`'s #11130 — `@tanstack/preact-query`'s `useQueries.ts` had the identical pattern and needed the same fix.

Now `_optimisticResults` is `undefined` when `subscribed` is `false`, matching the behavior already used for `shouldSubscribe`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useQueries` to avoid showing an optimistic fetching state when queries are unsubscribed.
  * Unsubscribed queries now remain idle, do not execute query functions, and do not register observers.

* **Tests**
  * Added coverage verifying the correct behavior for queries configured with `subscribed: false`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->