### PR TITLE
Simplifed query methods/internal tests new lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,51 @@ export default [
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
       'no-case-declarations': 'off',
+      /**
+       * Disallows direct calls to deprecated imperative query methods of `QueryClient`
+       * for new tests and code
+       *
+       * Existing tests that directly test the methods from before the refactoring
+       * will be grandfathered in and allowed to continue using the deprecated methods.
+       * They should not be removed, but new tests should use the new methods instead.
+       */
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="fetchQuery"]',
+          message: 'Use queryClient.query(options) instead.',
+        },
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="prefetchQuery"]',
+          message:
+            'Use queryClient.query(options).catch(noop) instead if errors should be swallowed.',
+        },
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="ensureQueryData"]',
+          message:
+            "Use queryClient.query({ ...options, staleTime: 'static' }) instead.",
+        },
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="fetchInfiniteQuery"]',
+          message: 'Use queryClient.infiniteQuery(options) instead.',
+        },
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="prefetchInfiniteQuery"]',
+          message:
+            'Use queryClient.infiniteQuery(options).catch(noop) instead if errors should be swallowed.',
+        },
+        {
+          selector:
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="ensureInfiniteQueryData"]',
+          message:
+            "Use queryClient.infiniteQuery({ ...options, staleTime: 'static' }) instead.",
+        },
+      ],
       'prefer-const': 'off',
     },
   },

--- a/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
@@ -218,6 +218,12 @@ describe('infiniteQueryOptions', () => {
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      queryClient.query(options),
+    )
+
+    // deprecated methods below to be removed next major version
+    assertType(
+      // @ts-expect-error cannot pass infinite options to non-infinite query functions
       queryClient.ensureQueryData(options),
     )
     assertType(

--- a/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
@@ -72,6 +72,8 @@ describe('infiniteQueryOptions', () => {
       initialPageParam: 1,
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchInfiniteQuery(options)
 
     expectTypeOf(data).toEqualTypeOf<InfiniteData<string, number>>()
@@ -224,14 +226,17 @@ describe('infiniteQueryOptions', () => {
     // deprecated methods below to be removed next major version
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.ensureQueryData(options),
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.fetchQuery(options),
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.prefetchQuery(options),
     )
   })

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -76,6 +76,8 @@ it('should work when passed to fetchQuery', () => {
     queryFn: () => Promise.resolve(5),
   })
 
+  // grandfathered direct test
+  // eslint-disable-next-line no-restricted-syntax
   const data = new QueryClient().fetchQuery(options)
   assertType<Promise<number>>(data)
 })

--- a/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -228,6 +228,12 @@ describe('infiniteQueryOptions', () => {
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      queryClient.query(options),
+    )
+
+    // deprecated methods below to be removed next major version
+    assertType(
+      // @ts-expect-error cannot pass infinite options to non-infinite query functions
       queryClient.ensureQueryData(options),
     )
     assertType(

--- a/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -131,6 +131,8 @@ describe('infiniteQueryOptions', () => {
       initialPageParam: 1,
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchInfiniteQuery(options)
 
     expectTypeOf(data).toEqualTypeOf<InfiniteData<string, number>>()
@@ -234,14 +236,17 @@ describe('infiniteQueryOptions', () => {
     // deprecated methods below to be removed next major version
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.ensureQueryData(options),
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.fetchQuery(options),
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.prefetchQuery(options),
     )
   })

--- a/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/queryOptions.test-d.tsx
@@ -109,6 +109,8 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve(5),
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchQuery(options)
     expectTypeOf(data).toEqualTypeOf<number>()
   })

--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -31,6 +31,8 @@ describe('pageParam', () => {
 
   it('initialPageParam should define type of param passed to queryFunctionContext for fetchInfiniteQuery', () => {
     const queryClient = new QueryClient()
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.fetchInfiniteQuery({
       queryKey: queryKey(),
       queryFn: ({ pageParam }) => {
@@ -54,6 +56,8 @@ describe('pageParam', () => {
 
   it('initialPageParam should define type of param passed to queryFunctionContext for prefetchInfiniteQuery', () => {
     const queryClient = new QueryClient()
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.prefetchInfiniteQuery({
       queryKey: queryKey(),
       queryFn: ({ pageParam }) => {

--- a/packages/query-codemods/eslint.config.js
+++ b/packages/query-codemods/eslint.config.js
@@ -15,4 +15,11 @@ export default [
       'sort-imports': 'off',
     },
   },
+  {
+    files: ['src/**/__testfixtures__/**'],
+    rules: {
+      // Codemod fixtures intentionally preserve historical QueryClient syntax.
+      'no-restricted-syntax': 'off',
+    },
+  },
 ]

--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -192,6 +192,8 @@ describe('fetchInfiniteQuery', () => {
   })
 
   it('should allow passing pages', async () => {
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchInfiniteQuery({
       queryKey: queryKey(),
       queryFn: () => Promise.resolve('string'),
@@ -400,6 +402,8 @@ describe('fully typed usage', () => {
     const queryData1 = queryClient.getQueryData(filterKey)
     expectTypeOf(queryData1).toEqualTypeOf<TData | undefined>()
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const queryData2 = await queryClient.ensureQueryData(queryOptions)
     expectTypeOf(queryData2).toEqualTypeOf<TData>()
 
@@ -438,15 +442,21 @@ describe('fully typed usage', () => {
       QueryState<TData, TError> | undefined
     >()
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const fetchedQuery = await queryClient.fetchQuery(queryOptions)
     expectTypeOf(fetchedQuery).toEqualTypeOf<TData>()
 
     const queriedData = await queryClient.query(queryOptions)
     expectTypeOf(queriedData).toEqualTypeOf<TData>()
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.prefetchQuery(queryOptions)
 
     const fetchInfiniteQueryResult =
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.fetchInfiniteQuery(infiniteQueryOptions)
     expectTypeOf(fetchInfiniteQueryResult).toEqualTypeOf<
       InfiniteData<TData, unknown>
@@ -456,6 +466,8 @@ describe('fully typed usage', () => {
     expectTypeOf(infiniteQuery).toEqualTypeOf<InfiniteData<TData, unknown>>()
 
     const infiniteQueryData =
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.ensureInfiniteQueryData(infiniteQueryOptions)
     expectTypeOf(infiniteQueryData).toEqualTypeOf<
       InfiniteData<TData, unknown>
@@ -494,6 +506,8 @@ describe('fully typed usage', () => {
     queryClient.cancelQueries(queryFilters)
     queryClient.invalidateQueries(queryFilters)
     queryClient.refetchQueries(queryFilters)
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.prefetchInfiniteQuery(infiniteQueryOptions)
     queryClient.setQueryDefaults(filterKey, {} as any)
     queryClient.getMutationDefaults(mutationKey)
@@ -552,6 +566,8 @@ describe('fully typed usage', () => {
     const queryData1 = queryClient.getQueryData(filterKey)
     expectTypeOf(queryData1).toEqualTypeOf<unknown>()
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const queryData2 = await queryClient.ensureQueryData(queryOptions)
     expectTypeOf(queryData2).toEqualTypeOf<unknown>()
 
@@ -583,14 +599,20 @@ describe('fully typed usage', () => {
       QueryState<unknown, DefaultError> | undefined
     >()
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const fetchedQuery = await queryClient.fetchQuery(queryOptions)
     expectTypeOf(fetchedQuery).toEqualTypeOf<unknown>()
 
     const queriedData = await queryClient.query(queryOptions)
     expectTypeOf(queriedData).toEqualTypeOf<unknown>()
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.prefetchQuery(queryOptions)
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const fetchInfiniteQueryResult = await queryClient.fetchInfiniteQuery(
       fetchInfiniteQueryOptions,
     )
@@ -603,6 +625,8 @@ describe('fully typed usage', () => {
     )
     expectTypeOf(infiniteQuery).toEqualTypeOf<InfiniteData<unknown, unknown>>()
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const infiniteQueryData = await queryClient.ensureInfiniteQueryData(
       fetchInfiniteQueryOptions,
     )
@@ -649,6 +673,8 @@ describe('fully typed usage', () => {
     queryClient.cancelQueries(queryFilters)
     queryClient.invalidateQueries(queryFilters)
     queryClient.refetchQueries(queryFilters)
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.prefetchInfiniteQuery(fetchInfiniteQueryOptions)
     queryClient.setQueryDefaults(filterKey, {} as any)
     queryClient.getMutationDefaults(mutationKey)

--- a/packages/query-core/src/__tests__/queryClient.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test-d.tsx
@@ -9,12 +9,11 @@ import type {
   DataTag,
   DefaultError,
   DefaultedQueryObserverOptions,
-  EnsureQueryDataOptions,
-  FetchInfiniteQueryOptions,
   InfiniteData,
   InfiniteQueryExecuteOptions,
   MutationOptions,
   OmitKeyof,
+  QueryExecuteOptions,
   QueryKey,
   QueryObserverOptions,
 } from '../types'
@@ -349,6 +348,10 @@ describe('fully typed usage', () => {
     // Construct typed arguments
     //
 
+    const queryOptions: QueryExecuteOptions<TData, TError> = {
+      queryKey: ['key', 'query'],
+    }
+
     const infiniteQueryOptions: InfiniteQueryExecuteOptions<
       TData,
       TError,
@@ -362,21 +365,6 @@ describe('fully typed usage', () => {
       },
       initialPageParam: 0,
     }
-
-    const queryOptions: EnsureQueryDataOptions<TData, TError> = {
-      queryKey: ['key', 'query'],
-    }
-
-    const fetchInfiniteQueryOptions: FetchInfiniteQueryOptions<TData, TError> =
-      {
-        queryKey: ['key', 'infinite'],
-        pages: 5,
-        getNextPageParam: (lastPage) => {
-          expectTypeOf(lastPage).toEqualTypeOf<TData>()
-          return 0
-        },
-        initialPageParam: 0,
-      }
 
     const mutationOptions: MutationOptions<TData, TError> = {}
 
@@ -458,9 +446,8 @@ describe('fully typed usage', () => {
 
     queryClient.prefetchQuery(queryOptions)
 
-    const fetchInfiniteQueryResult = await queryClient.fetchInfiniteQuery(
-      fetchInfiniteQueryOptions,
-    )
+    const fetchInfiniteQueryResult =
+      await queryClient.fetchInfiniteQuery(infiniteQueryOptions)
     expectTypeOf(fetchInfiniteQueryResult).toEqualTypeOf<
       InfiniteData<TData, unknown>
     >()
@@ -468,9 +455,8 @@ describe('fully typed usage', () => {
     const infiniteQuery = await queryClient.infiniteQuery(infiniteQueryOptions)
     expectTypeOf(infiniteQuery).toEqualTypeOf<InfiniteData<TData, unknown>>()
 
-    const infiniteQueryData = await queryClient.ensureInfiniteQueryData(
-      fetchInfiniteQueryOptions,
-    )
+    const infiniteQueryData =
+      await queryClient.ensureInfiniteQueryData(infiniteQueryOptions)
     expectTypeOf(infiniteQueryData).toEqualTypeOf<
       InfiniteData<TData, unknown>
     >()
@@ -508,7 +494,7 @@ describe('fully typed usage', () => {
     queryClient.cancelQueries(queryFilters)
     queryClient.invalidateQueries(queryFilters)
     queryClient.refetchQueries(queryFilters)
-    queryClient.prefetchInfiniteQuery(fetchInfiniteQueryOptions)
+    queryClient.prefetchInfiniteQuery(infiniteQueryOptions)
     queryClient.setQueryDefaults(filterKey, {} as any)
     queryClient.getMutationDefaults(mutationKey)
   })
@@ -520,10 +506,10 @@ describe('fully typed usage', () => {
     // Construct typed arguments
     //
 
-    const queryOptions: EnsureQueryDataOptions = {
+    const queryOptions: QueryExecuteOptions = {
       queryKey: ['key'] as any,
     }
-    const fetchInfiniteQueryOptions: FetchInfiniteQueryOptions = {
+    const fetchInfiniteQueryOptions: InfiniteQueryExecuteOptions = {
       queryKey: ['key'] as any,
       pages: 5,
       getNextPageParam: (lastPage) => {

--- a/packages/query-core/src/__tests__/queryClient.test.tsx
+++ b/packages/query-core/src/__tests__/queryClient.test.tsx
@@ -473,6 +473,8 @@ describe('queryClient', () => {
       queryClient.setQueryData([key, 'id'], 'bar')
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureQueryData({ queryKey: [key, 'id'], queryFn }),
       ).resolves.toEqual('bar')
     })
@@ -484,15 +486,19 @@ describe('queryClient', () => {
       queryClient.setQueryData([key, 'id'], null)
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureQueryData({ queryKey: [key, 'id'], queryFn }),
       ).resolves.toEqual(null)
     })
 
-    it('should call fetchQuery and return its results if the query is not found', async () => {
+    it('should call ensureQueryData and return its results if the query is not found', async () => {
       const key = queryKey()
       const queryFn = () => Promise.resolve('data')
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureQueryData({ queryKey: [key], queryFn }),
       ).resolves.toEqual('data')
     })
@@ -508,6 +514,8 @@ describe('queryClient', () => {
         })
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureQueryData({
           queryKey: [key, 'id'],
           queryFn,
@@ -516,6 +524,8 @@ describe('queryClient', () => {
       ).resolves.toEqual('old')
       await vi.advanceTimersByTimeAsync(TIMEOUT + 10)
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureQueryData({
           queryKey: [key, 'id'],
           queryFn,
@@ -524,11 +534,13 @@ describe('queryClient', () => {
       ).resolves.toEqual('new')
     })
 
-    it('should not fetch with initialDat', async () => {
+    it('should not fetch with initialData', async () => {
       const key = queryKey()
       const queryFn = vi.fn().mockImplementation(() => Promise.resolve('data'))
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureQueryData({
           queryKey: [key, 'id'],
           queryFn,
@@ -642,6 +654,8 @@ describe('queryClient', () => {
       queryClient.setQueryData([key, 'id'], { pages: ['bar'], pageParams: [0] })
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureInfiniteQueryData({
           queryKey: [key, 'id'],
           queryFn,
@@ -656,6 +670,8 @@ describe('queryClient', () => {
       const queryFn = () => Promise.resolve('data')
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureInfiniteQueryData({
           queryKey: [key, 'id'],
           queryFn,
@@ -673,6 +689,8 @@ describe('queryClient', () => {
       const queryFn = () => sleep(TIMEOUT).then(() => 'new')
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureInfiniteQueryData({
           queryKey: [key, 'id'],
           queryFn,
@@ -683,6 +701,8 @@ describe('queryClient', () => {
       ).resolves.toEqual({ pages: ['old'], pageParams: [0] })
       await vi.advanceTimersByTimeAsync(TIMEOUT + 10)
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.ensureInfiniteQueryData({
           queryKey: [key, 'id'],
           queryFn,
@@ -775,6 +795,8 @@ describe('queryClient', () => {
         Promise.resolve('data')
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.fetchQuery<StrictData, any, StrictData, StrictQueryKey>({
           queryKey: key,
           queryFn: fetchFn,
@@ -787,6 +809,8 @@ describe('queryClient', () => {
       const key = queryKey()
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.fetchQuery({
           queryKey: key,
           queryFn: (): Promise<unknown> => {
@@ -800,10 +824,15 @@ describe('queryClient', () => {
       const key = queryKey()
 
       const fetchFn = () => Promise.resolve('data')
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const first = await queryClient.fetchQuery({
         queryKey: key,
         queryFn: fetchFn,
       })
+
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const second = await queryClient.fetchQuery({
         queryKey: key,
         queryFn: fetchFn,
@@ -816,6 +845,9 @@ describe('queryClient', () => {
       const key = queryKey()
 
       const fetchFn = vi.fn(() => Promise.resolve({ data: 'data' }))
+
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const first = await queryClient.fetchQuery({
         queryKey: key,
         queryFn: fetchFn,
@@ -830,6 +862,8 @@ describe('queryClient', () => {
         refetchType: 'none',
       })
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const second = await queryClient.fetchQuery({
         queryKey: key,
         queryFn: fetchFn,
@@ -843,6 +877,8 @@ describe('queryClient', () => {
 
     it('should be able to fetch when garbage collection time is set to 0 and then be removed', async () => {
       const key1 = queryKey()
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const promise = queryClient.fetchQuery({
         queryKey: key1,
         queryFn: () => sleep(10).then(() => 1),
@@ -856,6 +892,8 @@ describe('queryClient', () => {
 
     it('should keep a query in cache if garbage collection time is Infinity', async () => {
       const key1 = queryKey()
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const promise = queryClient.fetchQuery({
         queryKey: key1,
         queryFn: () => sleep(10).then(() => 1),
@@ -869,9 +907,10 @@ describe('queryClient', () => {
 
     it('should not force fetch', async () => {
       const key = queryKey()
-
       queryClient.setQueryData(key, 'og')
       const fetchFn = () => Promise.resolve('new')
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const first = await queryClient.fetchQuery({
         queryKey: key,
         queryFn: fetchFn,
@@ -888,6 +927,8 @@ describe('queryClient', () => {
       const queryFn = () => ++count
 
       queryClient.setQueryData(key, count)
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const firstPromise = queryClient.fetchQuery({
         queryKey: key,
         queryFn,
@@ -895,12 +936,16 @@ describe('queryClient', () => {
       })
       await expect(firstPromise).resolves.toBe(0)
       await vi.advanceTimersByTimeAsync(10)
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const secondPromise = queryClient.fetchQuery({
         queryKey: key,
         queryFn,
         staleTime: 10,
       })
       await expect(secondPromise).resolves.toBe(1)
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const thirdPromise = queryClient.fetchQuery({
         queryKey: key,
         queryFn,
@@ -908,6 +953,8 @@ describe('queryClient', () => {
       })
       await expect(thirdPromise).resolves.toBe(1)
       await vi.advanceTimersByTimeAsync(10)
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const fourthPromise = queryClient.fetchQuery({
         queryKey: key,
         queryFn,
@@ -919,6 +966,8 @@ describe('queryClient', () => {
     it('should allow new meta', async () => {
       const key = queryKey()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const first = await queryClient.fetchQuery({
         queryKey: key,
         queryFn: ({ meta }) => Promise.resolve(meta),
@@ -928,6 +977,8 @@ describe('queryClient', () => {
       })
       expect(first).toStrictEqual({ foo: true })
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const second = await queryClient.fetchQuery({
         queryKey: key,
         queryFn: ({ meta }) => Promise.resolve(meta),
@@ -1382,6 +1433,8 @@ describe('queryClient', () => {
         Promise.resolve(data.pages[0])
 
       await expect(
+        // grandfathered direct test
+        // eslint-disable-next-line no-restricted-syntax
         queryClient.fetchInfiniteQuery<
           StrictData,
           any,
@@ -1394,6 +1447,8 @@ describe('queryClient', () => {
 
     it('should return infinite query data', async () => {
       const key = queryKey()
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const result = await queryClient.fetchInfiniteQuery({
         queryKey: key,
         initialPageParam: 10,
@@ -1648,6 +1703,8 @@ describe('queryClient', () => {
       const fetchFn: QueryFunction<StrictData, StrictQueryKey, number> = () =>
         Promise.resolve('data')
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.prefetchInfiniteQuery<
         StrictData,
         any,
@@ -1667,6 +1724,8 @@ describe('queryClient', () => {
     it('should return infinite query data', async () => {
       const key = queryKey()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.prefetchInfiniteQuery({
         queryKey: key,
         queryFn: ({ pageParam }) => Number(pageParam),
@@ -1684,6 +1743,8 @@ describe('queryClient', () => {
     it('should prefetch multiple pages', async () => {
       const key = queryKey()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.prefetchInfiniteQuery({
         queryKey: key,
         queryFn: ({ pageParam }) => String(pageParam),
@@ -1705,6 +1766,8 @@ describe('queryClient', () => {
       const key = queryKey()
       let count = 0
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.prefetchInfiniteQuery({
         queryKey: key,
         queryFn: ({ pageParam }) => String(pageParam),
@@ -1833,6 +1896,8 @@ describe('queryClient', () => {
       const fetchFn: QueryFunction<StrictData, StrictQueryKey> = () =>
         Promise.resolve('data')
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.prefetchQuery<
         StrictData,
         any,
@@ -1848,6 +1913,8 @@ describe('queryClient', () => {
     it('should return undefined when an error is thrown', async () => {
       const key = queryKey()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       const result = await queryClient.prefetchQuery({
         queryKey: key,
         queryFn: (): Promise<unknown> => {
@@ -1862,6 +1929,8 @@ describe('queryClient', () => {
     it('should be garbage collected after gcTime if unused', async () => {
       const key = queryKey()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       await queryClient.prefetchQuery({
         queryKey: key,
         queryFn: () => 'data',

--- a/packages/query-core/src/queryClient.ts
+++ b/packages/query-core/src/queryClient.ts
@@ -153,6 +153,7 @@ export class QueryClient {
     const cachedData = query.state.data
 
     if (cachedData === undefined) {
+      // eslint-disable-next-line no-restricted-syntax
       return this.fetchQuery(options)
     }
 
@@ -160,6 +161,7 @@ export class QueryClient {
       options.revalidateIfStale &&
       query.isStaleByTime(resolveQueryValue(defaultedOptions.staleTime, query))
     ) {
+      // eslint-disable-next-line no-restricted-syntax
       void this.prefetchQuery(defaultedOptions)
     }
 
@@ -431,6 +433,7 @@ export class QueryClient {
   >(
     options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   ): Promise<void> {
+    // eslint-disable-next-line no-restricted-syntax
     return this.fetchQuery(options).then(noop).catch(noop)
   }
 
@@ -476,6 +479,7 @@ export class QueryClient {
     >,
   ): Promise<InfiniteData<TData, TPageParam>> {
     options._type = 'infinite'
+    // eslint-disable-next-line no-restricted-syntax
     return this.fetchQuery(options as any)
   }
 
@@ -497,6 +501,7 @@ export class QueryClient {
       TPageParam
     >,
   ): Promise<void> {
+    // eslint-disable-next-line no-restricted-syntax
     return this.fetchInfiniteQuery(options).then(noop).catch(noop)
   }
 
@@ -520,6 +525,7 @@ export class QueryClient {
   ): Promise<InfiniteData<TData, TPageParam>> {
     options._type = 'infinite'
 
+    // eslint-disable-next-line no-restricted-syntax
     return this.ensureQueryData(options as any)
   }
 

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -267,6 +267,12 @@ describe('infiniteQueryOptions', () => {
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      queryClient.query(options),
+    )
+
+    // deprecated methods to be removed in v6
+    assertType(
+      // @ts-expect-error cannot pass infinite options to non-infinite query functions
       queryClient.ensureQueryData(options),
     )
     assertType(

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -157,6 +157,8 @@ describe('infiniteQueryOptions', () => {
       initialPageParam: 1,
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchInfiniteQuery(options)
 
     expectTypeOf(data).toEqualTypeOf<InfiniteData<string, number>>()
@@ -170,6 +172,8 @@ describe('infiniteQueryOptions', () => {
       select: (data) => data.pages,
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchInfiniteQuery(options)
 
     expectTypeOf(data).toEqualTypeOf<InfiniteData<string, number>>()
@@ -273,14 +277,17 @@ describe('infiniteQueryOptions', () => {
     // deprecated methods to be removed in v6
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.ensureQueryData(options),
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.fetchQuery(options),
     )
     assertType(
       // @ts-expect-error cannot pass infinite options to non-infinite query functions
+      // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
       queryClient.prefetchQuery(options),
     )
   })

--- a/packages/react-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/queryOptions.test-d.tsx
@@ -80,6 +80,8 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve(5),
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchQuery(options)
     expectTypeOf(data).toEqualTypeOf<number>()
   })
@@ -119,6 +121,8 @@ describe('queryOptions', () => {
       select: (data) => data.toString(),
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchQuery(options)
     expectTypeOf(data).toEqualTypeOf<number>()
   })

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -30,6 +30,8 @@ describe('pageParam', () => {
 
   it('initialPageParam should define type of param passed to queryFunctionContext for fetchInfiniteQuery', () => {
     const queryClient = new QueryClient()
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.fetchInfiniteQuery({
       queryKey: queryKey(),
       queryFn: ({ pageParam }) => {
@@ -53,6 +55,8 @@ describe('pageParam', () => {
 
   it('initialPageParam should define type of param passed to queryFunctionContext for prefetchInfiniteQuery', () => {
     const queryClient = new QueryClient()
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     queryClient.prefetchInfiniteQuery({
       queryKey: queryKey(),
       queryFn: ({ pageParam }) => {

--- a/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
+++ b/packages/solid-query/src/__tests__/queryOptions.test-d.tsx
@@ -90,6 +90,8 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve(5),
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchQuery(options)
     expectTypeOf(data).toEqualTypeOf<number>()
   })

--- a/packages/solid-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -30,6 +30,8 @@ describe('useInfiniteQuery', () => {
 
     it('initialPageParam should define type of param passed to queryFunctionContext for fetchInfiniteQuery', () => {
       const queryClient = new QueryClient()
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.fetchInfiniteQuery({
         queryKey: queryKey(),
         queryFn: ({ pageParam }) => {
@@ -41,6 +43,8 @@ describe('useInfiniteQuery', () => {
 
     it('initialPageParam should define type of param passed to queryFunctionContext for prefetchInfiniteQuery', () => {
       const queryClient = new QueryClient()
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.prefetchInfiniteQuery({
         queryKey: queryKey(),
         queryFn: ({ pageParam }) => {

--- a/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.test-d.ts
+++ b/packages/svelte-query/tests/createInfiniteQuery/createInfiniteQuery.test-d.ts
@@ -30,6 +30,8 @@ describe('createInfiniteQuery', () => {
 
     it('initialPageParam should define type of param passed to queryFunctionContext for fetchInfiniteQuery', () => {
       const queryClient = new QueryClient()
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.fetchInfiniteQuery({
         queryKey: queryKey(),
         queryFn: ({ pageParam }) => {
@@ -41,6 +43,8 @@ describe('createInfiniteQuery', () => {
 
     it('initialPageParam should define type of param passed to queryFunctionContext for prefetchInfiniteQuery', () => {
       const queryClient = new QueryClient()
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.prefetchInfiniteQuery({
         queryKey: queryKey(),
         queryFn: ({ pageParam }) => {

--- a/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
+++ b/packages/svelte-query/tests/infiniteQueryOptions.test-d.ts
@@ -113,6 +113,8 @@ describe('infiniteQueryOptions', () => {
       initialPageParam: 1,
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchInfiniteQuery(options)
 
     expectTypeOf(data).toEqualTypeOf<InfiniteData<string, number>>()

--- a/packages/svelte-query/tests/queryOptions.test-d.ts
+++ b/packages/svelte-query/tests/queryOptions.test-d.ts
@@ -90,6 +90,8 @@ describe('queryOptions', () => {
       queryFn: () => Promise.resolve(5),
     })
 
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchQuery(options)
     expectTypeOf(data).toEqualTypeOf<number>()
   })

--- a/packages/vue-query/src/__tests__/queryClient.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test-d.ts
@@ -115,6 +115,8 @@ describe('setQueryData', () => {
 describe('fetchInfiniteQuery', () => {
   it('should allow passing pages', async () => {
     const key = queryKey()
+    // grandfathered direct test
+    // eslint-disable-next-line no-restricted-syntax
     const data = await new QueryClient().fetchInfiniteQuery({
       queryKey: key,
       queryFn: () => Promise.resolve('string'),

--- a/packages/vue-query/src/__tests__/queryClient.test.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test.ts
@@ -88,6 +88,8 @@ describe('QueryCache', () => {
     it('should properly unwrap parameter', () => {
       const queryClient = new QueryClient()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.ensureQueryData({
         queryKey: queryKeyRef,
         queryFn: fn,
@@ -331,6 +333,8 @@ describe('QueryCache', () => {
     it('should properly unwrap parameter', () => {
       const queryClient = new QueryClient()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.fetchQuery({
         queryKey: queryKeyRef,
       })
@@ -390,6 +394,8 @@ describe('QueryCache', () => {
     it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.prefetchQuery({ queryKey: queryKeyRef, queryFn: fn })
 
       expect(QueryClientOrigin.prototype.prefetchQuery).toHaveBeenCalledWith({
@@ -403,6 +409,8 @@ describe('QueryCache', () => {
     it('should properly unwrap parameter', () => {
       const queryClient = new QueryClient()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.fetchInfiniteQuery({
         queryKey: queryKeyRef,
         initialPageParam: 0,
@@ -426,6 +434,8 @@ describe('QueryCache', () => {
         getNextPageParam: () => 12,
       })
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.fetchInfiniteQuery(options)
 
       expect(
@@ -495,6 +505,8 @@ describe('QueryCache', () => {
     it('should properly unwrap parameters', () => {
       const queryClient = new QueryClient()
 
+      // grandfathered direct test
+      // eslint-disable-next-line no-restricted-syntax
       queryClient.prefetchInfiniteQuery({
         queryKey: queryKeyRef,
         queryFn: fn,

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -162,6 +162,7 @@ describe('queryOptions', () => {
     // Should not error
     const data = queryClient.invalidateQueries(options)
     // Should not error
+    // eslint-disable-next-line no-restricted-syntax -- grandfathered direct test
     const data2 = queryClient.fetchQuery(options)
 
     expectTypeOf(data).toEqualTypeOf<Promise<void>>()

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -97,6 +97,8 @@ export class QueryClient extends QC {
       EnsureQueryDataOptions<TQueryFnData, TError, TData, TQueryKey>
     >,
   ): Promise<TData> {
+    // grandfathered deprecated wrapper implementation
+    // eslint-disable-next-line no-restricted-syntax
     return super.ensureQueryData(cloneDeepUnref(options))
   }
 
@@ -344,6 +346,8 @@ export class QueryClient extends QC {
       FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>
     >,
   ): Promise<TData> {
+    // grandfathered deprecated wrapper implementation
+    // eslint-disable-next-line no-restricted-syntax
     return super.fetchQuery(cloneDeepUnref(options))
   }
 
@@ -378,6 +382,8 @@ export class QueryClient extends QC {
       FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>
     >,
   ): Promise<void> {
+    // grandfathered deprecated wrapper implementation
+    // eslint-disable-next-line no-restricted-syntax
     return super.prefetchQuery(cloneDeepUnref(options))
   }
 
@@ -499,6 +505,8 @@ export class QueryClient extends QC {
       >
     >,
   ): Promise<InfiniteData<TData, TPageParam>> {
+    // grandfathered deprecated wrapper implementation
+    // eslint-disable-next-line no-restricted-syntax
     return super.fetchInfiniteQuery(cloneDeepUnref(options))
   }
 
@@ -554,6 +562,8 @@ export class QueryClient extends QC {
       >
     >,
   ): Promise<void> {
+    // grandfathered deprecated wrapper implementation
+    // eslint-disable-next-line no-restricted-syntax
     return super.prefetchInfiniteQuery(cloneDeepUnref(options))
   }
 


### PR DESCRIPTION
## 🎯 Changes

Prevents outdated methods (`fetchQuery` et al) being used via a lint rule.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added linting guidance that flags direct use of deprecated imperative query-fetching methods and recommends the newer query APIs.

- **Tests**
  - Updated type and integration tests to accommodate the linting guidance while preserving existing coverage.
  - Added validation that infinite-query options cannot be used with standard query methods.
  - Added coverage for conditional Vue query functions using `skipToken`.
  - Corrected a test description and minor spelling error.

- **Chores**
  - Relaxed selected lint rules for codemod fixture files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->