### PR TITLE
fix(lit-query): propagate mutation state generics

### DIFF
--- a/.changeset/lit-mutation-state-generics.md
+++ b/.changeset/lit-mutation-state-generics.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/lit-query': patch
+---
+
+fix(types): propagate generic type parameters to the `useMutationState` select callback

--- a/packages/lit-query/src/tests/mutation-state-types.test.ts
+++ b/packages/lit-query/src/tests/mutation-state-types.test.ts
@@ -1,0 +1,27 @@
+import { QueryClient } from '@tanstack/query-core'
+import { describe, expectTypeOf, it } from 'vitest'
+import { useMutationState } from '../useMutationState.js'
+import { TestControllerHost } from './testHost.js'
+import type { Mutation, MutationState } from '@tanstack/query-core'
+
+describe('useMutationState types', () => {
+  it('propagates typed mutation state generics to the select callback', () => {
+    type MyData = { data: Array<string> }
+    type MyError = { code: number; message: string }
+    type MyVariables = { id: number }
+
+    useMutationState<MutationState<MyData, MyError, MyVariables>>(
+      new TestControllerHost(),
+      {
+        filters: { mutationKey: ['key'] },
+        select: (mutation) => {
+          expectTypeOf(mutation).toEqualTypeOf<
+            Mutation<MyData, MyError, MyVariables, unknown>
+          >()
+          return mutation.state
+        },
+      },
+      new QueryClient(),
+    )
+  })
+})

--- a/packages/lit-query/src/useMutationState.ts
+++ b/packages/lit-query/src/useMutationState.ts
@@ -17,11 +17,26 @@ import { BaseController } from './controllers/BaseController.js'
 /**
  * Options accepted by `useMutationState`.
  */
-export type MutationStateOptions<TResult> = {
+type MutationTypeFromResult<TResult> = [TResult] extends [
+  MutationState<
+    infer TData,
+    infer TError,
+    infer TVariables,
+    infer TOnMutateResult
+  >,
+]
+  ? Mutation<TData, TError, TVariables, TOnMutateResult>
+  : Mutation
+
+export type MutationStateOptions<
+  TResult,
+  TMutation extends Mutation<any, any, any, any> =
+    MutationTypeFromResult<TResult>,
+> = {
   /** Filters used to select mutations from the mutation cache. */
   filters?: Accessor<MutationFilters>
   /** Maps each matching mutation to the value returned by the accessor. */
-  select?: (mutation: Mutation) => TResult
+  select?: (mutation: TMutation) => TResult
 }
 
 /**
@@ -35,13 +50,16 @@ export type MutationStateAccessor<TResult> = ValueAccessor<TResult[]> & {
   destroy: () => void
 }
 
-class MutationStateController<TResult> extends BaseController<TResult[]> {
+class MutationStateController<
+  TResult,
+  TMutation extends Mutation<any, any, any, any>,
+> extends BaseController<TResult[]> {
   private queryClient: QueryClient | undefined
   private unsubscribe: (() => void) | undefined
 
   constructor(
     host: ReactiveControllerHost,
-    private readonly options: MutationStateOptions<TResult>,
+    private readonly options: MutationStateOptions<TResult, TMutation>,
     queryClient?: QueryClient,
   ) {
     super(host, [], queryClient)
@@ -148,7 +166,7 @@ class MutationStateController<TResult> extends BaseController<TResult[]> {
 
     return mutations.map((mutation) => {
       if (select) {
-        return select(mutation)
+        return select(mutation as TMutation)
       }
 
       return mutation.state as TResult
@@ -191,12 +209,18 @@ class MutationStateController<TResult> extends BaseController<TResult[]> {
  */
 export function useMutationState<
   TResult = MutationState<unknown, unknown, unknown, unknown>,
+  TMutation extends Mutation<any, any, any, any> =
+    MutationTypeFromResult<TResult>,
 >(
   host: ReactiveControllerHost,
-  options: MutationStateOptions<TResult> = {},
+  options: MutationStateOptions<TResult, TMutation> = {},
   queryClient?: QueryClient,
 ): MutationStateAccessor<TResult> {
-  const controller = new MutationStateController(host, options, queryClient)
+  const controller = new MutationStateController<TResult, TMutation>(
+    host,
+    options,
+    queryClient,
+  )
   return Object.assign(
     createValueAccessor(() => controller.current),
     {


### PR DESCRIPTION
## 🎯 Changes

`@tanstack/lit-query` did not receive the `useMutationState` generic inference added to the other framework adapters in #10373. As a result, a selector with an explicitly typed `MutationState<TData, TError, TVariables>` still saw `Mutation<unknown, Error, unknown, unknown>`.

This PR:

- derives the selector's `Mutation` type from the selected `MutationState` result
- adds a focused compile-time regression test
- keeps runtime filtering/subscription behavior and scalar selector inference unchanged

The regression test fails on current `main` and passes with this change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript type inference for `useMutationState`.
  - Generic mutation types now flow correctly into the `select` callback, providing accurate types for mutation data, errors, and variables.

- **Tests**
  - Added type-level coverage to verify generic mutation types are correctly propagated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->