### PR TITLE
fix(solid-query): untrack the result read in useMutationState's cache subscription

### DIFF
--- a/.changeset/solid-query-mutation-state-untrack.md
+++ b/.changeset/solid-query-mutation-state-untrack.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/solid-query': patch
+---
+
+fix(solid-query): stop `useMutationState` making the computation that triggers a mutation depend on its result
+
+The mutation-cache subscription read the hook's own result signal. `MutationCache` notifies synchronously, so that read happened while the computation that called `mutate` was still the active listener — registering the signal as one of its dependencies, which `setResult` then immediately invalidated. Calling `mutate` from inside an effect therefore re-ran that effect on every mutation, and an unguarded `mutate` looped. The read is now untracked.

--- a/packages/solid-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutationState.test.tsx
@@ -111,4 +111,36 @@ describe('useMutationState', () => {
 
     expect(variables).toEqual([[], [1], []])
   })
+
+  it('should not make the computation that triggers a mutation depend on its result', async () => {
+    const mutationKey = queryKey()
+    let effectRuns = 0
+
+    function Page() {
+      const states = useMutationState(() => ({ filters: { mutationKey } }))
+      const mutation = useMutation(() => ({
+        mutationKey,
+        mutationFn: (input: number) => sleep(150).then(() => 'data' + input),
+      }))
+
+      createEffect(() => {
+        effectRuns++
+        // Guarded so that a genuine feedback loop still terminates the test.
+        if (effectRuns === 1) {
+          mutation.mutate(1)
+        }
+      })
+
+      return <div>count: {states().length}</div>
+    }
+
+    renderWithClient(queryClient, () => <Page />)
+    await vi.advanceTimersByTimeAsync(150)
+
+    // `mutate` notifies the mutation cache synchronously, so the subscription
+    // callback runs while this effect is the active computation. Reading the
+    // result signal there used to register it as a dependency of that effect,
+    // which `setResult` then immediately invalidated.
+    expect(effectRuns).toBe(1)
+  })
 })

--- a/packages/solid-query/src/useMutationState.ts
+++ b/packages/solid-query/src/useMutationState.ts
@@ -1,4 +1,10 @@
-import { createEffect, createMemo, createSignal, onCleanup } from 'solid-js'
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  untrack,
+} from 'solid-js'
 import { replaceEqualDeep } from '@tanstack/query-core'
 import { useQueryClientResolver } from './QueryClientProvider'
 import type {
@@ -66,11 +72,15 @@ export function useMutationState<
 
   createEffect(() => {
     const unsubscribe = mutationCache().subscribe(() => {
+      // `subscribe` invokes this synchronously, so reading `result` while the
+      // enclosing effect is still tracking would make the effect depend on the
+      // signal it sets, re-running and re-subscribing on every mutation.
+      const previousResult = untrack(result)
       const nextResult = replaceEqualDeep(
-        result(),
+        previousResult,
         getResult(mutationCache(), options()),
       )
-      if (result() !== nextResult) {
+      if (previousResult !== nextResult) {
         setResult(nextResult)
       }
     })


### PR DESCRIPTION
## 🎯 Changes

`useMutationState`'s mutation-cache subscription reads the hook's own `result` signal:

```ts
const unsubscribe = mutationCache().subscribe(() => {
  const nextResult = replaceEqualDeep(result(), getResult(mutationCache(), options()))
  if (result() !== nextResult) setResult(nextResult)
})
```

`MutationCache` notifies **synchronously**, so when a mutation is started from inside a Solid computation, that callback runs while the computation is still the active listener. The `result()` read therefore registers the signal as a dependency of *that* computation — and `setResult` immediately invalidates it.

The practical effect: calling `mutate` from inside a `createEffect` re-runs the effect on every mutation, and an unguarded `mutate` loops. It also attaches a spurious dependency to whatever computation happens to be running when any mutation settles, which is hard to attribute when it shows up as a runaway effect cascade in production.

The read is now untracked. Behaviour is otherwise identical.

### Regression test

Added to `useMutationState.test.tsx`: an effect that triggers one mutation, with a guard so a genuine loop still terminates.

- before: `expected 2 to be 1` — the effect re-ran
- after: passes

### Relationship to #9644

#9644 proposed the same `untrack` alongside a `useIsMutating` fix. That PR has been open since Sept 2025, last updated June 2026, and is now conflicted; its `useIsMutating` half has since landed separately. This is just the remaining half, rebased on `main` with a test and a changeset. Happy to close it in favour of #9644 if that one is revived.

Also related: #10907 (the `enabled: false` SSR hang) was a different symptom of solid-query reading signals from cache callbacks, and is already fixed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

Scope of what I ran: `vitest run` for `@tanstack/solid-query` — **247 runtime tests pass (13 files)**. `useQuery.test-d.tsx` fails 5 type assertions, but it does so identically on unmodified `main` with my changes stashed, so it is pre-existing and unrelated to this change.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented mutation-triggered computations from rerunning synchronously when their own mutation state changes.
  * Improved reactive behavior for `useMutationState` when mutations are initiated within reactive effects.

* **Tests**
  * Added coverage confirming effects run only once when triggering a mutation through `useMutationState`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->