### PR TITLE
test(solid-query): pin the stale read through a memo over `query.data` (#11351) 🤖🤖🤖

### DIFF
--- a/packages/solid-query/src/__tests__/useQuery-semantics.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery-semantics.test.tsx
@@ -6,7 +6,13 @@
 // re-pointed separately.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent } from '@solidjs/testing-library'
-import { Errored, Loading, createSignal } from 'solid-js'
+import {
+  Errored,
+  Loading,
+  createEffect,
+  createMemo,
+  createSignal,
+} from 'solid-js'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { QueryCache, QueryClient, useQuery } from '..'
 import { renderWithClient } from './utils'
@@ -508,6 +514,62 @@ describe('useQuery 2.0 read semantics', () => {
 
       await vi.advanceTimersByTimeAsync(10)
       expect(rendered.getByText('n: 42')).toBeInTheDocument()
+    })
+
+    // Reproduction for #11351. A tracked computation that reaches a leaf
+    // THROUGH a `createMemo(() => state.data)` indirection stops being
+    // notified after a refetch: the memo is an async consumer of the data
+    // node, its committed value is the same store face on every commit, and
+    // the propagation is pruned at the memo — so the effect's own reads of
+    // that same node are never re-evaluated. Its last observation is the
+    // superseded value, permanently.
+    //
+    // This is not a defect in the data node itself: the derive runs the
+    // expected four times, the commit lands, and an untracked read through
+    // the very same memo returns the new value. Every other reader shape
+    // (leaf read in the effect, leaf read inside the memo, leaf read off an
+    // untracked-captured face, a suspended memo over an UNRELATED async
+    // source) is notified correctly, and the behaviour reproduces with no
+    // TanStack code involved: solidjs/solid#3181.
+    //
+    // eslint-disable-next-line vitest/no-disabled-tests -- pending the upstream fix, kept as the reproduction
+    it.skip('notifies a leaf reader that goes through a memo over data', async () => {
+      const key = queryKey()
+      const server = { flag: false }
+      const observed: Array<boolean> = []
+
+      function Page() {
+        const state = useQuery(() => ({
+          queryKey: key,
+          queryFn: () => sleep(10).then(() => ({ ...server })),
+        }))
+        const data = createMemo(() => state.data)
+        createEffect(
+          () => data().flag,
+          (flag) => {
+            observed.push(flag)
+          },
+        )
+        return <span>flag: {String(state.data.flag)}</span>
+      }
+
+      const rendered = renderWithClient(queryClient, () => (
+        <Loading fallback={<span>loading</span>}>
+          <Page />
+        </Loading>
+      ))
+
+      await vi.advanceTimersByTimeAsync(10)
+      expect(observed).toEqual([false])
+
+      server.flag = true
+      void queryClient.refetchQueries({ queryKey: key })
+      await vi.advanceTimersByTimeAsync(10)
+
+      // The direct read swaps, so the commit itself landed.
+      expect(rendered.getByText('flag: true')).toBeInTheDocument()
+      // ...but the reader behind the memo was never told.
+      expect(observed.at(-1)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds a reproduction for #11351 to `useQuery-semantics.test.tsx`, in the `data store face` block.

A tracked computation that reaches a leaf **through** a `createMemo(() => query.data)` indirection
is not re-notified after a refetch, so its last observation stays the superseded value permanently.
A wrapper hook that gates or narrows `query.data` before handing it to consumers is exactly this
shape, so it reaches app code that never writes the memo explicitly.

The test is added as `it.skip`, following the existing convention in `useQuery.test.tsx` for a
documented divergence, because **the fix is not in this repo** — see below. Un-skipped it fails on
the last assertion only, *after* `expect(rendered.getByText('flag: true'))` has already passed: the
commit lands and the DOM swaps, and only the reader behind the memo is starved.

### Why no fix here

The data node is not at fault. `computeData` runs exactly the expected four times across mount and
refetch, `chainOnce` produces one chained promise per fetch with no identity churn, the commit
lands, an untracked read through the very same memo returns the new value, and neither the memo nor
the data node is left `isPending`. Only the notification to one reader shape is lost.

Narrowing across reader shapes (all against the real hook):

| Reader shape | Result |
| --- | --- |
| effect reads `query.data.flag` | pass |
| memo reads `query.data.flag`, effect reads the memo | pass |
| effect captures `query.data` via `untrack`, then reads `.flag` off it | pass |
| effect depends on a suspended memo over an **unrelated** async source, reads `query.data.flag` | pass |
| **memo reads `query.data`, effect reads `memo().flag`** | **fail** |
| memo reads `query.data`, effect reads **both** `query.data` and `memo().flag` | **fail** |

Row 6 is the one that rules out a missing subscription: the effect reads the projection directly
*and* depends on the memo, and is still not notified. Row 4 rules out "any suspended memo
dependency" — the memo has to be a consumer of *this* projection. A memo created after the first
settle is fine; only one that suspended on its first run is affected.

The behaviour reproduces with no TanStack code involved, so I filed it upstream:
**solidjs/solid#3181**. `2.0.0-rc.4` is the newest published `solid-js` / `@solidjs/signals`, so
there is no version bump that fixes it.

The workarounds I tried and rejected, in case they come up in review:

- Making the committed value's identity change per commit so the memo propagates — that is
  reconcile-off, and discards the fine-grained leaf tracking pinned by `'tracks deep reads at the
  leaf — unrelated changes do not re-run them'`.
- Returning a stable re-reading facade from `get data()` — works only if the getter drops its
  suspending read, which would stop `query.data` suspending into `<Loading>` and break primitive
  and array data.
- Not returning the promise on refetch, to avoid the hold — deletes the SWR hold semantics covered
  by `transition.test.tsx`.
- Not superseding the in-flight answer with a synchronous value at settle (a `landed` flag on
  `chainOnce`, returning the unlanded chained promise instead of `wrap(state.data)`) — **tried and
  reverted**: it does not fix the reproduction and it breaks `'keeps stale data and exposes error
  state when a refetch fails'`.

Happy to drop the skipped test and just leave the narrowing on the issue instead, if you'd rather
not carry it.

> Note on base branch: this targets `solid-query-v6-pre`, since the rc.1 code the issue is about
> does not exist on `main`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

Verified locally from the repo root:

```
pnpm nx run @tanstack/solid-query:test:lib      # 26 files, 346 passed, 2 skipped, no type errors
pnpm nx run @tanstack/solid-query:test:eslint   # clean
```

Baseline on `solid-query-v6-pre` before this change is 346 passed / 1 skipped, so the only delta is
the added skipped test.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

Made with [Cursor](https://cursor.com)