### PR TITLE
fix(query-core): stop leaking silent CancelledError when a fetch is removed/reset

### DIFF
--- a/.changeset/silent-cancels-leak.md
+++ b/.changeset/silent-cancels-leak.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Fix `Query.fetch()` rejecting with an internal, silent `CancelledError` when `removeQueries`/`resetQueries`/`clear()` cancels an in-flight fetch without starting a replacement one. It now resolves with the last known data instead, matching the behavior already used for `cancelRefetch`.

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -1130,6 +1130,53 @@ describe('query', () => {
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
 
+  it('should not reject a promise when removeQueries silently cancels an in-flight fetch and stale data exists', async () => {
+    const key = queryKey()
+
+    queryClient.setQueryData(key, 'initial')
+    const queryFn = vi
+      .fn()
+      .mockImplementation(() => sleep(100).then(() => 'new data'))
+
+    const promise = queryClient.fetchQuery({
+      queryKey: key,
+      queryFn,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+
+    // remove the query while the fetch above is still in flight; this does
+    // not start a replacement fetch, unlike refetchQueries({ cancelRefetch: true })
+    queryClient.removeQueries({ queryKey: key })
+
+    // the promise should resolve with the last known data instead of
+    // rejecting with an internal, silent CancelledError
+    await expect(promise).resolves.toBe('initial')
+  })
+
+  it('should reject a promise when removeQueries silently cancels an in-flight fetch and no data exists yet', async () => {
+    const key = queryKey()
+
+    const queryFn = vi
+      .fn()
+      .mockImplementation(() => sleep(100).then(() => 'data'))
+
+    const promise = queryClient.fetchQuery({
+      queryKey: key,
+      queryFn,
+    })
+    // swallow the expected rejection so it doesn't surface as an unhandled rejection
+    promise.catch(() => undefined)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+
+    queryClient.removeQueries({ queryKey: key })
+
+    await expect(promise).rejects.toBeInstanceOf(CancelledError)
+  })
+
   it('should have an error log when queryFn data is not serializable', async () => {
     const consoleMock = vi.spyOn(console, 'error')
 

--- a/packages/query-core/src/__tests__/query.test.tsx
+++ b/packages/query-core/src/__tests__/query.test.tsx
@@ -1177,6 +1177,30 @@ describe('query', () => {
     await expect(promise).rejects.toBeInstanceOf(CancelledError)
   })
 
+  it('should not reject a promise when resetQueries silently cancels an in-flight fetch and cached data exists (no initialData)', async () => {
+    const key = queryKey()
+
+    queryClient.setQueryData(key, 'initial')
+    const queryFn = vi
+      .fn()
+      .mockImplementation(() => sleep(100).then(() => 'new data'))
+
+    const promise = queryClient.fetchQuery({
+      queryKey: key,
+      queryFn,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+
+    // resetQueries destroys the query (silent cancel) and then immediately
+    // overwrites state with the query's initial state, so `this.state.data`
+    // alone is no longer enough to recover the last known data here.
+    queryClient.resetQueries({ queryKey: key })
+
+    await expect(promise).resolves.toBe('initial')
+  })
+
   it('should have an error log when queryFn data is not serializable', async () => {
     const consoleMock = vi.spyOn(console, 'error')
 

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -585,9 +585,18 @@ export class Query<
     } catch (error) {
       if (error instanceof CancelledError) {
         if (error.silent) {
-          // silent cancellation implies a new fetch is going to be started,
-          // so we piggyback onto that promise
-          return this.#retryer.promise
+          // silent cancellation usually implies a new fetch is going to be
+          // started, so we piggyback onto that promise
+          if (this.#retryer !== retryer) {
+            return this.#retryer.promise
+          }
+          // no replacement fetch was started (e.g. the query was removed or
+          // reset while fetching), so fall back to existing data instead of
+          // leaking this internal cancellation to the caller
+          if (this.state.data !== undefined) {
+            return this.state.data
+          }
+          throw error
         } else if (error.revert) {
           // transform error into reverted state data
           // if the initial fetch was cancelled, we have no data, so we have

--- a/packages/query-core/src/query.ts
+++ b/packages/query-core/src/query.ts
@@ -592,9 +592,13 @@ export class Query<
           }
           // no replacement fetch was started (e.g. the query was removed or
           // reset while fetching), so fall back to existing data instead of
-          // leaking this internal cancellation to the caller
-          if (this.state.data !== undefined) {
-            return this.state.data
+          // leaking this internal cancellation to the caller. `reset()` may
+          // have already overwritten `this.state` with the initial state by
+          // the time we get here, so also fall back to the state captured
+          // just before this fetch started.
+          const data = this.state.data ?? this.#revertState.data
+          if (data !== undefined) {
+            return data
           }
           throw error
         } else if (error.revert) {


### PR DESCRIPTION
## 🎯 Changes

`Query.fetch()`'s silent-cancellation handling assumed that whenever a fetch is cancelled with `{ silent: true }`, a replacement fetch is always about to start, so it piggybacks on `this.#retryer.promise` to get that replacement's result.

That assumption holds for the `cancelRefetch` path (a new retryer is created right after the cancel), but `Query.destroy()` also cancels silently (`this.cancel({ silent: true })`), and it is called by `removeQueries`, `resetQueries`, and `clear()` — none of which start a replacement fetch. In that case `this.#retryer` still points at the very same, already-rejected retryer, so `fetch()` ends up rejecting with the raw internal `CancelledError` instead of behaving like a normal cancellation. This surfaces directly through `fetchQuery`/`query()`/`ensureQueryData` and through `suspense`/`throwOnError` consumers if a concurrent `removeQueries`/`resetQueries`/`clear()` call races an in-flight fetch.

The fix only piggybacks on `this.#retryer.promise` when a *different* retryer was actually assigned (i.e. a replacement fetch really started). Otherwise it falls back to the existing data — mirroring what the neighboring `revert` branch already does — or rethrows if there's no data to fall back on.

Added two regression tests in `query.test.tsx` covering both cases (existing data vs. no data yet), and verified against the pre-fix code that the first test fails with the raw `CancelledError` as described above.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canceled fetches now resolve with the latest available data when queries are removed, reset, or cleared during an in-flight request.
  * Fetches without previously available data continue to report the cancellation error.
* **Tests**
  * Added coverage for silent cancellation scenarios and stale-data handling.
* **Release**
  * Included in a patch release of the query core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->