### PR TITLE
docs(preact-query): inline 'useQuery''s basic-example options instead of a 'queryOptions' factory

### DIFF
--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -89,7 +89,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:119](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L119)
+Defined in: [preact-query/src/useQuery.ts:117](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L117)
 
 ### Type Parameters
 
@@ -139,15 +139,13 @@ display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
 ### Examples
 
 ```tsx
-import { queryOptions, useQuery } from '@tanstack/preact-query'
-
-const postsOptions = queryOptions({
-  queryKey: ['posts'],
-  queryFn: fetchPosts,
-})
+import { useQuery } from '@tanstack/preact-query'
 
 function Posts() {
-  const { status, data, error, isFetching } = useQuery(postsOptions)
+  const { status, data, error, isFetching } = useQuery({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+  })
 
   if (status === 'pending') return 'Loading...'
   if (status === 'error') return <span>Error: {error.message}</span>
@@ -192,7 +190,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:297](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L297)
+Defined in: [preact-query/src/useQuery.ts:293](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L293)
 
 ### Type Parameters
 
@@ -242,15 +240,13 @@ display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
 ### Examples
 
 ```tsx
-import { queryOptions, useQuery } from '@tanstack/preact-query'
-
-const postsOptions = queryOptions({
-  queryKey: ['posts'],
-  queryFn: fetchPosts,
-})
+import { useQuery } from '@tanstack/preact-query'
 
 function Posts() {
-  const { status, data, error, isFetching } = useQuery(postsOptions)
+  const { status, data, error, isFetching } = useQuery({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+  })
 
   if (status === 'pending') return 'Loading...'
   if (status === 'error') return <span>Error: {error.message}</span>

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -68,15 +68,13 @@ export function useQuery<
  *
  * @example
  * ```tsx
- * import { queryOptions, useQuery } from '@tanstack/preact-query'
- *
- * const postsOptions = queryOptions({
- *   queryKey: ['posts'],
- *   queryFn: fetchPosts,
- * })
+ * import { useQuery } from '@tanstack/preact-query'
  *
  * function Posts() {
- *   const { status, data, error, isFetching } = useQuery(postsOptions)
+ *   const { status, data, error, isFetching } = useQuery({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *   })
  *
  *   if (status === 'pending') return 'Loading...'
  *   if (status === 'error') return <span>Error: {error.message}</span>
@@ -137,15 +135,13 @@ export function useQuery<
  *
  * @example
  * ```tsx
- * import { queryOptions, useQuery } from '@tanstack/preact-query'
- *
- * const postsOptions = queryOptions({
- *   queryKey: ['posts'],
- *   queryFn: fetchPosts,
- * })
+ * import { useQuery } from '@tanstack/preact-query'
  *
  * function Posts() {
- *   const { status, data, error, isFetching } = useQuery(postsOptions)
+ *   const { status, data, error, isFetching } = useQuery({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *   })
  *
  *   if (status === 'pending') return 'Loading...'
  *   if (status === 'error') return <span>Error: {error.message}</span>


### PR DESCRIPTION
## 🎯 Changes

`useQuery.ts`'s second and third overloads each opened with a basic-query example that wrapped its options in a `queryOptions` factory (`const postsOptions = queryOptions({...})`) even though nothing about the example needs that — no imperative call site shares the cache entry, unlike the file's hover-prefetch example where the factory is required. The very next example in each overload ("The same query, checking `isPending`/`isError` instead of `status`") already used an inline options object for the identical scenario, so the two adjacent examples disagreed on style for no functional reason.

Inlined both basic examples' options to match. `queryOptions.ts`/`infiniteQueryOptions.ts` themselves, and `useQuery.ts`'s/`useInfiniteQuery.ts`'s hover-prefetch examples, are unaffected — those genuinely need the factory to share a cache entry between a hook and an imperative API call. Checked `useSuspenseQuery.ts`, `useSuspenseInfiniteQuery.ts`, `useSuspenseQueries.ts`, `useInfiniteQuery.ts`, and `useMutation.ts` for the same inconsistency: none call their options factory outside of a cache-sharing example (`useInfiniteQuery.ts`'s only factory use is its own hover-prefetch example; the other four don't call their factory at all), so no other file needed this change.

Regenerated the corresponding reference docs with `pnpm run generate-docs`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified `useQuery` usage examples by showing query options inline.
  * Updated source references in the Preact `useQuery` documentation.
  * Clarified examples for supported `useQuery` overloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->