### PR TITLE
docs(preact-query): remove hover-prefetch example from 'useQuery'/'useInfiniteQuery'

### DIFF
--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -263,7 +263,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:390](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L390)
+Defined in: [preact-query/src/useInfiniteQuery.ts:344](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L344)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -412,51 +412,6 @@ function Projects() {
       </ul>
       <div ref={sentinelRef}>{isFetchingNextPage ? 'Loading more...' : null}</div>
     </>
-  )
-}
-```
-
-Warming the cache on hover, so `<Comments>` has data as soon as it's clicked. Requires an
-[infiniteQueryOptions](infiniteQueryOptions.md) factory, so the hook and the imperative call share the same cache entry:
-```tsx
-import {
-  infiniteQueryOptions,
-  noop,
-  useInfiniteQuery,
-  useQueryClient,
-} from '@tanstack/preact-query'
-
-const commentsOptions = (postId: string) =>
-  infiniteQueryOptions({
-    queryKey: ['post', postId, 'comments'],
-    queryFn: ({ pageParam }) => fetchComments(postId, pageParam),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => lastPage.nextId,
-  })
-
-function Comments({ postId }: { postId: string }) {
-  const { data, isPending, isError, error } = useInfiniteQuery(commentsOptions(postId))
-
-  if (isPending) return 'Loading...'
-  if (isError) return <span>Error: {error.message}</span>
-
-  return (
-    <ul>
-      {data.pages.map((page) => page.comments.map((c) => <li key={c.id}>{c.text}</li>))}
-    </ul>
-  )
-}
-
-function PostLink({ postId, title }: { postId: string; title: string }) {
-  const queryClient = useQueryClient()
-
-  return (
-    <a
-      href={`/posts/${postId}`}
-      onMouseEnter={() => queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)}
-    >
-      {title}
-    </a>
   )
 }
 ```

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -190,7 +190,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:293](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L293)
+Defined in: [preact-query/src/useQuery.ts:261](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L261)
 
 ### Type Parameters
 
@@ -355,37 +355,6 @@ function Posts() {
         Next Page
       </button>
     </div>
-  )
-}
-```
-
-Warming the cache on hover, so `<Post>` has data as soon as it's clicked. Requires a
-[queryOptions](queryOptions.md) factory, so the hook and the imperative call share the same cache entry:
-```tsx
-import { noop, queryOptions, useQuery, useQueryClient } from '@tanstack/preact-query'
-
-const postOptions = (id: string) =>
-  queryOptions({
-    queryKey: ['post', id],
-    queryFn: () => fetchPost(id),
-  })
-
-function Post({ id }: { id: string }) {
-  const { data, isError, error } = useQuery(postOptions(id))
-  if (isError) return <span>Error: {error.message}</span>
-  return <h1>{data?.title}</h1>
-}
-
-function PostLink({ id, title }: { id: string; title: string }) {
-  const queryClient = useQueryClient()
-
-  return (
-    <a
-      href={`/posts/${id}`}
-      onMouseEnter={() => queryClient.query(postOptions(id)).catch(noop)}
-    >
-      {title}
-    </a>
   )
 }
 ```

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -312,52 +312,6 @@ export function useInfiniteQuery<
  * ```
  *
  * @example
- * Warming the cache on hover, so `<Comments>` has data as soon as it's clicked. Requires an
- * {@link infiniteQueryOptions} factory, so the hook and the imperative call share the same cache entry:
- * ```tsx
- * import {
- *   infiniteQueryOptions,
- *   noop,
- *   useInfiniteQuery,
- *   useQueryClient,
- * } from '@tanstack/preact-query'
- *
- * const commentsOptions = (postId: string) =>
- *   infiniteQueryOptions({
- *     queryKey: ['post', postId, 'comments'],
- *     queryFn: ({ pageParam }) => fetchComments(postId, pageParam),
- *     initialPageParam: 0,
- *     getNextPageParam: (lastPage) => lastPage.nextId,
- *   })
- *
- * function Comments({ postId }: { postId: string }) {
- *   const { data, isPending, isError, error } = useInfiniteQuery(commentsOptions(postId))
- *
- *   if (isPending) return 'Loading...'
- *   if (isError) return <span>Error: {error.message}</span>
- *
- *   return (
- *     <ul>
- *       {data.pages.map((page) => page.comments.map((c) => <li key={c.id}>{c.text}</li>))}
- *     </ul>
- *   )
- * }
- *
- * function PostLink({ postId, title }: { postId: string; title: string }) {
- *   const queryClient = useQueryClient()
- *
- *   return (
- *     <a
- *       href={`/posts/${postId}`}
- *       onMouseEnter={() => queryClient.infiniteQuery(commentsOptions(postId)).catch(noop)}
- *     >
- *       {title}
- *     </a>
- *   )
- * }
- * ```
- *
- * @example
  * A query that's disabled, type safe, until `postId` is set — pass `skipToken` as `queryFn`
  * instead of setting `enabled: false`:
  * ```tsx

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -257,38 +257,6 @@ export function useQuery<
  *   )
  * }
  * ```
- *
- * @example
- * Warming the cache on hover, so `<Post>` has data as soon as it's clicked. Requires a
- * {@link queryOptions} factory, so the hook and the imperative call share the same cache entry:
- * ```tsx
- * import { noop, queryOptions, useQuery, useQueryClient } from '@tanstack/preact-query'
- *
- * const postOptions = (id: string) =>
- *   queryOptions({
- *     queryKey: ['post', id],
- *     queryFn: () => fetchPost(id),
- *   })
- *
- * function Post({ id }: { id: string }) {
- *   const { data, isError, error } = useQuery(postOptions(id))
- *   if (isError) return <span>Error: {error.message}</span>
- *   return <h1>{data?.title}</h1>
- * }
- *
- * function PostLink({ id, title }: { id: string; title: string }) {
- *   const queryClient = useQueryClient()
- *
- *   return (
- *     <a
- *       href={`/posts/${id}`}
- *       onMouseEnter={() => queryClient.query(postOptions(id)).catch(noop)}
- *     >
- *       {title}
- *     </a>
- *   )
- * }
- * ```
  */
 export function useQuery<
   TQueryFnData = unknown,


### PR DESCRIPTION
## 🎯 Changes

`useQuery` and `useInfiniteQuery` each had a hover-prefetch `@example` (`Warming the cache on hover, so <Post>/<Comments> has data as soon as it's clicked`) where the hook itself was used in one line, while the rest of the example (`PostLink`, `useQueryClient`, `queryClient.query`/`queryClient.infiniteQuery`) demonstrated a different, imperative API rather than the hook the example is documenting.

The cache-sharing fact these examples existed to convey is already stated by the `@see {@link queryOptions}` / `@see {@link infiniteQueryOptions}` lines already present on every overload of both hooks.

- `useQuery.ts`: removed the hover-prefetch example (the overload it was on keeps its other example)
- `useInfiniteQuery.ts`: same (the overload it was on keeps its other 3 examples)
- Regenerated the corresponding `docs/framework/preact/reference/functions/*.md` files with `pnpm run generate-docs`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated source references for the Preact `useQuery` and `useInfiniteQuery` API documentation.
  * Removed outdated cache-warming and hover-prefetching examples from both hook references.
  * Retained the relevant usage guidance, including the existing `skipToken` example.
  * No runtime behavior or public API changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->