### PR TITLE
docs(preact-query): correct 'pending' status description in useQuery's @returns

### DIFF
--- a/docs/framework/preact/reference/functions/useQuery.md
+++ b/docs/framework/preact/reference/functions/useQuery.md
@@ -128,9 +128,9 @@ be used.
 
 [`UseQueryResult`](../type-aliases/UseQueryResult.md)\<`TData`, `TError`\>
 
-The current query result. `status` is `pending` if there is no cached data and no query attempt
-has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
-display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+The current query result. `status` is `pending` if there is no cached data to display, `error` if
+the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+are derived booleans for convenience.
 
 ### See
 
@@ -229,9 +229,9 @@ be used.
 
 [`UseQueryResult`](../type-aliases/UseQueryResult.md)\<`TData`, `TError`\>
 
-The current query result. `status` is `pending` if there is no cached data and no query attempt
-has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
-display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+The current query result. `status` is `pending` if there is no cached data to display, `error` if
+the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+are derived booleans for convenience.
 
 ### See
 

--- a/packages/preact-query/src/useQuery.ts
+++ b/packages/preact-query/src/useQuery.ts
@@ -62,9 +62,9 @@ export function useQuery<
  * @param options - The {@link UndefinedInitialDataOptions} to use — everything you can pass to `useQuery`.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
- * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
- * display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+ * @returns The current query result. `status` is `pending` if there is no cached data to display, `error` if
+ * the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+ * are derived booleans for convenience.
  *
  * @example
  * ```tsx
@@ -129,9 +129,9 @@ export function useQuery<
  * @param options - The {@link UseQueryOptions} to use — everything you can pass to `useQuery`.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The current query result. `status` is `pending` if there is no cached data and no query attempt
- * has finished yet, `error` if the query attempt resulted in an error, or `success` if the query has data to
- * display. `isPending`/`isSuccess`/`isError` are derived booleans for convenience.
+ * @returns The current query result. `status` is `pending` if there is no cached data to display, `error` if
+ * the last fetch attempt failed, or `success` if the query has data to display. `isPending`/`isSuccess`/`isError`
+ * are derived booleans for convenience.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
## Summary
- `useQuery`'s `@returns` described `pending` as "no cached data and no query attempt has finished yet." That's inaccurate: `fetchState` (query-core) resets `status` to `pending` whenever there's no cached data, even after a prior attempt ended in `error`.
- `error` is also unconditional on data presence — a failed background refetch sets `status: 'error'` even while cached data still exists.
- Corrected to: "`status` is `pending` if there is no cached data to display, `error` if the last fetch attempt failed, or `success` if the query has data to display."
- Regenerated `docs/framework/preact/reference/functions/useQuery.md` to match.

Found while porting this same `@returns` sentence to svelte-query (#11352) and verifying it against `query.ts`'s `fetchState`/`case 'error'`/`case 'success'` reducers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `useQuery` status descriptions.
  * Updated guidance to explain that `pending` applies when no cached data is available and `error` indicates the latest fetch attempt failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->