### PR TITLE
docs(preact-query): trim 'queryOptions'/'infiniteQueryOptions' examples to what the factory needs to prove

### DIFF
--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -95,7 +95,7 @@ function Projects() {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:240](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L240)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:231](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L231)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -142,13 +142,9 @@ automatically as the user scrolls.
 
 ### Example
 
-A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+A parameterized factory, so the same options object can be reused per `postId`:
 ```tsx
-import {
-  infiniteQueryOptions,
-  noop,
-  useInfiniteQuery,
-} from '@tanstack/preact-query'
+import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
 
 export const commentsOptions = (postId: string) =>
   infiniteQueryOptions({
@@ -170,11 +166,6 @@ function Comments({ postId }: { postId: string }) {
     </ul>
   )
 }
-
-// `commentsOptions` also works with imperative APIs like `queryClient.infiniteQuery` —
-// see `useInfiniteQuery` for an example that warms the cache this way before rendering `<Comments>`.
-const postId = '1'
-queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
 ```
 
 ### See
@@ -187,7 +178,7 @@ queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:311](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L311)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:293](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L293)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -234,13 +225,9 @@ automatically as the user scrolls) and that use `skipToken` to disable the query
 
 ### Example
 
-A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+A parameterized factory, so the same options object can be reused per `postId`:
 ```tsx
-import {
-  infiniteQueryOptions,
-  noop,
-  useInfiniteQuery,
-} from '@tanstack/preact-query'
+import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
 
 export const commentsOptions = (postId: string) =>
   infiniteQueryOptions({
@@ -262,11 +249,6 @@ function Comments({ postId }: { postId: string }) {
     </ul>
   )
 }
-
-// `commentsOptions` also works with imperative APIs like `queryClient.infiniteQuery` —
-// see `useInfiniteQuery` for an example that warms the cache this way before rendering `<Comments>`.
-const postId = '1'
-queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
 ```
 
 ### See

--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -84,7 +84,7 @@ function Posts() {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:213](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L213)
+Defined in: [preact-query/src/queryOptions.ts:180](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L180)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -124,11 +124,11 @@ The same options object, typed so that `queryKey` carries the inferred data type
 
 [useQuery](useQuery.md) to run a query with these options.
 
-### Examples
+### Example
 
-A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+A parameterized factory, so the same options object can be reused per `id`:
 ```tsx
-import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
+import { queryOptions, useQuery } from '@tanstack/preact-query'
 
 export const postOptions = (id: string) =>
   queryOptions({
@@ -144,38 +144,6 @@ function Post({ id }: { id: string }) {
 
   return <h1>{data.title}</h1>
 }
-
-// `postOptions` also works with imperative APIs like `queryClient.query` —
-// see `useQuery` for an example that warms the cache this way before rendering `<Post>`.
-const postId = '1'
-queryClient.query(postOptions(postId)).catch(noop)
-```
-
-The same options object works with every API that accepts query options:
-```tsx
-import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
-
-const todosOptions = queryOptions({
-  queryKey: ['todos'],
-  queryFn: fetchTodos,
-})
-
-function Todos() {
-  const { data, isPending, isError, error } = useQuery(todosOptions)
-
-  if (isPending) return 'Loading...'
-  if (isError) return <span>Error: {error.message}</span>
-
-  return (
-    <ul>
-      {data.map((todo) => <li key={todo.id}>{todo.title}</li>)}
-    </ul>
-  )
-}
-
-// The same options object works with the imperative APIs too:
-queryClient.query(todosOptions).catch(noop)
-queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefined
 ```
 
 ## Call Signature
@@ -184,7 +152,7 @@ queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefi
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:309](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L309)
+Defined in: [preact-query/src/queryOptions.ts:243](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L243)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -230,9 +198,9 @@ This is the only overload that accepts `queryFn: skipToken`, shown below.
 
 ### Examples
 
-A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+A parameterized factory, so the same options object can be reused per `id`:
 ```tsx
-import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
+import { queryOptions, useQuery } from '@tanstack/preact-query'
 
 export const postOptions = (id: string) =>
   queryOptions({
@@ -248,38 +216,6 @@ function Post({ id }: { id: string }) {
 
   return <h1>{data.title}</h1>
 }
-
-// `postOptions` also works with imperative APIs like `queryClient.query` —
-// see `useQuery` for an example that warms the cache this way before rendering `<Post>`.
-const postId = '1'
-queryClient.query(postOptions(postId)).catch(noop)
-```
-
-The same options object works with every API that accepts query options:
-```tsx
-import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
-
-const todosOptions = queryOptions({
-  queryKey: ['todos'],
-  queryFn: fetchTodos,
-})
-
-function Todos() {
-  const { data, isPending, isError, error } = useQuery(todosOptions)
-
-  if (isPending) return 'Loading...'
-  if (isError) return <span>Error: {error.message}</span>
-
-  return (
-    <ul>
-      {data.map((todo) => <li key={todo.id}>{todo.title}</li>)}
-    </ul>
-  )
-}
-
-// The same options object works with the imperative APIs too:
-queryClient.query(todosOptions).catch(noop)
-queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefined
 ```
 
 A factory that disables the query, type safe, until `postId` is set:

--- a/packages/preact-query/src/infiniteQueryOptions.ts
+++ b/packages/preact-query/src/infiniteQueryOptions.ts
@@ -199,13 +199,9 @@ export function infiniteQueryOptions<
  * automatically as the user scrolls.
  *
  * @example
- * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+ * A parameterized factory, so the same options object can be reused per `postId`:
  * ```tsx
- * import {
- *   infiniteQueryOptions,
- *   noop,
- *   useInfiniteQuery,
- * } from '@tanstack/preact-query'
+ * import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
  *
  * export const commentsOptions = (postId: string) =>
  *   infiniteQueryOptions({
@@ -227,11 +223,6 @@ export function infiniteQueryOptions<
  *     </ul>
  *   )
  * }
- *
- * // `commentsOptions` also works with imperative APIs like `queryClient.infiniteQuery` —
- * // see `useInfiniteQuery` for an example that warms the cache this way before rendering `<Comments>`.
- * const postId = '1'
- * queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
  * ```
  *
  * @see {@link useInfiniteQuery} to run an infinite query with these options.
@@ -270,13 +261,9 @@ export function infiniteQueryOptions<
  * automatically as the user scrolls) and that use `skipToken` to disable the query until `postId` is set.
  *
  * @example
- * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+ * A parameterized factory, so the same options object can be reused per `postId`:
  * ```tsx
- * import {
- *   infiniteQueryOptions,
- *   noop,
- *   useInfiniteQuery,
- * } from '@tanstack/preact-query'
+ * import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/preact-query'
  *
  * export const commentsOptions = (postId: string) =>
  *   infiniteQueryOptions({
@@ -298,11 +285,6 @@ export function infiniteQueryOptions<
  *     </ul>
  *   )
  * }
- *
- * // `commentsOptions` also works with imperative APIs like `queryClient.infiniteQuery` —
- * // see `useInfiniteQuery` for an example that warms the cache this way before rendering `<Comments>`.
- * const postId = '1'
- * queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)
  * ```
  *
  * @see {@link useInfiniteQuery} to run an infinite query with these options.

--- a/packages/preact-query/src/queryOptions.ts
+++ b/packages/preact-query/src/queryOptions.ts
@@ -157,9 +157,9 @@ export function queryOptions<
  * @returns The same options object, typed so that `queryKey` carries the inferred data type.
  *
  * @example
- * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+ * A parameterized factory, so the same options object can be reused per `id`:
  * ```tsx
- * import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
+ * import { queryOptions, useQuery } from '@tanstack/preact-query'
  *
  * export const postOptions = (id: string) =>
  *   queryOptions({
@@ -175,39 +175,6 @@ export function queryOptions<
  *
  *   return <h1>{data.title}</h1>
  * }
- *
- * // `postOptions` also works with imperative APIs like `queryClient.query` —
- * // see `useQuery` for an example that warms the cache this way before rendering `<Post>`.
- * const postId = '1'
- * queryClient.query(postOptions(postId)).catch(noop)
- * ```
- *
- * @example
- * The same options object works with every API that accepts query options:
- * ```tsx
- * import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
- *
- * const todosOptions = queryOptions({
- *   queryKey: ['todos'],
- *   queryFn: fetchTodos,
- * })
- *
- * function Todos() {
- *   const { data, isPending, isError, error } = useQuery(todosOptions)
- *
- *   if (isPending) return 'Loading...'
- *   if (isError) return <span>Error: {error.message}</span>
- *
- *   return (
- *     <ul>
- *       {data.map((todo) => <li key={todo.id}>{todo.title}</li>)}
- *     </ul>
- *   )
- * }
- *
- * // The same options object works with the imperative APIs too:
- * queryClient.query(todosOptions).catch(noop)
- * queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefined
  * ```
  */
 export function queryOptions<
@@ -231,9 +198,9 @@ export function queryOptions<
  * @remarks This is the only overload that accepts `queryFn: skipToken`, shown below.
  *
  * @example
- * A parameterized factory, reused across a hook and an imperative call with the same cache entry:
+ * A parameterized factory, so the same options object can be reused per `id`:
  * ```tsx
- * import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
+ * import { queryOptions, useQuery } from '@tanstack/preact-query'
  *
  * export const postOptions = (id: string) =>
  *   queryOptions({
@@ -249,39 +216,6 @@ export function queryOptions<
  *
  *   return <h1>{data.title}</h1>
  * }
- *
- * // `postOptions` also works with imperative APIs like `queryClient.query` —
- * // see `useQuery` for an example that warms the cache this way before rendering `<Post>`.
- * const postId = '1'
- * queryClient.query(postOptions(postId)).catch(noop)
- * ```
- *
- * @example
- * The same options object works with every API that accepts query options:
- * ```tsx
- * import { noop, queryOptions, useQuery } from '@tanstack/preact-query'
- *
- * const todosOptions = queryOptions({
- *   queryKey: ['todos'],
- *   queryFn: fetchTodos,
- * })
- *
- * function Todos() {
- *   const { data, isPending, isError, error } = useQuery(todosOptions)
- *
- *   if (isPending) return 'Loading...'
- *   if (isError) return <span>Error: {error.message}</span>
- *
- *   return (
- *     <ul>
- *       {data.map((todo) => <li key={todo.id}>{todo.title}</li>)}
- *     </ul>
- *   )
- * }
- *
- * // The same options object works with the imperative APIs too:
- * queryClient.query(todosOptions).catch(noop)
- * queryClient.getQueryData(todosOptions.queryKey) // typed as Array<Todo> | undefined
  * ```
  *
  * @example


### PR DESCRIPTION
## 🎯 Changes

`queryOptions.ts`'s "parameterized factory" example and `infiniteQueryOptions.ts`'s equivalent both appended a `queryClient.query(...)`/`queryClient.infiniteQuery(...)` call after the consuming component, introduced by a `// see useQuery/useInfiniteQuery for an example that warms the cache this way` comment pointing at the hover-prefetch example those two files already carry. Since the hook files (`useQuery.ts`, `useInfiniteQuery.ts`) already demonstrate that imperative-call scenario in depth, repeating a truncated version of it here duplicated the pointer without adding anything the reader couldn't get from following it. Removed the trailing imperative-call lines and the now-unused `noop` import, and reworded the example's caption to describe what it actually shows (reusing the options object per `id`/`postId`), since the old caption ("reused across a hook and an imperative call") no longer matched.

`queryOptions.ts` also had a second example ("The same options object works with every API that accepts query options") that, once its own trailing `queryClient.query(...)`/`getQueryData(...)` calls are held to the same standard, becomes functionally identical to the first example — same shape, same point, no unique behavior of its own. Removed it entirely rather than trim it down to a near-duplicate of the first.

`infiniteQueryOptions.ts` had no equivalent second example, so nothing else changed there. `mutationOptions.ts` already keeps both its examples fully self-contained inside their consuming component — no changes needed.

Regenerated the corresponding reference docs with `pnpm run generate-docs`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified `queryOptions` and `infiniteQueryOptions` examples to focus on reusable, parameterized option factories.
  - Removed imperative query-client usage examples and unnecessary imports.
  - Updated source references and refined example headings and descriptions across the Preact documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->