### PR TITLE
types(solid-query): support optional initialData in infiniteQueryOptions

### DIFF
--- a/.changeset/silent-flows-options.md
+++ b/.changeset/silent-flows-options.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+types(solid-query): support optional initialData in infiniteQueryOptions

--- a/packages/solid-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -136,4 +136,42 @@ describe('infiniteQueryOptions', () => {
       }>
     >()
   })
+
+  it('should infer defined types when initialData is a function that can return undefined', () => {
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => ({ wow: true }),
+      initialData: () =>
+        Math.random() > 0.5
+          ? {
+              pageParams: [undefined],
+              pages: [{ wow: true }],
+            }
+          : undefined,
+      getNextPageParam: () => 10,
+      initialPageParam: 0,
+    })
+
+    expectTypeOf(() => useInfiniteQuery(() => options).data).toEqualTypeOf<
+      () => InfiniteData<{ wow: boolean }, unknown> | undefined
+    >()
+  })
+
+  it('should infer defined types when initialData is undefined or defined', () => {
+    const initialData:
+      | InfiniteData<{ wow: boolean }, unknown>
+      | undefined = undefined
+
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => ({ wow: true }),
+      initialData,
+      getNextPageParam: () => 10,
+      initialPageParam: 0,
+    })
+
+    expectTypeOf(() => useInfiniteQuery(() => options).data).toEqualTypeOf<
+      () => InfiniteData<{ wow: boolean }, unknown> | undefined
+    >()
+  })
 })

--- a/packages/solid-query/src/infiniteQueryOptions.ts
+++ b/packages/solid-query/src/infiniteQueryOptions.ts
@@ -1,6 +1,7 @@
 import type {
   DefaultError,
   InfiniteData,
+  InitialDataFunction,
   NonUndefinedGuard,
   QueryKey,
   QueryKeyWithDataTag,
@@ -16,7 +17,12 @@ export type UndefinedInitialDataInfiniteOptions<
   TPageParam = unknown,
 > = Accessor<
   InfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & {
-    initialData?: undefined
+    initialData?:
+      | undefined
+      | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
+      | InitialDataFunction<
+          NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
+        >
   }
 >
 


### PR DESCRIPTION
## 🎯 Changes

In `@tanstack/solid-query`, passing an `initialData` that can be `undefined` (e.g. `initialData: someCondition ? initialData : undefined`) to `infiniteQueryOptions` was previously rejected by the TypeScript compiler with a type error because `UndefinedInitialDataInfiniteOptions` did not accept optional/undefined `initialData`.

This PR:
- Broadens `UndefinedInitialDataInfiniteOptions.initialData` to accept optional/undefined initial data, aligning it with `queryOptions` and other adapters.
- Adds type-level test coverage in `packages/solid-query/src/__tests__/infiniteQueryOptions.test-d.tsx` for conditional and possibly-undefined `initialData`.
- Includes a patch changeset for `@tanstack/solid-query`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for infinite queries when `initialData` is provided directly or through a function.
  * Correctly supports initial data that may be undefined while preserving accurate query data types.
  * Improved support for optional initial data in infinite query configuration.
* **Tests**
  * Added coverage for conditional and variable-based `initialData` scenarios.
  * Verified inferred data types across supported initial data patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->