### PR TITLE
docs(preact-query): define 'App' before 'ErrorBoundary' in 'QueryErrorResetBoundary' example

### DIFF
--- a/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
+++ b/docs/framework/preact/reference/functions/QueryErrorResetBoundary.md
@@ -33,6 +33,18 @@ import { useErrorBoundary } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import { QueryErrorResetBoundary } from '@tanstack/preact-query'
 
+function App() {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary reset={reset}>
+          <Page />
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}
+
 function ErrorBoundary({
   children,
   reset,
@@ -52,17 +64,5 @@ function ErrorBoundary({
   }
 
   return children
-}
-
-function App() {
-  return (
-    <QueryErrorResetBoundary>
-      {({ reset }) => (
-        <ErrorBoundary reset={reset}>
-          <Page />
-        </ErrorBoundary>
-      )}
-    </QueryErrorResetBoundary>
-  )
 }
 ```

--- a/packages/preact-query/src/QueryErrorResetBoundary.tsx
+++ b/packages/preact-query/src/QueryErrorResetBoundary.tsx
@@ -122,6 +122,18 @@ export interface QueryErrorResetBoundaryProps {
  * import type { ComponentChildren } from 'preact'
  * import { QueryErrorResetBoundary } from '@tanstack/preact-query'
  *
+ * function App() {
+ *   return (
+ *     <QueryErrorResetBoundary>
+ *       {({ reset }) => (
+ *         <ErrorBoundary reset={reset}>
+ *           <Page />
+ *         </ErrorBoundary>
+ *       )}
+ *     </QueryErrorResetBoundary>
+ *   )
+ * }
+ *
  * function ErrorBoundary({
  *   children,
  *   reset,
@@ -141,18 +153,6 @@ export interface QueryErrorResetBoundaryProps {
  *   }
  *
  *   return children
- * }
- *
- * function App() {
- *   return (
- *     <QueryErrorResetBoundary>
- *       {({ reset }) => (
- *         <ErrorBoundary reset={reset}>
- *           <Page />
- *         </ErrorBoundary>
- *       )}
- *     </QueryErrorResetBoundary>
- *   )
  * }
  * ```
  */


### PR DESCRIPTION
## 🎯 Changes

`QueryErrorResetBoundary`'s `@example` defined `ErrorBoundary` before `App`, the reverse of the ordering used across `useSuspenseQuery`/`useSuspenseInfiniteQuery`/`useSuspenseQueries` (#11337), where the main component tree (`App`) is shown first and the auxiliary `ErrorBoundary` implementation follows.

- `QueryErrorResetBoundary.tsx`: reordered the example so `App` is defined before `ErrorBoundary`, matching that convention
- Regenerated `docs/framework/preact/reference/functions/QueryErrorResetBoundary.md` with `pnpm run generate-docs`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the `QueryErrorResetBoundary` example for improved readability and consistency.
  * No user-facing functionality or API behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->