### PR TITLE
fix(solid-query): untrack the client read in useMutation's cache subscription

### DIFF
--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -105,6 +105,30 @@ describe('useMutation', () => {
     consoleMock.mockRestore()
   })
 
+  it('should not emit a strict-read diagnostic on mount', () => {
+    const consoleMock = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+
+    function Page() {
+      const mutation = useMutation(() => ({
+        mutationFn: () => Promise.resolve('mutation'),
+      }))
+
+      return <button disabled={mutation.isPending}>mutate</button>
+    }
+
+    renderWithClient(queryClient, () => <Page />)
+
+    expect(
+      consoleMock.mock.calls.filter((args) =>
+        args.some((arg) => String(arg).includes('STRICT_READ_UNTRACKED')),
+      ),
+    ).toEqual([])
+
+    consoleMock.mockRestore()
+  })
+
   it('should be able to call `onSuccess` and `onSettled` after each successful mutate', async () => {
     let countRef = 0
     const [count, setCount] = createSignal(0)

--- a/packages/solid-query/src/useMutation.ts
+++ b/packages/solid-query/src/useMutation.ts
@@ -119,7 +119,7 @@ export function useMutation<
   let activeMutation: Mutation<TData, TError, TVariables> | null = null
   const [flightVersion, setFlightVersion] = createSignal(0)
   if (!isServer) {
-    const unsubscribe = client()
+    const unsubscribe = untrack(client)
       .getMutationCache()
       .subscribe((event) => {
         if ('mutation' in event && event.mutation === activeMutation) {


### PR DESCRIPTION
## Problem

Any component that calls `useMutation` triggers Solid's `STRICT_READ_UNTRACKED` dev diagnostic on mount:

```
[STRICT_READ_UNTRACKED] Reactive value read directly in <Page> will not update. Move it into a tracking scope (JSX, a memo, or an effect's compute function).
```

The hook sets up its mutation-cache subscription in the component body with a bare `client()` read — `client` is a `createMemo`, so this is a reactive read outside any tracking scope.

## Fix

Wrap the read in `untrack`, matching how `useBaseQuery` guards the same body-scope read (`untrack(client)`). The subscription is intentionally a one-time setup, so a snapshot read is the correct semantics.

The other cache-reading hooks (`useIsMutating`, `useMutationState`, `useIsFetching`) are unaffected: `createCacheAggregate` already wraps their `subscribe`/`read` callbacks in `untrack` internally.

## Test

Added a regression test that renders a bare `useMutation` component and asserts no `STRICT_READ_UNTRACKED` warning is emitted. It fails without the fix and passes with it. Full solid-query suite passes (26 files, 345 tests, no type errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)