### PR TITLE
fix(react-query/HydrationBoundary): hydrate existing queries during SSR

### DIFF
--- a/.changeset/lucky-bats-listen.md
+++ b/.changeset/lucky-bats-listen.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-query': patch
+---
+
+fix(react-query/HydrationBoundary): hydrate existing queries during SSR
+
+`HydrationBoundary` holds back hydration of queries that are already in the cache until after the render phase, so that transitions don't update mounted observers mid-render. There is no effect phase during SSR, so those queries were never hydrated at all. A `useQuery` rendered above the boundary creates a cache entry without fetching, which was enough to make the boundary skip the prefetched data and leave a child `useSuspenseQuery` to fetch again on the server.

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -1,7 +1,7 @@
 'use client'
 import * as React from 'react'
 
-import { hydrate } from '@tanstack/query-core'
+import { environmentManager, hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './QueryClientProvider'
 import type {
   DehydratedState,
@@ -50,6 +50,12 @@ export const HydrationBoundary = ({
   // If the transition is aborted, we will have hydrated any _new_ queries, but
   // we throw away the fresh data for any existing ones to avoid unexpectedly
   // updating the UI.
+  //
+  // On the server there is no effect phase to hold back until, so holding back
+  // would mean never hydrating those queries at all. Neither reason for holding
+  // back applies there either: there are no transitions to abort, and no
+  // observer can have subscribed yet because subscriptions happen in effects,
+  // so hydrating in render cannot be an observed side effect.
   const hydrationQueue: DehydratedState['queries'] | undefined =
     React.useMemo(() => {
       if (state) {
@@ -83,7 +89,11 @@ export const HydrationBoundary = ({
                   existingQuery.state.dataUpdatedAt)
 
             if (hydrationIsNewer) {
-              existingQueries.push(dehydratedQuery)
+              if (environmentManager.isServer()) {
+                newQueries.push(dehydratedQuery)
+              } else {
+                existingQueries.push(dehydratedQuery)
+              }
             }
           }
         }

--- a/packages/react-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/react-query/src/__tests__/ssr-hydration.test.tsx
@@ -1,15 +1,17 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { hydrateRoot } from 'react-dom/client'
-import { act } from 'react'
+import { Suspense, act } from 'react'
 import * as ReactDOMServer from 'react-dom/server'
 import { queryKey } from '@tanstack/query-test-utils'
 import {
+  HydrationBoundary,
   QueryCache,
   QueryClient,
   QueryClientProvider,
   dehydrate,
   hydrate,
   useQuery,
+  useSuspenseQuery,
 } from '..'
 import { setIsServer } from './utils'
 
@@ -269,5 +271,53 @@ describe('Server side rendering with de/rehydration', () => {
     unmount()
     queryClient.clear()
     consoleMock.mockRestore()
+  })
+
+  // https://github.com/TanStack/query/issues/10145
+  it('should hydrate a query that a useQuery above the boundary put in the cache', async () => {
+    const key = queryKey()
+    const renderQueryFn = vi.fn(() => fetchData('rendered'))
+
+    function Header() {
+      const result = useQuery({ queryKey: key, queryFn: renderQueryFn })
+      return <PrintStateComponent componentName="Header" result={result} />
+    }
+
+    function Detail() {
+      const result = useSuspenseQuery({ queryKey: key, queryFn: renderQueryFn })
+      return <PrintStateComponent componentName="Detail" result={result} />
+    }
+
+    setIsServer(true)
+
+    const prefetchClient = new QueryClient()
+    await prefetchClient.prefetchQuery({
+      queryKey: key,
+      queryFn: () => fetchData('prefetched'),
+    })
+    const dehydratedState = dehydrate(prefetchClient)
+
+    // `Header` renders before the boundary and puts a pending query for the
+    // same key in the cache, even though it never fetches on the server.
+    const renderClient = new QueryClient()
+    const markup = ReactDOMServer.renderToString(
+      <QueryClientProvider client={renderClient}>
+        <Header />
+        <HydrationBoundary state={dehydratedState}>
+          <Suspense fallback="loading">
+            <Detail />
+          </Suspense>
+        </HydrationBoundary>
+      </QueryClientProvider>,
+    )
+
+    prefetchClient.clear()
+    renderClient.clear()
+    setIsServer(false)
+
+    expect(markup).toContain(
+      'Detail - status:success fetching:false data:prefetched',
+    )
+    expect(renderQueryFn).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Fixes #10145.

`HydrationBoundary` defers hydrating queries that already exist in the cache until a `useEffect`, so client transitions do not update mounted observers during render. During SSR that effect never runs, so those queries are dropped.

A `useQuery` above the boundary creates a cache entry without fetching (`pending` / `idle` / `dataUpdatedAt: 0`). The boundary then treats the prefetched key as existing and skips it. A child `useSuspenseQuery` for the same key fetches again on the server.

On the server neither reason for deferral applies (no transitions to abort, and observers have not subscribed yet). This change hydrates existing queries in render when `environmentManager.isServer()` is true. Client deferral is unchanged.

This is intentionally narrower than #10159, which hydrated never-fetched idle queries on the client as well. That was unsafe once an observer had subscribed.

This covers the reported SSR refetch / client-requestor-on-server failure. It does not stop a redundant client fetch on first hydration of the same tree, and it does not address the outer-`useSuspenseQuery` mismatch described in the issue thread.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side hydration for queries already present in the cache.
  * Prevented unnecessary refetching when cached data is used across hydration boundaries.
  * Improved compatibility between standard and suspense-based queries during SSR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->