### PR TITLE
chore: use infiniteQuery instead of fetchInfiniteQuery et al

### DIFF
--- a/packages/preact-query/src/__tests__/ssr.test.tsx
+++ b/packages/preact-query/src/__tests__/ssr.test.tsx
@@ -167,11 +167,13 @@ describe('Server Side Rendering', () => {
       )
     }
 
-    queryClient.prefetchInfiniteQuery({
-      queryKey: key,
-      queryFn,
-      initialPageParam: 0,
-    })
+    void queryClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn,
+        initialPageParam: 0,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const markup = renderToString(

--- a/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   QueryCache,
   QueryClient,
+  noop,
   usePrefetchInfiniteQuery,
   useSuspenseInfiniteQuery,
 } from '..'
@@ -107,7 +108,7 @@ describe('usePrefetchInfiniteQuery', () => {
         allPages.length < data.length ? allPages.length : undefined,
     }
 
-    queryClient.prefetchInfiniteQuery({ ...queryOpts, pages: 3 })
+    void queryClient.infiniteQuery({ ...queryOpts, pages: 3 }).catch(noop)
     await vi.advanceTimersByTimeAsync(30)
     queryOpts.queryFn.mockClear()
 

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -1536,7 +1536,7 @@ describe('dehydration and rehydration', () => {
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
 
-    const prefetchPromise = queryClient.prefetchInfiniteQuery({
+    const prefetchPromise = queryClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1548,7 +1548,7 @@ describe('dehydration and rehydration', () => {
         items: Array<string>
         nextCursor: number
       }) => lastPage.nextCursor,
-    })
+    }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1575,7 +1575,7 @@ describe('dehydration and rehydration', () => {
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
 
-    const prefetchPromise = queryClient.prefetchInfiniteQuery({
+    const prefetchPromise = queryClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1585,7 +1585,7 @@ describe('dehydration and rehydration', () => {
       initialPageParam: 0,
       getNextPageParam: (lastPage: { data: string; next: number }) =>
         lastPage.next,
-    })
+    }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1595,7 +1595,7 @@ describe('dehydration and rehydration', () => {
     const hydrationClient = new QueryClient({ queryCache: hydrationCache })
     hydrate(hydrationClient, dehydrated)
 
-    const resultPromise = hydrationClient.fetchInfiniteQuery({
+    const resultPromise = hydrationClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1617,7 +1617,7 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.prefetchInfiniteQuery({
+    const prefetchPromise = serverClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1627,7 +1627,7 @@ describe('dehydration and rehydration', () => {
       initialPageParam: 0,
       getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
         lastPage.next,
-    })
+    }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1652,7 +1652,7 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.prefetchInfiniteQuery({
+    const prefetchPromise = serverClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1662,7 +1662,7 @@ describe('dehydration and rehydration', () => {
       initialPageParam: 0,
       getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
         lastPage.next,
-    })
+    }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1679,7 +1679,7 @@ describe('dehydration and rehydration', () => {
     expect(beforeRefetch?.pages).toHaveLength(1)
     expect(beforeRefetch?.pageParams).toHaveLength(1)
 
-    const resultPromise = clientClient.fetchInfiniteQuery({
+    const resultPromise = clientClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1703,7 +1703,7 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.prefetchInfiniteQuery({
+    const prefetchPromise = serverClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1713,7 +1713,7 @@ describe('dehydration and rehydration', () => {
       initialPageParam: 0,
       getNextPageParam: (lastPage: { data: string; next: number }) =>
         lastPage.next,
-    })
+    }).catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1734,7 +1734,7 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.prefetchInfiniteQuery({
+    const prefetchPromise = serverClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1745,7 +1745,7 @@ describe('dehydration and rehydration', () => {
       pages: 2,
       getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
         lastPage.next,
-    })
+    }).catch(noop)
     await vi.advanceTimersByTimeAsync(20)
     await prefetchPromise
 
@@ -1761,7 +1761,7 @@ describe('dehydration and rehydration', () => {
     }>(key)
     expect(beforeRefetch?.pages).toHaveLength(2)
 
-    const resultPromise = clientClient.fetchInfiniteQuery({
+    const resultPromise = clientClient.infiniteQuery({
       queryKey: key,
       queryFn: ({ pageParam }) =>
         sleep(10).then(() => ({
@@ -1772,7 +1772,7 @@ describe('dehydration and rehydration', () => {
       pages: 2,
       getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
         lastPage.next,
-    })
+    }).catch(noop)
     await vi.advanceTimersByTimeAsync(20)
     const result = await resultPromise
 

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -1536,19 +1536,21 @@ describe('dehydration and rehydration', () => {
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
 
-    const prefetchPromise = queryClient.infiniteQuery({
-      queryKey: key,
-      queryFn: ({ pageParam }) =>
-        sleep(10).then(() => ({
-          items: [`page-${pageParam}`],
-          nextCursor: pageParam + 1,
-        })),
-      initialPageParam: 0,
-      getNextPageParam: (lastPage: {
-        items: Array<string>
-        nextCursor: number
-      }) => lastPage.nextCursor,
-    }).catch(noop)
+    const prefetchPromise = queryClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn: ({ pageParam }) =>
+          sleep(10).then(() => ({
+            items: [`page-${pageParam}`],
+            nextCursor: pageParam + 1,
+          })),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage: {
+          items: Array<string>
+          nextCursor: number
+        }) => lastPage.nextCursor,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1575,17 +1577,19 @@ describe('dehydration and rehydration', () => {
     const queryCache = new QueryCache()
     const queryClient = new QueryClient({ queryCache })
 
-    const prefetchPromise = queryClient.infiniteQuery({
-      queryKey: key,
-      queryFn: ({ pageParam }) =>
-        sleep(10).then(() => ({
-          data: `page-${pageParam}`,
-          next: pageParam + 1,
-        })),
-      initialPageParam: 0,
-      getNextPageParam: (lastPage: { data: string; next: number }) =>
-        lastPage.next,
-    }).catch(noop)
+    const prefetchPromise = queryClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn: ({ pageParam }) =>
+          sleep(10).then(() => ({
+            data: `page-${pageParam}`,
+            next: pageParam + 1,
+          })),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage: { data: string; next: number }) =>
+          lastPage.next,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1617,17 +1621,19 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.infiniteQuery({
-      queryKey: key,
-      queryFn: ({ pageParam }) =>
-        sleep(10).then(() => ({
-          items: [`item-${pageParam}`],
-          next: pageParam + 1,
-        })),
-      initialPageParam: 0,
-      getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
-        lastPage.next,
-    }).catch(noop)
+    const prefetchPromise = serverClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn: ({ pageParam }) =>
+          sleep(10).then(() => ({
+            items: [`item-${pageParam}`],
+            next: pageParam + 1,
+          })),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
+          lastPage.next,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1652,17 +1658,19 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.infiniteQuery({
-      queryKey: key,
-      queryFn: ({ pageParam }) =>
-        sleep(10).then(() => ({
-          items: [`page-${pageParam}`],
-          next: pageParam + 1,
-        })),
-      initialPageParam: 0,
-      getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
-        lastPage.next,
-    }).catch(noop)
+    const prefetchPromise = serverClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn: ({ pageParam }) =>
+          sleep(10).then(() => ({
+            items: [`page-${pageParam}`],
+            next: pageParam + 1,
+          })),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
+          lastPage.next,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1703,17 +1711,19 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.infiniteQuery({
-      queryKey: key,
-      queryFn: ({ pageParam }) =>
-        sleep(10).then(() => ({
-          data: `p${pageParam}`,
-          next: pageParam + 1,
-        })),
-      initialPageParam: 0,
-      getNextPageParam: (lastPage: { data: string; next: number }) =>
-        lastPage.next,
-    }).catch(noop)
+    const prefetchPromise = serverClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn: ({ pageParam }) =>
+          sleep(10).then(() => ({
+            data: `p${pageParam}`,
+            next: pageParam + 1,
+          })),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage: { data: string; next: number }) =>
+          lastPage.next,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
     await prefetchPromise
 
@@ -1734,18 +1744,20 @@ describe('dehydration and rehydration', () => {
     const key = queryKey()
     const serverClient = new QueryClient({ queryCache: new QueryCache() })
 
-    const prefetchPromise = serverClient.infiniteQuery({
-      queryKey: key,
-      queryFn: ({ pageParam }) =>
-        sleep(10).then(() => ({
-          items: [`item-${pageParam}`],
-          next: pageParam + 1,
-        })),
-      initialPageParam: 0,
-      pages: 2,
-      getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
-        lastPage.next,
-    }).catch(noop)
+    const prefetchPromise = serverClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn: ({ pageParam }) =>
+          sleep(10).then(() => ({
+            items: [`item-${pageParam}`],
+            next: pageParam + 1,
+          })),
+        initialPageParam: 0,
+        pages: 2,
+        getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
+          lastPage.next,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(20)
     await prefetchPromise
 
@@ -1761,18 +1773,20 @@ describe('dehydration and rehydration', () => {
     }>(key)
     expect(beforeRefetch?.pages).toHaveLength(2)
 
-    const resultPromise = clientClient.infiniteQuery({
-      queryKey: key,
-      queryFn: ({ pageParam }) =>
-        sleep(10).then(() => ({
-          items: [`item-${pageParam}`],
-          next: pageParam + 1,
-        })),
-      initialPageParam: 0,
-      pages: 2,
-      getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
-        lastPage.next,
-    }).catch(noop)
+    const resultPromise = clientClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn: ({ pageParam }) =>
+          sleep(10).then(() => ({
+            items: [`item-${pageParam}`],
+            next: pageParam + 1,
+          })),
+        initialPageParam: 0,
+        pages: 2,
+        getNextPageParam: (lastPage: { items: Array<string>; next: number }) =>
+          lastPage.next,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(20)
     const result = await resultPromise
 

--- a/packages/react-query/src/__tests__/ssr.test.tsx
+++ b/packages/react-query/src/__tests__/ssr.test.tsx
@@ -153,11 +153,13 @@ describe('Server Side Rendering', () => {
       )
     }
 
-    queryClient.prefetchInfiniteQuery({
-      queryKey: key,
-      queryFn,
-      initialPageParam: 0,
-    })
+    void queryClient
+      .infiniteQuery({
+        queryKey: key,
+        queryFn,
+        initialPageParam: 0,
+      })
+      .catch(noop)
     await vi.advanceTimersByTimeAsync(10)
 
     const markup = renderToString(

--- a/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/usePrefetchInfiniteQuery.test.tsx
@@ -5,6 +5,7 @@ import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   QueryCache,
   QueryClient,
+  noop,
   usePrefetchInfiniteQuery,
   useSuspenseInfiniteQuery,
 } from '..'
@@ -104,7 +105,7 @@ describe('usePrefetchInfiniteQuery', () => {
         allPages.length < data.length ? allPages.length : undefined,
     }
 
-    queryClient.prefetchInfiniteQuery({ ...queryOpts, pages: 3 })
+    void queryClient.infiniteQuery({ ...queryOpts, pages: 3 }).catch(noop)
     await vi.advanceTimersByTimeAsync(30)
     queryOpts.queryFn.mockClear()
 


### PR DESCRIPTION
## 🎯 Changes

infiniteQuery version of https://github.com/TanStack/query/pull/11340

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated infinite-query SSR, hydration, and prefetch coverage to use the unified infinite-query API.
  * Preserved existing query options, caching behavior, assertions, and hydration scenarios.
  * Added safe handling for rejected asynchronous query operations in test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->