### PR TITLE
docs(preact-query): rename onError's third example parameter from 'context' to 'onMutateResult'

### DIFF
--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -133,11 +133,11 @@ function AddTodo() {
         newTodo,
       ])
 
-      // Passed to `onError` as `context` if the mutation fails.
+      // Passed to `onError` as `onMutateResult` if the mutation fails.
       return { previousTodos }
     },
-    onError: (_err, _newTodo, context) => {
-      queryClient.setQueryData(['todos'], context?.previousTodos)
+    onError: (_err, _newTodo, onMutateResult) => {
+      queryClient.setQueryData(['todos'], onMutateResult?.previousTodos)
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['todos'] })

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -106,11 +106,11 @@ import { useSyncExternalStore } from './utils'
  *         newTodo,
  *       ])
  *
- *       // Passed to `onError` as `context` if the mutation fails.
+ *       // Passed to `onError` as `onMutateResult` if the mutation fails.
  *       return { previousTodos }
  *     },
- *     onError: (_err, _newTodo, context) => {
- *       queryClient.setQueryData(['todos'], context?.previousTodos)
+ *     onError: (_err, _newTodo, onMutateResult) => {
+ *       queryClient.setQueryData(['todos'], onMutateResult?.previousTodos)
  *     },
  *     onSettled: () => {
  *       queryClient.invalidateQueries({ queryKey: ['todos'] })


### PR DESCRIPTION
## Summary
- `onError`'s actual signature is `(error, variables, onMutateResult, context)` — the third parameter is `onMutate`'s return value, and the fourth is a separate `MutationFunctionContext`.
- The optimistic-update JSDoc example in `useMutation.ts` named the third parameter `context`, which reads as if it were the fourth (real) `context` parameter. Renamed to `onMutateResult` to match the actual signature.
- Regenerated `docs/framework/preact/reference/functions/useMutation.md` to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated optimistic-update examples to use clearer callback parameter naming when restoring previous data after a mutation error.
  - Aligned examples across the Preact reference documentation and implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->