### PR TITLE
test: replace 'prefetchQuery'/'fetchQuery'/'ensureQueryData' with 'query'

### DIFF
--- a/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
+++ b/packages/angular-query-persist-client/src/__tests__/with-persist-query-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   QueryClient,
   injectQuery,
+  noop,
   provideTanStackQuery,
 } from '@tanstack/angular-query-experimental'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
@@ -71,10 +72,12 @@ describe('withPersistQueryClient', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -162,10 +165,12 @@ describe('withPersistQueryClient', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -253,10 +258,12 @@ describe('withPersistQueryClient', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -333,10 +340,12 @@ describe('withPersistQueryClient', () => {
   it('should call onSuccess after successful restoring', async () => {
     const key = queryKey()
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()

--- a/packages/preact-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/preact-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -7,7 +7,7 @@ import type {
   Persister,
 } from '../../../query-persist-client-core/src'
 import { persistQueryClientSave } from '../../../query-persist-client-core/src'
-import { notifyManager } from '../../../query-core/src'
+import { notifyManager, noop } from '../../../query-core/src'
 import { act, cleanup, render } from '@testing-library/preact'
 import type { UseQueryResult } from '../../../preact-query/src'
 import { QueryClient, useQuery } from '../../../preact-query/src'
@@ -53,10 +53,12 @@ describe('PersistQueryClientProvider (preact)', () => {
     const states: Array<UseQueryResult<string>> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()

--- a/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
@@ -10,6 +10,7 @@ import {
   QueryClient,
   QueryClientProvider,
   dehydrate,
+  noop,
   useQuery,
 } from '..'
 
@@ -22,10 +23,12 @@ describe('Preact hydration', () => {
   beforeEach(async () => {
     vi.useFakeTimers()
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: stringKey,
-      queryFn: () => sleep(10).then(() => ['stringCached']),
-    })
+    void queryClient
+      .query({
+        queryKey: stringKey,
+        queryFn: () => sleep(10).then(() => ['stringCached']),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     const dehydrated = dehydrate(queryClient)
     stringifiedState = JSON.stringify(dehydrated)
@@ -132,14 +135,18 @@ describe('Preact hydration', () => {
 
       const intermediateClient = new QueryClient()
 
-      intermediateClient.prefetchQuery({
-        queryKey: stringKey,
-        queryFn: () => sleep(20).then(() => ['should change']),
-      })
-      intermediateClient.prefetchQuery({
-        queryKey: addedKey,
-        queryFn: () => sleep(20).then(() => [addedKey[0]]),
-      })
+      void intermediateClient
+        .query({
+          queryKey: stringKey,
+          queryFn: () => sleep(20).then(() => ['should change']),
+        })
+        .catch(noop)
+      void intermediateClient
+        .query({
+          queryKey: addedKey,
+          queryFn: () => sleep(20).then(() => [addedKey[0]]),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(20)
       const dehydrated = dehydrate(intermediateClient)
       intermediateClient.clear()
@@ -202,14 +209,18 @@ describe('Preact hydration', () => {
       expect(rendered.getByText(stringKey[0]!)).toBeInTheDocument()
 
       const intermediateClient = new QueryClient()
-      intermediateClient.prefetchQuery({
-        queryKey: stringKey,
-        queryFn: () => sleep(20).then(() => ['should not change']),
-      })
-      intermediateClient.prefetchQuery({
-        queryKey: addedKey,
-        queryFn: () => sleep(20).then(() => [addedKey[0]]),
-      })
+      void intermediateClient
+        .query({
+          queryKey: stringKey,
+          queryFn: () => sleep(20).then(() => ['should not change']),
+        })
+        .catch(noop)
+      void intermediateClient
+        .query({
+          queryKey: addedKey,
+          queryFn: () => sleep(20).then(() => [addedKey[0]]),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(20)
 
       const newDehydratedState = dehydrate(intermediateClient)
@@ -431,10 +442,12 @@ describe('Preact hydration', () => {
     // For the bug to trigger, there needs to already be a query in the cache,
     // with a dataUpdatedAt earlier than the dehydratedAt of the next query
     const clientQueryClient = new QueryClient()
-    clientQueryClient.prefetchQuery({
-      queryKey: promiseKey,
-      queryFn: () => sleep(20).then(() => 'existing'),
-    })
+    void clientQueryClient
+      .query({
+        queryKey: promiseKey,
+        queryFn: () => sleep(20).then(() => 'existing'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(20)
 
     const prefetchQueryClient = new QueryClient({
@@ -444,11 +457,13 @@ describe('Preact hydration', () => {
         },
       },
     })
-    prefetchQueryClient.prefetchQuery({
-      queryKey: promiseKey,
-      queryFn: () =>
-        sleep(10).then(() => Promise.reject(new Error('Query failed'))),
-    })
+    void prefetchQueryClient
+      .query({
+        queryKey: promiseKey,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Query failed'))),
+      })
+      .catch(noop)
 
     const dehydratedState = dehydrate(prefetchQueryClient)
 

--- a/packages/preact-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/preact-query/src/__tests__/ssr-hydration.test.tsx
@@ -11,6 +11,7 @@ import {
   QueryClientProvider,
   dehydrate,
   hydrate,
+  noop,
   useQuery,
 } from '..'
 import { setIsServer } from './utils'
@@ -72,10 +73,12 @@ describe('Server side rendering with de/rehydration', () => {
     const prefetchClient = new QueryClient({
       queryCache: prefetchCache,
     })
-    await prefetchClient.prefetchQuery({
-      queryKey: successKey,
-      queryFn: () => fetchDataSuccess('success'),
-    })
+    await prefetchClient
+      .query({
+        queryKey: successKey,
+        queryFn: () => fetchDataSuccess('success'),
+      })
+      .catch(noop)
     const dehydratedStateServer = dehydrate(prefetchClient)
     const renderCache = new QueryCache()
     const renderClient = new QueryClient({
@@ -149,10 +152,12 @@ describe('Server side rendering with de/rehydration', () => {
     const prefetchClient = new QueryClient({
       queryCache: prefetchCache,
     })
-    await prefetchClient.prefetchQuery({
-      queryKey: errorKey,
-      queryFn: () => fetchDataError(),
-    })
+    await prefetchClient
+      .query({
+        queryKey: errorKey,
+        queryFn: () => fetchDataError(),
+      })
+      .catch(noop)
     const dehydratedStateServer = dehydrate(prefetchClient)
     const renderCache = new QueryCache()
     const renderClient = new QueryClient({

--- a/packages/preact-query/src/__tests__/ssr.test.tsx
+++ b/packages/preact-query/src/__tests__/ssr.test.tsx
@@ -7,6 +7,7 @@ import {
   QueryCache,
   QueryClient,
   QueryClientProvider,
+  noop,
   useInfiniteQuery,
   useMutationState,
   useQuery,
@@ -59,7 +60,7 @@ describe('Server Side Rendering', () => {
   it('should add prefetched data to cache', async () => {
     const key = queryKey()
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn: () => sleep(10).then(() => 'data'),
     })
@@ -87,7 +88,7 @@ describe('Server Side Rendering', () => {
       )
     }
 
-    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    void queryClient.query({ queryKey: key, queryFn }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const markup = renderToString(

--- a/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   QueryCache,
   QueryClient,
+  noop,
   usePrefetchQuery,
   useQueryErrorResetBoundary,
   useSuspenseQuery,
@@ -87,7 +88,7 @@ describe('usePrefetchQuery', () => {
       )
     }
 
-    queryClient.fetchQuery(queryOpts)
+    void queryClient.query(queryOpts).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     queryOpts.queryFn.mockClear()
     const rendered = renderWithClient(queryClient, <App />)
@@ -132,7 +133,7 @@ describe('usePrefetchQuery', () => {
       )
     }
 
-    queryClient.prefetchQuery(queryOpts)
+    void queryClient.query(queryOpts).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     queryFn.mockClear()
     const rendered = renderWithClient(queryClient, <App />)
@@ -222,7 +223,7 @@ describe('usePrefetchQuery', () => {
       )
     }
 
-    queryClient.prefetchQuery(queryOpts)
+    void queryClient.query(queryOpts).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     queryFn.mockClear()
 

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -22,6 +22,7 @@ import {
   dehydrate,
   hydrate,
   keepPreviousData,
+  noop,
   skipToken,
   useQuery,
 } from '..'
@@ -282,10 +283,12 @@ describe('useQuery', () => {
   it('should set isFetchedAfterMount to true after a query has been fetched', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     function Page() {
       const result = useQuery({ queryKey: key, queryFn: () => 'new data' })
@@ -1845,10 +1848,12 @@ describe('useQuery', () => {
     const states1: Array<UseQueryResult<string>> = []
     const states2: Array<UseQueryResult<string>> = []
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetch'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetch'),
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(20)
 
@@ -2644,10 +2649,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     function Page() {
       const state = useQuery({
@@ -2681,10 +2688,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(0)
 
@@ -3035,10 +3044,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     function Page() {
       const state = useQuery({
@@ -3549,11 +3560,13 @@ describe('useQuery', () => {
     const prefetchQueryFn = vi.fn<(...args: Array<unknown>) => string>()
     prefetchQueryFn.mockImplementation(() => 'not yet...')
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: prefetchQueryFn,
-      staleTime: 10,
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: prefetchQueryFn,
+        staleTime: 10,
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3582,11 +3595,13 @@ describe('useQuery', () => {
       vi.fn<(...args: Array<unknown>) => Promise<string>>()
     prefetchQueryFn.mockImplementation(() => sleep(10).then(() => 'not yet...'))
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: prefetchQueryFn,
-      staleTime: 1000,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: prefetchQueryFn,
+        staleTime: 1000,
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(0)
 
@@ -3662,10 +3677,12 @@ describe('useQuery', () => {
 
       useEffect(() => {
         async function prefetch() {
-          await queryClient.prefetchQuery({
-            queryKey: key,
-            queryFn: () => Promise.resolve('prefetched data'),
-          })
+          await queryClient
+            .query({
+              queryKey: key,
+              queryFn: () => Promise.resolve('prefetched data'),
+            })
+            .catch(noop)
           act(() => setPrefetched(true))
         }
 
@@ -6014,7 +6031,7 @@ describe('useQuery', () => {
       return <></>
     }
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn })
+    await queryClient.query({ queryKey: key, queryFn }).catch(noop)
     renderWithClient(queryClient, <Page />)
 
     await vi.advanceTimersByTimeAsync(0)
@@ -6598,10 +6615,12 @@ describe('useQuery', () => {
       defaultOptions: { dehydrate: { shouldDehydrateQuery: () => true } },
     })
 
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => Promise.resolve('server')),
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => Promise.resolve('server')),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 
@@ -6653,11 +6672,13 @@ describe('useQuery', () => {
       },
     })
 
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () =>
-        sleep(10).then(() => Promise.reject(new Error('server error'))),
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('server error'))),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -5,6 +5,7 @@ import { QueryCache } from '../queryCache'
 import { dehydrate, hydrate } from '../hydration'
 import { dehydrateQuery } from '../index'
 import { MutationCache } from '../mutationCache'
+import { noop } from '../utils'
 import { executeMutation, mockOnlineManagerIsOnline } from './utils'
 
 describe('dehydration and rehydration', () => {
@@ -62,12 +63,12 @@ describe('dehydration and rehydration', () => {
       const shouldRedactErrors = vi.fn(() => false)
       const queryClient = new QueryClient()
       const promise = queryClient
-        .prefetchQuery({
+        .query({
           queryKey: key,
           queryFn: () => Promise.reject(testError),
           retry: false,
         })
-        .catch(() => undefined)
+        .catch(noop)
       const query = queryClient.getQueryCache().find({ queryKey: key })!
 
       const dehydrated = dehydrateQuery(query, undefined, shouldRedactErrors)
@@ -90,30 +91,42 @@ describe('dehydration and rehydration', () => {
 
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: stringKey,
-      queryFn: () => sleep(0).then(() => 'string'),
-    })
-    queryClient.prefetchQuery({
-      queryKey: numberKey,
-      queryFn: () => sleep(0).then(() => 1),
-    })
-    queryClient.prefetchQuery({
-      queryKey: booleanKey,
-      queryFn: () => sleep(0).then(() => true),
-    })
-    queryClient.prefetchQuery({
-      queryKey: nullKey,
-      queryFn: () => sleep(0).then(() => null),
-    })
-    queryClient.prefetchQuery({
-      queryKey: arrayKey,
-      queryFn: () => sleep(0).then(() => ['string', 0]),
-    })
-    queryClient.prefetchQuery({
-      queryKey: nestedKey,
-      queryFn: () => sleep(0).then(() => ({ key: [{ nestedKey: 1 }] })),
-    })
+    void queryClient
+      .query({
+        queryKey: stringKey,
+        queryFn: () => sleep(0).then(() => 'string'),
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: numberKey,
+        queryFn: () => sleep(0).then(() => 1),
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: booleanKey,
+        queryFn: () => sleep(0).then(() => true),
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: nullKey,
+        queryFn: () => sleep(0).then(() => null),
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: arrayKey,
+        queryFn: () => sleep(0).then(() => ['string', 0]),
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: nestedKey,
+        queryFn: () => sleep(0).then(() => ({ key: [{ nestedKey: 1 }] })),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
     const dehydrated = dehydrate(queryClient)
     const stringified = JSON.stringify(dehydrated)
@@ -142,36 +155,48 @@ describe('dehydration and rehydration', () => {
 
     const fetchDataAfterHydration =
       vi.fn<(...args: Array<unknown>) => unknown>()
-    await hydrationClient.prefetchQuery({
-      queryKey: stringKey,
-      queryFn: fetchDataAfterHydration,
-      staleTime: 1000,
-    })
-    await hydrationClient.prefetchQuery({
-      queryKey: numberKey,
-      queryFn: fetchDataAfterHydration,
-      staleTime: 1000,
-    })
-    await hydrationClient.prefetchQuery({
-      queryKey: booleanKey,
-      queryFn: fetchDataAfterHydration,
-      staleTime: 1000,
-    })
-    await hydrationClient.prefetchQuery({
-      queryKey: nullKey,
-      queryFn: fetchDataAfterHydration,
-      staleTime: 1000,
-    })
-    await hydrationClient.prefetchQuery({
-      queryKey: arrayKey,
-      queryFn: fetchDataAfterHydration,
-      staleTime: 1000,
-    })
-    await hydrationClient.prefetchQuery({
-      queryKey: nestedKey,
-      queryFn: fetchDataAfterHydration,
-      staleTime: 1000,
-    })
+    await hydrationClient
+      .query({
+        queryKey: stringKey,
+        queryFn: fetchDataAfterHydration,
+        staleTime: 1000,
+      })
+      .catch(noop)
+    await hydrationClient
+      .query({
+        queryKey: numberKey,
+        queryFn: fetchDataAfterHydration,
+        staleTime: 1000,
+      })
+      .catch(noop)
+    await hydrationClient
+      .query({
+        queryKey: booleanKey,
+        queryFn: fetchDataAfterHydration,
+        staleTime: 1000,
+      })
+      .catch(noop)
+    await hydrationClient
+      .query({
+        queryKey: nullKey,
+        queryFn: fetchDataAfterHydration,
+        staleTime: 1000,
+      })
+      .catch(noop)
+    await hydrationClient
+      .query({
+        queryKey: arrayKey,
+        queryFn: fetchDataAfterHydration,
+        staleTime: 1000,
+      })
+      .catch(noop)
+    await hydrationClient
+      .query({
+        queryKey: nestedKey,
+        queryFn: fetchDataAfterHydration,
+        staleTime: 1000,
+      })
+      .catch(noop)
     expect(fetchDataAfterHydration).toHaveBeenCalledTimes(0)
 
     queryClient.clear()
@@ -182,10 +207,12 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(0).then(() => 'string'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(0).then(() => 'string'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
 
     const dehydrated = dehydrate(queryClient, {
@@ -201,11 +228,13 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(0).then(() => 'string'),
-      gcTime: 50,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(0).then(() => 'string'),
+        gcTime: 50,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
     const dehydrated = dehydrate(queryClient)
     const stringified = JSON.stringify(dehydrated)
@@ -230,10 +259,12 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(0).then(() => 'string'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(0).then(() => 'string'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
     const dehydrated = dehydrate(queryClient)
     const stringified = JSON.stringify(dehydrated)
@@ -257,11 +288,13 @@ describe('dehydration and rehydration', () => {
         dehydrate: { shouldDehydrateQuery: () => true },
       },
     })
-    queryClient.prefetchQuery({
-      queryKey: key,
-      retry: 0,
-      queryFn: () => Promise.reject(new Error('error')),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        retry: 0,
+        queryFn: () => Promise.reject(new Error('error')),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
     const dehydrated = dehydrate(queryClient)
     expect(dehydrated.queries.length).toBe(1)
@@ -326,10 +359,12 @@ describe('dehydration and rehydration', () => {
     const complexKey = [...key, { key: ['string'], key2: 0 }]
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: complexKey,
-      queryFn: () => sleep(0).then(() => 'string'),
-    })
+    void queryClient
+      .query({
+        queryKey: complexKey,
+        queryFn: () => sleep(0).then(() => 'string'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
     const dehydrated = dehydrate(queryClient)
     const stringified = JSON.stringify(dehydrated)
@@ -348,11 +383,13 @@ describe('dehydration and rehydration', () => {
 
     const fetchDataAfterHydration =
       vi.fn<(...args: Array<unknown>) => unknown>()
-    await hydrationClient.prefetchQuery({
-      queryKey: complexKey,
-      queryFn: fetchDataAfterHydration,
-      staleTime: 100,
-    })
+    await hydrationClient
+      .query({
+        queryKey: complexKey,
+        queryFn: fetchDataAfterHydration,
+        staleTime: 100,
+      })
+      .catch(noop)
     expect(fetchDataAfterHydration).toHaveBeenCalledTimes(0)
 
     queryClient.clear()
@@ -369,21 +406,27 @@ describe('dehydration and rehydration', () => {
 
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: successKey,
-      queryFn: () => sleep(0).then(() => 'success'),
-    })
+    void queryClient
+      .query({
+        queryKey: successKey,
+        queryFn: () => sleep(0).then(() => 'success'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
-    queryClient.prefetchQuery({
-      queryKey: loadingKey,
-      queryFn: () => sleep(10000).then(() => 'loading'),
-    })
-    queryClient.prefetchQuery({
-      queryKey: errorKey,
-      queryFn: () => {
-        throw new Error()
-      },
-    })
+    void queryClient
+      .query({
+        queryKey: loadingKey,
+        queryFn: () => sleep(10000).then(() => 'loading'),
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: errorKey,
+        queryFn: () => {
+          throw new Error()
+        },
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
     const dehydrated = dehydrate(queryClient)
     const stringified = JSON.stringify(dehydrated)
@@ -411,14 +454,18 @@ describe('dehydration and rehydration', () => {
     const numberKey = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: stringKey,
-      queryFn: () => sleep(0).then(() => 'string'),
-    })
-    queryClient.prefetchQuery({
-      queryKey: numberKey,
-      queryFn: () => sleep(0).then(() => 1),
-    })
+    void queryClient
+      .query({
+        queryKey: stringKey,
+        queryFn: () => sleep(0).then(() => 'string'),
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: numberKey,
+        queryFn: () => sleep(0).then(() => 1),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
     const dehydrated = dehydrate(queryClient, {
       shouldDehydrateQuery: (query) => query.queryKey !== stringKey,
@@ -450,10 +497,12 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    const promise1 = queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(5).then(() => 'string-older'),
-    })
+    const promise1 = queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(5).then(() => 'string-older'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(5)
     await promise1
     const dehydrated = dehydrate(queryClient)
@@ -464,10 +513,12 @@ describe('dehydration and rehydration', () => {
     const parsed = JSON.parse(stringified)
     const hydrationCache = new QueryCache()
     const hydrationClient = new QueryClient({ queryCache: hydrationCache })
-    const promise2 = hydrationClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(5).then(() => 'string-newer'),
-    })
+    const promise2 = hydrationClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(5).then(() => 'string-newer'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(5)
     await promise2
 
@@ -484,10 +535,12 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const hydrationCache = new QueryCache()
     const hydrationClient = new QueryClient({ queryCache: hydrationCache })
-    const promise1 = hydrationClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(5).then(() => 'string-older'),
-    })
+    const promise1 = hydrationClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(5).then(() => 'string-older'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(5)
     await promise1
 
@@ -495,10 +548,12 @@ describe('dehydration and rehydration', () => {
 
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    const promise2 = queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(5).then(() => 'string-newer'),
-    })
+    const promise2 = queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(5).then(() => 'string-newer'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(5)
     await promise2
     const dehydrated = dehydrate(queryClient)
@@ -708,10 +763,12 @@ describe('dehydration and rehydration', () => {
       return promise
     }
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => customFetchData(),
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => customFetchData(),
+      })
+      .catch(noop)
 
     queryClient.refetchQueries({ queryKey: key })
 
@@ -738,17 +795,21 @@ describe('dehydration and rehydration', () => {
     const noMetaKey = queryKey()
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
-    queryClient.prefetchQuery({
-      queryKey: metaKey,
-      queryFn: () => Promise.resolve('meta'),
-      meta: {
-        some: 'meta',
-      },
-    })
-    queryClient.prefetchQuery({
-      queryKey: noMetaKey,
-      queryFn: () => Promise.resolve('no-meta'),
-    })
+    void queryClient
+      .query({
+        queryKey: metaKey,
+        queryFn: () => Promise.resolve('meta'),
+        meta: {
+          some: 'meta',
+        },
+      })
+      .catch(noop)
+    void queryClient
+      .query({
+        queryKey: noMetaKey,
+        queryFn: () => Promise.resolve('no-meta'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
 
     const dehydrated = dehydrate(queryClient)
@@ -861,7 +922,7 @@ describe('dehydration and rehydration', () => {
       queryFn: () => sleep(10).then(() => 'string'),
     } as const
 
-    const prefetchPromise = queryClient.prefetchQuery(options)
+    const prefetchPromise = queryClient.query(options).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -877,7 +938,7 @@ describe('dehydration and rehydration', () => {
     const hydrationCache = new QueryCache()
     const hydrationClient = new QueryClient({ queryCache: hydrationCache })
 
-    const promise = hydrationClient.prefetchQuery(options)
+    const promise = hydrationClient.query(options).catch(noop)
     hydrate(hydrationClient, parsed)
     expect(hydrationCache.find({ queryKey: key })?.state.fetchStatus).toBe(
       'fetching',
@@ -932,16 +993,20 @@ describe('dehydration and rehydration', () => {
       queryCache,
       defaultOptions: { dehydrate: { shouldDehydrateQuery: () => true } },
     })
-    queryClient.prefetchQuery({
-      queryKey: successKey,
-      queryFn: () => sleep(0).then(() => 'success'),
-    })
+    void queryClient
+      .query({
+        queryKey: successKey,
+        queryFn: () => sleep(0).then(() => 'success'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
 
-    const promise = queryClient.prefetchQuery({
-      queryKey: pendingKey,
-      queryFn: () => sleep(10).then(() => 'pending'),
-    })
+    const promise = queryClient
+      .query({
+        queryKey: pendingKey,
+        queryFn: () => sleep(10).then(() => 'pending'),
+      })
+      .catch(noop)
     const dehydrated = dehydrate(queryClient)
 
     expect(dehydrated.queries[0]?.promise).toBeUndefined()
@@ -960,16 +1025,20 @@ describe('dehydration and rehydration', () => {
       queryCache,
       defaultOptions: { dehydrate: { shouldDehydrateQuery: () => true } },
     })
-    queryClient.prefetchQuery({
-      queryKey: successKey,
-      queryFn: () => sleep(0).then(() => 'success'),
-    })
+    void queryClient
+      .query({
+        queryKey: successKey,
+        queryFn: () => sleep(0).then(() => 'success'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(0)
 
-    void queryClient.prefetchQuery({
-      queryKey: pendingKey,
-      queryFn: () => sleep(20).then(() => 'pending'),
-    })
+    void queryClient
+      .query({
+        queryKey: pendingKey,
+        queryFn: () => sleep(20).then(() => 'pending'),
+      })
+      .catch(noop)
     const dehydrated = dehydrate(queryClient)
     // no stringify/parse here because promises can't be serialized to json
     // but nextJs still can do it
@@ -1029,10 +1098,13 @@ describe('dehydration and rehydration', () => {
       },
     })
 
-    const promise = queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(20).then(() => new Date('2024-01-01T00:00:00.000Z')),
-    })
+    const promise = queryClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          sleep(20).then(() => new Date('2024-01-01T00:00:00.000Z')),
+      })
+      .catch(noop)
     const dehydrated = dehydrate(queryClient)
     expect(dehydrated.queries[0]?.promise).toBeInstanceOf(Promise)
 
@@ -1064,10 +1136,13 @@ describe('dehydration and rehydration', () => {
       },
     })
 
-    const promise = queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(0).then(() => new Date('2024-01-01T00:00:00.000Z')),
-    })
+    const promise = queryClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          sleep(0).then(() => new Date('2024-01-01T00:00:00.000Z')),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(20)
     const dehydrated = dehydrate(queryClient)
 
@@ -1096,10 +1171,13 @@ describe('dehydration and rehydration', () => {
         },
       },
     })
-    const hydrationPromise = hydrationClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(5).then(() => new Date('2024-01-01T00:00:00.000Z')),
-    })
+    const hydrationPromise = hydrationClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          sleep(5).then(() => new Date('2024-01-01T00:00:00.000Z')),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(5)
     await hydrationPromise
 
@@ -1113,10 +1191,13 @@ describe('dehydration and rehydration', () => {
         },
       },
     })
-    const queryPromise = queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => new Date('2024-01-02T00:00:00.000Z')),
-    })
+    const queryPromise = queryClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => new Date('2024-01-02T00:00:00.000Z')),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await queryPromise
     const dehydrated = dehydrate(queryClient)
@@ -1145,10 +1226,12 @@ describe('dehydration and rehydration', () => {
       },
     })
 
-    const promise = serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'server data'),
-    })
+    const promise = serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'server data'),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 
@@ -1181,10 +1264,12 @@ describe('dehydration and rehydration', () => {
       },
     })
 
-    const promise = serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'server data'),
-    })
+    const promise = serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'server data'),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 
@@ -1238,7 +1323,7 @@ describe('dehydration and rehydration', () => {
       queryFn: () => sleep(10).then(() => countRef.current),
     }
 
-    const promise = serverQueryClient.prefetchQuery(query)
+    const promise = serverQueryClient.query(query).catch(noop)
 
     let dehydrated = dehydrate(serverQueryClient)
 
@@ -1269,7 +1354,7 @@ describe('dehydration and rehydration', () => {
     countRef.current++
     await vi.advanceTimersByTimeAsync(1)
     serverQueryClient.clear()
-    const promise2 = serverQueryClient.prefetchQuery(query)
+    const promise2 = serverQueryClient.query(query).catch(noop)
 
     dehydrated = dehydrate(serverQueryClient)
 
@@ -1308,12 +1393,12 @@ describe('dehydration and rehydration', () => {
     const testError = new Error('original error')
 
     const promise = queryClient
-      .prefetchQuery({
+      .query({
         queryKey: key,
         queryFn: () => Promise.reject(testError),
         retry: false,
       })
-      .catch(() => undefined)
+      .catch(noop)
 
     const dehydrated = dehydrate(queryClient)
 
@@ -1338,12 +1423,12 @@ describe('dehydration and rehydration', () => {
     })
 
     const promise = queryClient
-      .prefetchQuery({
+      .query({
         queryKey: key,
         queryFn: () => Promise.reject(new Error('test error')),
         retry: false,
       })
-      .catch(() => undefined)
+      .catch(noop)
 
     const dehydrated = dehydrate(queryClient)
 
@@ -1376,12 +1461,12 @@ describe('dehydration and rehydration', () => {
     const testError = new Error('test error')
 
     const promise = queryClient
-      .prefetchQuery({
+      .query({
         queryKey: key,
         queryFn: () => Promise.reject(testError),
         retry: false,
       })
-      .catch(() => undefined)
+      .catch(noop)
 
     const dehydrated = dehydrate(queryClient)
 
@@ -1416,10 +1501,12 @@ describe('dehydration and rehydration', () => {
         },
       },
     })
-    const originalPromise = serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => null,
-    })
+    const originalPromise = serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => null,
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 
@@ -1718,10 +1805,12 @@ describe('dehydration and rehydration', () => {
       resolvePrefetch = res
     })
     // Keep the query pending so it dehydrates with status: 'pending' and a promise
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => prefetchPromise,
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => prefetchPromise,
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
     expect(dehydrated.queries[0]?.state.status).toBe('pending')
@@ -1740,12 +1829,14 @@ describe('dehydration and rehydration', () => {
     // Query already exists in the cache in a pending state, as it would after
     // a first hydration pass or an initial render.
     const clientQueryClient = new QueryClient()
-    void clientQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => {
-        throw new Error('QueryFn on client should not be called')
-      },
-    })
+    void clientQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => {
+          throw new Error('QueryFn on client should not be called')
+        },
+      })
+      .catch(noop)
 
     const query = clientQueryClient.getQueryCache().find({ queryKey: key })!
     expect(query.state.status).toBe('pending')
@@ -1772,10 +1863,12 @@ describe('dehydration and rehydration', () => {
     const prefetchPromise = new Promise((res) => {
       resolvePrefetch = res
     })
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => prefetchPromise,
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => prefetchPromise,
+      })
+      .catch(noop)
     const dehydrated = dehydrate(serverQueryClient)
 
     // Simulate a synchronous thenable – the promise was already resolved
@@ -1827,10 +1920,12 @@ describe('dehydration and rehydration', () => {
     const prefetchPromise = new Promise((res) => {
       resolvePrefetch = res
     })
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => prefetchPromise,
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => prefetchPromise,
+      })
+      .catch(noop)
     const dehydrated = dehydrate(serverQueryClient)
 
     // Simulate a synchronous thenable – the promise was already resolved
@@ -1882,13 +1977,15 @@ describe('dehydration and rehydration', () => {
     })
 
     let resolvePrefetch: undefined | ((value?: unknown) => void)
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () =>
-        new Promise((res) => {
-          resolvePrefetch = res
-        }),
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          new Promise((res) => {
+            resolvePrefetch = res
+          }),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
     expect(dehydrated.queries[0]?.state.status).toBe('pending')
@@ -1927,13 +2024,15 @@ describe('dehydration and rehydration', () => {
     })
 
     let resolvePrefetch: undefined | ((value?: unknown) => void)
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () =>
-        new Promise((res) => {
-          resolvePrefetch = res
-        }),
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          new Promise((res) => {
+            resolvePrefetch = res
+          }),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -12,6 +12,7 @@ import {
   QueryObserver,
   dehydrate,
   hydrate,
+  noop,
 } from '..'
 import { hashQueryKeyByOptions } from '../utils'
 import { mockOnlineManagerIsOnline, setIsServer } from './utils'
@@ -35,21 +36,27 @@ describe('query', () => {
 
   it('should use the longest garbage collection time it has seen', async () => {
     const key = queryKey()
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-      gcTime: 100,
-    })
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-      gcTime: 200,
-    })
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-      gcTime: 10,
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+        gcTime: 100,
+      })
+      .catch(noop)
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+        gcTime: 200,
+      })
+      .catch(noop)
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+        gcTime: 10,
+      })
+      .catch(noop)
     const query = queryCache.find({ queryKey: key })!
     expect(query.gcTime).toBe(200)
   })
@@ -63,7 +70,7 @@ describe('query', () => {
     let count = 0
     let result
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn: () => {
         count++
@@ -109,7 +116,7 @@ describe('query', () => {
     let count = 0
     let result
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn: () => {
         count++
@@ -156,7 +163,7 @@ describe('query', () => {
     const visibilityMock = mockVisibilityState('hidden')
     let count = 0
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn: (): Promise<unknown> => {
         count++
@@ -240,7 +247,7 @@ describe('query', () => {
 
     expect(queryCache.find({ queryKey: key })?.state.data).toBe('data')
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn: ({ signal }) => sleep(100).then(() => 'data2' + String(signal)),
     })
@@ -271,7 +278,7 @@ describe('query', () => {
       >()
       .mockResolvedValue('data')
 
-    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    void queryClient.query({ queryKey: key, queryFn }).catch(noop)
 
     expect(queryFn).toHaveBeenCalledTimes(1)
     const args = queryFn.mock.calls[0]![0]
@@ -284,10 +291,12 @@ describe('query', () => {
   it('should continue if cancellation is not supported and signal is not consumed', async () => {
     const key = queryKey()
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(100).then(() => 'data'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(100).then(() => 'data'),
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -313,11 +322,13 @@ describe('query', () => {
   it('should not continue when last observer unsubscribed if the signal was consumed', async () => {
     const key = queryKey()
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: ({ signal }) =>
-        sleep(100).then(() => (signal.aborted ? 'aborted' : 'data')),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: ({ signal }) =>
+          sleep(100).then(() => (signal.aborted ? 'aborted' : 'data')),
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -362,7 +373,7 @@ describe('query', () => {
       throw new Error()
     })
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn,
       retry: 3,
@@ -404,7 +415,7 @@ describe('query', () => {
 
     let error
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn,
       retry: 3,
@@ -437,7 +448,7 @@ describe('query', () => {
     let error
 
     queryClient
-      .fetchQuery({
+      .query({
         queryKey: key,
         queryFn,
         retry: 3,
@@ -471,10 +482,12 @@ describe('query', () => {
   it('should reset to default state when created from hydration', async () => {
     const key = queryKey()
     const client = new QueryClient()
-    await client.prefetchQuery({
-      queryKey: key,
-      queryFn: () => Promise.resolve('string'),
-    })
+    await client
+      .query({
+        queryKey: key,
+        queryFn: () => Promise.resolve('string'),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(client)
 
@@ -496,7 +509,7 @@ describe('query', () => {
 
     queryFn.mockImplementation(() => sleep(50).then(() => 'data'))
 
-    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    void queryClient.query({ queryKey: key, queryFn }).catch(noop)
     const query = queryCache.find({ queryKey: key })!
     await vi.advanceTimersByTimeAsync(10)
     query.cancel()
@@ -513,10 +526,12 @@ describe('query', () => {
 
   it('cancelling a resolved query should not have any effect', async () => {
     const key = queryKey()
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+      })
+      .catch(noop)
     const query = queryCache.find({ queryKey: key })!
     query.cancel()
     await vi.advanceTimersByTimeAsync(10)
@@ -527,10 +542,12 @@ describe('query', () => {
     const key = queryKey()
     const error = new Error('error')
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => Promise.reject(error),
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => Promise.reject(error),
+      })
+      .catch(noop)
     const query = queryCache.find({ queryKey: key })!
     query.cancel()
     await vi.advanceTimersByTimeAsync(10)
@@ -549,10 +566,12 @@ describe('query', () => {
     })
     const testClient = new QueryClient({ queryCache: testCache })
 
-    const prefetch = testClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'data'),
-    })
+    const prefetch = testClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'data'),
+      })
+      .catch(noop)
     const query = testCache.find({ queryKey: key })!
     const firstPromise = query.promise
     expect(firstPromise).toBeDefined()
@@ -571,22 +590,28 @@ describe('query', () => {
   it('the previous query status should be kept when refetching', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
+    await queryClient
+      .query({ queryKey: key, queryFn: () => 'data' })
+      .catch(noop)
     const query = queryCache.find({ queryKey: key })!
     expect(query.state.status).toBe('success')
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => Promise.reject<string>('reject'),
-      retry: false,
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => Promise.reject<string>('reject'),
+        retry: false,
+      })
+      .catch(noop)
     expect(query.state.status).toBe('error')
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => Promise.reject<unknown>('reject')),
-      retry: false,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => Promise.reject<unknown>('reject')),
+        retry: false,
+      })
+      .catch(noop)
     expect(query.state.status).toBe('error')
 
     await vi.advanceTimersByTimeAsync(10)
@@ -704,11 +729,13 @@ describe('query', () => {
 
     const key = queryKey()
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-      meta,
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+        meta,
+      })
+      .catch(noop)
 
     const query = queryCache.find({ queryKey: key })!
 
@@ -724,9 +751,11 @@ describe('query', () => {
     const key = queryKey()
     const queryFn = () => 'data'
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn, meta })
+    await queryClient.query({ queryKey: key, queryFn, meta }).catch(noop)
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn, meta: undefined })
+    await queryClient
+      .query({ queryKey: key, queryFn, meta: undefined })
+      .catch(noop)
 
     const query = queryCache.find({ queryKey: key })!
 
@@ -744,7 +773,7 @@ describe('query', () => {
 
     queryClient.setQueryDefaults(key, { meta })
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn })
+    await queryClient.query({ queryKey: key, queryFn }).catch(noop)
 
     const query = queryCache.find({ queryKey: key })!
 
@@ -760,7 +789,7 @@ describe('query', () => {
 
     const key = queryKey()
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn, meta })
+    await queryClient.query({ queryKey: key, queryFn, meta }).catch(noop)
 
     expect(queryFn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -791,7 +820,9 @@ describe('query', () => {
   it('should not add an existing observer', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
+    await queryClient
+      .query({ queryKey: key, queryFn: () => 'data' })
+      .catch(noop)
     const query = queryCache.find({ queryKey: key })!
     expect(query.getObserversCount()).toEqual(0)
 
@@ -810,7 +841,9 @@ describe('query', () => {
   it('should not try to remove an observer that does not exist', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
+    await queryClient
+      .query({ queryKey: key, queryFn: () => 'data' })
+      .catch(noop)
     const query = queryCache.find({ queryKey: key })!
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
@@ -848,7 +881,9 @@ describe('query', () => {
   it('should not change state on invalidate() if already invalidated', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
+    await queryClient
+      .query({ queryKey: key, queryFn: () => 'data' })
+      .catch(noop)
     const query = queryCache.find({ queryKey: key })!
 
     query.invalidate()
@@ -868,7 +903,7 @@ describe('query', () => {
 
     const updates: Array<string> = []
 
-    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    void queryClient.query({ queryKey: key, queryFn }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     const query = queryCache.find({ queryKey: key })!
 
@@ -988,12 +1023,14 @@ describe('query', () => {
 
     const initialDataUpdatedAtSpy = vi.fn()
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-      initialData: 'initial',
-      initialDataUpdatedAt: initialDataUpdatedAtSpy,
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+        initialData: 'initial',
+        initialDataUpdatedAt: initialDataUpdatedAtSpy,
+      })
+      .catch(noop)
 
     expect(initialDataUpdatedAtSpy).toHaveBeenCalled()
   })
@@ -1001,13 +1038,15 @@ describe('query', () => {
   it('should work with initialDataUpdatedAt set to zero', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-      staleTime: Infinity,
-      initialData: 'initial',
-      initialDataUpdatedAt: 0,
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+        staleTime: Infinity,
+        initialData: 'initial',
+        initialDataUpdatedAt: 0,
+      })
+      .catch(noop)
 
     expect(queryCache.find({ queryKey: key })?.state).toMatchObject({
       data: 'initial',
@@ -1110,7 +1149,7 @@ describe('query', () => {
       .fn()
       .mockImplementation(() => sleep(100).then(() => 'data' + x))
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn,
     })
@@ -1151,11 +1190,13 @@ describe('query', () => {
 
     queryFn.mockImplementation(() => sleep(10).then(() => data))
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn,
-      initialData,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn,
+        initialData,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const query = queryCache.find({ queryKey: key })!
@@ -1183,13 +1224,15 @@ describe('query', () => {
       .fn<() => Promise<string>>()
       .mockImplementation(() => sleep(10).then(() => 'data'))
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn,
-      structuralSharing: () => {
-        throw Error('Any error')
-      },
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn,
+        structuralSharing: () => {
+          throw Error('Any error')
+        },
+      })
+      .catch(noop)
 
     const query = queryCache.find({ queryKey: key })!
 
@@ -1201,11 +1244,13 @@ describe('query', () => {
   it('should use persister if provided', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'data',
-      persister: () => Promise.resolve('persisted data'),
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'data',
+        persister: () => Promise.resolve('persisted data'),
+      })
+      .catch(noop)
 
     const query = queryCache.find({ queryKey: key })!
     expect(query.state.data).toBe('persisted data')
@@ -1237,10 +1282,12 @@ describe('query', () => {
     const consoleMock = vi.spyOn(console, 'error')
     const key: unknown = 'string-key'
 
-    await queryClient.prefetchQuery({
-      queryKey: key as QueryKey,
-      queryFn: () => 'data',
-    })
+    await queryClient
+      .query({
+        queryKey: key as QueryKey,
+        queryFn: () => 'data',
+      })
+      .catch(noop)
 
     expect(consoleMock).toHaveBeenCalledWith(
       "As of v4, queryKey needs to be an Array. If you are using a string like 'repoData', please change it to an Array, e.g. ['repoData']",
@@ -1271,11 +1318,13 @@ describe('query', () => {
     const key = queryKey()
     const queryFn = vi.fn(() => sleep(100).then(() => 'data'))
 
-    const promise = queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn,
-      staleTime: 1000,
-    })
+    const promise = queryClient
+      .query({
+        queryKey: key,
+        queryFn,
+        staleTime: 1000,
+      })
+      .catch(noop)
 
     vi.advanceTimersByTime(50)
 
@@ -1382,10 +1431,12 @@ describe('query', () => {
     const queryFn = vi.fn().mockImplementation(() => 'fetched-data')
 
     // First prefetch the query (creates query without data)
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn,
+      })
+      .catch(noop)
 
     const query = queryCache.find({ queryKey: key })!
     expect(query.state.data).toBeUndefined()

--- a/packages/query-core/src/__tests__/queryCache.test.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryCache, QueryClient, QueryObserver, hashKey } from '..'
+import { QueryCache, QueryClient, QueryObserver, hashKey, noop } from '..'
 
 describe('queryCache', () => {
   let queryClient: QueryClient
@@ -32,10 +32,12 @@ describe('queryCache', () => {
       const key = queryKey()
       const callback = vi.fn()
       queryCache.subscribe(callback)
-      queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => 'data'),
-      })
+      void queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(100).then(() => 'data'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       const query = queryCache.find({ queryKey: key })
       expect(callback).toHaveBeenNthCalledWith(1, { query, type: 'added' })
@@ -85,10 +87,12 @@ describe('queryCache', () => {
       const key = queryKey()
       const callback = vi.fn()
       queryCache.subscribe(callback)
-      queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => 'data'),
-      })
+      void queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(100).then(() => 'data'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       const query = queryCache.find({ queryKey: key })
       expect(callback).toHaveBeenNthCalledWith(1, { query, type: 'added' })
@@ -98,11 +102,13 @@ describe('queryCache', () => {
       const key = queryKey()
       const callback = vi.fn()
       queryCache.subscribe(callback)
-      queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => 'data'),
-        initialData: 'initial',
-      })
+      void queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(100).then(() => 'data'),
+          initialData: 'initial',
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       const query = queryCache.find({ queryKey: key })
       expect(callback).toHaveBeenNthCalledWith(1, { query, type: 'added' })
@@ -131,20 +137,26 @@ describe('queryCache', () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const key3 = queryKey()
-      testClient.prefetchQuery({
-        queryKey: key1,
-        queryFn: () => sleep(100).then(() => 'data1'),
-      })
+      void testClient
+        .query({
+          queryKey: key1,
+          queryFn: () => sleep(100).then(() => 'data1'),
+        })
+        .catch(noop)
       expect(testCache.findAll().length).toBe(1)
-      testClient.prefetchQuery({
-        queryKey: key2,
-        queryFn: () => sleep(100).then(() => 'data2'),
-      })
+      void testClient
+        .query({
+          queryKey: key2,
+          queryFn: () => sleep(100).then(() => 'data2'),
+        })
+        .catch(noop)
       expect(testCache.findAll().length).toBe(2)
-      testClient.prefetchQuery({
-        queryKey: key3,
-        queryFn: () => sleep(100).then(() => 'data3'),
-      })
+      void testClient
+        .query({
+          queryKey: key3,
+          queryFn: () => sleep(100).then(() => 'data3'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       expect(testCache.findAll().length).toBe(1)
       expect(testCache.findAll()[0]!.state.data).toBe('data3')
@@ -156,10 +168,12 @@ describe('queryCache', () => {
   describe('find', () => {
     it('find should filter correctly', async () => {
       const key = queryKey()
-      queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => 'data1'),
-      })
+      void queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(100).then(() => 'data1'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       const query = queryCache.find({ queryKey: key })!
       expect(query.state.data).toBe('data1')
@@ -167,10 +181,12 @@ describe('queryCache', () => {
 
     it('find should filter correctly with exact set to false', async () => {
       const key = queryKey()
-      queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => 'data1'),
-      })
+      void queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(100).then(() => 'data1'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       const query = queryCache.find({ queryKey: key, exact: false })!
       expect(query.state.data).toBe('data1')
@@ -182,22 +198,30 @@ describe('queryCache', () => {
       const key1 = queryKey()
       const key2 = queryKey()
       const keyFetching = queryKey()
-      queryClient.prefetchQuery({
-        queryKey: key1,
-        queryFn: () => sleep(100).then(() => 'data1'),
-      })
-      queryClient.prefetchQuery({
-        queryKey: key2,
-        queryFn: () => sleep(100).then(() => 'data2'),
-      })
-      queryClient.prefetchQuery({
-        queryKey: [{ a: 'a', b: 'b' }],
-        queryFn: () => sleep(100).then(() => 'data3'),
-      })
-      queryClient.prefetchQuery({
-        queryKey: ['posts', 1],
-        queryFn: () => sleep(100).then(() => 'data4'),
-      })
+      void queryClient
+        .query({
+          queryKey: key1,
+          queryFn: () => sleep(100).then(() => 'data1'),
+        })
+        .catch(noop)
+      void queryClient
+        .query({
+          queryKey: key2,
+          queryFn: () => sleep(100).then(() => 'data2'),
+        })
+        .catch(noop)
+      void queryClient
+        .query({
+          queryKey: [{ a: 'a', b: 'b' }],
+          queryFn: () => sleep(100).then(() => 'data3'),
+        })
+        .catch(noop)
+      void queryClient
+        .query({
+          queryKey: ['posts', 1],
+          queryFn: () => sleep(100).then(() => 'data4'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       queryClient.invalidateQueries({ queryKey: key2 })
       const query1 = queryCache.find({ queryKey: key1 })!
@@ -288,10 +312,12 @@ describe('queryCache', () => {
         queryCache.findAll({ queryKey: key2, fetchStatus: undefined }),
       ).toEqual([query2])
 
-      queryClient.prefetchQuery({
-        queryKey: keyFetching,
-        queryFn: () => sleep(20).then(() => 'dataFetching'),
-      })
+      void queryClient
+        .query({
+          queryKey: keyFetching,
+          queryFn: () => sleep(20).then(() => 'dataFetching'),
+        })
+        .catch(noop)
       expect(queryCache.findAll({ fetchStatus: 'fetching' })).toEqual([
         queryCache.find({ queryKey: keyFetching }),
       ])
@@ -302,14 +328,18 @@ describe('queryCache', () => {
     it('should return all the queries when no filters are defined', async () => {
       const key1 = queryKey()
       const key2 = queryKey()
-      await queryClient.prefetchQuery({
-        queryKey: key1,
-        queryFn: () => 'data1',
-      })
-      await queryClient.prefetchQuery({
-        queryKey: key2,
-        queryFn: () => 'data2',
-      })
+      await queryClient
+        .query({
+          queryKey: key1,
+          queryFn: () => 'data1',
+        })
+        .catch(noop)
+      await queryClient
+        .query({
+          queryKey: key2,
+          queryFn: () => 'data2',
+        })
+        .catch(noop)
       expect(queryCache.findAll().length).toBe(2)
     })
   })
@@ -322,10 +352,13 @@ describe('queryCache', () => {
       const onError = vi.fn()
       const testCache = new QueryCache({ onSuccess, onError, onSettled })
       const testClient = new QueryClient({ queryCache: testCache })
-      testClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => Promise.reject<unknown>('error')),
-      })
+      void testClient
+        .query({
+          queryKey: key,
+          queryFn: () =>
+            sleep(100).then(() => Promise.reject<unknown>('error')),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       const query = testCache.find({ queryKey: key })
       expect(onError).toHaveBeenCalledWith('error', query)
@@ -344,10 +377,12 @@ describe('queryCache', () => {
       const onError = vi.fn()
       const testCache = new QueryCache({ onSuccess, onError, onSettled })
       const testClient = new QueryClient({ queryCache: testCache })
-      testClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => ({ data: 5 })),
-      })
+      void testClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(100).then(() => ({ data: 5 })),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
       const query = testCache.find({ queryKey: key })
       expect(onSuccess).toHaveBeenCalledWith({ data: 5 }, query)
@@ -403,10 +438,12 @@ describe('queryCache', () => {
     it('should not try to add a query already added to the cache', async () => {
       const key = queryKey()
 
-      queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(100).then(() => 'data1'),
-      })
+      void queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(100).then(() => 'data1'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(100)
 
       const query = queryCache.findAll()[0]!

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -47,7 +47,9 @@ describe('queryClient', () => {
         defaultOptions: { queries: { queryFn } },
       })
 
-      expect(() => testClient.prefetchQuery({ queryKey: key })).not.toThrow()
+      expect(() =>
+        testClient.query({ queryKey: key }).catch(noop),
+      ).not.toThrow()
     })
 
     it('should merge defaultOptions when query is added to cache', async () => {
@@ -60,7 +62,7 @@ describe('queryClient', () => {
       })
 
       const fetchData = () => Promise.resolve('data')
-      await testClient.prefetchQuery({ queryKey: key, queryFn: fetchData })
+      await testClient.query({ queryKey: key, queryFn: fetchData }).catch(noop)
       const newQuery = testClient.getQueryCache().find({ queryKey: key })
       expect(newQuery?.options.gcTime).toBe(Infinity)
     })
@@ -334,10 +336,12 @@ describe('queryClient', () => {
 
     it('should not set isFetching to false', async () => {
       const key = queryKey()
-      queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => sleep(10).then(() => 23),
-      })
+      void queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => sleep(10).then(() => 23),
+        })
+        .catch(noop)
       expect(queryClient.getQueryState(key)).toMatchObject({
         data: undefined,
         fetchStatus: 'fetching',
@@ -402,15 +406,19 @@ describe('queryClient', () => {
   describe('isFetching', () => {
     it('should return length of fetching queries', async () => {
       expect(queryClient.isFetching()).toBe(0)
-      queryClient.prefetchQuery({
-        queryKey: queryKey(),
-        queryFn: () => sleep(10).then(() => 'data'),
-      })
+      void queryClient
+        .query({
+          queryKey: queryKey(),
+          queryFn: () => sleep(10).then(() => 'data'),
+        })
+        .catch(noop)
       expect(queryClient.isFetching()).toBe(1)
-      queryClient.prefetchQuery({
-        queryKey: queryKey(),
-        queryFn: () => sleep(5).then(() => 'data'),
-      })
+      void queryClient
+        .query({
+          queryKey: queryKey(),
+          queryFn: () => sleep(5).then(() => 'data'),
+        })
+        .catch(noop)
       expect(queryClient.isFetching()).toBe(2)
       await vi.advanceTimersByTimeAsync(5)
       expect(queryClient.isFetching()).toEqual(1)
@@ -1925,7 +1933,7 @@ describe('queryClient', () => {
       const fetchFn = () => Promise.resolve('data')
 
       // check the query was added to the cache
-      await queryClient.prefetchQuery({ queryKey: key, queryFn: fetchFn })
+      await queryClient.query({ queryKey: key, queryFn: fetchFn }).catch(noop)
       expect(queryCache.find({ queryKey: key })?.state.data).toBe('data')
 
       // check the error doesn't occur
@@ -1943,7 +1951,7 @@ describe('queryClient', () => {
       const key1 = queryKey()
       queryClient.setQueryData(key1, 'data')
 
-      const pending = queryClient.fetchQuery({
+      const pending = queryClient.query({
         queryKey: key1,
         queryFn: () => sleep(1000).then(() => 'data2'),
       })
@@ -1964,14 +1972,16 @@ describe('queryClient', () => {
 
     it('should not revert if revert option is set to false', async () => {
       const key1 = queryKey()
-      await queryClient.fetchQuery({
+      await queryClient.query({
         queryKey: key1,
         queryFn: () => 'data',
       })
-      queryClient.prefetchQuery({
-        queryKey: key1,
-        queryFn: () => sleep(1000).then(() => 'data2'),
-      })
+      void queryClient
+        .query({
+          queryKey: key1,
+          queryFn: () => sleep(1000).then(() => 'data2'),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(10)
       await queryClient.cancelQueries({ queryKey: key1 }, { revert: false })
       const state1 = queryClient.getQueryState(key1)
@@ -1983,7 +1993,7 @@ describe('queryClient', () => {
     it('should throw CancelledError for imperative methods when initial fetch is cancelled', async () => {
       const key = queryKey()
 
-      const promise = queryClient.fetchQuery({
+      const promise = queryClient.query({
         queryKey: key,
         queryFn: () => sleep(50).then(() => 25),
       })
@@ -2012,7 +2022,7 @@ describe('queryClient', () => {
       const queryFn = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data')
-      await queryClient.fetchQuery({ queryKey: key, queryFn })
+      await queryClient.query({ queryKey: key, queryFn })
       const observer1 = new QueryObserver(queryClient, {
         queryKey: key,
         queryFn,
@@ -2028,7 +2038,7 @@ describe('queryClient', () => {
       const queryFn = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data')
-      await queryClient.fetchQuery({ queryKey: key, queryFn })
+      await queryClient.query({ queryKey: key, queryFn })
       const observer1 = new QueryObserver(queryClient, {
         queryKey: key,
         queryFn,
@@ -2055,8 +2065,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer1 = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2087,8 +2097,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2110,8 +2120,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2134,8 +2144,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       queryClient.invalidateQueries({ queryKey: key1 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
@@ -2160,8 +2170,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2183,8 +2193,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2206,8 +2216,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2229,8 +2239,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2247,7 +2257,7 @@ describe('queryClient', () => {
       const key1 = queryKey()
       const queryFnError = () => Promise.reject<unknown>('error')
       try {
-        await queryClient.fetchQuery({
+        await queryClient.query({
           queryKey: key1,
           queryFn: queryFnError,
           retry: false,
@@ -2270,7 +2280,7 @@ describe('queryClient', () => {
       const queryFn1 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data1')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
       const onlineMock = mockOnlineManagerIsOnline(false)
 
       await queryClient.refetchQueries({ queryKey: key1 })
@@ -2286,7 +2296,7 @@ describe('queryClient', () => {
       const queryFn1 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data1')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
       const onlineMock = mockOnlineManagerIsOnline(false)
 
       await queryClient.refetchQueries({ queryKey: key1 })
@@ -2299,7 +2309,7 @@ describe('queryClient', () => {
     it('should not refetch static queries', async () => {
       const key = queryKey()
       const queryFn = vi.fn(() => 'data1')
-      await queryClient.fetchQuery({ queryKey: key, queryFn: queryFn })
+      await queryClient.query({ queryKey: key, queryFn: queryFn })
 
       expect(queryFn).toHaveBeenCalledTimes(1)
 
@@ -2326,8 +2336,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2349,8 +2359,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         enabled: false,
@@ -2372,8 +2382,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2398,8 +2408,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2426,8 +2436,8 @@ describe('queryClient', () => {
       const queryFn2 = vi
         .fn<(...args: Array<unknown>) => string>()
         .mockReturnValue('data2')
-      await queryClient.fetchQuery({ queryKey: key1, queryFn: queryFn1 })
-      await queryClient.fetchQuery({ queryKey: key2, queryFn: queryFn2 })
+      await queryClient.query({ queryKey: key1, queryFn: queryFn1 })
+      await queryClient.query({ queryKey: key2, queryFn: queryFn2 })
       const observer = new QueryObserver(queryClient, {
         queryKey: key1,
         queryFn: queryFn1,
@@ -2532,7 +2542,7 @@ describe('queryClient', () => {
     it('should not refetch static queries after invalidation', async () => {
       const key = queryKey()
       const queryFn = vi.fn(() => 'data1')
-      await queryClient.fetchQuery({ queryKey: key, queryFn: queryFn })
+      await queryClient.query({ queryKey: key, queryFn: queryFn })
 
       expect(queryFn).toHaveBeenCalledTimes(1)
 
@@ -2555,7 +2565,9 @@ describe('queryClient', () => {
 
       const callback = vi.fn()
 
-      await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
+      await queryClient
+        .query({ queryKey: key, queryFn: () => 'data' })
+        .catch(noop)
 
       queryCache.subscribe(callback)
 
@@ -2575,7 +2587,9 @@ describe('queryClient', () => {
     it('should reset query', async () => {
       const key = queryKey()
 
-      await queryClient.prefetchQuery({ queryKey: key, queryFn: () => 'data' })
+      await queryClient
+        .query({ queryKey: key, queryFn: () => 'data' })
+        .catch(noop)
 
       let state = queryClient.getQueryState(key)
       expect(state?.data).toEqual('data')
@@ -2593,11 +2607,13 @@ describe('queryClient', () => {
     it('should reset query data to initial data if set', async () => {
       const key = queryKey()
 
-      await queryClient.prefetchQuery({
-        queryKey: key,
-        queryFn: () => 'data',
-        initialData: 'initial',
-      })
+      await queryClient
+        .query({
+          queryKey: key,
+          queryFn: () => 'data',
+          initialData: 'initial',
+        })
+        .catch(noop)
 
       let state = queryClient.getQueryState(key)
       expect(state?.data).toEqual('data')
@@ -2617,7 +2633,7 @@ describe('queryClient', () => {
         .mockResolvedValue('data')
 
       await expect(
-        queryClient.fetchQuery({
+        queryClient.query({
           queryKey: key,
           queryFn,
           retry: false,

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -8,7 +8,13 @@ import {
   vi,
 } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryClient, QueryObserver, focusManager, timeoutManager } from '..'
+import {
+  QueryClient,
+  QueryObserver,
+  focusManager,
+  noop,
+  timeoutManager,
+} from '..'
 import { setIsServer } from './utils'
 import type { QueryObserverResult } from '..'
 
@@ -815,7 +821,7 @@ describe('queryObserver', () => {
       enabled: false,
     })
     const unsubscribe = observer.subscribe(callback)
-    await queryClient.fetchQuery({ queryKey: key, queryFn })
+    await queryClient.query({ queryKey: key, queryFn })
     await vi.advanceTimersByTimeAsync(0)
     unsubscribe()
     expect(queryFn).toHaveBeenCalledTimes(1)
@@ -836,7 +842,7 @@ describe('queryObserver', () => {
       results.push(x)
     })
     observer.setOptions({ queryKey: key, enabled: false, staleTime: 10 })
-    await queryClient.fetchQuery({ queryKey: key, queryFn })
+    await queryClient.query({ queryKey: key, queryFn })
     await vi.advanceTimersByTimeAsync(0)
     unsubscribe()
     expect(queryFn).toHaveBeenCalledTimes(1)
@@ -862,7 +868,7 @@ describe('queryObserver', () => {
     const unsubscribe2 = observer.subscribe((x) => {
       results2.push(x)
     })
-    await queryClient.fetchQuery({ queryKey: key, queryFn })
+    await queryClient.query({ queryKey: key, queryFn })
     await vi.advanceTimersByTimeAsync(0)
     unsubscribe1()
     unsubscribe2()
@@ -1534,10 +1540,12 @@ describe('queryObserver', () => {
   it('should return true from shouldFetchOnWindowFocus when refetchOnWindowFocus is "always" even if the query is fresh', async () => {
     const key = queryKey()
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'data'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'data'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const observer = new QueryObserver(queryClient, {
@@ -1586,10 +1594,12 @@ describe('queryObserver', () => {
     const key = queryKey()
     const refetchOnWindowFocus = vi.fn(() => 'always' as const)
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'data'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'data'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const observer = new QueryObserver(queryClient, {

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -4,6 +4,7 @@ import {
   QueryObserver,
   dehydrate,
   hydrate,
+  noop,
   onlineManager,
 } from '@tanstack/query-core'
 import { fireEvent, render } from '@solidjs/testing-library'
@@ -318,7 +319,7 @@ describe('Devtools', () => {
     })
 
     it('should render a query row when a hydrated query uses a custom hash function', async () => {
-      queryClient.fetchQuery({
+      queryClient.query({
         queryKey: ['posts'],
         queryFn: () => [{ id: 1 }],
         queryKeyHashFn: () => 'custom-posts-hash',
@@ -745,10 +746,12 @@ describe('Devtools', () => {
 
     it('should restore the previous query options when "Restore Loading" is clicked after "Trigger Loading"', async () => {
       const queryFn = vi.fn(() => Promise.resolve('original'))
-      queryClient.prefetchQuery({
-        queryKey: ['action-restore-loading'],
-        queryFn,
-      })
+      void queryClient
+        .query({
+          queryKey: ['action-restore-loading'],
+          queryFn,
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(0)
       expect(queryFn).toHaveBeenCalledTimes(1)
 

--- a/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
+++ b/packages/query-sync-storage-persister/src/__tests__/storageIsFull.test.ts
@@ -4,6 +4,7 @@ import {
   QueryCache,
   QueryClient,
   dehydrate,
+  noop,
 } from '@tanstack/query-core'
 import { removeOldestQuery } from '@tanstack/query-persist-client-core'
 import { sleep } from '@tanstack/query-test-utils'
@@ -52,26 +53,36 @@ describe('create persister', () => {
       storage,
     })
 
-    await queryClient.prefetchQuery({
-      queryKey: ['string'],
-      queryFn: () => Promise.resolve('string'),
-    })
-    await queryClient.prefetchQuery({
-      queryKey: ['number'],
-      queryFn: () => Promise.resolve(1),
-    })
-    await queryClient.prefetchQuery({
-      queryKey: ['boolean'],
-      queryFn: () => Promise.resolve(true),
-    })
-    await queryClient.prefetchQuery({
-      queryKey: ['null'],
-      queryFn: () => Promise.resolve(null),
-    })
-    await queryClient.prefetchQuery({
-      queryKey: ['array'],
-      queryFn: () => Promise.resolve(['string', 0]),
-    })
+    await queryClient
+      .query({
+        queryKey: ['string'],
+        queryFn: () => Promise.resolve('string'),
+      })
+      .catch(noop)
+    await queryClient
+      .query({
+        queryKey: ['number'],
+        queryFn: () => Promise.resolve(1),
+      })
+      .catch(noop)
+    await queryClient
+      .query({
+        queryKey: ['boolean'],
+        queryFn: () => Promise.resolve(true),
+      })
+      .catch(noop)
+    await queryClient
+      .query({
+        queryKey: ['null'],
+        queryFn: () => Promise.resolve(null),
+      })
+      .catch(noop)
+    await queryClient
+      .query({
+        queryKey: ['array'],
+        queryFn: () => Promise.resolve(['string', 0]),
+      })
+      .catch(noop)
 
     const persistClient = {
       buster: 'test-buster',
@@ -97,31 +108,41 @@ describe('create persister', () => {
       retry: removeOldestQuery,
     })
 
-    await queryClient.prefetchQuery({
-      queryKey: ['A'],
-      queryFn: () => Promise.resolve('A'.repeat(N)),
-    })
+    await queryClient
+      .query({
+        queryKey: ['A'],
+        queryFn: () => Promise.resolve('A'.repeat(N)),
+      })
+      .catch(noop)
     await sleep(1)
-    await queryClient.prefetchQuery({
-      queryKey: ['B'],
-      queryFn: () => Promise.resolve('B'.repeat(N)),
-    })
+    await queryClient
+      .query({
+        queryKey: ['B'],
+        queryFn: () => Promise.resolve('B'.repeat(N)),
+      })
+      .catch(noop)
     await sleep(1)
-    await queryClient.prefetchQuery({
-      queryKey: ['C'],
-      queryFn: () => Promise.resolve('C'.repeat(N)),
-    })
+    await queryClient
+      .query({
+        queryKey: ['C'],
+        queryFn: () => Promise.resolve('C'.repeat(N)),
+      })
+      .catch(noop)
     await sleep(1)
-    await queryClient.prefetchQuery({
-      queryKey: ['D'],
-      queryFn: () => Promise.resolve('D'.repeat(N)),
-    })
+    await queryClient
+      .query({
+        queryKey: ['D'],
+        queryFn: () => Promise.resolve('D'.repeat(N)),
+      })
+      .catch(noop)
 
     await sleep(1)
-    await queryClient.prefetchQuery({
-      queryKey: ['E'],
-      queryFn: () => Promise.resolve('E'.repeat(N)),
-    })
+    await queryClient
+      .query({
+        queryKey: ['E'],
+        queryFn: () => Promise.resolve('E'.repeat(N)),
+      })
+      .catch(noop)
 
     const persistClient = {
       buster: 'test-limit',
@@ -140,10 +161,12 @@ describe('create persister', () => {
     ).not.toBeUndefined()
 
     // update query Data
-    await queryClient.prefetchQuery({
-      queryKey: ['A'],
-      queryFn: () => Promise.resolve('a'.repeat(N)),
-    })
+    await queryClient
+      .query({
+        queryKey: ['A'],
+        queryFn: () => Promise.resolve('a'.repeat(N)),
+      })
+      .catch(noop)
     const updatedPersistClient = {
       buster: 'test-limit',
       timestamp: Date.now(),
@@ -173,10 +196,12 @@ describe('create persister', () => {
       retry: removeOldestQuery,
     })
 
-    await queryClient.prefetchQuery({
-      queryKey: ['A'],
-      queryFn: () => Promise.resolve('A'.repeat(N)),
-    })
+    await queryClient
+      .query({
+        queryKey: ['A'],
+        queryFn: () => Promise.resolve('A'.repeat(N)),
+      })
+      .catch(noop)
     await sleep(1)
 
     const persistClient = {

--- a/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
-import { QueryClient, useQueries, useQuery } from '@tanstack/react-query'
+import { QueryClient, noop, useQueries, useQuery } from '@tanstack/react-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { PersistQueryClientProvider } from '../PersistQueryClientProvider'
@@ -63,10 +63,12 @@ describe('PersistQueryClientProvider', () => {
     const states: Array<UseQueryResult<string>> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -138,10 +140,12 @@ describe('PersistQueryClientProvider', () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -206,10 +210,12 @@ describe('PersistQueryClientProvider', () => {
     const states: Array<UseQueryResult> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -286,10 +292,12 @@ describe('PersistQueryClientProvider', () => {
     const states: Array<DefinedUseQueryResult<string>> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -366,10 +374,12 @@ describe('PersistQueryClientProvider', () => {
     const states: Array<UseQueryResult<string>> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -438,10 +448,12 @@ describe('PersistQueryClientProvider', () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -490,10 +502,12 @@ describe('PersistQueryClientProvider', () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -609,10 +623,12 @@ describe('PersistQueryClientProvider', () => {
     const states: Array<UseQueryResult> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -745,10 +761,12 @@ describe('PersistQueryClientProvider', () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createPersister()

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -8,6 +8,7 @@ import {
   QueryClient,
   QueryClientProvider,
   dehydrate,
+  noop,
   useQuery,
 } from '..'
 import type { hydrate } from '@tanstack/query-core'
@@ -18,10 +19,12 @@ describe('React hydration', () => {
   beforeEach(async () => {
     vi.useFakeTimers()
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: ['string'],
-      queryFn: () => sleep(10).then(() => ['stringCached']),
-    })
+    void queryClient
+      .query({
+        queryKey: ['string'],
+        queryFn: () => sleep(10).then(() => ['stringCached']),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     const dehydrated = dehydrate(queryClient)
     stringifiedState = JSON.stringify(dehydrated)
@@ -128,14 +131,18 @@ describe('React hydration', () => {
 
       const intermediateClient = new QueryClient()
 
-      intermediateClient.prefetchQuery({
-        queryKey: ['string'],
-        queryFn: () => sleep(20).then(() => ['should change']),
-      })
-      intermediateClient.prefetchQuery({
-        queryKey: ['added'],
-        queryFn: () => sleep(20).then(() => ['added']),
-      })
+      void intermediateClient
+        .query({
+          queryKey: ['string'],
+          queryFn: () => sleep(20).then(() => ['should change']),
+        })
+        .catch(noop)
+      void intermediateClient
+        .query({
+          queryKey: ['added'],
+          queryFn: () => sleep(20).then(() => ['added']),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(20)
       const dehydrated = dehydrate(intermediateClient)
       intermediateClient.clear()
@@ -198,14 +205,18 @@ describe('React hydration', () => {
       expect(rendered.getByText('string')).toBeInTheDocument()
 
       const intermediateClient = new QueryClient()
-      intermediateClient.prefetchQuery({
-        queryKey: ['string'],
-        queryFn: () => sleep(20).then(() => ['should not change']),
-      })
-      intermediateClient.prefetchQuery({
-        queryKey: ['added'],
-        queryFn: () => sleep(20).then(() => ['added']),
-      })
+      void intermediateClient
+        .query({
+          queryKey: ['string'],
+          queryFn: () => sleep(20).then(() => ['should not change']),
+        })
+        .catch(noop)
+      void intermediateClient
+        .query({
+          queryKey: ['added'],
+          queryFn: () => sleep(20).then(() => ['added']),
+        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(20)
 
       const newDehydratedState = dehydrate(intermediateClient)
@@ -427,10 +438,12 @@ describe('React hydration', () => {
     // For the bug to trigger, there needs to already be a query in the cache,
     // with a dataUpdatedAt earlier than the dehydratedAt of the next query
     const clientQueryClient = new QueryClient()
-    clientQueryClient.prefetchQuery({
-      queryKey: ['promise'],
-      queryFn: () => sleep(20).then(() => 'existing'),
-    })
+    void clientQueryClient
+      .query({
+        queryKey: ['promise'],
+        queryFn: () => sleep(20).then(() => 'existing'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(20)
 
     const prefetchQueryClient = new QueryClient({
@@ -440,11 +453,13 @@ describe('React hydration', () => {
         },
       },
     })
-    prefetchQueryClient.prefetchQuery({
-      queryKey: ['promise'],
-      queryFn: () =>
-        sleep(10).then(() => Promise.reject(new Error('Query failed'))),
-    })
+    void prefetchQueryClient
+      .query({
+        queryKey: ['promise'],
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Query failed'))),
+      })
+      .catch(noop)
 
     const dehydratedState = dehydrate(prefetchQueryClient)
 

--- a/packages/react-query/src/__tests__/ssr-hydration.test.tsx
+++ b/packages/react-query/src/__tests__/ssr-hydration.test.tsx
@@ -9,6 +9,7 @@ import {
   QueryClientProvider,
   dehydrate,
   hydrate,
+  noop,
   useQuery,
 } from '..'
 import { setIsServer } from './utils'
@@ -71,10 +72,12 @@ describe('Server side rendering with de/rehydration', () => {
     const prefetchClient = new QueryClient({
       queryCache: prefetchCache,
     })
-    await prefetchClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => fetchDataSuccess('success'),
-    })
+    await prefetchClient
+      .query({
+        queryKey: key,
+        queryFn: () => fetchDataSuccess('success'),
+      })
+      .catch(noop)
     const dehydratedStateServer = dehydrate(prefetchClient)
     const renderCache = new QueryCache()
     const renderClient = new QueryClient({
@@ -149,10 +152,12 @@ describe('Server side rendering with de/rehydration', () => {
     const prefetchClient = new QueryClient({
       queryCache: prefetchCache,
     })
-    await prefetchClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => fetchDataError(),
-    })
+    await prefetchClient
+      .query({
+        queryKey: key,
+        queryFn: () => fetchDataError(),
+      })
+      .catch(noop)
     const dehydratedStateServer = dehydrate(prefetchClient)
     const renderCache = new QueryCache()
     const renderClient = new QueryClient({

--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -6,6 +6,7 @@ import {
   QueryCache,
   QueryClient,
   QueryClientProvider,
+  noop,
   useInfiniteQuery,
   useIsFetching,
   useMutation,
@@ -61,7 +62,7 @@ describe('Server Side Rendering', () => {
   it('should add prefetched data to cache', async () => {
     const key = queryKey()
 
-    const promise = queryClient.fetchQuery({
+    const promise = queryClient.query({
       queryKey: key,
       queryFn: () => sleep(10).then(() => 'data'),
     })
@@ -89,7 +90,7 @@ describe('Server Side Rendering', () => {
       )
     }
 
-    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    void queryClient.query({ queryKey: key, queryFn }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const markup = renderToString(
@@ -185,7 +186,7 @@ describe('Server Side Rendering', () => {
       )
     }
 
-    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    void queryClient.query({ queryKey: key, queryFn }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const markup = renderToString(
@@ -222,8 +223,8 @@ describe('Server Side Rendering', () => {
       )
     }
 
-    queryClient.prefetchQuery({ queryKey: key1, queryFn: queryFn1 })
-    queryClient.prefetchQuery({ queryKey: key2, queryFn: queryFn2 })
+    void queryClient.query({ queryKey: key1, queryFn: queryFn1 }).catch(noop)
+    void queryClient.query({ queryKey: key2, queryFn: queryFn2 }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const markup = renderToString(

--- a/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchQuery.test.tsx
@@ -6,6 +6,7 @@ import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   QueryCache,
   QueryClient,
+  noop,
   usePrefetchQuery,
   useQueryErrorResetBoundary,
   useSuspenseQuery,
@@ -85,7 +86,7 @@ describe('usePrefetchQuery', () => {
       )
     }
 
-    queryClient.fetchQuery(queryOpts)
+    queryClient.query(queryOpts)
     await vi.advanceTimersByTimeAsync(10)
     queryOpts.queryFn.mockClear()
     const rendered = renderWithClient(queryClient, <App />)
@@ -130,7 +131,7 @@ describe('usePrefetchQuery', () => {
       )
     }
 
-    queryClient.prefetchQuery(queryOpts)
+    void queryClient.query(queryOpts).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     queryFn.mockClear()
     const rendered = renderWithClient(queryClient, <App />)
@@ -220,7 +221,7 @@ describe('usePrefetchQuery', () => {
       )
     }
 
-    queryClient.prefetchQuery(queryOpts)
+    void queryClient.query(queryOpts).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     queryFn.mockClear()
 

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -14,6 +14,7 @@ import {
   dehydrate,
   hydrate,
   keepPreviousData,
+  noop,
   skipToken,
   useQuery,
 } from '..'
@@ -274,10 +275,12 @@ describe('useQuery', () => {
   it('should set isFetchedAfterMount to true after a query has been fetched', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     function Page() {
       const result = useQuery({ queryKey: key, queryFn: () => 'new data' })
@@ -1837,10 +1840,12 @@ describe('useQuery', () => {
     const states1: Array<UseQueryResult<string>> = []
     const states2: Array<UseQueryResult<string>> = []
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetch'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetch'),
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(20)
 
@@ -2636,10 +2641,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     function Page() {
       const state = useQuery({
@@ -2673,10 +2680,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(0)
 
@@ -3023,10 +3032,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     function Page() {
       const state = useQuery({
@@ -3537,11 +3548,13 @@ describe('useQuery', () => {
     const prefetchQueryFn = vi.fn<(...args: Array<unknown>) => string>()
     prefetchQueryFn.mockImplementation(() => 'not yet...')
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: prefetchQueryFn,
-      staleTime: 10,
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: prefetchQueryFn,
+        staleTime: 10,
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(10)
 
@@ -3570,11 +3583,13 @@ describe('useQuery', () => {
       vi.fn<(...args: Array<unknown>) => Promise<string>>()
     prefetchQueryFn.mockImplementation(() => sleep(10).then(() => 'not yet...'))
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: prefetchQueryFn,
-      staleTime: 1000,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: prefetchQueryFn,
+        staleTime: 1000,
+      })
+      .catch(noop)
 
     await vi.advanceTimersByTimeAsync(0)
 
@@ -3651,10 +3666,12 @@ describe('useQuery', () => {
 
       React.useEffect(() => {
         async function prefetch() {
-          await queryClient.prefetchQuery({
-            queryKey: key,
-            queryFn: () => Promise.resolve('prefetched data'),
-          })
+          await queryClient
+            .query({
+              queryKey: key,
+              queryFn: () => Promise.resolve('prefetched data'),
+            })
+            .catch(noop)
           act(() => setPrefetched(true))
         }
 
@@ -6045,7 +6062,7 @@ describe('useQuery', () => {
       return <></>
     }
 
-    await queryClient.prefetchQuery({ queryKey: key, queryFn })
+    await queryClient.query({ queryKey: key, queryFn }).catch(noop)
     renderWithClient(queryClient, <Page />)
 
     await vi.advanceTimersByTimeAsync(0)
@@ -6631,10 +6648,12 @@ describe('useQuery', () => {
       defaultOptions: { dehydrate: { shouldDehydrateQuery: () => true } },
     })
 
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => Promise.resolve('server')),
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => Promise.resolve('server')),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 
@@ -6686,11 +6705,13 @@ describe('useQuery', () => {
       },
     })
 
-    void serverQueryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () =>
-        sleep(10).then(() => Promise.reject(new Error('server error'))),
-    })
+    void serverQueryClient
+      .query({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('server error'))),
+      })
+      .catch(noop)
 
     const dehydrated = dehydrate(serverQueryClient)
 

--- a/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
+++ b/packages/solid-query-persist-client/src/__tests__/PersistQueryClientProvider.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@solidjs/testing-library'
-import { QueryClient, useQueries, useQuery } from '@tanstack/solid-query'
+import { QueryClient, noop, useQueries, useQuery } from '@tanstack/solid-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
 import { createEffect, createSignal, onMount } from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
@@ -63,10 +63,12 @@ describe('PersistQueryClientProvider', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -142,10 +144,12 @@ describe('PersistQueryClientProvider', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -226,10 +230,12 @@ describe('PersistQueryClientProvider', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -310,10 +316,12 @@ describe('PersistQueryClientProvider', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -388,10 +396,12 @@ describe('PersistQueryClientProvider', () => {
     const key = queryKey()
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -494,10 +504,12 @@ describe('PersistQueryClientProvider', () => {
     }> = []
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()

--- a/packages/solid-query/src/__tests__/useIsFetching.test.tsx
+++ b/packages/solid-query/src/__tests__/useIsFetching.test.tsx
@@ -265,7 +265,7 @@ describe('useIsFetching', () => {
 
     const rendered = render(() => <Page />)
 
-    const firstQuery = queryClient1.fetchQuery({
+    const firstQuery = queryClient1.query({
       queryKey: key1,
       queryFn: () => sleep(20).then(() => 'test1'),
     })
@@ -277,7 +277,7 @@ describe('useIsFetching', () => {
     expect(unsubscribe1).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('isFetching: 0')).toBeInTheDocument()
 
-    const secondQuery = queryClient2.fetchQuery({
+    const secondQuery = queryClient2.query({
       queryKey: key2,
       queryFn: () => sleep(20).then(() => 'test2'),
     })

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -29,6 +29,7 @@ import {
   QueryCache,
   QueryClient,
   keepPreviousData,
+  noop,
   useQuery,
 } from '..'
 import {
@@ -302,10 +303,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetched'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetched'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     function Page() {
@@ -1472,10 +1475,12 @@ describe('useQuery', () => {
     const states1: Array<UseQueryResult<string>> = []
     const states2: Array<UseQueryResult<string>> = []
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetch'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetch'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(20)
 
     function FirstComponent() {
@@ -1994,10 +1999,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetched'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetched'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     function Page() {
@@ -2034,10 +2041,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetched'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetched'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     function Page() {
@@ -2485,10 +2494,12 @@ describe('useQuery', () => {
     const key = queryKey()
     const states: Array<UseQueryResult<string>> = []
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetched'),
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetched'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     function Page() {
@@ -3043,11 +3054,13 @@ describe('useQuery', () => {
     const prefetchQueryFn = vi.fn<(...args: Array<unknown>) => string>()
     prefetchQueryFn.mockImplementation(() => 'not yet...')
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: prefetchQueryFn,
-      staleTime: 10,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: prefetchQueryFn,
+        staleTime: 10,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     function Page() {
@@ -3078,11 +3091,13 @@ describe('useQuery', () => {
       vi.fn<(...args: Array<unknown>) => Promise<string>>()
     prefetchQueryFn.mockImplementation(() => sleep(10).then(() => 'not yet...'))
 
-    queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: prefetchQueryFn,
-      staleTime: 1000,
-    })
+    void queryClient
+      .query({
+        queryKey: key,
+        queryFn: prefetchQueryFn,
+        staleTime: 1000,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     function Page() {
@@ -3167,10 +3182,12 @@ describe('useQuery', () => {
 
       createEffect(() => {
         async function prefetch() {
-          await queryClient.prefetchQuery({
-            queryKey: key,
-            queryFn: () => Promise.resolve('prefetched data'),
-          })
+          await queryClient
+            .query({
+              queryKey: key,
+              queryFn: () => Promise.resolve('prefetched data'),
+            })
+            .catch(noop)
           setPrefetched(true)
         }
         prefetch()
@@ -5563,7 +5580,7 @@ describe('useQuery', () => {
       return <></>
     }
 
-    queryClient.prefetchQuery({ queryKey: key, queryFn })
+    void queryClient.query({ queryKey: key, queryFn }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     renderWithClient(queryClient, () => <Page />)

--- a/packages/svelte-query-persist-client/tests/PersistQueryClientProvider.svelte.test.ts
+++ b/packages/svelte-query-persist-client/tests/PersistQueryClientProvider.svelte.test.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/svelte'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { QueryClient } from '@tanstack/svelte-query'
+import { QueryClient, noop } from '@tanstack/svelte-query'
 import { persistQueryClientSave } from '@tanstack/query-persist-client-core'
 import { sleep } from '@tanstack/query-test-utils'
 import AwaitOnSuccess from './AwaitOnSuccess/Provider.svelte'
@@ -64,10 +64,12 @@ describe('PersistQueryClientProvider', () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: ['test'],
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: ['test'],
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -116,10 +118,12 @@ describe('PersistQueryClientProvider', () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: ['test'],
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: ['test'],
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -168,10 +172,12 @@ describe('PersistQueryClientProvider', () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: ['test'],
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: ['test'],
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -220,10 +226,12 @@ describe('PersistQueryClientProvider', () => {
     const states = new StatelessRef<Array<StatusResult<string>>>([])
 
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: ['test'],
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: ['test'],
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -271,10 +279,12 @@ describe('PersistQueryClientProvider', () => {
 
   it('should call onSuccess after successful restoring', async () => {
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: ['test'],
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: ['test'],
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()
@@ -304,10 +314,12 @@ describe('PersistQueryClientProvider', () => {
 
   it('should await onSuccess after successful restoring', async () => {
     const queryClient = new QueryClient()
-    queryClient.prefetchQuery({
-      queryKey: ['test'],
-      queryFn: () => sleep(10).then(() => 'hydrated'),
-    })
+    void queryClient
+      .query({
+        queryKey: ['test'],
+        queryFn: () => sleep(10).then(() => 'hydrated'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const persister = createMockPersister()

--- a/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
+++ b/packages/svelte-query/tests/HydrationBoundary/HydrationBoundary.svelte.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/svelte'
-import { QueryClient, dehydrate } from '@tanstack/query-core'
+import { QueryClient, dehydrate, noop } from '@tanstack/query-core'
 import { sleep } from '@tanstack/query-test-utils'
 import Base from './Base.svelte'
 
@@ -12,10 +12,12 @@ describe('HydrationBoundary', () => {
     vi.useFakeTimers()
     queryClient = new QueryClient()
     const dehydrateClient = new QueryClient()
-    dehydrateClient.prefetchQuery({
-      queryKey: ['string'],
-      queryFn: () => sleep(10).then(() => 'stringCached'),
-    })
+    void dehydrateClient
+      .query({
+        queryKey: ['string'],
+        queryFn: () => sleep(10).then(() => 'stringCached'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     const dehydrated = dehydrate(dehydrateClient)
     stringifiedState = JSON.stringify(dehydrated)

--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -10,7 +10,12 @@ import {
   vi,
 } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryClient, createQuery, keepPreviousData } from '../../src/index.js'
+import {
+  QueryClient,
+  createQuery,
+  keepPreviousData,
+  noop,
+} from '../../src/index.js'
 import { promiseWithResolvers, withEffectRoot } from '../utils.svelte.js'
 import Base from './Base.svelte'
 import Counter from './Counter.svelte'
@@ -232,10 +237,12 @@ describe('createQuery', () => {
   it('should set isFetchedAfterMount to true after a query has been fetched', async () => {
     const key = queryKey()
 
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => Promise.resolve('prefetched'),
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => Promise.resolve('prefetched'),
+      })
+      .catch(noop)
 
     const { promise, resolve } = promiseWithResolvers<string>()
 
@@ -1072,10 +1079,12 @@ describe('createQuery', () => {
     const key = queryKey()
 
     // Prefetch the query
-    const prefetchPromise = queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => sleep(10).then(() => 'prefetch'),
-    })
+    const prefetchPromise = queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => sleep(10).then(() => 'prefetch'),
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1474,10 +1483,12 @@ describe('createQuery', () => {
     const key = queryKey()
 
     // Prefetch the query
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     const rendered = render(Base, {
       props: {
@@ -1507,10 +1518,12 @@ describe('createQuery', () => {
     const key = queryKey()
 
     // Prefetch the query
-    await queryClient.prefetchQuery({
-      queryKey: key,
-      queryFn: () => 'prefetched',
-    })
+    await queryClient
+      .query({
+        queryKey: key,
+        queryFn: () => 'prefetched',
+      })
+      .catch(noop)
 
     const rendered = render(Base, {
       props: {


### PR DESCRIPTION
## 🎯 Changes

Tests that used the deprecated `prefetchQuery`/`fetchQuery`/`ensureQueryData` methods (That did not directly test the deprecated methods themselves) refactored to use `query`.

This applies to where the imperative call is a side effect of the test itself. We still have the tests that test the methods directly, all of which already have equivalents for the new methods.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated query, hydration, persistence, SSR, and devtools test coverage to use the unified query execution behavior.
  * Added explicit handling for expected query failures, preventing unhandled promise rejections during test runs.
  * Preserved existing test scenarios, assertions, and asynchronous behavior across supported frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->