### PR TITLE
docs(preact-query): add 'select' example to 'useQuery'

### DIFF
--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -190,7 +190,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:261](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L261)
+Defined in: [preact-query/src/useQuery.ts:285](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L285)
 
 ### Type Parameters
 
@@ -355,6 +355,29 @@ function Posts() {
         Next Page
       </button>
     </div>
+  )
+}
+```
+
+`select` shapes the returned `data` without changing what's stored in the cache — the cache still
+holds the full `Post[]`:
+```tsx
+import { useQuery } from '@tanstack/preact-query'
+
+function PostTitles() {
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+    select: (posts) => posts.map((post) => post.title),
+  })
+
+  if (isPending) return 'Loading...'
+  if (isError) return <span>Error: {error.message}</span>
+
+  return (
+    <ul>
+      {data.map((title) => <li key={title}>{title}</li>)}
+    </ul>
   )
 }
 ```

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -264,6 +264,29 @@ function Posts() {
 }
 ```
 
+`select` shapes the returned `data` without changing what's stored in the cache — the cache still
+holds the full `Post[]`:
+```tsx
+import { useQuery } from '@tanstack/preact-query'
+
+function PostTitles() {
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+    select: (posts) => posts.map((post) => post.title),
+  })
+
+  if (isPending) return 'Loading...'
+  if (isError) return <span>Error: {error.message}</span>
+
+  return (
+    <ul>
+      {data.map((title) => <li key={title}>{title}</li>)}
+    </ul>
+  )
+}
+```
+
 A dependent query, only enabled once `postId` is set — use `isLoading`, not `isPending`, so the
 loading state doesn't show while the query is disabled:
 ```tsx
@@ -355,29 +378,6 @@ function Posts() {
         Next Page
       </button>
     </div>
-  )
-}
-```
-
-`select` shapes the returned `data` without changing what's stored in the cache — the cache still
-holds the full `Post[]`:
-```tsx
-import { useQuery } from '@tanstack/preact-query'
-
-function PostTitles() {
-  const { data, isPending, isError, error } = useQuery({
-    queryKey: ['posts'],
-    queryFn: fetchPosts,
-    select: (posts) => posts.map((post) => post.title),
-  })
-
-  if (isPending) return 'Loading...'
-  if (isError) return <span>Error: {error.message}</span>
-
-  return (
-    <ul>
-      {data.map((title) => <li key={title}>{title}</li>)}
-    </ul>
   )
 }
 ```

--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -190,7 +190,7 @@ function Posts() {
 function useQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): UseQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useQuery.ts:285](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L285)
+Defined in: [preact-query/src/useQuery.ts:281](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQuery.ts#L281)
 
 ### Type Parameters
 
@@ -264,26 +264,22 @@ function Posts() {
 }
 ```
 
-`select` shapes the returned `data` without changing what's stored in the cache — the cache still
-holds the full `Post[]`:
+`select` derives whatever `data` a component needs from the cached value, without changing what's
+actually stored in the cache — the cache still holds the full `Post[]`, but `data` here is a `number`:
 ```tsx
 import { useQuery } from '@tanstack/preact-query'
 
-function PostTitles() {
+function PostCount() {
   const { data, isPending, isError, error } = useQuery({
     queryKey: ['posts'],
     queryFn: fetchPosts,
-    select: (posts) => posts.map((post) => post.title),
+    select: (posts) => posts.length,
   })
 
   if (isPending) return 'Loading...'
   if (isError) return <span>Error: {error.message}</span>
 
-  return (
-    <ul>
-      {data.map((title) => <li key={title}>{title}</li>)}
-    </ul>
-  )
+  return <span>{data} posts</span>
 }
 ```
 

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -160,26 +160,22 @@ export function useQuery<
  * ```
  *
  * @example
- * `select` shapes the returned `data` without changing what's stored in the cache — the cache still
- * holds the full `Post[]`:
+ * `select` derives whatever `data` a component needs from the cached value, without changing what's
+ * actually stored in the cache — the cache still holds the full `Post[]`, but `data` here is a `number`:
  * ```tsx
  * import { useQuery } from '@tanstack/preact-query'
  *
- * function PostTitles() {
+ * function PostCount() {
  *   const { data, isPending, isError, error } = useQuery({
  *     queryKey: ['posts'],
  *     queryFn: fetchPosts,
- *     select: (posts) => posts.map((post) => post.title),
+ *     select: (posts) => posts.length,
  *   })
  *
  *   if (isPending) return 'Loading...'
  *   if (isError) return <span>Error: {error.message}</span>
  *
- *   return (
- *     <ul>
- *       {data.map((title) => <li key={title}>{title}</li>)}
- *     </ul>
- *   )
+ *   return <span>{data} posts</span>
  * }
  * ```
  *

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -160,6 +160,30 @@ export function useQuery<
  * ```
  *
  * @example
+ * `select` shapes the returned `data` without changing what's stored in the cache — the cache still
+ * holds the full `Post[]`:
+ * ```tsx
+ * import { useQuery } from '@tanstack/preact-query'
+ *
+ * function PostTitles() {
+ *   const { data, isPending, isError, error } = useQuery({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *     select: (posts) => posts.map((post) => post.title),
+ *   })
+ *
+ *   if (isPending) return 'Loading...'
+ *   if (isError) return <span>Error: {error.message}</span>
+ *
+ *   return (
+ *     <ul>
+ *       {data.map((title) => <li key={title}>{title}</li>)}
+ *     </ul>
+ *   )
+ * }
+ * ```
+ *
+ * @example
  * A dependent query, only enabled once `postId` is set — use `isLoading`, not `isPending`, so the
  * loading state doesn't show while the query is disabled:
  * ```tsx
@@ -254,30 +278,6 @@ export function useQuery<
  *         Next Page
  *       </button>
  *     </div>
- *   )
- * }
- * ```
- *
- * @example
- * `select` shapes the returned `data` without changing what's stored in the cache — the cache still
- * holds the full `Post[]`:
- * ```tsx
- * import { useQuery } from '@tanstack/preact-query'
- *
- * function PostTitles() {
- *   const { data, isPending, isError, error } = useQuery({
- *     queryKey: ['posts'],
- *     queryFn: fetchPosts,
- *     select: (posts) => posts.map((post) => post.title),
- *   })
- *
- *   if (isPending) return 'Loading...'
- *   if (isError) return <span>Error: {error.message}</span>
- *
- *   return (
- *     <ul>
- *       {data.map((title) => <li key={title}>{title}</li>)}
- *     </ul>
  *   )
  * }
  * ```

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -257,6 +257,30 @@ export function useQuery<
  *   )
  * }
  * ```
+ *
+ * @example
+ * `select` shapes the returned `data` without changing what's stored in the cache — the cache still
+ * holds the full `Post[]`:
+ * ```tsx
+ * import { useQuery } from '@tanstack/preact-query'
+ *
+ * function PostTitles() {
+ *   const { data, isPending, isError, error } = useQuery({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *     select: (posts) => posts.map((post) => post.title),
+ *   })
+ *
+ *   if (isPending) return 'Loading...'
+ *   if (isError) return <span>Error: {error.message}</span>
+ *
+ *   return (
+ *     <ul>
+ *       {data.map((title) => <li key={title}>{title}</li>)}
+ *     </ul>
+ *   )
+ * }
+ * ```
  */
 export function useQuery<
   TQueryFnData = unknown,


### PR DESCRIPTION
## 🎯 Changes

`useQuery`'s `select` option had no `@example` showing its usage, despite the other 8 examples on this overload covering `initialData`, `isPending`/`isError`, `enabled`, `skipToken`, seeding, and pagination.

- `useQuery.ts`: added an example showing `select` deriving a `number` (post count) from the cached `Post[]` — a type-changing transform, so the example demonstrates the reason `select` exists (`TData` can differ from what's cached) rather than a subset that would render the same as the basic example above it. Placed right after the basic example, since `select` is a more commonly used option than the dependent-query/pagination examples that follow.
- Regenerated `docs/framework/preact/reference/functions/useQuery.md` with `pnpm run generate-docs`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the referenced source-code line for the third `useQuery` overload.
  - Moved the `select` option example before the dependent-query examples.
  - Updated the example to show deriving a post count while retaining the complete results in the cache.
  - Clarified how transformed data is displayed separately from the cached result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->