### PR TITLE
fix(react-query): retry queries with falsy errors on mount

### DIFF
--- a/.changeset/fuzzy-rats-mutate.md
+++ b/.changeset/fuzzy-rats-mutate.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-query': patch
+---
+
+Allow queries with falsy errors to retry on mount when `throwOnError` returns false.

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -6802,6 +6802,35 @@ describe('useQuery', () => {
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
 
+  it('should retry on mount when throwOnError returns false for a falsy error', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn(() => Promise.reject())
+
+    function Component() {
+      const { status } = useQuery({
+        queryKey: key,
+        queryFn,
+        throwOnError: () => false,
+        retryOnMount: () => true,
+        staleTime: Infinity,
+        retry: false,
+      })
+
+      return <div data-testid="status">{status}</div>
+    }
+
+    const rendered1 = renderWithClient(queryClient, <Component />)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered1.getByTestId('status')).toHaveTextContent('error')
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    rendered1.unmount()
+
+    const rendered2 = renderWithClient(queryClient, <Component />)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered2.getByTestId('status')).toHaveTextContent('error')
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
   it('should not retry on mount when throwOnError function returns true', async () => {
     const key = queryKey()
     let fetchCount = 0

--- a/packages/react-query/src/errorBoundaryUtils.ts
+++ b/packages/react-query/src/errorBoundaryUtils.ts
@@ -27,10 +27,14 @@ export const ensurePreventErrorBoundaryRetry = <
   errorResetBoundary: QueryErrorResetBoundaryValue,
   query: Query<TQueryFnData, TError, TQueryData, TQueryKey> | undefined,
 ) => {
-  const throwOnError =
-    query?.state.error && typeof options.throwOnError === 'function'
-      ? shouldThrowError(options.throwOnError, [query.state.error, query])
-      : options.throwOnError
+  let throwOnError = options.throwOnError
+
+  if (query?.state.status === 'error' && typeof throwOnError === 'function') {
+    throwOnError = shouldThrowError(throwOnError, [
+      query.state.error as TError,
+      query,
+    ])
+  }
 
   if (options.suspense || throwOnError) {
     // Prevent retrying failed query if the error boundary has not been reset yet


### PR DESCRIPTION
Fixes #11327
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

When a query rejected with a falsy value such as `undefined`, `ensurePreventErrorBoundaryRetry` did not evaluate the function-valued `throwOnError` option because it checked the truthiness of
`query.state.error`.

The callback function itself was then treated as truthy, causing `retryOnMount` to be set to `false` even when `throwOnError` would return `false`.

This change checks `query.state.status === 'error'` instead, ensuring that the `throwOnError` callback is evaluated for all query errors, including falsy ones.

A regression test verifies that a query rejecting with `undefined` retries after remounting when `throwOnError` returns `false`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queries that fail with an empty or falsy error so they correctly retry when mounted again.
  * Improved handling of `throwOnError: false` together with `retryOnMount: true`, ensuring failed queries can retry as configured.

* **Release**
  * Included in a patch release of `@tanstack/react-query`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->