### PR TITLE
fix(solid-query): keep removed queries out of cache

### DIFF
--- a/.changeset/solid-query-removed-query-tombstone.md
+++ b/.changeset/solid-query-removed-query-tombstone.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Keep actively observed queries removed until an explicit refetch, cache write,
+or query change recreates them.

--- a/packages/solid-query/src/__tests__/useQuery-semantics.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery-semantics.test.tsx
@@ -102,6 +102,55 @@ describe('useQuery 2.0 read semantics', () => {
     expect(rendered.getByText('data2')).toBeInTheDocument()
   })
 
+  it('does not recreate a removed query while it is observed', async () => {
+    const key = queryKey()
+    const events: Array<string> = []
+    let fetches = 0
+    let refetch!: () => Promise<unknown>
+    const queryFn = () => Promise.resolve(`data${++fetches}`)
+
+    await queryClient.prefetchQuery({
+      queryKey: key,
+      queryFn,
+      staleTime: Infinity,
+    })
+
+    function Page() {
+      const state = useQuery(() => ({
+        queryKey: key,
+        queryFn,
+        staleTime: Infinity,
+      }))
+      refetch = state.refetch
+      return <span>{state.data}</span>
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+    expect(rendered.getByText('data1')).toBeInTheDocument()
+
+    const unsubscribe = queryCache.subscribe((event) => {
+      events.push(event.type)
+    })
+
+    queryClient.removeQueries({ queryKey: key })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(queryCache.find({ queryKey: key })).toBeUndefined()
+    expect(queryClient.getQueryData(key)).toBeUndefined()
+    expect(fetches).toBe(1)
+    expect(events).toEqual(['removed'])
+    expect(rendered.getByText('data1')).toBeInTheDocument()
+
+    await refetch()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(queryClient.getQueryData(key)).toBe('data2')
+    expect(fetches).toBe(2)
+    expect(rendered.getByText('data2')).toBeInTheDocument()
+
+    unsubscribe()
+  })
+
   it('surfaces a first-load failure to <Errored>', async () => {
     const key = queryKey()
 

--- a/packages/solid-query/src/useBaseQuery.ts
+++ b/packages/solid-query/src/useBaseQuery.ts
@@ -19,6 +19,7 @@ import type { QueryClient } from './QueryClient'
 import type {
   DefaultedQueryObserverOptions,
   Query,
+  QueryCacheNotifyEvent,
   QueryKey,
   QueryObserver,
   QueryObserverResult,
@@ -198,13 +199,33 @@ export function useBaseQueryLayer<
   const [primed, setPrimed] = createSignal(!hydratedMount, {
     ownedWrite: true,
   })
-  const onCacheEvent = (event: { query: { queryHash: string } }) => {
+  /**
+   * Keep the last explicitly removed entry as a read-only tombstone. A
+   * removal still invalidates the projections, but their pull must not call
+   * `cache.build()` for the same hash: doing so would undo removeQueries()
+   * synchronously and let the observer mount-fetch the replacement. A later
+   * cache write, explicit refetch or key change clears/bypasses the tombstone.
+   */
+  let removedQuery:
+    | Query<TQueryFnData, TError, TQueryData, TQueryKey>
+    | undefined
+  const onCacheEvent = (event: QueryCacheNotifyEvent) => {
     // Match the committed options hash OR the latest computed one (they
     // diverge during a hold — see `latestHash`).
     if (
       event.query.queryHash === untrack(defaultedOptions).queryHash ||
       event.query.queryHash === latestHash
     ) {
+      if (event.type === 'removed') {
+        removedQuery = event.query as Query<
+          TQueryFnData,
+          TError,
+          TQueryData,
+          TQueryKey
+        >
+      } else if (event.type === 'added') {
+        removedQuery = undefined
+      }
       setVersion((v) => v + 1)
     }
   }
@@ -236,6 +257,7 @@ export function useBaseQueryLayer<
   const syncClient = (c: QueryClient) => {
     if (isServer || c === activeClient) return
     activeClient = c
+    removedQuery = undefined
     cacheSub?.()
     cacheSub = c.getQueryCache().subscribe(onCacheEvent)
     observerSub?.()
@@ -365,7 +387,17 @@ export function useBaseQueryLayer<
     version()
     const c = client()
     syncClient(c)
-    return c.getQueryCache().build(c, defaultedOptions() as any) as any
+    const opts = defaultedOptions()
+    if (
+      removedQuery?.queryHash === opts.queryHash &&
+      !c.getQueryCache().get(opts.queryHash)
+    ) {
+      return removedQuery
+    }
+    if (removedQuery?.queryHash !== opts.queryHash) {
+      removedQuery = undefined
+    }
+    return c.getQueryCache().build(c, opts as any) as any
   }
 
   const isEnabled = () => {


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

FIX #11350. 

Prevents an actively observed query from being recreated immediately after the `removeQueries()` function removes it from the cache. `TQuery` stores the removed query as a read-only tombstone for fixed read operations. This prevents a situation where reactive cache updates call `cache.build()` for the same query hash and cause unexpected re-fetch. An explicit re-fetch, a write to the cache, a change to the query key, or change to the `QueryClient` can result in the query being recreated as expected.

Added a regression test covering both behaviors:
- removing observed query keeps it out of the cache without another fetch.
- explicitly refetching recreates the query and updates its data.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
