### PR TITLE
docs(svelte-query): add JSDoc '@example's across hooks and options factories

### DIFF
--- a/docs/framework/svelte/reference/functions/createInfiniteQuery.md
+++ b/docs/framework/svelte/reference/functions/createInfiniteQuery.md
@@ -7,7 +7,7 @@ title: createInfiniteQuery
 function createInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): CreateInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/createInfiniteQuery.ts:16](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createInfiniteQuery.ts#L16)
+Defined in: [packages/svelte-query/src/createInfiniteQuery.ts:109](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createInfiniteQuery.ts#L109)
 
 ## Type Parameters
 
@@ -37,10 +37,107 @@ Defined in: [packages/svelte-query/src/createInfiniteQuery.ts:16](https://github
 
 [`Accessor`](../type-aliases/Accessor.md)\<[`CreateInfiniteQueryOptions`](../type-aliases/CreateInfiniteQueryOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`, `TPageParam`\>\>
 
+The [CreateInfiniteQueryOptions](../type-aliases/CreateInfiniteQueryOptions.md) to use — everything you can pass to
+`createInfiniteQuery`, wrapped in an [Accessor](../type-aliases/Accessor.md) so options can be reactive.
+
 ### queryClient?
 
 [`Accessor`](../type-aliases/Accessor.md)\<`QueryClient`\>
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ## Returns
 
 [`CreateInfiniteQueryResult`](../type-aliases/CreateInfiniteQueryResult.md)\<`TData`, `TError`\>
+
+The current query result, plus `fetchNextPage`/`fetchPreviousPage`/`hasNextPage`/`hasPreviousPage`
+to page through the query.
+
+## See
+
+[infiniteQueryOptions](infiniteQueryOptions.md) to share these options between `createInfiniteQuery` and imperative APIs
+like `queryClient.infiniteQuery`.
+
+## Examples
+
+Fetching the next page from a "Load More" button click:
+```svelte
+<script lang="ts">
+  import { createInfiniteQuery } from '@tanstack/svelte-query'
+
+  const query = createInfiniteQuery(() => ({
+    queryKey: ['projects'],
+    queryFn: ({ pageParam }) => fetchProjects(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextId,
+  }))
+</script>
+
+{#if query.isPending}
+  Loading...
+{:else if query.isError}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <ul>
+    {#each query.data.pages as page}
+      {#each page.projects as project (project.id)}
+        <li>{project.name}</li>
+      {/each}
+    {/each}
+  </ul>
+  <button
+    onclick={() => query.fetchNextPage()}
+    disabled={!query.hasNextPage || query.isFetching}
+  >
+    {query.isFetchingNextPage
+      ? 'Loading more...'
+      : query.hasNextPage
+        ? 'Load More'
+        : 'Nothing more to load'}
+  </button>
+{/if}
+```
+
+Fetching the next page automatically as the user scrolls, using an `IntersectionObserver` on a
+sentinel element after the list:
+```svelte
+<script lang="ts">
+  import { createInfiniteQuery } from '@tanstack/svelte-query'
+
+  const query = createInfiniteQuery(() => ({
+    queryKey: ['projects'],
+    queryFn: ({ pageParam }) => fetchProjects(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextId,
+  }))
+
+  let sentinel: HTMLDivElement | undefined = $state()
+
+  $effect(() => {
+    if (sentinel == null || !query.hasNextPage || query.isFetching) return
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry?.isIntersecting) query.fetchNextPage()
+    })
+    observer.observe(sentinel)
+
+    return () => observer.disconnect()
+  })
+</script>
+
+{#if query.isPending}
+  Loading...
+{:else if query.isError}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <ul>
+    {#each query.data.pages as page}
+      {#each page.projects as project (project.id)}
+        <li>{project.name}</li>
+      {/each}
+    {/each}
+  </ul>
+  <div bind:this={sentinel}></div>
+{/if}
+```

--- a/docs/framework/svelte/reference/functions/createMutation.md
+++ b/docs/framework/svelte/reference/functions/createMutation.md
@@ -126,11 +126,11 @@ Optimistic update via `onMutate`, rolling back on `onError`:
         newTodo,
       ])
 
-      // Passed to `onError` as `context` if the mutation fails.
+      // Passed to `onError` as `onMutateResult` if the mutation fails.
       return { previousTodos }
     },
-    onError: (_err, _newTodo, context) => {
-      queryClient.setQueryData(['todos'], context?.previousTodos)
+    onError: (_err, _newTodo, onMutateResult) => {
+      queryClient.setQueryData(['todos'], onMutateResult?.previousTodos)
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['todos'] })

--- a/docs/framework/svelte/reference/functions/createMutation.md
+++ b/docs/framework/svelte/reference/functions/createMutation.md
@@ -7,7 +7,10 @@ title: createMutation
 function createMutation<TData, TError, TVariables, TContext>(options, queryClient?): CreateMutationResult<TData, TError, TVariables, TContext>;
 ```
 
-Defined in: [packages/svelte-query/src/createMutation.svelte.ts:17](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createMutation.svelte.ts#L17)
+Defined in: [packages/svelte-query/src/createMutation.svelte.ts:110](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createMutation.svelte.ts#L110)
+
+Unlike queries, mutations are typically used to create/update/delete data or perform server side-effects.
+`createMutation` is the function for that.
 
 ## Type Parameters
 
@@ -33,14 +36,107 @@ Defined in: [packages/svelte-query/src/createMutation.svelte.ts:17](https://gith
 
 [`Accessor`](../type-aliases/Accessor.md)\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TContext`\>\>
 
-A function that returns mutation options
+The [CreateMutationOptions](../type-aliases/CreateMutationOptions.md) to use, wrapped in an [Accessor](../type-aliases/Accessor.md) so options can be
+reactive.
 
 ### queryClient?
 
 [`Accessor`](../type-aliases/Accessor.md)\<`QueryClient`\>
 
-Custom query client which overrides provider
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
 
 ## Returns
 
 [`CreateMutationResult`](../type-aliases/CreateMutationResult.md)\<`TData`, `TError`, `TVariables`, `TContext`\>
+
+`mutate`/`mutateAsync` also accept per-call `onSuccess`/`onError`/`onSettled` callbacks as a second
+argument, useful for triggering call-site side effects (e.g. navigation) without coupling them to the shared
+mutation definition. If you make multiple requests, `onSuccess` will fire only after the latest call you've
+made.
+
+## See
+
+[mutationOptions](mutationOptions.md) to share these options across multiple `createMutation` call sites, or to look
+the mutation up elsewhere via its `mutationKey` (e.g. with `useMutationState`).
+
+## Examples
+
+```svelte
+<script lang="ts">
+  import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+
+  const queryClient = useQueryClient()
+
+  const addMutation = createMutation(() => ({
+    mutationFn: addTodo,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  }))
+</script>
+
+<button
+  onclick={() =>
+    addMutation.mutate('Item', {
+      onError: (error) => console.error('Failed to add item:', error),
+    })
+  }
+>
+  Add
+</button>
+```
+
+Rendering the mutation's own state, rather than just firing it off:
+```svelte
+<script lang="ts">
+  import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+
+  const queryClient = useQueryClient()
+
+  const addMutation = createMutation(() => ({
+    mutationFn: addTodo,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  }))
+</script>
+
+{#if addMutation.isPending}
+  Adding todo...
+{:else}
+  {#if addMutation.isError}
+    <div>An error occurred: {addMutation.error.message}</div>
+  {/if}
+  <button onclick={() => addMutation.mutate('Item')}>Add</button>
+{/if}
+```
+
+Optimistic update via `onMutate`, rolling back on `onError`:
+```svelte
+<script lang="ts">
+  import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+
+  const queryClient = useQueryClient()
+
+  const addMutation = createMutation(() => ({
+    mutationFn: addTodo,
+    onMutate: async (newTodo: string) => {
+      await queryClient.cancelQueries({ queryKey: ['todos'] })
+      const previousTodos = queryClient.getQueryData<Array<string>>(['todos'])
+
+      queryClient.setQueryData<Array<string>>(['todos'], (old) => [
+        ...(old ?? []),
+        newTodo,
+      ])
+
+      // Passed to `onError` as `context` if the mutation fails.
+      return { previousTodos }
+    },
+    onError: (_err, _newTodo, context) => {
+      queryClient.setQueryData(['todos'], context?.previousTodos)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] })
+    },
+  }))
+</script>
+
+<button onclick={() => addMutation.mutate('Item')}>Add</button>
+```

--- a/docs/framework/svelte/reference/functions/createMutation.md
+++ b/docs/framework/svelte/reference/functions/createMutation.md
@@ -7,7 +7,7 @@ title: createMutation
 function createMutation<TData, TError, TVariables, TContext>(options, queryClient?): CreateMutationResult<TData, TError, TVariables, TContext>;
 ```
 
-Defined in: [packages/svelte-query/src/createMutation.svelte.ts:110](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createMutation.svelte.ts#L110)
+Defined in: [packages/svelte-query/src/createMutation.svelte.ts:171](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createMutation.svelte.ts#L171)
 
 Unlike queries, mutations are typically used to create/update/delete data or perform server side-effects.
 `createMutation` is the function for that.
@@ -139,4 +139,63 @@ Optimistic update via `onMutate`, rolling back on `onError`:
 </script>
 
 <button onclick={() => addMutation.mutate('Item')}>Add</button>
+```
+
+Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
+promise per call instead, so you can wait for all of them:
+```svelte
+<script lang="ts">
+  import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+
+  const queryClient = useQueryClient()
+
+  const addMutation = createMutation(() => ({
+    mutationFn: addTodo,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  }))
+
+  async function handleAddAll(todos: Array<string>) {
+    try {
+      await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
+    } catch (error) {
+      console.error('Failed to add todos:', error)
+    }
+  }
+</script>
+
+<button onclick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+  Add all
+</button>
+```
+
+If some of the mutations above can fail independently of the others, and you want to know which ones
+did — rather than losing that information the moment the first one rejects — swap `Promise.all` for
+`Promise.allSettled`:
+```svelte
+<script lang="ts">
+  import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+
+  const queryClient = useQueryClient()
+
+  const addMutation = createMutation(() => ({
+    mutationFn: addTodo,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  }))
+
+  async function handleAddAll(todos: Array<string>) {
+    const addResults = await Promise.allSettled(
+      todos.map((todo) => addMutation.mutateAsync(todo)),
+    )
+
+    addResults.forEach((addResult, index) => {
+      if (addResult.status === 'rejected') {
+        console.error(`Failed to add "${todos[index]}":`, addResult.reason)
+      }
+    })
+  }
+</script>
+
+<button onclick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+  Add all
+</button>
 ```

--- a/docs/framework/svelte/reference/functions/createQueries.md
+++ b/docs/framework/svelte/reference/functions/createQueries.md
@@ -7,7 +7,7 @@ title: createQueries
 function createQueries<T, TCombinedResult>(createQueriesOptions, queryClient?): TCombinedResult;
 ```
 
-Defined in: [packages/svelte-query/src/createQueries.svelte.ts:189](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQueries.svelte.ts#L189)
+Defined in: [packages/svelte-query/src/createQueries.svelte.ts:260](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQueries.svelte.ts#L260)
 
 ## Type Parameters
 
@@ -29,10 +29,82 @@ Defined in: [packages/svelte-query/src/createQueries.svelte.ts:189](https://gith
      \| readonly \[\{ \[K in string \| number \| symbol\]: GetCreateQueryOptionsForCreateQueries\<T\[K\<K\>\]\> \}\];
 \}\>
 
+The `queries` array to run, and an optional `combine` function, wrapped in an
+[Accessor](../type-aliases/Accessor.md) so options can be reactive.
+
 ### queryClient?
 
 [`Accessor`](../type-aliases/Accessor.md)\<`QueryClient`\>
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context
+will be used.
+
 ## Returns
 
 `TCombinedResult`
+
+An array with one result per query, in the same order as `queries` — or, if `combine` is provided,
+whatever `combine` returns.
+
+## Examples
+
+```svelte
+<script lang="ts">
+  import { createQueries } from '@tanstack/svelte-query'
+
+  let { ids }: { ids: Array<number> } = $props()
+
+  const postQueries = createQueries(() => ({
+    queries: ids.map((id) => ({
+      queryKey: ['post', id],
+      queryFn: () => fetchPost(id),
+      staleTime: Infinity,
+    })),
+  }))
+</script>
+
+<ul>
+  {#each postQueries as query, index (ids[index])}
+    {#if query.isPending}
+      <li>Loading...</li>
+    {:else if query.isError}
+      <li>Error: {query.error.message}</li>
+    {:else}
+      <li>{query.data.title}</li>
+    {/if}
+  {/each}
+</ul>
+```
+
+Combining results into a single value:
+```svelte
+<script lang="ts">
+  import { createQueries } from '@tanstack/svelte-query'
+
+  let { ids }: { ids: Array<number> } = $props()
+
+  const combined = createQueries(() => ({
+    queries: ids.map((id) => ({
+      queryKey: ['post', id],
+      queryFn: () => fetchPost(id),
+    })),
+    combine: (postQueries) => ({
+      data: postQueries.map((query) => query.data),
+      isPending: postQueries.some((query) => query.isPending),
+      isError: postQueries.some((query) => query.isError),
+    }),
+  }))
+</script>
+
+{#if combined.isPending}
+  Loading...
+{:else if combined.isError}
+  Error loading posts
+{:else}
+  <ul>
+    {#each combined.data as post}
+      <li>{post?.title}</li>
+    {/each}
+  </ul>
+{/if}
+```

--- a/docs/framework/svelte/reference/functions/createQuery.md
+++ b/docs/framework/svelte/reference/functions/createQuery.md
@@ -9,7 +9,7 @@ title: createQuery
 function createQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): CreateQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/createQuery.ts:49](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L49)
+Defined in: [packages/svelte-query/src/createQuery.ts:74](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L74)
 
 ### Type Parameters
 
@@ -57,7 +57,7 @@ display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
 
 [queryOptions](queryOptions.md) to share these options between `createQuery` and imperative APIs like `queryClient.query`.
 
-### Example
+### Examples
 
 ```svelte
 <script lang="ts">
@@ -82,13 +82,37 @@ display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
 {/if}
 ```
 
+The same query, checking `isPending`/`isError` instead of `status` — pick whichever reads better to you:
+```svelte
+<script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query'
+
+  const query = createQuery(() => ({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+  }))
+</script>
+
+{#if query.isPending}
+  Loading...
+{:else if query.isError}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <ul>
+    {#each query.data as post (post.id)}
+      <li>{post.title}</li>
+    {/each}
+  </ul>
+{/if}
+```
+
 ## Call Signature
 
 ```ts
 function createQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): DefinedCreateQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/createQuery.ts:97](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L97)
+Defined in: [packages/svelte-query/src/createQuery.ts:122](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L122)
 
 This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
 
@@ -169,7 +193,7 @@ since `initialData` guarantees data upfront). `isSuccess`/`isError` are derived 
 function createQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): CreateQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/createQuery.ts:223](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L223)
+Defined in: [packages/svelte-query/src/createQuery.ts:248](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L248)
 
 ### Type Parameters
 

--- a/docs/framework/svelte/reference/functions/createQuery.md
+++ b/docs/framework/svelte/reference/functions/createQuery.md
@@ -49,9 +49,9 @@ be used.
 
 [`CreateQueryResult`](../type-aliases/CreateQueryResult.md)\<`TData`, `TError`\>
 
-The current query result. `status` is `pending` if there is no cached data and no query attempt
-has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
-display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+The current query result. `status` is `pending` if there is no cached data to display, `error` if
+the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+are derived booleans for convenience.
 
 ### See
 
@@ -233,9 +233,9 @@ be used.
 
 [`CreateQueryResult`](../type-aliases/CreateQueryResult.md)\<`TData`, `TError`\>
 
-The current query result. `status` is `pending` if there is no cached data and no query attempt
-has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
-display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+The current query result. `status` is `pending` if there is no cached data to display, `error` if
+the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+are derived booleans for convenience.
 
 ### See
 

--- a/docs/framework/svelte/reference/functions/createQuery.md
+++ b/docs/framework/svelte/reference/functions/createQuery.md
@@ -9,7 +9,7 @@ title: createQuery
 function createQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): CreateQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/createQuery.ts:15](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L15)
+Defined in: [packages/svelte-query/src/createQuery.ts:49](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L49)
 
 ### Type Parameters
 
@@ -35,13 +35,52 @@ Defined in: [packages/svelte-query/src/createQuery.ts:15](https://github.com/Tan
 
 [`Accessor`](../type-aliases/Accessor.md)\<[`UndefinedInitialDataOptions`](../type-aliases/UndefinedInitialDataOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`\>\>
 
+The [UndefinedInitialDataOptions](../type-aliases/UndefinedInitialDataOptions.md) to use — everything you can pass to `createQuery`,
+wrapped in an [Accessor](../type-aliases/Accessor.md) so options can be reactive.
+
 #### queryClient?
 
 [`Accessor`](../type-aliases/Accessor.md)\<`QueryClient`\>
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ### Returns
 
 [`CreateQueryResult`](../type-aliases/CreateQueryResult.md)\<`TData`, `TError`\>
+
+The current query result. `status` is `pending` if there is no cached data and no query attempt
+has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
+display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+
+### See
+
+[queryOptions](queryOptions.md) to share these options between `createQuery` and imperative APIs like `queryClient.query`.
+
+### Example
+
+```svelte
+<script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query'
+
+  const query = createQuery(() => ({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+  }))
+</script>
+
+{#if query.status === 'pending'}
+  Loading...
+{:else if query.status === 'error'}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <ul>
+    {#each query.data as post (post.id)}
+      <li>{post.title}</li>
+    {/each}
+  </ul>
+{/if}
+```
 
 ## Call Signature
 
@@ -49,7 +88,9 @@ Defined in: [packages/svelte-query/src/createQuery.ts:15](https://github.com/Tan
 function createQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): DefinedCreateQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/createQuery.ts:27](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L27)
+Defined in: [packages/svelte-query/src/createQuery.ts:97](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L97)
+
+This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
 
 ### Type Parameters
 
@@ -75,13 +116,52 @@ Defined in: [packages/svelte-query/src/createQuery.ts:27](https://github.com/Tan
 
 [`Accessor`](../type-aliases/Accessor.md)\<[`DefinedInitialDataOptions`](../type-aliases/DefinedInitialDataOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`\>\>
 
+The [DefinedInitialDataOptions](../type-aliases/DefinedInitialDataOptions.md) to use — everything you can pass to `createQuery`,
+with `initialData` set, wrapped in an [Accessor](../type-aliases/Accessor.md) so options can be reactive.
+
 #### queryClient?
 
 [`Accessor`](../type-aliases/Accessor.md)\<`QueryClient`\>
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ### Returns
 
 [`DefinedCreateQueryResult`](../type-aliases/DefinedCreateQueryResult.md)\<`TData`, `TError`\>
+
+The current query result, typed so that `status` is `success` — or `error` if a fetch attempt
+fails while keeping the existing data (`status` never resolves to `pending` in this overload's type,
+since `initialData` guarantees data upfront). `isSuccess`/`isError` are derived booleans for convenience.
+
+### See
+
+[queryOptions](queryOptions.md) to share these options between `createQuery` and imperative APIs like `queryClient.query`.
+
+### Example
+
+```svelte
+<script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query'
+
+  // `data` is `Post[]`, never `undefined`, thanks to `initialData` — even if a refetch fails,
+  // so the list stays visible alongside the error.
+  const query = createQuery(() => ({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+    initialData: [],
+  }))
+</script>
+
+{#if query.isError}
+  <span>Error: {query.error.message}</span>
+{/if}
+<ul>
+  {#each query.data as post (post.id)}
+    <li>{post.title}</li>
+  {/each}
+</ul>
+```
 
 ## Call Signature
 
@@ -89,7 +169,7 @@ Defined in: [packages/svelte-query/src/createQuery.ts:27](https://github.com/Tan
 function createQuery<TQueryFnData, TError, TData, TQueryKey>(options, queryClient?): CreateQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/createQuery.ts:39](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L39)
+Defined in: [packages/svelte-query/src/createQuery.ts:223](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/createQuery.ts#L223)
 
 ### Type Parameters
 
@@ -115,10 +195,126 @@ Defined in: [packages/svelte-query/src/createQuery.ts:39](https://github.com/Tan
 
 [`Accessor`](../type-aliases/Accessor.md)\<[`CreateQueryOptions`](../type-aliases/CreateQueryOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`\>\>
 
+The [CreateQueryOptions](../type-aliases/CreateQueryOptions.md) to use — everything you can pass to `createQuery`, wrapped
+in an [Accessor](../type-aliases/Accessor.md) so options can be reactive.
+
 #### queryClient?
 
 [`Accessor`](../type-aliases/Accessor.md)\<`QueryClient`\>
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ### Returns
 
 [`CreateQueryResult`](../type-aliases/CreateQueryResult.md)\<`TData`, `TError`\>
+
+The current query result. `status` is `pending` if there is no cached data and no query attempt
+has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
+display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+
+### See
+
+[queryOptions](queryOptions.md) to share these options between `createQuery` and imperative APIs like `queryClient.query`.
+
+### Examples
+
+`select` derives whatever `data` a component needs from the cached value, without changing what's
+actually stored in the cache — the cache still holds the full `Post[]`, but `data` here is a `number`:
+```svelte
+<script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query'
+
+  const query = createQuery(() => ({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+    select: (posts) => posts.length,
+  }))
+</script>
+
+{#if query.isPending}
+  Loading...
+{:else if query.isError}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <span>{query.data} posts</span>
+{/if}
+```
+
+A dependent query, only enabled once `postId` is set — use `isLoading`, not `isPending`, so the
+loading state doesn't show while the query is disabled:
+```svelte
+<script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query'
+
+  let { postId }: { postId: number | undefined } = $props()
+
+  const query = createQuery(() => ({
+    queryKey: ['post', postId],
+    queryFn: () => fetchPost(postId!),
+    enabled: postId != null,
+  }))
+</script>
+
+{#if postId == null}
+  Select a post
+{:else if query.isLoading}
+  Loading...
+{:else if query.isError}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <h1>{query.data?.title}</h1>
+{/if}
+```
+
+Seeding a detail query from an already-cached list, to skip the loading state:
+```svelte
+<script lang="ts">
+  import { createQuery, useQueryClient } from '@tanstack/svelte-query'
+
+  let { postId }: { postId: number } = $props()
+
+  const queryClient = useQueryClient()
+
+  const query = createQuery(() => ({
+    queryKey: ['post', postId],
+    queryFn: () => fetchPost(postId),
+    initialData: () =>
+      queryClient
+        .getQueryData<Array<Post>>(['posts'])
+        ?.find((post) => post.id === postId),
+  }))
+</script>
+
+{#if query.isError}
+  <span>Error: {query.error.message}</span>
+{/if}
+<h1>{query.data?.title}</h1>
+```
+
+Paginated data, keeping the previous page's data visible while the next page loads:
+```svelte
+<script lang="ts">
+  import { createQuery, keepPreviousData } from '@tanstack/svelte-query'
+
+  let page = $state(0)
+
+  const query = createQuery(() => ({
+    queryKey: ['posts', page],
+    queryFn: () => fetchPosts(page),
+    placeholderData: keepPreviousData,
+  }))
+</script>
+
+{#if query.isError}
+  <span>Error: {query.error.message}</span>
+{/if}
+<ul>
+  {#each query.data ?? [] as post (post.id)}
+    <li>{post.title}</li>
+  {/each}
+</ul>
+<button disabled={query.isPlaceholderData} onclick={() => page++}>
+  Next Page
+</button>
+```

--- a/docs/framework/svelte/reference/functions/getIsRestoringContext.md
+++ b/docs/framework/svelte/reference/functions/getIsRestoringContext.md
@@ -7,7 +7,7 @@ title: getIsRestoringContext
 function getIsRestoringContext(): Box<boolean>;
 ```
 
-Defined in: [packages/svelte-query/src/context.ts:27](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L27)
+Defined in: [packages/svelte-query/src/context.ts:52](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L52)
 
 Retrieves a `isRestoring` from Svelte's context
 

--- a/docs/framework/svelte/reference/functions/getQueryClientContext.md
+++ b/docs/framework/svelte/reference/functions/getQueryClientContext.md
@@ -7,10 +7,17 @@ title: getQueryClientContext
 function getQueryClientContext(): QueryClient;
 ```
 
-Defined in: [packages/svelte-query/src/context.ts:8](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L8)
+Defined in: [packages/svelte-query/src/context.ts:14](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L14)
 
-Retrieves a Client from Svelte's context
+Retrieves the `QueryClient` set on Svelte's context by `QueryClientProvider` (or by
+[setQueryClientContext](setQueryClientContext.md) directly). This is what [useQueryClient](useQueryClient.md) calls internally.
 
 ## Returns
 
 `QueryClient`
+
+The `QueryClient` from the nearest `QueryClientProvider`.
+
+## Throws
+
+If no `QueryClient` was found in context.

--- a/docs/framework/svelte/reference/functions/getQueryClientContext.md
+++ b/docs/framework/svelte/reference/functions/getQueryClientContext.md
@@ -16,7 +16,7 @@ Retrieves the `QueryClient` set on Svelte's context by `QueryClientProvider` (or
 
 `QueryClient`
 
-The `QueryClient` from the nearest `QueryClientProvider`.
+The `QueryClient` set on context, whether by `QueryClientProvider` or [setQueryClientContext](setQueryClientContext.md).
 
 ## Throws
 

--- a/docs/framework/svelte/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/svelte/reference/functions/infiniteQueryOptions.md
@@ -7,7 +7,11 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [packages/svelte-query/src/infiniteQueryOptions.ts:4](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/infiniteQueryOptions.ts#L4)
+Defined in: [packages/svelte-query/src/infiniteQueryOptions.ts:48](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/infiniteQueryOptions.ts#L48)
+
+You can generally pass everything to `infiniteQueryOptions` that you can also pass to `createInfiniteQuery`.
+These options can be shared across `createInfiniteQuery` calls and imperative APIs such as
+`queryClient.infiniteQuery`. `options.queryKey` is required and is the query key to generate options for.
 
 ## Type Parameters
 
@@ -37,6 +41,50 @@ Defined in: [packages/svelte-query/src/infiniteQueryOptions.ts:4](https://github
 
 [`CreateInfiniteQueryOptions`](../type-aliases/CreateInfiniteQueryOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`, `TPageParam`\>
 
+The [CreateInfiniteQueryOptions](../type-aliases/CreateInfiniteQueryOptions.md) to use — everything you can pass to
+`createInfiniteQuery`.
+
 ## Returns
 
 [`CreateInfiniteQueryOptions`](../type-aliases/CreateInfiniteQueryOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`, `TPageParam`\>
+
+The same options object.
+
+## See
+
+[createInfiniteQuery](createInfiniteQuery.md) to run an infinite query with these options.
+
+## Example
+
+A parameterized factory, so the same options object can be reused per `postId`:
+```svelte
+<script lang="ts">
+  import { infiniteQueryOptions, createInfiniteQuery } from '@tanstack/svelte-query'
+
+  let { postId }: { postId: string } = $props()
+
+  const commentsOptions = (postId: string) =>
+    infiniteQueryOptions({
+      queryKey: ['post', postId, 'comments'],
+      queryFn: ({ pageParam }) => fetchComments(postId, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextId,
+    })
+
+  const query = createInfiniteQuery(() => commentsOptions(postId))
+</script>
+
+{#if query.isPending}
+  Loading...
+{:else if query.isError}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <ul>
+    {#each query.data.pages as page}
+      {#each page.comments as comment (comment.id)}
+        <li>{comment.text}</li>
+      {/each}
+    {/each}
+  </ul>
+{/if}
+```

--- a/docs/framework/svelte/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/svelte/reference/functions/infiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [packages/svelte-query/src/infiniteQueryOptions.ts:48](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/infiniteQueryOptions.ts#L48)
+Defined in: [packages/svelte-query/src/infiniteQueryOptions.ts:78](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/infiniteQueryOptions.ts#L78)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `createInfiniteQuery`.
 These options can be shared across `createInfiniteQuery` calls and imperative APIs such as
@@ -54,7 +54,36 @@ The same options object.
 
 [createInfiniteQuery](createInfiniteQuery.md) to run an infinite query with these options.
 
-## Example
+## Examples
+
+`initialData` skips the loading state on first render — even if a refetch fails, the list stays
+visible alongside the error:
+```svelte
+<script lang="ts">
+  import { infiniteQueryOptions, createInfiniteQuery } from '@tanstack/svelte-query'
+
+  const projectsOptions = infiniteQueryOptions({
+    queryKey: ['projects'],
+    queryFn: ({ pageParam }) => fetchProjects(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextId,
+    initialData: { pages: [], pageParams: [] },
+  })
+
+  const query = createInfiniteQuery(() => projectsOptions)
+</script>
+
+{#if query.isError}
+  <span>Error: {query.error.message}</span>
+{/if}
+<ul>
+  {#each query.data?.pages ?? [] as page}
+    {#each page.projects as project (project.id)}
+      <li>{project.name}</li>
+    {/each}
+  {/each}
+</ul>
+```
 
 A parameterized factory, so the same options object can be reused per `postId`:
 ```svelte

--- a/docs/framework/svelte/reference/functions/mutationOptions.md
+++ b/docs/framework/svelte/reference/functions/mutationOptions.md
@@ -9,7 +9,11 @@ title: mutationOptions
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): WithRequired<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [packages/svelte-query/src/mutationOptions.ts:4](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts#L4)
+Defined in: [packages/svelte-query/src/mutationOptions.ts:34](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts#L34)
+
+You can generally pass everything to `mutationOptions` that you can also pass to `createMutation`. This
+overload requires `mutationKey`, so the resulting options can be looked up elsewhere (e.g. with
+`useMutationState`).
 
 ### Type Parameters
 
@@ -35,9 +39,39 @@ Defined in: [packages/svelte-query/src/mutationOptions.ts:4](https://github.com/
 
 `WithRequired`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>
 
+The options to use — everything you can pass to `createMutation`, with `mutationKey` set.
+
 ### Returns
 
 `WithRequired`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>
+
+The same options object.
+
+### See
+
+[createMutation](createMutation.md) to run a mutation with these options.
+
+### Example
+
+Looking the mutation up elsewhere via its `mutationKey`, e.g. for a global "saving…" indicator:
+```svelte
+<script lang="ts">
+  import { mutationOptions, useMutationState } from '@tanstack/svelte-query'
+
+  const createPostOptions = mutationOptions({
+    mutationKey: ['posts', 'create'],
+    mutationFn: createPost,
+  })
+
+  const pending = useMutationState({
+    filters: { mutationKey: createPostOptions.mutationKey, status: 'pending' },
+  })
+</script>
+
+{#if pending.length > 0}
+  <span>Saving…</span>
+{/if}
+```
 
 ## Call Signature
 
@@ -45,7 +79,9 @@ Defined in: [packages/svelte-query/src/mutationOptions.ts:4](https://github.com/
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): Omit<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [packages/svelte-query/src/mutationOptions.ts:18](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts#L18)
+Defined in: [packages/svelte-query/src/mutationOptions.ts:71](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/mutationOptions.ts#L71)
+
+You can generally pass everything to `mutationOptions` that you can also pass to `createMutation`.
 
 ### Type Parameters
 
@@ -71,6 +107,30 @@ Defined in: [packages/svelte-query/src/mutationOptions.ts:18](https://github.com
 
 `Omit`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>
 
+The options to use — everything you can pass to `createMutation`.
+
 ### Returns
 
 `Omit`\<[`CreateMutationOptions`](../type-aliases/CreateMutationOptions.md)\<`TData`, `TError`, `TVariables`, `TOnMutateResult`\>, `"mutationKey"`\>
+
+The same options object.
+
+### See
+
+[createMutation](createMutation.md) to run a mutation with these options.
+
+### Example
+
+```svelte
+<script lang="ts">
+  import { mutationOptions, createMutation } from '@tanstack/svelte-query'
+
+  const createPostOptions = mutationOptions({
+    mutationFn: createPost,
+  })
+
+  const mutation = createMutation(() => createPostOptions)
+</script>
+
+<button onclick={() => mutation.mutate({ title: 'Hello' })}>Create</button>
+```

--- a/docs/framework/svelte/reference/functions/queryOptions.md
+++ b/docs/framework/svelte/reference/functions/queryOptions.md
@@ -9,7 +9,13 @@ title: queryOptions
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/queryOptions.ts:30](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/queryOptions.ts#L30)
+Defined in: [packages/svelte-query/src/queryOptions.ts:68](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/queryOptions.ts#L68)
+
+You can generally pass everything to `queryOptions` that you can also pass to `createQuery`. These options
+can be shared across `createQuery` calls and imperative APIs such as `queryClient.query`. `options.queryKey`
+is required and is the query key to generate options for.
+
+This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
 
 ### Type Parameters
 
@@ -35,9 +41,45 @@ Defined in: [packages/svelte-query/src/queryOptions.ts:30](https://github.com/Ta
 
 [`DefinedInitialDataOptions`](../type-aliases/DefinedInitialDataOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`\>
 
+The [DefinedInitialDataOptions](../type-aliases/DefinedInitialDataOptions.md) to use — everything you can pass to `createQuery`,
+with `initialData` set.
+
 ### Returns
 
 [`CreateQueryOptions`](../type-aliases/CreateQueryOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`\> & `object` & `QueryKeyWithDataTag`\<`TQueryKey`, `TQueryFnData`, `TError`\>
+
+The same options object, typed so that `queryKey` carries the inferred data type.
+
+### See
+
+[createQuery](createQuery.md) to run a query with these options.
+
+### Example
+
+```svelte
+<script lang="ts">
+  import { queryOptions, createQuery } from '@tanstack/svelte-query'
+
+  const postsOptions = queryOptions({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+    initialData: [],
+  })
+
+  // `data` is `Post[]`, never `undefined`, thanks to `initialData` — even if a refetch fails,
+  // so the list stays visible alongside the error.
+  const query = createQuery(() => postsOptions)
+</script>
+
+{#if query.isError}
+  <span>Error: {query.error.message}</span>
+{/if}
+<ul>
+  {#each query.data as post (post.id)}
+    <li>{post.title}</li>
+  {/each}
+</ul>
+```
 
 ## Call Signature
 
@@ -45,7 +87,11 @@ Defined in: [packages/svelte-query/src/queryOptions.ts:30](https://github.com/Ta
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/queryOptions.ts:40](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/queryOptions.ts#L40)
+Defined in: [packages/svelte-query/src/queryOptions.ts:113](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/queryOptions.ts#L113)
+
+You can generally pass everything to `queryOptions` that you can also pass to `createQuery`. These options
+can be shared across `createQuery` calls and imperative APIs such as `queryClient.query`. `options.queryKey`
+is required and is the query key to generate options for.
 
 ### Type Parameters
 
@@ -71,6 +117,41 @@ Defined in: [packages/svelte-query/src/queryOptions.ts:40](https://github.com/Ta
 
 [`UndefinedInitialDataOptions`](../type-aliases/UndefinedInitialDataOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`\>
 
+The [UndefinedInitialDataOptions](../type-aliases/UndefinedInitialDataOptions.md) to use — everything you can pass to `createQuery`.
+
 ### Returns
 
 [`CreateQueryOptions`](../type-aliases/CreateQueryOptions.md)\<`TQueryFnData`, `TError`, `TData`, `TQueryKey`\> & `object` & `QueryKeyWithDataTag`\<`TQueryKey`, `TQueryFnData`, `TError`\>
+
+The same options object, typed so that `queryKey` carries the inferred data type.
+
+### See
+
+[createQuery](createQuery.md) to run a query with these options.
+
+### Example
+
+A parameterized factory, so the same options object can be reused per `id`:
+```svelte
+<script lang="ts">
+  import { queryOptions, createQuery } from '@tanstack/svelte-query'
+
+  let { id }: { id: string } = $props()
+
+  const postOptions = (id: string) =>
+    queryOptions({
+      queryKey: ['post', id],
+      queryFn: () => fetchPost(id),
+    })
+
+  const query = createQuery(() => postOptions(id))
+</script>
+
+{#if query.isPending}
+  Loading...
+{:else if query.isError}
+  <span>Error: {query.error.message}</span>
+{:else}
+  <h1>{query.data.title}</h1>
+{/if}
+```

--- a/docs/framework/svelte/reference/functions/setIsRestoringContext.md
+++ b/docs/framework/svelte/reference/functions/setIsRestoringContext.md
@@ -7,7 +7,7 @@ title: setIsRestoringContext
 function setIsRestoringContext(isRestoring): void;
 ```
 
-Defined in: [packages/svelte-query/src/context.ts:39](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L39)
+Defined in: [packages/svelte-query/src/context.ts:64](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L64)
 
 Sets a `isRestoring` on Svelte's context
 

--- a/docs/framework/svelte/reference/functions/setQueryClientContext.md
+++ b/docs/framework/svelte/reference/functions/setQueryClientContext.md
@@ -35,6 +35,6 @@ The `QueryClient` to make available to descendant components.
 </script>
 
 <QueryClientProvider client={queryClient}>
-  <App />
+  ...
 </QueryClientProvider>
 ```

--- a/docs/framework/svelte/reference/functions/setQueryClientContext.md
+++ b/docs/framework/svelte/reference/functions/setQueryClientContext.md
@@ -7,9 +7,11 @@ title: setQueryClientContext
 function setQueryClientContext(client): void;
 ```
 
-Defined in: [packages/svelte-query/src/context.ts:20](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L20)
+Defined in: [packages/svelte-query/src/context.ts:45](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/context.ts#L45)
 
-Sets a QueryClient on Svelte's context
+Sets a `QueryClient` on Svelte's context, so it can be read with [getQueryClientContext](getQueryClientContext.md) (or
+[useQueryClient](useQueryClient.md)) from any descendant component. `QueryClientProvider` wraps this — use it directly
+only if you need to set the client from your own component instead.
 
 ## Parameters
 
@@ -17,6 +19,22 @@ Sets a QueryClient on Svelte's context
 
 `QueryClient`
 
+The `QueryClient` to make available to descendant components.
+
 ## Returns
 
 `void`
+
+## Example
+
+```svelte
+<script lang="ts">
+  import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query'
+
+  const queryClient = new QueryClient()
+</script>
+
+<QueryClientProvider client={queryClient}>
+  <App />
+</QueryClientProvider>
+```

--- a/docs/framework/svelte/reference/functions/useHydrate.md
+++ b/docs/framework/svelte/reference/functions/useHydrate.md
@@ -10,7 +10,12 @@ function useHydrate(
    queryClient?): void;
 ```
 
-Defined in: [packages/svelte-query/src/useHydrate.ts:5](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useHydrate.ts#L5)
+Defined in: [packages/svelte-query/src/useHydrate.ts:33](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useHydrate.ts#L33)
+
+Adds a previously dehydrated `state` into the `queryClient` (from the nearest context, or the one
+passed explicitly). If the client already contains data, the new queries will be intelligently merged based
+on update timestamp. `HydrationBoundary` wraps this — use it directly only if you need to hydrate from your
+own component instead.
 
 ## Parameters
 
@@ -18,14 +23,39 @@ Defined in: [packages/svelte-query/src/useHydrate.ts:5](https://github.com/TanSt
 
 `unknown`
 
+The dehydrated state to hydrate into the cache, as produced by `dehydrate`.
+
 ### options?
 
 `HydrateOptions`
+
+HydrateOptions to control the hydration.
 
 ### queryClient?
 
 `QueryClient`
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ## Returns
 
 `void`
+
+## Example
+
+Server-side prefetch handed off to the client via `dehydrate` — `dehydratedState` would typically come
+from a server load function that prefetched with `queryClient.query` and called `dehydrate(queryClient)`:
+```svelte
+<script lang="ts">
+  import { HydrationBoundary } from '@tanstack/svelte-query'
+  import type { DehydratedState } from '@tanstack/svelte-query'
+  import Posts from './Posts.svelte'
+
+  let { dehydratedState }: { dehydratedState: DehydratedState } = $props()
+</script>
+
+<HydrationBoundary state={dehydratedState}>
+  <Posts />
+</HydrationBoundary>
+```

--- a/docs/framework/svelte/reference/functions/useIsFetching.md
+++ b/docs/framework/svelte/reference/functions/useIsFetching.md
@@ -7,7 +7,7 @@ title: useIsFetching
 function useIsFetching(filters?, queryClient?): ReactiveValue<number>;
 ```
 
-Defined in: [packages/svelte-query/src/useIsFetching.svelte.ts:5](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useIsFetching.svelte.ts#L5)
+Defined in: [packages/svelte-query/src/useIsFetching.svelte.ts:40](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useIsFetching.svelte.ts#L40)
 
 ## Parameters
 
@@ -15,10 +15,46 @@ Defined in: [packages/svelte-query/src/useIsFetching.svelte.ts:5](https://github
 
 `QueryFilters`\<readonly `unknown`[]\>
 
+QueryFilters to narrow down which queries to count. Omit to count every fetching
+query.
+
 ### queryClient?
 
 `QueryClient`
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ## Returns
 
 `ReactiveValue`\<`number`\>
+
+A reactive value — read `.current` to get how many matching queries are currently fetching.
+
+## Examples
+
+```svelte
+<script lang="ts">
+  import { useIsFetching } from '@tanstack/svelte-query'
+
+  // How many queries matching the posts prefix are fetching?
+  const isFetchingPosts = useIsFetching({ queryKey: ['posts'] })
+</script>
+
+{#if isFetchingPosts.current}
+  <span>Refreshing posts...</span>
+{/if}
+```
+
+A global loading indicator for any query fetching in the background, not just the ones on screen:
+```svelte
+<script lang="ts">
+  import { useIsFetching } from '@tanstack/svelte-query'
+
+  const isFetching = useIsFetching()
+</script>
+
+{#if isFetching.current}
+  <div>Queries are fetching in the background...</div>
+{/if}
+```

--- a/docs/framework/svelte/reference/functions/useIsMutating.md
+++ b/docs/framework/svelte/reference/functions/useIsMutating.md
@@ -7,7 +7,10 @@ title: useIsMutating
 function useIsMutating(filters?, queryClient?): ReactiveValue<number>;
 ```
 
-Defined in: [packages/svelte-query/src/useIsMutating.svelte.ts:5](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useIsMutating.svelte.ts#L5)
+Defined in: [packages/svelte-query/src/useIsMutating.svelte.ts:28](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useIsMutating.svelte.ts#L28)
+
+`useIsMutating` is an optional hook that returns the `number` of mutations that your application is
+running (useful for app-wide loading indicators).
 
 ## Parameters
 
@@ -15,10 +18,32 @@ Defined in: [packages/svelte-query/src/useIsMutating.svelte.ts:5](https://github
 
 `MutationFilters`\<`unknown`, `Error`, `unknown`, `unknown`\>
 
+MutationFilters to narrow down which mutations to count.
+
 ### queryClient?
 
 `QueryClient`
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ## Returns
 
 `ReactiveValue`\<`number`\>
+
+A reactive value — read `.current` to get how many matching mutations are currently running.
+
+## Example
+
+```svelte
+<script lang="ts">
+  import { useIsMutating } from '@tanstack/svelte-query'
+
+  // How many mutations matching the posts prefix are in progress?
+  const isMutatingPosts = useIsMutating({ mutationKey: ['posts'] })
+</script>
+
+{#if isMutatingPosts.current}
+  <span>Saving posts...</span>
+{/if}
+```

--- a/docs/framework/svelte/reference/functions/useMutationState.md
+++ b/docs/framework/svelte/reference/functions/useMutationState.md
@@ -87,7 +87,7 @@ Get all data for specific mutations via the `mutationKey`:
 
 Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
 mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
-latest invocation:
+latest successful mutation (the `status: 'success'` filter above excludes pending/errored ones):
 ```svelte
 <script lang="ts">
   import { useMutationState } from '@tanstack/svelte-query'

--- a/docs/framework/svelte/reference/functions/useMutationState.md
+++ b/docs/framework/svelte/reference/functions/useMutationState.md
@@ -7,7 +7,10 @@ title: useMutationState
 function useMutationState<TResult, TMutation>(options, queryClient?): TResult[];
 ```
 
-Defined in: [packages/svelte-query/src/useMutationState.svelte.ts:29](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useMutationState.svelte.ts#L29)
+Defined in: [packages/svelte-query/src/useMutationState.svelte.ts:99](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/useMutationState.svelte.ts#L99)
+
+`useMutationState` gives you access to all mutations (matching the given `filters`), including ones that
+were created by a different component or hook instance, or even ones no longer mounted.
 
 ## Type Parameters
 
@@ -25,10 +28,77 @@ Defined in: [packages/svelte-query/src/useMutationState.svelte.ts:29](https://gi
 
 [`MutationStateOptions`](../type-aliases/MutationStateOptions.md)\<`TResult`, `TMutation`\> = `{}`
 
+The `filters` to narrow down matched mutations, and an optional `select` to transform the
+mutation state.
+
 ### queryClient?
 
 `QueryClient`
 
+Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+be used.
+
 ## Returns
 
 `TResult`[]
+
+An Array of whatever `select` returns for each matching mutation.
+
+## Examples
+
+Get all variables of all running mutations:
+```svelte
+<script lang="ts">
+  import { useMutationState } from '@tanstack/svelte-query'
+
+  const pendingVariables = useMutationState({
+    filters: { status: 'pending' },
+    select: (mutation) => mutation.state.variables,
+  })
+</script>
+
+{pendingVariables.length} posts saving...
+```
+
+Get all data for specific mutations via the `mutationKey`:
+```svelte
+<script lang="ts">
+  import { createMutation, useMutationState } from '@tanstack/svelte-query'
+
+  const mutationKey = ['posts']
+
+  // Some mutation that we want to get the state for
+  const mutation = createMutation(() => ({
+    mutationKey,
+    mutationFn: createPosts,
+  }))
+
+  const savedPosts = useMutationState({
+    // this mutation key needs to match the mutation key of the given mutation (see above)
+    filters: { mutationKey, status: 'success' },
+    select: (mutation) => mutation.state.data,
+  })
+</script>
+
+<button onclick={() => mutation.mutate(['New Post'])}>
+  Create post ({savedPosts.length} saved so far)
+</button>
+```
+
+Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
+mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
+latest invocation:
+```svelte
+<script lang="ts">
+  import { useMutationState } from '@tanstack/svelte-query'
+
+  const savedPosts = useMutationState({
+    filters: { mutationKey: ['posts'], status: 'success' },
+    select: (mutation) => mutation.state.data,
+  })
+
+  const latestSavedPost = $derived(savedPosts[savedPosts.length - 1])
+</script>
+
+{latestSavedPost ? 'Saved' : 'Nothing saved yet'}
+```

--- a/packages/svelte-query/src/context.ts
+++ b/packages/svelte-query/src/context.ts
@@ -9,7 +9,7 @@ const _contextKey = Symbol('QueryClient')
  * {@link setQueryClientContext} directly). This is what {@link useQueryClient} calls internally.
  *
  * @throws If no `QueryClient` was found in context.
- * @returns The `QueryClient` from the nearest `QueryClientProvider`.
+ * @returns The `QueryClient` set on context, whether by `QueryClientProvider` or {@link setQueryClientContext}.
  */
 export const getQueryClientContext = (): QueryClient => {
   const client = getContext<QueryClient | undefined>(_contextKey)
@@ -38,7 +38,7 @@ export const getQueryClientContext = (): QueryClient => {
  * </script>
  *
  * <QueryClientProvider client={queryClient}>
- *   <App />
+ *   ...
  * </QueryClientProvider>
  * ```
  */

--- a/packages/svelte-query/src/context.ts
+++ b/packages/svelte-query/src/context.ts
@@ -4,7 +4,13 @@ import type { Box } from './containers.svelte'
 
 const _contextKey = Symbol('QueryClient')
 
-/** Retrieves a Client from Svelte's context */
+/**
+ * Retrieves the `QueryClient` set on Svelte's context by `QueryClientProvider` (or by
+ * {@link setQueryClientContext} directly). This is what {@link useQueryClient} calls internally.
+ *
+ * @throws If no `QueryClient` was found in context.
+ * @returns The `QueryClient` from the nearest `QueryClientProvider`.
+ */
 export const getQueryClientContext = (): QueryClient => {
   const client = getContext<QueryClient | undefined>(_contextKey)
   if (!client) {
@@ -16,7 +22,26 @@ export const getQueryClientContext = (): QueryClient => {
   return client
 }
 
-/** Sets a QueryClient on Svelte's context */
+/**
+ * Sets a `QueryClient` on Svelte's context, so it can be read with {@link getQueryClientContext} (or
+ * {@link useQueryClient}) from any descendant component. `QueryClientProvider` wraps this — use it directly
+ * only if you need to set the client from your own component instead.
+ *
+ * @param client - The `QueryClient` to make available to descendant components.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query'
+ *
+ *   const queryClient = new QueryClient()
+ * </script>
+ *
+ * <QueryClientProvider client={queryClient}>
+ *   <App />
+ * </QueryClientProvider>
+ * ```
+ */
 export const setQueryClientContext = (client: QueryClient): void => {
   setContext(_contextKey, client)
 }

--- a/packages/svelte-query/src/createInfiniteQuery.ts
+++ b/packages/svelte-query/src/createInfiniteQuery.ts
@@ -13,6 +13,99 @@ import type {
   CreateInfiniteQueryResult,
 } from './types.js'
 
+/**
+ * @see {@link infiniteQueryOptions} to share these options between `createInfiniteQuery` and imperative APIs
+ * like `queryClient.infiniteQuery`.
+ * @param options - The {@link CreateInfiniteQueryOptions} to use — everything you can pass to
+ * `createInfiniteQuery`, wrapped in an {@link Accessor} so options can be reactive.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns The current query result, plus `fetchNextPage`/`fetchPreviousPage`/`hasNextPage`/`hasPreviousPage`
+ * to page through the query.
+ *
+ * @example
+ * Fetching the next page from a "Load More" button click:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createInfiniteQuery } from '@tanstack/svelte-query'
+ *
+ *   const query = createInfiniteQuery(() => ({
+ *     queryKey: ['projects'],
+ *     queryFn: ({ pageParam }) => fetchProjects(pageParam),
+ *     initialPageParam: 0,
+ *     getNextPageParam: (lastPage) => lastPage.nextId,
+ *   }))
+ * </script>
+ *
+ * {#if query.isPending}
+ *   Loading...
+ * {:else if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <ul>
+ *     {#each query.data.pages as page}
+ *       {#each page.projects as project (project.id)}
+ *         <li>{project.name}</li>
+ *       {/each}
+ *     {/each}
+ *   </ul>
+ *   <button
+ *     onclick={() => query.fetchNextPage()}
+ *     disabled={!query.hasNextPage || query.isFetching}
+ *   >
+ *     {query.isFetchingNextPage
+ *       ? 'Loading more...'
+ *       : query.hasNextPage
+ *         ? 'Load More'
+ *         : 'Nothing more to load'}
+ *   </button>
+ * {/if}
+ * ```
+ *
+ * @example
+ * Fetching the next page automatically as the user scrolls, using an `IntersectionObserver` on a
+ * sentinel element after the list:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createInfiniteQuery } from '@tanstack/svelte-query'
+ *
+ *   const query = createInfiniteQuery(() => ({
+ *     queryKey: ['projects'],
+ *     queryFn: ({ pageParam }) => fetchProjects(pageParam),
+ *     initialPageParam: 0,
+ *     getNextPageParam: (lastPage) => lastPage.nextId,
+ *   }))
+ *
+ *   let sentinel: HTMLDivElement | undefined = $state()
+ *
+ *   $effect(() => {
+ *     if (sentinel == null || !query.hasNextPage || query.isFetching) return
+ *
+ *     const observer = new IntersectionObserver(([entry]) => {
+ *       if (entry?.isIntersecting) query.fetchNextPage()
+ *     })
+ *     observer.observe(sentinel)
+ *
+ *     return () => observer.disconnect()
+ *   })
+ * </script>
+ *
+ * {#if query.isPending}
+ *   Loading...
+ * {:else if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <ul>
+ *     {#each query.data.pages as page}
+ *       {#each page.projects as project (project.id)}
+ *         <li>{project.name}</li>
+ *       {/each}
+ *     {/each}
+ *   </ul>
+ *   <div bind:this={sentinel}></div>
+ * {/if}
+ * ```
+ */
 export function createInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,

--- a/packages/svelte-query/src/createMutation.svelte.ts
+++ b/packages/svelte-query/src/createMutation.svelte.ts
@@ -11,8 +11,101 @@ import type {
 import type { DefaultError, QueryClient } from '@tanstack/query-core'
 
 /**
- * @param options - A function that returns mutation options
- * @param queryClient - Custom query client which overrides provider
+ * Unlike queries, mutations are typically used to create/update/delete data or perform server side-effects.
+ * `createMutation` is the function for that.
+ *
+ * @see {@link mutationOptions} to share these options across multiple `createMutation` call sites, or to look
+ * the mutation up elsewhere via its `mutationKey` (e.g. with `useMutationState`).
+ * @param options - The {@link CreateMutationOptions} to use, wrapped in an {@link Accessor} so options can be
+ * reactive.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns `mutate`/`mutateAsync` also accept per-call `onSuccess`/`onError`/`onSettled` callbacks as a second
+ * argument, useful for triggering call-site side effects (e.g. navigation) without coupling them to the shared
+ * mutation definition. If you make multiple requests, `onSuccess` will fire only after the latest call you've
+ * made.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+ *
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = createMutation(() => ({
+ *     mutationFn: addTodo,
+ *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+ *   }))
+ * </script>
+ *
+ * <button
+ *   onclick={() =>
+ *     addMutation.mutate('Item', {
+ *       onError: (error) => console.error('Failed to add item:', error),
+ *     })
+ *   }
+ * >
+ *   Add
+ * </button>
+ * ```
+ *
+ * @example
+ * Rendering the mutation's own state, rather than just firing it off:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+ *
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = createMutation(() => ({
+ *     mutationFn: addTodo,
+ *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+ *   }))
+ * </script>
+ *
+ * {#if addMutation.isPending}
+ *   Adding todo...
+ * {:else}
+ *   {#if addMutation.isError}
+ *     <div>An error occurred: {addMutation.error.message}</div>
+ *   {/if}
+ *   <button onclick={() => addMutation.mutate('Item')}>Add</button>
+ * {/if}
+ * ```
+ *
+ * @example
+ * Optimistic update via `onMutate`, rolling back on `onError`:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+ *
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = createMutation(() => ({
+ *     mutationFn: addTodo,
+ *     onMutate: async (newTodo: string) => {
+ *       await queryClient.cancelQueries({ queryKey: ['todos'] })
+ *       const previousTodos = queryClient.getQueryData<Array<string>>(['todos'])
+ *
+ *       queryClient.setQueryData<Array<string>>(['todos'], (old) => [
+ *         ...(old ?? []),
+ *         newTodo,
+ *       ])
+ *
+ *       // Passed to `onError` as `context` if the mutation fails.
+ *       return { previousTodos }
+ *     },
+ *     onError: (_err, _newTodo, context) => {
+ *       queryClient.setQueryData(['todos'], context?.previousTodos)
+ *     },
+ *     onSettled: () => {
+ *       queryClient.invalidateQueries({ queryKey: ['todos'] })
+ *     },
+ *   }))
+ * </script>
+ *
+ * <button onclick={() => addMutation.mutate('Item')}>Add</button>
+ * ```
  */
 export function createMutation<
   TData = unknown,

--- a/packages/svelte-query/src/createMutation.svelte.ts
+++ b/packages/svelte-query/src/createMutation.svelte.ts
@@ -106,6 +106,67 @@ import type { DefaultError, QueryClient } from '@tanstack/query-core'
  *
  * <button onclick={() => addMutation.mutate('Item')}>Add</button>
  * ```
+ *
+ * @example
+ * Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
+ * promise per call instead, so you can wait for all of them:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+ *
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = createMutation(() => ({
+ *     mutationFn: addTodo,
+ *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+ *   }))
+ *
+ *   async function handleAddAll(todos: Array<string>) {
+ *     try {
+ *       await Promise.all(todos.map((todo) => addMutation.mutateAsync(todo)))
+ *     } catch (error) {
+ *       console.error('Failed to add todos:', error)
+ *     }
+ *   }
+ * </script>
+ *
+ * <button onclick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+ *   Add all
+ * </button>
+ * ```
+ *
+ * @example
+ * If some of the mutations above can fail independently of the others, and you want to know which ones
+ * did — rather than losing that information the moment the first one rejects — swap `Promise.all` for
+ * `Promise.allSettled`:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+ *
+ *   const queryClient = useQueryClient()
+ *
+ *   const addMutation = createMutation(() => ({
+ *     mutationFn: addTodo,
+ *     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+ *   }))
+ *
+ *   async function handleAddAll(todos: Array<string>) {
+ *     const addResults = await Promise.allSettled(
+ *       todos.map((todo) => addMutation.mutateAsync(todo)),
+ *     )
+ *
+ *     addResults.forEach((addResult, index) => {
+ *       if (addResult.status === 'rejected') {
+ *         console.error(`Failed to add "${todos[index]}":`, addResult.reason)
+ *       }
+ *     })
+ *   }
+ * </script>
+ *
+ * <button onclick={() => handleAddAll(['Todo 1', 'Todo 2', 'Todo 3'])}>
+ *   Add all
+ * </button>
+ * ```
  */
 export function createMutation<
   TData = unknown,

--- a/packages/svelte-query/src/createMutation.svelte.ts
+++ b/packages/svelte-query/src/createMutation.svelte.ts
@@ -92,11 +92,11 @@ import type { DefaultError, QueryClient } from '@tanstack/query-core'
  *         newTodo,
  *       ])
  *
- *       // Passed to `onError` as `context` if the mutation fails.
+ *       // Passed to `onError` as `onMutateResult` if the mutation fails.
  *       return { previousTodos }
  *     },
- *     onError: (_err, _newTodo, context) => {
- *       queryClient.setQueryData(['todos'], context?.previousTodos)
+ *     onError: (_err, _newTodo, onMutateResult) => {
+ *       queryClient.setQueryData(['todos'], onMutateResult?.previousTodos)
  *     },
  *     onSettled: () => {
  *       queryClient.invalidateQueries({ queryKey: ['todos'] })

--- a/packages/svelte-query/src/createQueries.svelte.ts
+++ b/packages/svelte-query/src/createQueries.svelte.ts
@@ -186,6 +186,77 @@ export type QueriesResults<
           >
         : { [K in keyof T]: GetCreateQueryResult<T[K]> }
 
+/**
+ * @param createQueriesOptions - The `queries` array to run, and an optional `combine` function, wrapped in an
+ * {@link Accessor} so options can be reactive.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context
+ * will be used.
+ * @returns An array with one result per query, in the same order as `queries` — or, if `combine` is provided,
+ * whatever `combine` returns.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQueries } from '@tanstack/svelte-query'
+ *
+ *   let { ids }: { ids: Array<number> } = $props()
+ *
+ *   const postQueries = createQueries(() => ({
+ *     queries: ids.map((id) => ({
+ *       queryKey: ['post', id],
+ *       queryFn: () => fetchPost(id),
+ *       staleTime: Infinity,
+ *     })),
+ *   }))
+ * </script>
+ *
+ * <ul>
+ *   {#each postQueries as query, index (ids[index])}
+ *     {#if query.isPending}
+ *       <li>Loading...</li>
+ *     {:else if query.isError}
+ *       <li>Error: {query.error.message}</li>
+ *     {:else}
+ *       <li>{query.data.title}</li>
+ *     {/if}
+ *   {/each}
+ * </ul>
+ * ```
+ *
+ * @example
+ * Combining results into a single value:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQueries } from '@tanstack/svelte-query'
+ *
+ *   let { ids }: { ids: Array<number> } = $props()
+ *
+ *   const combined = createQueries(() => ({
+ *     queries: ids.map((id) => ({
+ *       queryKey: ['post', id],
+ *       queryFn: () => fetchPost(id),
+ *     })),
+ *     combine: (postQueries) => ({
+ *       data: postQueries.map((query) => query.data),
+ *       isPending: postQueries.some((query) => query.isPending),
+ *       isError: postQueries.some((query) => query.isError),
+ *     }),
+ *   }))
+ * </script>
+ *
+ * {#if combined.isPending}
+ *   Loading...
+ * {:else if combined.isError}
+ *   Error loading posts
+ * {:else}
+ *   <ul>
+ *     {#each combined.data as post}
+ *       <li>{post?.title}</li>
+ *     {/each}
+ *   </ul>
+ * {/if}
+ * ```
+ */
 export function createQueries<
   T extends Array<any>,
   TCombinedResult = QueriesResults<T>,

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -45,6 +45,31 @@ import type {
  *   </ul>
  * {/if}
  * ```
+ *
+ * @example
+ * The same query, checking `isPending`/`isError` instead of `status` — pick whichever reads better to you:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQuery } from '@tanstack/svelte-query'
+ *
+ *   const query = createQuery(() => ({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *   }))
+ * </script>
+ *
+ * {#if query.isPending}
+ *   Loading...
+ * {:else if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <ul>
+ *     {#each query.data as post (post.id)}
+ *       <li>{post.title}</li>
+ *     {/each}
+ *   </ul>
+ * {/if}
+ * ```
  */
 export function createQuery<
   TQueryFnData = unknown,

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -12,6 +12,40 @@ import type {
   UndefinedInitialDataOptions,
 } from './queryOptions.js'
 
+/**
+ * @see {@link queryOptions} to share these options between `createQuery` and imperative APIs like `queryClient.query`.
+ * @param options - The {@link UndefinedInitialDataOptions} to use — everything you can pass to `createQuery`,
+ * wrapped in an {@link Accessor} so options can be reactive.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
+ * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
+ * display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQuery } from '@tanstack/svelte-query'
+ *
+ *   const query = createQuery(() => ({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *   }))
+ * </script>
+ *
+ * {#if query.status === 'pending'}
+ *   Loading...
+ * {:else if query.status === 'error'}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <ul>
+ *     {#each query.data as post (post.id)}
+ *       <li>{post.title}</li>
+ *     {/each}
+ *   </ul>
+ * {/if}
+ * ```
+ */
 export function createQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -24,6 +58,42 @@ export function createQuery<
   queryClient?: Accessor<QueryClient>,
 ): CreateQueryResult<TData, TError>
 
+/**
+ * This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
+ *
+ * @see {@link queryOptions} to share these options between `createQuery` and imperative APIs like `queryClient.query`.
+ * @param options - The {@link DefinedInitialDataOptions} to use — everything you can pass to `createQuery`,
+ * with `initialData` set, wrapped in an {@link Accessor} so options can be reactive.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns The current query result, typed so that `status` is `success` — or `error` if a fetch attempt
+ * fails while keeping the existing data (`status` never resolves to `pending` in this overload's type,
+ * since `initialData` guarantees data upfront). `isSuccess`/`isError` are derived booleans for convenience.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQuery } from '@tanstack/svelte-query'
+ *
+ *   // `data` is `Post[]`, never `undefined`, thanks to `initialData` — even if a refetch fails,
+ *   // so the list stays visible alongside the error.
+ *   const query = createQuery(() => ({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *     initialData: [],
+ *   }))
+ * </script>
+ *
+ * {#if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {/if}
+ * <ul>
+ *   {#each query.data as post (post.id)}
+ *     <li>{post.title}</li>
+ *   {/each}
+ * </ul>
+ * ```
+ */
 export function createQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -36,6 +106,120 @@ export function createQuery<
   queryClient?: Accessor<QueryClient>,
 ): DefinedCreateQueryResult<TData, TError>
 
+/**
+ * @see {@link queryOptions} to share these options between `createQuery` and imperative APIs like `queryClient.query`.
+ * @param options - The {@link CreateQueryOptions} to use — everything you can pass to `createQuery`, wrapped
+ * in an {@link Accessor} so options can be reactive.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
+ * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
+ * display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+ *
+ * @example
+ * `select` derives whatever `data` a component needs from the cached value, without changing what's
+ * actually stored in the cache — the cache still holds the full `Post[]`, but `data` here is a `number`:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQuery } from '@tanstack/svelte-query'
+ *
+ *   const query = createQuery(() => ({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *     select: (posts) => posts.length,
+ *   }))
+ * </script>
+ *
+ * {#if query.isPending}
+ *   Loading...
+ * {:else if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <span>{query.data} posts</span>
+ * {/if}
+ * ```
+ *
+ * @example
+ * A dependent query, only enabled once `postId` is set — use `isLoading`, not `isPending`, so the
+ * loading state doesn't show while the query is disabled:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQuery } from '@tanstack/svelte-query'
+ *
+ *   let { postId }: { postId: number | undefined } = $props()
+ *
+ *   const query = createQuery(() => ({
+ *     queryKey: ['post', postId],
+ *     queryFn: () => fetchPost(postId!),
+ *     enabled: postId != null,
+ *   }))
+ * </script>
+ *
+ * {#if postId == null}
+ *   Select a post
+ * {:else if query.isLoading}
+ *   Loading...
+ * {:else if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <h1>{query.data?.title}</h1>
+ * {/if}
+ * ```
+ *
+ * @example
+ * Seeding a detail query from an already-cached list, to skip the loading state:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQuery, useQueryClient } from '@tanstack/svelte-query'
+ *
+ *   let { postId }: { postId: number } = $props()
+ *
+ *   const queryClient = useQueryClient()
+ *
+ *   const query = createQuery(() => ({
+ *     queryKey: ['post', postId],
+ *     queryFn: () => fetchPost(postId),
+ *     initialData: () =>
+ *       queryClient
+ *         .getQueryData<Array<Post>>(['posts'])
+ *         ?.find((post) => post.id === postId),
+ *   }))
+ * </script>
+ *
+ * {#if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {/if}
+ * <h1>{query.data?.title}</h1>
+ * ```
+ *
+ * @example
+ * Paginated data, keeping the previous page's data visible while the next page loads:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createQuery, keepPreviousData } from '@tanstack/svelte-query'
+ *
+ *   let page = $state(0)
+ *
+ *   const query = createQuery(() => ({
+ *     queryKey: ['posts', page],
+ *     queryFn: () => fetchPosts(page),
+ *     placeholderData: keepPreviousData,
+ *   }))
+ * </script>
+ *
+ * {#if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {/if}
+ * <ul>
+ *   {#each query.data ?? [] as post (post.id)}
+ *     <li>{post.title}</li>
+ *   {/each}
+ * </ul>
+ * <button disabled={query.isPlaceholderData} onclick={() => page++}>
+ *   Next Page
+ * </button>
+ * ```
+ */
 export function createQuery<
   TQueryFnData,
   TError = DefaultError,

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -18,9 +18,9 @@ import type {
  * wrapped in an {@link Accessor} so options can be reactive.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
- * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
- * display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+ * @returns The current query result. `status` is `pending` if there is no cached data to display, `error` if
+ * the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+ * are derived booleans for convenience.
  *
  * @example
  * ```svelte
@@ -137,9 +137,9 @@ export function createQuery<
  * in an {@link Accessor} so options can be reactive.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
- * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
- * display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+ * @returns The current query result. `status` is `pending` if there is no cached data to display, `error` if
+ * the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+ * are derived booleans for convenience.
  *
  * @example
  * `select` derives whatever `data` a component needs from the cached value, without changing what's

--- a/packages/svelte-query/src/infiniteQueryOptions.ts
+++ b/packages/svelte-query/src/infiniteQueryOptions.ts
@@ -12,6 +12,36 @@ import type { CreateInfiniteQueryOptions } from './types.js'
  * @returns The same options object.
  *
  * @example
+ * `initialData` skips the loading state on first render — even if a refetch fails, the list stays
+ * visible alongside the error:
+ * ```svelte
+ * <script lang="ts">
+ *   import { infiniteQueryOptions, createInfiniteQuery } from '@tanstack/svelte-query'
+ *
+ *   const projectsOptions = infiniteQueryOptions({
+ *     queryKey: ['projects'],
+ *     queryFn: ({ pageParam }) => fetchProjects(pageParam),
+ *     initialPageParam: 0,
+ *     getNextPageParam: (lastPage) => lastPage.nextId,
+ *     initialData: { pages: [], pageParams: [] },
+ *   })
+ *
+ *   const query = createInfiniteQuery(() => projectsOptions)
+ * </script>
+ *
+ * {#if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {/if}
+ * <ul>
+ *   {#each query.data?.pages ?? [] as page}
+ *     {#each page.projects as project (project.id)}
+ *       <li>{project.name}</li>
+ *     {/each}
+ *   {/each}
+ * </ul>
+ * ```
+ *
+ * @example
  * A parameterized factory, so the same options object can be reused per `postId`:
  * ```svelte
  * <script lang="ts">

--- a/packages/svelte-query/src/infiniteQueryOptions.ts
+++ b/packages/svelte-query/src/infiniteQueryOptions.ts
@@ -1,6 +1,50 @@
 import type { DefaultError, InfiniteData, QueryKey } from '@tanstack/query-core'
 import type { CreateInfiniteQueryOptions } from './types.js'
 
+/**
+ * You can generally pass everything to `infiniteQueryOptions` that you can also pass to `createInfiniteQuery`.
+ * These options can be shared across `createInfiniteQuery` calls and imperative APIs such as
+ * `queryClient.infiniteQuery`. `options.queryKey` is required and is the query key to generate options for.
+ *
+ * @see {@link createInfiniteQuery} to run an infinite query with these options.
+ * @param options - The {@link CreateInfiniteQueryOptions} to use — everything you can pass to
+ * `createInfiniteQuery`.
+ * @returns The same options object.
+ *
+ * @example
+ * A parameterized factory, so the same options object can be reused per `postId`:
+ * ```svelte
+ * <script lang="ts">
+ *   import { infiniteQueryOptions, createInfiniteQuery } from '@tanstack/svelte-query'
+ *
+ *   let { postId }: { postId: string } = $props()
+ *
+ *   const commentsOptions = (postId: string) =>
+ *     infiniteQueryOptions({
+ *       queryKey: ['post', postId, 'comments'],
+ *       queryFn: ({ pageParam }) => fetchComments(postId, pageParam),
+ *       initialPageParam: 0,
+ *       getNextPageParam: (lastPage) => lastPage.nextId,
+ *     })
+ *
+ *   const query = createInfiniteQuery(() => commentsOptions(postId))
+ * </script>
+ *
+ * {#if query.isPending}
+ *   Loading...
+ * {:else if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <ul>
+ *     {#each query.data.pages as page}
+ *       {#each page.comments as comment (comment.id)}
+ *         <li>{comment.text}</li>
+ *       {/each}
+ *     {/each}
+ *   </ul>
+ * {/if}
+ * ```
+ */
 export function infiniteQueryOptions<
   TQueryFnData,
   TError = DefaultError,

--- a/packages/svelte-query/src/mutationOptions.ts
+++ b/packages/svelte-query/src/mutationOptions.ts
@@ -1,6 +1,36 @@
 import type { DefaultError, WithRequired } from '@tanstack/query-core'
 import type { CreateMutationOptions } from './types.js'
 
+/**
+ * You can generally pass everything to `mutationOptions` that you can also pass to `createMutation`. This
+ * overload requires `mutationKey`, so the resulting options can be looked up elsewhere (e.g. with
+ * `useMutationState`).
+ *
+ * @see {@link createMutation} to run a mutation with these options.
+ * @param options - The options to use — everything you can pass to `createMutation`, with `mutationKey` set.
+ * @returns The same options object.
+ *
+ * @example
+ * Looking the mutation up elsewhere via its `mutationKey`, e.g. for a global "saving…" indicator:
+ * ```svelte
+ * <script lang="ts">
+ *   import { mutationOptions, useMutationState } from '@tanstack/svelte-query'
+ *
+ *   const createPostOptions = mutationOptions({
+ *     mutationKey: ['posts', 'create'],
+ *     mutationFn: createPost,
+ *   })
+ *
+ *   const pending = useMutationState({
+ *     filters: { mutationKey: createPostOptions.mutationKey, status: 'pending' },
+ *   })
+ * </script>
+ *
+ * {#if pending.length > 0}
+ *   <span>Saving…</span>
+ * {/if}
+ * ```
+ */
 export function mutationOptions<
   TData = unknown,
   TError = DefaultError,
@@ -15,6 +45,29 @@ export function mutationOptions<
   CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>,
   'mutationKey'
 >
+
+/**
+ * You can generally pass everything to `mutationOptions` that you can also pass to `createMutation`.
+ *
+ * @see {@link createMutation} to run a mutation with these options.
+ * @param options - The options to use — everything you can pass to `createMutation`.
+ * @returns The same options object.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { mutationOptions, createMutation } from '@tanstack/svelte-query'
+ *
+ *   const createPostOptions = mutationOptions({
+ *     mutationFn: createPost,
+ *   })
+ *
+ *   const mutation = createMutation(() => createPostOptions)
+ * </script>
+ *
+ * <button onclick={() => mutation.mutate({ title: 'Hello' })}>Create</button>
+ * ```
+ */
 export function mutationOptions<
   TData = unknown,
   TError = DefaultError,

--- a/packages/svelte-query/src/queryOptions.ts
+++ b/packages/svelte-query/src/queryOptions.ts
@@ -27,6 +27,44 @@ export type DefinedInitialDataOptions<
     | (() => NonUndefinedGuard<TQueryFnData>)
 }
 
+/**
+ * You can generally pass everything to `queryOptions` that you can also pass to `createQuery`. These options
+ * can be shared across `createQuery` calls and imperative APIs such as `queryClient.query`. `options.queryKey`
+ * is required and is the query key to generate options for.
+ *
+ * This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
+ *
+ * @see {@link createQuery} to run a query with these options.
+ * @param options - The {@link DefinedInitialDataOptions} to use — everything you can pass to `createQuery`,
+ * with `initialData` set.
+ * @returns The same options object, typed so that `queryKey` carries the inferred data type.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { queryOptions, createQuery } from '@tanstack/svelte-query'
+ *
+ *   const postsOptions = queryOptions({
+ *     queryKey: ['posts'],
+ *     queryFn: fetchPosts,
+ *     initialData: [],
+ *   })
+ *
+ *   // `data` is `Post[]`, never `undefined`, thanks to `initialData` — even if a refetch fails,
+ *   // so the list stays visible alongside the error.
+ *   const query = createQuery(() => postsOptions)
+ * </script>
+ *
+ * {#if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {/if}
+ * <ul>
+ *   {#each query.data as post (post.id)}
+ *     <li>{post.title}</li>
+ *   {/each}
+ * </ul>
+ * ```
+ */
 export function queryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -37,6 +75,41 @@ export function queryOptions<
 ): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
   QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
+/**
+ * You can generally pass everything to `queryOptions` that you can also pass to `createQuery`. These options
+ * can be shared across `createQuery` calls and imperative APIs such as `queryClient.query`. `options.queryKey`
+ * is required and is the query key to generate options for.
+ *
+ * @see {@link createQuery} to run a query with these options.
+ * @param options - The {@link UndefinedInitialDataOptions} to use — everything you can pass to `createQuery`.
+ * @returns The same options object, typed so that `queryKey` carries the inferred data type.
+ *
+ * @example
+ * A parameterized factory, so the same options object can be reused per `id`:
+ * ```svelte
+ * <script lang="ts">
+ *   import { queryOptions, createQuery } from '@tanstack/svelte-query'
+ *
+ *   let { id }: { id: string } = $props()
+ *
+ *   const postOptions = (id: string) =>
+ *     queryOptions({
+ *       queryKey: ['post', id],
+ *       queryFn: () => fetchPost(id),
+ *     })
+ *
+ *   const query = createQuery(() => postOptions(id))
+ * </script>
+ *
+ * {#if query.isPending}
+ *   Loading...
+ * {:else if query.isError}
+ *   <span>Error: {query.error.message}</span>
+ * {:else}
+ *   <h1>{query.data.title}</h1>
+ * {/if}
+ * ```
+ */
 export function queryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,

--- a/packages/svelte-query/src/useHydrate.ts
+++ b/packages/svelte-query/src/useHydrate.ts
@@ -2,6 +2,34 @@ import { hydrate } from '@tanstack/query-core'
 import { useQueryClient } from './useQueryClient.js'
 import type { HydrateOptions, QueryClient } from '@tanstack/query-core'
 
+/**
+ * Adds a previously dehydrated `state` into the `queryClient` (from the nearest context, or the one
+ * passed explicitly). If the client already contains data, the new queries will be intelligently merged based
+ * on update timestamp. `HydrationBoundary` wraps this — use it directly only if you need to hydrate from your
+ * own component instead.
+ *
+ * @param state - The dehydrated state to hydrate into the cache, as produced by `dehydrate`.
+ * @param options - {@link HydrateOptions} to control the hydration.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ *
+ * @example
+ * Server-side prefetch handed off to the client via `dehydrate` — `dehydratedState` would typically come
+ * from a server load function that prefetched with `queryClient.query` and called `dehydrate(queryClient)`:
+ * ```svelte
+ * <script lang="ts">
+ *   import { HydrationBoundary } from '@tanstack/svelte-query'
+ *   import type { DehydratedState } from '@tanstack/svelte-query'
+ *   import Posts from './Posts.svelte'
+ *
+ *   let { dehydratedState }: { dehydratedState: DehydratedState } = $props()
+ * </script>
+ *
+ * <HydrationBoundary state={dehydratedState}>
+ *   <Posts />
+ * </HydrationBoundary>
+ * ```
+ */
 export function useHydrate(
   state?: unknown,
   options?: HydrateOptions,

--- a/packages/svelte-query/src/useIsFetching.svelte.ts
+++ b/packages/svelte-query/src/useIsFetching.svelte.ts
@@ -2,6 +2,41 @@ import { ReactiveValue } from './containers.svelte.js'
 import { useQueryClient } from './useQueryClient.js'
 import type { QueryClient, QueryFilters } from '@tanstack/query-core'
 
+/**
+ * @param filters - {@link QueryFilters} to narrow down which queries to count. Omit to count every fetching
+ * query.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns A reactive value — read `.current` to get how many matching queries are currently fetching.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { useIsFetching } from '@tanstack/svelte-query'
+ *
+ *   // How many queries matching the posts prefix are fetching?
+ *   const isFetchingPosts = useIsFetching({ queryKey: ['posts'] })
+ * </script>
+ *
+ * {#if isFetchingPosts.current}
+ *   <span>Refreshing posts...</span>
+ * {/if}
+ * ```
+ *
+ * @example
+ * A global loading indicator for any query fetching in the background, not just the ones on screen:
+ * ```svelte
+ * <script lang="ts">
+ *   import { useIsFetching } from '@tanstack/svelte-query'
+ *
+ *   const isFetching = useIsFetching()
+ * </script>
+ *
+ * {#if isFetching.current}
+ *   <div>Queries are fetching in the background...</div>
+ * {/if}
+ * ```
+ */
 export function useIsFetching(
   filters?: QueryFilters,
   queryClient?: QueryClient,

--- a/packages/svelte-query/src/useIsMutating.svelte.ts
+++ b/packages/svelte-query/src/useIsMutating.svelte.ts
@@ -2,6 +2,29 @@ import { useQueryClient } from './useQueryClient.js'
 import { ReactiveValue } from './containers.svelte.js'
 import type { MutationFilters, QueryClient } from '@tanstack/query-core'
 
+/**
+ * `useIsMutating` is an optional hook that returns the `number` of mutations that your application is
+ * running (useful for app-wide loading indicators).
+ *
+ * @param filters - {@link MutationFilters} to narrow down which mutations to count.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns A reactive value — read `.current` to get how many matching mutations are currently running.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { useIsMutating } from '@tanstack/svelte-query'
+ *
+ *   // How many mutations matching the posts prefix are in progress?
+ *   const isMutatingPosts = useIsMutating({ mutationKey: ['posts'] })
+ * </script>
+ *
+ * {#if isMutatingPosts.current}
+ *   <span>Saving posts...</span>
+ * {/if}
+ * ```
+ */
 export function useIsMutating(
   filters?: MutationFilters,
   queryClient?: QueryClient,

--- a/packages/svelte-query/src/useMutationState.svelte.ts
+++ b/packages/svelte-query/src/useMutationState.svelte.ts
@@ -26,6 +26,76 @@ function getResult<
     )
 }
 
+/**
+ * `useMutationState` gives you access to all mutations (matching the given `filters`), including ones that
+ * were created by a different component or hook instance, or even ones no longer mounted.
+ *
+ * @param options - The `filters` to narrow down matched mutations, and an optional `select` to transform the
+ * mutation state.
+ * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
+ * be used.
+ * @returns An Array of whatever `select` returns for each matching mutation.
+ *
+ * @example
+ * Get all variables of all running mutations:
+ * ```svelte
+ * <script lang="ts">
+ *   import { useMutationState } from '@tanstack/svelte-query'
+ *
+ *   const pendingVariables = useMutationState({
+ *     filters: { status: 'pending' },
+ *     select: (mutation) => mutation.state.variables,
+ *   })
+ * </script>
+ *
+ * {pendingVariables.length} posts saving...
+ * ```
+ *
+ * @example
+ * Get all data for specific mutations via the `mutationKey`:
+ * ```svelte
+ * <script lang="ts">
+ *   import { createMutation, useMutationState } from '@tanstack/svelte-query'
+ *
+ *   const mutationKey = ['posts']
+ *
+ *   // Some mutation that we want to get the state for
+ *   const mutation = createMutation(() => ({
+ *     mutationKey,
+ *     mutationFn: createPosts,
+ *   }))
+ *
+ *   const savedPosts = useMutationState({
+ *     // this mutation key needs to match the mutation key of the given mutation (see above)
+ *     filters: { mutationKey, status: 'success' },
+ *     select: (mutation) => mutation.state.data,
+ *   })
+ * </script>
+ *
+ * <button onclick={() => mutation.mutate(['New Post'])}>
+ *   Create post ({savedPosts.length} saved so far)
+ * </button>
+ * ```
+ *
+ * @example
+ * Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
+ * mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
+ * latest invocation:
+ * ```svelte
+ * <script lang="ts">
+ *   import { useMutationState } from '@tanstack/svelte-query'
+ *
+ *   const savedPosts = useMutationState({
+ *     filters: { mutationKey: ['posts'], status: 'success' },
+ *     select: (mutation) => mutation.state.data,
+ *   })
+ *
+ *   const latestSavedPost = $derived(savedPosts[savedPosts.length - 1])
+ * </script>
+ *
+ * {latestSavedPost ? 'Saved' : 'Nothing saved yet'}
+ * ```
+ */
 export function useMutationState<
   TResult = MutationState,
   TMutation extends Mutation<any, any, any, any> =

--- a/packages/svelte-query/src/useMutationState.svelte.ts
+++ b/packages/svelte-query/src/useMutationState.svelte.ts
@@ -80,7 +80,7 @@ function getResult<
  * @example
  * Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
  * mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
- * latest invocation:
+ * latest successful mutation (the `status: 'success'` filter above excludes pending/errored ones):
  * ```svelte
  * <script lang="ts">
  *   import { useMutationState } from '@tanstack/svelte-query'


### PR DESCRIPTION
## 🎯 Changes

`packages/svelte-query/src/` had no `@example`s across its public API — `createQuery`, `createInfiniteQuery`, `createMutation`, `createQueries`, and the options factories had no JSDoc examples at all, unlike `@tanstack/preact-query`, which already documents its equivalents.

Added JSDoc `@example`s, following the same conventions used in `@tanstack/preact-query` (`@see`/`@param`/`@returns` tags, module-level factory examples kept minimal, Suspense/`skipToken`-guard examples omitted since neither has an equivalent in `svelte-query` today), adapted to Svelte's idioms (`.svelte` code fences, the `Accessor` pattern for reactive options, Runes such as `$state`/`$props`, and `{#if}`/`{#each}` control flow instead of JSX):

- `createQuery.ts`: 7 examples across all 3 overloads (status, `isPending`/`isError` alternative, select, enabled, seeding, pagination, initialData)
- `createInfiniteQuery.ts`: 2 examples (Load More button, `IntersectionObserver` auto-fetch)
- `createMutation.svelte.ts`: 5 examples (basic + invalidate, rendering mutation state, optimistic update, `mutateAsync` with `Promise.all`, `mutateAsync` with `Promise.allSettled`); also fixed a stale `@see {@link createMutationState}` reference to `{@link useMutationState}`
- `createQueries.svelte.ts`: 2 examples (basic array, `combine`)
- `queryOptions.ts`: 2 examples (basic with `initialData`, parameterized factory)
- `infiniteQueryOptions.ts`: 1 example (parameterized factory)
- `mutationOptions.ts`: 2 examples (`mutationKey` lookup via `useMutationState`, basic create)
- `context.ts`: JSDoc + 1 example on `setQueryClientContext`/`getQueryClientContext` — `QueryClientProvider.svelte` itself can't carry TypeDoc-visible JSDoc (TypeDoc resolves `.svelte` components to Svelte's own `.d.ts`, not the source), so the example is documented on the underlying context functions it wraps
- `useHydrate.ts`: JSDoc + 1 example, same `.svelte`-wrapper caveat as above
- `useIsFetching.svelte.ts`: 2 examples, using `.current` (it returns a `ReactiveValue<number>`)
- `useIsMutating.svelte.ts`: 1 example, `.current` access (same return shape as `useIsFetching`)
- `useMutationState.svelte.ts`: 3 examples, direct array access (`Array<TResult>`, no `.current` — different return shape than the two above)
- Regenerated the corresponding `docs/framework/svelte/reference/functions/*.md` files with `pnpm run generate-docs`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Svelte Query API references with updated source links, parameter and return-value details, and clarified behavior.
  * Added practical Svelte examples for queries, mutations, infinite pagination, hydration, context management, and mutation state tracking.
  * Documented reusable query and mutation option patterns, including initial data, custom clients, optimistic updates, and batch operations.
  * Improved inline API guidance without changing functionality or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->