### PR TITLE
fix: make Algolia load more keyboard accessible

### DIFF
--- a/examples/react/algolia/src/SearchResults.tsx
+++ b/examples/react/algolia/src/SearchResults.tsx
@@ -59,9 +59,13 @@ export default function SearchResults({ query = '' }: SearchResultsProps) {
           )}
         </div>
         {hasNextPage && (
-          <div className="search-more" onClick={() => fetchNextPage()}>
+          <button
+            type="button"
+            className="search-more"
+            onClick={() => fetchNextPage()}
+          >
             more
-          </div>
+          </button>
         )}
         {isFetchingNextPage && (
           <div className="search-status">Fetching next page...</div>

--- a/examples/react/algolia/src/styles.css
+++ b/examples/react/algolia/src/styles.css
@@ -22,12 +22,21 @@
 }
 
 .search-more {
+  appearance: none;
+  background: none;
+  border: 0;
   color: blue;
+  font: inherit;
   padding-left: 20px;
   padding-top: 20px;
   cursor: pointer;
   font-weight: bold;
   text-transform: uppercase;
+}
+
+.search-more:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 
 .product {


### PR DESCRIPTION
## Bug
The More action was a clickable div and could only be activated with a pointer.

## Fix
The action is a native button with focus-visible styling, so keyboard activation follows browser button behavior.

## Validation
prettier --check on both changed files and git diff --check passed. Full workspace build remains blocked by an upstream tsdown config-loader dependency error (tsx/esm/api), unrelated to this change.

Reviewed and reproduced by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard accessibility for the “more” pagination control by using a button with a visible focus indicator.
  * Preserved the existing pagination behavior and label.
* **Style**
  * Updated the control styling to match its previous appearance while removing default button formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->