### PR TITLE
docs(preact-query): add 'QueryErrorResetBoundary' and 'ErrorBoundary' to 'useSuspenseQuery'/'useSuspenseInfiniteQuery'/'useSuspenseQueries' examples

### DIFF
--- a/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
@@ -7,7 +7,7 @@ title: useSuspenseInfiniteQuery
 function useSuspenseInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseSuspenseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:123](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L123)
+Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:124](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L124)
 
 The options for `useSuspenseInfiniteQuery` are the same as for `useInfiniteQuery`, except for `throwOnError`,
 `enabled`, and `placeholderData`.
@@ -74,7 +74,8 @@ conditions like `hasNextPage && !isFetching`.
 
 ## Example
 
-`data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+The query error is thrown if a fetch fails and no cached data exists yet, so an error boundary is
+required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
 Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'

--- a/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseInfiniteQuery.md
@@ -7,7 +7,7 @@ title: useSuspenseInfiniteQuery
 function useSuspenseInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseSuspenseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:83](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L83)
+Defined in: [preact-query/src/useSuspenseInfiniteQuery.ts:123](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseInfiniteQuery.ts#L123)
 
 The options for `useSuspenseInfiniteQuery` are the same as for `useInfiniteQuery`, except for `throwOnError`,
 `enabled`, and `placeholderData`.
@@ -74,9 +74,16 @@ conditions like `hasNextPage && !isFetching`.
 
 ## Example
 
+`data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'
-import { useSuspenseInfiniteQuery } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+import {
+  QueryErrorResetBoundary,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/preact-query'
+import type { ComponentChildren } from 'preact'
 
 function Projects() {
   // `data` is guaranteed to be defined here — no `isPending` check needed.
@@ -111,9 +118,42 @@ function Projects() {
 
 function App() {
   return (
-    <Suspense fallback={<h1>Loading projects...</h1>}>
-      <Projects />
-    </Suspense>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              There was an error!
+              <button onClick={() => resetErrorBoundary()}>Try again</button>
+            </div>
+          )}
+        >
+          <Suspense fallback={<h1>Loading projects...</h1>}>
+            <Projects />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   )
+}
+
+function ErrorBoundary({
+  children,
+  onReset,
+  fallbackRender,
+}: {
+  children: ComponentChildren
+  onReset: () => void
+  fallbackRender: (props: {
+    error: Error
+    resetErrorBoundary: () => void
+  }) => ComponentChildren
+}) {
+  const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+
+  if (error) return fallbackRender({ error, resetErrorBoundary })
+
+  return children
 }
 ```

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -9,7 +9,7 @@ title: useSuspenseQueries
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:292](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L292)
+Defined in: [preact-query/src/useSuspenseQueries.ts:408](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L408)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -65,9 +65,16 @@ this, make sure to set a high enough `staleTime`. Cancellation does not work.
 
 ### Examples
 
+`data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'
-import { useSuspenseQueries } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+import {
+  QueryErrorResetBoundary,
+  useSuspenseQueries,
+} from '@tanstack/preact-query'
+import type { ComponentChildren } from 'preact'
 
 function Posts({ ids }: { ids: Array<number> }) {
   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
@@ -89,10 +96,43 @@ function Posts({ ids }: { ids: Array<number> }) {
 
 function App() {
   return (
-    <Suspense fallback={<h1>Loading posts...</h1>}>
-      <Posts ids={[1, 2, 3]} />
-    </Suspense>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              There was an error!
+              <button onClick={() => resetErrorBoundary()}>Try again</button>
+            </div>
+          )}
+        >
+          <Suspense fallback={<h1>Loading posts...</h1>}>
+            <Posts ids={[1, 2, 3]} />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   )
+}
+
+function ErrorBoundary({
+  children,
+  onReset,
+  fallbackRender,
+}: {
+  children: ComponentChildren
+  onReset: () => void
+  fallbackRender: (props: {
+    error: Error
+    resetErrorBoundary: () => void
+  }) => ComponentChildren
+}) {
+  const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+
+  if (error) return fallbackRender({ error, resetErrorBoundary })
+
+  return children
 }
 ```
 
@@ -100,7 +140,12 @@ Several different queries — use `useSuspenseQueries` instead of multiple `useS
 they fetch in parallel rather than suspending one after another:
 ```tsx
 import { Suspense } from 'preact/compat'
-import { useSuspenseQueries } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+import {
+  QueryErrorResetBoundary,
+  useSuspenseQueries,
+} from '@tanstack/preact-query'
+import type { ComponentChildren } from 'preact'
 
 function Dashboard() {
   const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
@@ -122,10 +167,43 @@ function Dashboard() {
 
 function App() {
   return (
-    <Suspense fallback={<h1>Loading dashboard...</h1>}>
-      <Dashboard />
-    </Suspense>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              There was an error!
+              <button onClick={() => resetErrorBoundary()}>Try again</button>
+            </div>
+          )}
+        >
+          <Suspense fallback={<h1>Loading dashboard...</h1>}>
+            <Dashboard />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   )
+}
+
+function ErrorBoundary({
+  children,
+  onReset,
+  fallbackRender,
+}: {
+  children: ComponentChildren
+  onReset: () => void
+  fallbackRender: (props: {
+    error: Error
+    resetErrorBoundary: () => void
+  }) => ComponentChildren
+}) {
+  const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+
+  if (error) return fallbackRender({ error, resetErrorBoundary })
+
+  return children
 }
 ```
 
@@ -133,7 +211,12 @@ function App() {
 not on every individual query update. This overload is the only one that accepts `combine`:
 ```tsx
 import { Suspense } from 'preact/compat'
-import { useSuspenseQueries } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+import {
+  QueryErrorResetBoundary,
+  useSuspenseQueries,
+} from '@tanstack/preact-query'
+import type { ComponentChildren } from 'preact'
 
 function Refresh() {
   const anyFetching = useSuspenseQueries({
@@ -149,10 +232,43 @@ function Refresh() {
 
 function App() {
   return (
-    <Suspense fallback={<h1>Loading dashboard...</h1>}>
-      <Refresh />
-    </Suspense>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              There was an error!
+              <button onClick={() => resetErrorBoundary()}>Try again</button>
+            </div>
+          )}
+        >
+          <Suspense fallback={<h1>Loading dashboard...</h1>}>
+            <Refresh />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   )
+}
+
+function ErrorBoundary({
+  children,
+  onReset,
+  fallbackRender,
+}: {
+  children: ComponentChildren
+  onReset: () => void
+  fallbackRender: (props: {
+    error: Error
+    resetErrorBoundary: () => void
+  }) => ComponentChildren
+}) {
+  const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+
+  if (error) return fallbackRender({ error, resetErrorBoundary })
+
+  return children
 }
 ```
 
@@ -162,7 +278,7 @@ function App() {
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:393](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L393)
+Defined in: [preact-query/src/useSuspenseQueries.ts:587](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L587)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -217,9 +333,16 @@ this, make sure to set a high enough `staleTime`. Cancellation does not work.
 
 ### Examples
 
+`data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'
-import { useSuspenseQueries } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+import {
+  QueryErrorResetBoundary,
+  useSuspenseQueries,
+} from '@tanstack/preact-query'
+import type { ComponentChildren } from 'preact'
 
 function Posts({ ids }: { ids: Array<number> }) {
   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
@@ -241,10 +364,43 @@ function Posts({ ids }: { ids: Array<number> }) {
 
 function App() {
   return (
-    <Suspense fallback={<h1>Loading posts...</h1>}>
-      <Posts ids={[1, 2, 3]} />
-    </Suspense>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              There was an error!
+              <button onClick={() => resetErrorBoundary()}>Try again</button>
+            </div>
+          )}
+        >
+          <Suspense fallback={<h1>Loading posts...</h1>}>
+            <Posts ids={[1, 2, 3]} />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   )
+}
+
+function ErrorBoundary({
+  children,
+  onReset,
+  fallbackRender,
+}: {
+  children: ComponentChildren
+  onReset: () => void
+  fallbackRender: (props: {
+    error: Error
+    resetErrorBoundary: () => void
+  }) => ComponentChildren
+}) {
+  const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+
+  if (error) return fallbackRender({ error, resetErrorBoundary })
+
+  return children
 }
 ```
 
@@ -252,7 +408,12 @@ Several different queries — use `useSuspenseQueries` instead of multiple `useS
 they fetch in parallel rather than suspending one after another:
 ```tsx
 import { Suspense } from 'preact/compat'
-import { useSuspenseQueries } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+import {
+  QueryErrorResetBoundary,
+  useSuspenseQueries,
+} from '@tanstack/preact-query'
+import type { ComponentChildren } from 'preact'
 
 function Dashboard() {
   const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
@@ -274,9 +435,42 @@ function Dashboard() {
 
 function App() {
   return (
-    <Suspense fallback={<h1>Loading dashboard...</h1>}>
-      <Dashboard />
-    </Suspense>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              There was an error!
+              <button onClick={() => resetErrorBoundary()}>Try again</button>
+            </div>
+          )}
+        >
+          <Suspense fallback={<h1>Loading dashboard...</h1>}>
+            <Dashboard />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   )
+}
+
+function ErrorBoundary({
+  children,
+  onReset,
+  fallbackRender,
+}: {
+  children: ComponentChildren
+  onReset: () => void
+  fallbackRender: (props: {
+    error: Error
+    resetErrorBoundary: () => void
+  }) => ComponentChildren
+}) {
+  const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+
+  if (error) return fallbackRender({ error, resetErrorBoundary })
+
+  return children
 }
 ```

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -9,7 +9,7 @@ title: useSuspenseQueries
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:408](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L408)
+Defined in: [preact-query/src/useSuspenseQueries.ts:409](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L409)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -65,7 +65,8 @@ this, make sure to set a high enough `staleTime`. Cancellation does not work.
 
 ### Examples
 
-`data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+The query error is thrown if a fetch fails and no cached data exists yet, so an error boundary is
+required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
 Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'
@@ -278,7 +279,7 @@ function ErrorBoundary({
 function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useSuspenseQueries.ts:587](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L587)
+Defined in: [preact-query/src/useSuspenseQueries.ts:589](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L589)
 
 The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
 `throwOnError`, `enabled`, or `placeholderData`.
@@ -333,7 +334,8 @@ this, make sure to set a high enough `staleTime`. Cancellation does not work.
 
 ### Examples
 
-`data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+The query error is thrown if a fetch fails and no cached data exists yet, so an error boundary is
+required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
 Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'

--- a/docs/framework/preact/reference/functions/useSuspenseQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQuery.md
@@ -7,7 +7,7 @@ title: useSuspenseQuery
 function useSuspenseQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseSuspenseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseQuery.ts:57](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L57)
+Defined in: [preact-query/src/useSuspenseQuery.ts:94](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L94)
 
 The options for `useSuspenseQuery` are the same as for `useQuery`, except for `throwOnError`, `enabled`, and
 `placeholderData`.
@@ -63,9 +63,13 @@ fetch in parallel.
 
 ## Example
 
+`data` is thrown as an error if the fetch fails, so an error boundary is required around `<Suspense>`.
+Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'
-import { useSuspenseQuery } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+import { QueryErrorResetBoundary, useSuspenseQuery } from '@tanstack/preact-query'
+import type { ComponentChildren } from 'preact'
 
 function Posts() {
   // `data` is guaranteed to be defined here — no `isPending` check needed.
@@ -88,9 +92,42 @@ function Posts() {
 
 function App() {
   return (
-    <Suspense fallback={<h1>Loading posts...</h1>}>
-      <Posts />
-    </Suspense>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              There was an error!
+              <button onClick={() => resetErrorBoundary()}>Try again</button>
+            </div>
+          )}
+        >
+          <Suspense fallback={<h1>Loading posts...</h1>}>
+            <Posts />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   )
+}
+
+function ErrorBoundary({
+  children,
+  onReset,
+  fallbackRender,
+}: {
+  children: ComponentChildren
+  onReset: () => void
+  fallbackRender: (props: {
+    error: Error
+    resetErrorBoundary: () => void
+  }) => ComponentChildren
+}) {
+  const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+
+  if (error) return fallbackRender({ error, resetErrorBoundary })
+
+  return children
 }
 ```

--- a/docs/framework/preact/reference/functions/useSuspenseQuery.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQuery.md
@@ -7,7 +7,7 @@ title: useSuspenseQuery
 function useSuspenseQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseSuspenseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useSuspenseQuery.ts:94](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L94)
+Defined in: [preact-query/src/useSuspenseQuery.ts:95](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQuery.ts#L95)
 
 The options for `useSuspenseQuery` are the same as for `useQuery`, except for `throwOnError`, `enabled`, and
 `placeholderData`.
@@ -63,7 +63,8 @@ fetch in parallel.
 
 ## Example
 
-`data` is thrown as an error if the fetch fails, so an error boundary is required around `<Suspense>`.
+The query error is thrown if the fetch fails and no cached data exists yet, so an error boundary is
+required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
 Use [QueryErrorResetBoundary](QueryErrorResetBoundary.md) to let the user retry after such an error:
 ```tsx
 import { Suspense } from 'preact/compat'

--- a/packages/preact-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/preact-query/src/useSuspenseInfiniteQuery.ts
@@ -36,9 +36,16 @@ import { useBaseQuery } from './useBaseQuery'
  * accordingly).
  *
  * @example
+ * `data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+ * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'
- * import { useSuspenseInfiniteQuery } from '@tanstack/preact-query'
+ * import { useErrorBoundary } from 'preact/hooks'
+ * import {
+ *   QueryErrorResetBoundary,
+ *   useSuspenseInfiniteQuery,
+ * } from '@tanstack/preact-query'
+ * import type { ComponentChildren } from 'preact'
  *
  * function Projects() {
  *   // `data` is guaranteed to be defined here — no `isPending` check needed.
@@ -73,10 +80,43 @@ import { useBaseQuery } from './useBaseQuery'
  *
  * function App() {
  *   return (
- *     <Suspense fallback={<h1>Loading projects...</h1>}>
- *       <Projects />
- *     </Suspense>
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary
+ *           onReset={reset}
+ *           fallbackRender={({ resetErrorBoundary }) => (
+ *             <div>
+ *               There was an error!
+ *               <button onClick={() => resetErrorBoundary()}>Try again</button>
+ *             </div>
+ *           )}
+ *         >
+ *           <Suspense fallback={<h1>Loading projects...</h1>}>
+ *             <Projects />
+ *           </Suspense>
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
  *   )
+ * }
+ *
+ * function ErrorBoundary({
+ *   children,
+ *   onReset,
+ *   fallbackRender,
+ * }: {
+ *   children: ComponentChildren
+ *   onReset: () => void
+ *   fallbackRender: (props: {
+ *     error: Error
+ *     resetErrorBoundary: () => void
+ *   }) => ComponentChildren
+ * }) {
+ *   const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+ *
+ *   if (error) return fallbackRender({ error, resetErrorBoundary })
+ *
+ *   return children
  * }
  * ```
  */

--- a/packages/preact-query/src/useSuspenseInfiniteQuery.ts
+++ b/packages/preact-query/src/useSuspenseInfiniteQuery.ts
@@ -36,7 +36,8 @@ import { useBaseQuery } from './useBaseQuery'
  * accordingly).
  *
  * @example
- * `data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+ * The query error is thrown if a fetch fails and no cached data exists yet, so an error boundary is
+ * required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
  * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -196,9 +196,16 @@ export type SuspenseQueriesResults<
  * this, make sure to set a high enough `staleTime`. Cancellation does not work.
  *
  * @example
+ * `data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+ * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'
- * import { useSuspenseQueries } from '@tanstack/preact-query'
+ * import { useErrorBoundary } from 'preact/hooks'
+ * import {
+ *   QueryErrorResetBoundary,
+ *   useSuspenseQueries,
+ * } from '@tanstack/preact-query'
+ * import type { ComponentChildren } from 'preact'
  *
  * function Posts({ ids }: { ids: Array<number> }) {
  *   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
@@ -220,10 +227,43 @@ export type SuspenseQueriesResults<
  *
  * function App() {
  *   return (
- *     <Suspense fallback={<h1>Loading posts...</h1>}>
- *       <Posts ids={[1, 2, 3]} />
- *     </Suspense>
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary
+ *           onReset={reset}
+ *           fallbackRender={({ resetErrorBoundary }) => (
+ *             <div>
+ *               There was an error!
+ *               <button onClick={() => resetErrorBoundary()}>Try again</button>
+ *             </div>
+ *           )}
+ *         >
+ *           <Suspense fallback={<h1>Loading posts...</h1>}>
+ *             <Posts ids={[1, 2, 3]} />
+ *           </Suspense>
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
  *   )
+ * }
+ *
+ * function ErrorBoundary({
+ *   children,
+ *   onReset,
+ *   fallbackRender,
+ * }: {
+ *   children: ComponentChildren
+ *   onReset: () => void
+ *   fallbackRender: (props: {
+ *     error: Error
+ *     resetErrorBoundary: () => void
+ *   }) => ComponentChildren
+ * }) {
+ *   const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+ *
+ *   if (error) return fallbackRender({ error, resetErrorBoundary })
+ *
+ *   return children
  * }
  * ```
  *
@@ -232,7 +272,12 @@ export type SuspenseQueriesResults<
  * they fetch in parallel rather than suspending one after another:
  * ```tsx
  * import { Suspense } from 'preact/compat'
- * import { useSuspenseQueries } from '@tanstack/preact-query'
+ * import { useErrorBoundary } from 'preact/hooks'
+ * import {
+ *   QueryErrorResetBoundary,
+ *   useSuspenseQueries,
+ * } from '@tanstack/preact-query'
+ * import type { ComponentChildren } from 'preact'
  *
  * function Dashboard() {
  *   const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
@@ -254,10 +299,43 @@ export type SuspenseQueriesResults<
  *
  * function App() {
  *   return (
- *     <Suspense fallback={<h1>Loading dashboard...</h1>}>
- *       <Dashboard />
- *     </Suspense>
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary
+ *           onReset={reset}
+ *           fallbackRender={({ resetErrorBoundary }) => (
+ *             <div>
+ *               There was an error!
+ *               <button onClick={() => resetErrorBoundary()}>Try again</button>
+ *             </div>
+ *           )}
+ *         >
+ *           <Suspense fallback={<h1>Loading dashboard...</h1>}>
+ *             <Dashboard />
+ *           </Suspense>
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
  *   )
+ * }
+ *
+ * function ErrorBoundary({
+ *   children,
+ *   onReset,
+ *   fallbackRender,
+ * }: {
+ *   children: ComponentChildren
+ *   onReset: () => void
+ *   fallbackRender: (props: {
+ *     error: Error
+ *     resetErrorBoundary: () => void
+ *   }) => ComponentChildren
+ * }) {
+ *   const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+ *
+ *   if (error) return fallbackRender({ error, resetErrorBoundary })
+ *
+ *   return children
  * }
  * ```
  *
@@ -266,7 +344,12 @@ export type SuspenseQueriesResults<
  * not on every individual query update. This overload is the only one that accepts `combine`:
  * ```tsx
  * import { Suspense } from 'preact/compat'
- * import { useSuspenseQueries } from '@tanstack/preact-query'
+ * import { useErrorBoundary } from 'preact/hooks'
+ * import {
+ *   QueryErrorResetBoundary,
+ *   useSuspenseQueries,
+ * } from '@tanstack/preact-query'
+ * import type { ComponentChildren } from 'preact'
  *
  * function Refresh() {
  *   const anyFetching = useSuspenseQueries({
@@ -282,10 +365,43 @@ export type SuspenseQueriesResults<
  *
  * function App() {
  *   return (
- *     <Suspense fallback={<h1>Loading dashboard...</h1>}>
- *       <Refresh />
- *     </Suspense>
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary
+ *           onReset={reset}
+ *           fallbackRender={({ resetErrorBoundary }) => (
+ *             <div>
+ *               There was an error!
+ *               <button onClick={() => resetErrorBoundary()}>Try again</button>
+ *             </div>
+ *           )}
+ *         >
+ *           <Suspense fallback={<h1>Loading dashboard...</h1>}>
+ *             <Refresh />
+ *           </Suspense>
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
  *   )
+ * }
+ *
+ * function ErrorBoundary({
+ *   children,
+ *   onReset,
+ *   fallbackRender,
+ * }: {
+ *   children: ComponentChildren
+ *   onReset: () => void
+ *   fallbackRender: (props: {
+ *     error: Error
+ *     resetErrorBoundary: () => void
+ *   }) => ComponentChildren
+ * }) {
+ *   const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+ *
+ *   if (error) return fallbackRender({ error, resetErrorBoundary })
+ *
+ *   return children
  * }
  * ```
  */
@@ -325,9 +441,16 @@ export function useSuspenseQueries<
  * this, make sure to set a high enough `staleTime`. Cancellation does not work.
  *
  * @example
+ * `data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+ * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'
- * import { useSuspenseQueries } from '@tanstack/preact-query'
+ * import { useErrorBoundary } from 'preact/hooks'
+ * import {
+ *   QueryErrorResetBoundary,
+ *   useSuspenseQueries,
+ * } from '@tanstack/preact-query'
+ * import type { ComponentChildren } from 'preact'
  *
  * function Posts({ ids }: { ids: Array<number> }) {
  *   // Every result is guaranteed to be defined — no per-query `isPending` check needed.
@@ -349,10 +472,43 @@ export function useSuspenseQueries<
  *
  * function App() {
  *   return (
- *     <Suspense fallback={<h1>Loading posts...</h1>}>
- *       <Posts ids={[1, 2, 3]} />
- *     </Suspense>
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary
+ *           onReset={reset}
+ *           fallbackRender={({ resetErrorBoundary }) => (
+ *             <div>
+ *               There was an error!
+ *               <button onClick={() => resetErrorBoundary()}>Try again</button>
+ *             </div>
+ *           )}
+ *         >
+ *           <Suspense fallback={<h1>Loading posts...</h1>}>
+ *             <Posts ids={[1, 2, 3]} />
+ *           </Suspense>
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
  *   )
+ * }
+ *
+ * function ErrorBoundary({
+ *   children,
+ *   onReset,
+ *   fallbackRender,
+ * }: {
+ *   children: ComponentChildren
+ *   onReset: () => void
+ *   fallbackRender: (props: {
+ *     error: Error
+ *     resetErrorBoundary: () => void
+ *   }) => ComponentChildren
+ * }) {
+ *   const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+ *
+ *   if (error) return fallbackRender({ error, resetErrorBoundary })
+ *
+ *   return children
  * }
  * ```
  *
@@ -361,7 +517,12 @@ export function useSuspenseQueries<
  * they fetch in parallel rather than suspending one after another:
  * ```tsx
  * import { Suspense } from 'preact/compat'
- * import { useSuspenseQueries } from '@tanstack/preact-query'
+ * import { useErrorBoundary } from 'preact/hooks'
+ * import {
+ *   QueryErrorResetBoundary,
+ *   useSuspenseQueries,
+ * } from '@tanstack/preact-query'
+ * import type { ComponentChildren } from 'preact'
  *
  * function Dashboard() {
  *   const [usersQuery, teamsQuery, projectsQuery] = useSuspenseQueries({
@@ -383,10 +544,43 @@ export function useSuspenseQueries<
  *
  * function App() {
  *   return (
- *     <Suspense fallback={<h1>Loading dashboard...</h1>}>
- *       <Dashboard />
- *     </Suspense>
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary
+ *           onReset={reset}
+ *           fallbackRender={({ resetErrorBoundary }) => (
+ *             <div>
+ *               There was an error!
+ *               <button onClick={() => resetErrorBoundary()}>Try again</button>
+ *             </div>
+ *           )}
+ *         >
+ *           <Suspense fallback={<h1>Loading dashboard...</h1>}>
+ *             <Dashboard />
+ *           </Suspense>
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
  *   )
+ * }
+ *
+ * function ErrorBoundary({
+ *   children,
+ *   onReset,
+ *   fallbackRender,
+ * }: {
+ *   children: ComponentChildren
+ *   onReset: () => void
+ *   fallbackRender: (props: {
+ *     error: Error
+ *     resetErrorBoundary: () => void
+ *   }) => ComponentChildren
+ * }) {
+ *   const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+ *
+ *   if (error) return fallbackRender({ error, resetErrorBoundary })
+ *
+ *   return children
  * }
  * ```
  */

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -196,7 +196,8 @@ export type SuspenseQueriesResults<
  * this, make sure to set a high enough `staleTime`. Cancellation does not work.
  *
  * @example
- * `data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+ * The query error is thrown if a fetch fails and no cached data exists yet, so an error boundary is
+ * required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
  * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'
@@ -441,7 +442,8 @@ export function useSuspenseQueries<
  * this, make sure to set a high enough `staleTime`. Cancellation does not work.
  *
  * @example
- * `data` is thrown as an error if a fetch fails, so an error boundary is required around `<Suspense>`.
+ * The query error is thrown if a fetch fails and no cached data exists yet, so an error boundary is
+ * required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
  * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'

--- a/packages/preact-query/src/useSuspenseQuery.ts
+++ b/packages/preact-query/src/useSuspenseQuery.ts
@@ -22,7 +22,8 @@ import { useBaseQuery } from './useBaseQuery'
  * is missing, and `status` is either `success` or `error` (with the derived flags set accordingly).
  *
  * @example
- * `data` is thrown as an error if the fetch fails, so an error boundary is required around `<Suspense>`.
+ * The query error is thrown if the fetch fails and no cached data exists yet, so an error boundary is
+ * required around `<Suspense>`. A failed background refetch instead continues to render the cached data.
  * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'

--- a/packages/preact-query/src/useSuspenseQuery.ts
+++ b/packages/preact-query/src/useSuspenseQuery.ts
@@ -22,9 +22,13 @@ import { useBaseQuery } from './useBaseQuery'
  * is missing, and `status` is either `success` or `error` (with the derived flags set accordingly).
  *
  * @example
+ * `data` is thrown as an error if the fetch fails, so an error boundary is required around `<Suspense>`.
+ * Use {@link QueryErrorResetBoundary} to let the user retry after such an error:
  * ```tsx
  * import { Suspense } from 'preact/compat'
- * import { useSuspenseQuery } from '@tanstack/preact-query'
+ * import { useErrorBoundary } from 'preact/hooks'
+ * import { QueryErrorResetBoundary, useSuspenseQuery } from '@tanstack/preact-query'
+ * import type { ComponentChildren } from 'preact'
  *
  * function Posts() {
  *   // `data` is guaranteed to be defined here — no `isPending` check needed.
@@ -47,10 +51,43 @@ import { useBaseQuery } from './useBaseQuery'
  *
  * function App() {
  *   return (
- *     <Suspense fallback={<h1>Loading posts...</h1>}>
- *       <Posts />
- *     </Suspense>
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary
+ *           onReset={reset}
+ *           fallbackRender={({ resetErrorBoundary }) => (
+ *             <div>
+ *               There was an error!
+ *               <button onClick={() => resetErrorBoundary()}>Try again</button>
+ *             </div>
+ *           )}
+ *         >
+ *           <Suspense fallback={<h1>Loading posts...</h1>}>
+ *             <Posts />
+ *           </Suspense>
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
  *   )
+ * }
+ *
+ * function ErrorBoundary({
+ *   children,
+ *   onReset,
+ *   fallbackRender,
+ * }: {
+ *   children: ComponentChildren
+ *   onReset: () => void
+ *   fallbackRender: (props: {
+ *     error: Error
+ *     resetErrorBoundary: () => void
+ *   }) => ComponentChildren
+ * }) {
+ *   const [error, resetErrorBoundary] = useErrorBoundary(() => onReset())
+ *
+ *   if (error) return fallbackRender({ error, resetErrorBoundary })
+ *
+ *   return children
  * }
  * ```
  */


### PR DESCRIPTION
## 🎯 Changes

`useSuspenseQuery`, `useSuspenseInfiniteQuery`, and `useSuspenseQueries` throw the query error when a fetch fails and no cached data exists yet (a failed background refetch instead keeps rendering the cached data) — but none of the `@example` code showed an error boundary, so the examples couldn't actually run as shown.

Each example now wraps `<Suspense>` in a `QueryErrorResetBoundary` + `ErrorBoundary`, using `preact/hooks`' `useErrorBoundary` (matching the pattern already established in `QueryErrorResetBoundary.tsx`) and exposing `onReset`/`fallbackRender` props shaped like `react-error-boundary`'s API, so retrying after an error correctly resets the query's error state via `QueryErrorResetBoundary`'s `reset()`.

- `useSuspenseQuery.ts`: added `QueryErrorResetBoundary` and `ErrorBoundary` around the single example
- `useSuspenseInfiniteQuery.ts`: same, around the single example
- `useSuspenseQueries.ts`: same, applied to all 5 examples across both overloads (basic, parallel, and `combine`)
- Corrected the example caption's suspense-error wording (query error, not `data`; only thrown when no cached data exists yet) at all 4 sites
- Regenerated the corresponding `docs/framework/preact/reference/functions/*.md` files with `pnpm run generate-docs`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).