### PR TITLE
fix(solid-query): don't re-create and refetch a removed query

### DIFF
--- a/.changeset/solid-removed-query-not-rebuilt.md
+++ b/.changeset/solid-removed-query-not-rebuilt.md
@@ -1,0 +1,18 @@
+---
+'@tanstack/solid-query': patch
+---
+
+fix: stop a mounted observer from re-creating and refetching a removed
+query. The read layer bumps its per-hook version signal on every cache
+event for its hash, `removed` included, and the recompute that followed
+called `queryCache.build()`, which put the entry the caller had just
+deleted straight back. The resurrection was not passive: the rebuilt
+entry also re-pointed the still-live observer, whose mount-fetch policy
+then refetched and repopulated the key, so `removeQueries()` (and
+`clear()`) could not be made to stick while any hook observed the key.
+`query()` now reuses the entry it last read when the cache no longer
+holds that hash, and only builds when the hash is genuinely new, so a
+removal leaves the cache empty and fires no fetch, while the mounted
+reader holds its last value until options change or a real entry returns
+through `setQueryData`, a refetch or a later mount. This is the behavior
+of the other adapters, and of solid-query at 6.0.0-rc.0.

--- a/packages/solid-query/src/__tests__/useQuery-semantics.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery-semantics.test.tsx
@@ -510,4 +510,84 @@ describe('useQuery 2.0 read semantics', () => {
       expect(rendered.getByText('n: 42')).toBeInTheDocument()
     })
   })
+
+  describe('cache removal', () => {
+    // `removeQueries()` drops entries instead of refetching them, and a
+    // mounted observer must not undo that: the read layer recomputes on the
+    // 'removed' event, and rebuilding the entry there would re-point the
+    // observer and let its mount-fetch policy repopulate the removed key.
+    it('leaves a removed query out of the cache while an observer is mounted', async () => {
+      const key = queryKey()
+      let fetches = 0
+      const queryFn = () =>
+        sleep(10).then(() => (++fetches === 1 ? 'v1' : 'v2'))
+      const events: Array<string> = []
+
+      function Page() {
+        const state = useQuery(() => ({
+          queryKey: key,
+          queryFn,
+          staleTime: 60_000,
+        }))
+        return <span>{state.data}</span>
+      }
+
+      const rendered = renderWithClient(queryClient, () => (
+        <Loading fallback={<span>loading</span>}>
+          <Page />
+        </Loading>
+      ))
+
+      await vi.advanceTimersByTimeAsync(10)
+      expect(rendered.getByText('v1')).toBeInTheDocument()
+
+      queryCache.subscribe((event) => events.push(event.type))
+      queryClient.removeQueries({ queryKey: key })
+      await vi.advanceTimersByTimeAsync(30)
+
+      // No 'added' behind the 'removed', so nothing re-created the entry.
+      expect(events).toEqual(['removed'])
+      expect(queryCache.getAll()).toHaveLength(0)
+      expect(queryClient.getQueryData(key)).toBeUndefined()
+      // The removal is not a refetch trigger.
+      expect(fetches).toBe(1)
+      // The mounted reader holds the value it last had, rather than
+      // suspending back into <Loading> over a key that no longer exists.
+      expect(rendered.getByText('v1')).toBeInTheDocument()
+    })
+
+    it('picks up a real entry written after a removal', async () => {
+      const key = queryKey()
+
+      function Page() {
+        const state = useQuery(() => ({
+          queryKey: key,
+          queryFn: () => sleep(10).then(() => 'v1'),
+          staleTime: 60_000,
+        }))
+        return <span>{state.data}</span>
+      }
+
+      const rendered = renderWithClient(queryClient, () => (
+        <Loading fallback={<span>loading</span>}>
+          <Page />
+        </Loading>
+      ))
+
+      await vi.advanceTimersByTimeAsync(10)
+      expect(rendered.getByText('v1')).toBeInTheDocument()
+
+      queryClient.removeQueries({ queryKey: key })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(queryCache.getAll()).toHaveLength(0)
+
+      // The held-over entry must not shadow the cache once it owns the hash
+      // again: a write rebuilds it, and the reader tracks the new instance.
+      queryClient.setQueryData(key, 'v2')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(queryCache.getAll()).toHaveLength(1)
+      expect(rendered.getByText('v2')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -216,6 +216,27 @@ export function useBaseQueryLayer<
    * swap re-attaches the rebuilt observer iff its predecessor was attached. */
   let shouldAttach = false
   let activeClient = untrack(client)
+  /**
+   * The entry this hook last read at its current hash, and the fallback for
+   * `query()` when the cache no longer holds that hash. Removal is the case
+   * that needs it: `removeQueries()` (or `clear()`) fires 'removed' for a
+   * hash this hook is mounted on, which bumps `version` and re-runs every
+   * derived read, and a plain `build()` there would re-create the entry the
+   * caller just removed. That resurrection is not passive, since the 'added'
+   * entry also re-points the still-live observer, whose mount-fetch policy
+   * then refetches and repopulates the key, contrary to `removeQueries`
+   * being documented to remove entries instead of refetching them.
+   *
+   * The removed instance keeps its final state, so reads hold their last
+   * value until options change or a real entry returns (`setQueryData`, a
+   * refetch, a later mount). That is what the other adapters do: a React
+   * observer keeps rendering the removed query's last result while the
+   * cache stays empty.
+   *
+   * Cleared on a client swap, below: the fallback is only meaningful for the
+   * cache it was read from.
+   */
+  let lastQuery: Query<TQueryFnData, TError, TQueryData, TQueryKey> | undefined
 
   const attach = () => {
     if (!disposed && !observerSub && !untrack(isRestoring)) {
@@ -236,6 +257,7 @@ export function useBaseQueryLayer<
   const syncClient = (c: QueryClient) => {
     if (isServer || c === activeClient) return
     activeClient = c
+    lastQuery = undefined
     cacheSub?.()
     cacheSub = c.getQueryCache().subscribe(onCacheEvent)
     observerSub?.()
@@ -365,7 +387,14 @@ export function useBaseQueryLayer<
     version()
     const c = client()
     syncClient(c)
-    return c.getQueryCache().build(c, defaultedOptions() as any) as any
+    const cache = c.getQueryCache()
+    const opts = defaultedOptions()
+    const existing = cache.get<TQueryFnData, TError, TQueryData, TQueryKey>(
+      opts.queryHash,
+    )
+    if (existing) return (lastQuery = existing)
+    if (lastQuery?.queryHash === opts.queryHash) return lastQuery
+    return (lastQuery = cache.build(c, opts as any) as any)
   }
 
   const isEnabled = () => {


### PR DESCRIPTION
Fixes #11350.

Targets `solid-query-v6-pre`, since the affected read layer arrived with the 2.0-native rewrite (#11308) and the regression is between `6.0.0-rc.0` and `6.0.0-rc.1`. One housekeeping note that follows from that base: GitHub only honours a closing keyword when the PR targets the default branch, so the `Fixes` above registers as a plain cross-reference and #11350 will need closing by hand on merge.

## The bug

Calling `queryClient.removeQueries()` while a `useQuery` observer is mounted removes the entry and then immediately brings it back, and the recreated entry starts a fresh fetch of the key that was just removed. A caller that removes entries to make them unreadable, for example an identity boundary that must guarantee the previous user's data cannot be read, cannot make the removal last.

## Cause

`useBaseQueryLayer` has one version signal per hook, bumped by `onCacheEvent` for any cache event on its hash. `'removed'` is such an event, and the recompute it triggers ran through `query()`:

```ts
const query = () => {
  version()
  const c = client()
  syncClient(c)
  return c.getQueryCache().build(c, defaultedOptions() as any) as any
}
```

`queryCache.build()` creates the entry when the cache does not hold it, so the hook's own removal notification made it rebuild what the caller had just deleted. The resurrection is not passive: the `'added'` entry also re-points the still-live observer, and its mount-fetch policy then refetches and repopulates the key. Hence the reported event sequence, `removed, added, observerRemoved, observerAdded, updated`.

This contradicts the documented contract for the method, that `removeQueries` "removes matching queries from the cache instead of refetching them".

## Fix

`query()` keeps the entry it last read and falls back to it when the cache no longer holds that hash, building only when the hash is genuinely new. A removal now leaves the cache empty and fires no fetch, and the mounted reader holds its last value until options change or a real entry returns through `setQueryData`, a refetch or a later mount. `cache.get()` is consulted first on every read, so a live entry is never shadowed by the held-over one. The fallback is dropped on a client swap in `syncClient`, as it is only meaningful for the cache it was read from.

Because `useInfiniteQuery` and `useQueries` both go through this layer, the one change covers all three hooks.

## Verification

The reporter's scenario, run against the react adapter on this branch to establish the reference, and against solid-query before and after the change:

| | react-query | solid-query rc.1 | solid-query, patched |
|---|---|---|---|
| cache events after removal | `removed` | `removed, added, observerRemoved, observerAdded, ...` | `removed` |
| cache entries | 0 | 1 | 0 |
| `getQueryData` | `undefined` | `'v2'` | `undefined` |
| queryFn calls | 1 | 2 | 1 |
| mounted reader shows | `v1` | `v2` | `v1` |

The patched adapter matches react-query exactly, and matches `6.0.0-rc.0` as reported.

Two regression tests in `useQuery-semantics.test.tsx`. Both fail on the unpatched branch, the first on the event sequence and the second on the entry count:

- `leaves a removed query out of the cache while an observer is mounted`, which asserts the cache event list is exactly `['removed']` with no `'added'` behind it, an empty cache, an unchanged fetch count, and that the reader holds its last value rather than suspending over a key that no longer exists.
- `picks up a real entry written after a removal`, which guards the fallback against becoming a stale read: a `setQueryData` after the removal rebuilds the entry, and the reader must track the new instance.

Full `@tanstack/solid-query` suite passes, 26 files and 348 tests, along with `@tanstack/solid-query-devtools` and `@tanstack/solid-query-persist-client`. `test:eslint` and `tsc --build` are clean.

