### PR TITLE
fix(query-core): do not schedule garbage collection on the server

### DIFF
--- a/.changeset/quiet-timers-rest.md
+++ b/.changeset/quiet-timers-rest.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Do not schedule garbage collection on the server. A timer scheduled during server rendering captures the async context it was created in and keeps that whole render alive until it fires, while the client it would clean up is dropped with the response. Only queries and mutations with an explicit finite `gcTime` were affected, since the server default is already `Infinity`.

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -13,6 +13,7 @@ import {
   dehydrate,
   hydrate,
   noop,
+  timeoutManager,
 } from '..'
 import { hashQueryKeyByOptions } from '../utils'
 import { mockOnlineManagerIsOnline, setIsServer } from './utils'
@@ -1014,6 +1015,25 @@ describe('query', () => {
 
       expect(query.gcTime).toBe(Infinity)
     } finally {
+      resetIsServer()
+    }
+  })
+
+  it('should not schedule garbage collection on the server, even with an explicit gcTime', () => {
+    const resetIsServer = setIsServer(true)
+    const scheduled = vi.spyOn(timeoutManager, 'setTimeout')
+
+    try {
+      const query = queryCache.build(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => 'data',
+        gcTime: 1000,
+      })
+
+      expect(query.gcTime).toBe(1000)
+      expect(scheduled).not.toHaveBeenCalled()
+    } finally {
+      scheduled.mockRestore()
       resetIsServer()
     }
   })

--- a/packages/query-core/src/removable.ts
+++ b/packages/query-core/src/removable.ts
@@ -14,6 +14,10 @@ export abstract class Removable {
   protected scheduleGc(): void {
     this.clearGcTimeout()
 
+    if (isServerEnvironment()) {
+      return
+    }
+
     if (isValidTimeout(this.gcTime)) {
       this.#gcTimeout = timeoutManager.setTimeout(() => {
         this.optionalRemove()


### PR DESCRIPTION
## 🎯 Changes

Fixes #11320.

`updateGcTime` falls back to `Infinity` on the server, so by default nothing is scheduled there. An explicit finite `gcTime` bypasses that fallback, and `scheduleGc()` then schedules a timer during server rendering.

A Node timer captures the async context it is created in, so it keeps the whole SSR render alive until it fires: the framework's request store, the `react-dom/server` `Request`, the produced HTML and the RSC payload. It cannot clean up anything either — the per-request client is unreachable long before `gcTime` elapses.

`scheduleGc()` now returns early on the server. The `gcTime` value is untouched; nothing else reads it there. Long-lived Node processes that do want garbage collection opt in with `environmentManager.setIsServer(() => false)`.

Reproduction from the issue — 2000 simulated renders, 512 KB of render context each, forced GC before measuring:

```
before, gcTime 60_000:  pendingTimers=2000  external=1001MB  rss=1068MB
after,  gcTime 60_000:  pendingTimers=0     external=1MB     rss=116MB
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request. (Ran `test:eslint`, `test:lib`, `test:types`, `test:build` and `build` for `query-core` and `react-query`: 647 + 571 tests green.)
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-side rendering by preventing unnecessary garbage-collection timers from keeping renders alive.
  - Queries with explicitly configured finite cache lifetimes are no longer scheduled for garbage collection on the server, while client-side behavior remains unchanged.

- **Tests**
  - Added coverage to verify that server-rendered queries do not schedule garbage-collection timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->