### PR TITLE
test(query-core/subscribable): add unit tests for 'Subscribable' base class

### DIFF
--- a/packages/query-core/src/__tests__/subscribable.test.tsx
+++ b/packages/query-core/src/__tests__/subscribable.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Subscribable } from '../subscribable'
+
+type Listener = () => void
+
+class SubscribableTest extends Subscribable<Listener> {
+  onSubscribeSpy = vi.fn()
+  onUnsubscribeSpy = vi.fn()
+
+  protected onSubscribe(): void {
+    this.onSubscribeSpy()
+  }
+
+  protected onUnsubscribe(): void {
+    this.onUnsubscribeSpy()
+  }
+}
+
+describe('Subscribable', () => {
+  it('should call onSubscribe when a listener subscribes', () => {
+    const subscribable = new SubscribableTest()
+
+    subscribable.subscribe(() => undefined)
+
+    expect(subscribable.onSubscribeSpy).toHaveBeenCalledTimes(1)
+    expect(subscribable.onUnsubscribeSpy).toHaveBeenCalledTimes(0)
+  })
+
+  it('should call onSubscribe once per subscribe call', () => {
+    const subscribable = new SubscribableTest()
+
+    subscribable.subscribe(() => undefined)
+    subscribable.subscribe(() => undefined)
+
+    expect(subscribable.onSubscribeSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should call onUnsubscribe when a listener unsubscribes', () => {
+    const subscribable = new SubscribableTest()
+
+    const unsubscribe = subscribable.subscribe(() => undefined)
+    unsubscribe()
+
+    expect(subscribable.onUnsubscribeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return `false` from hasListeners when there are no listeners', () => {
+    const subscribable = new SubscribableTest()
+
+    expect(subscribable.hasListeners()).toBe(false)
+  })
+
+  it('should return `true` from hasListeners while a listener is subscribed', () => {
+    const subscribable = new SubscribableTest()
+
+    subscribable.subscribe(() => undefined)
+
+    expect(subscribable.hasListeners()).toBe(true)
+  })
+
+  it('should return `false` from hasListeners after the last listener unsubscribes', () => {
+    const subscribable = new SubscribableTest()
+
+    const unsubscribe = subscribable.subscribe(() => undefined)
+    unsubscribe()
+
+    expect(subscribable.hasListeners()).toBe(false)
+  })
+
+  it('should still have listeners while at least one remains subscribed', () => {
+    const subscribable = new SubscribableTest()
+
+    const unsubscribe1 = subscribable.subscribe(() => undefined)
+    subscribable.subscribe(() => undefined)
+
+    unsubscribe1()
+
+    expect(subscribable.hasListeners()).toBe(true)
+  })
+
+  it('should deduplicate the same listener reference', () => {
+    const subscribable = new SubscribableTest()
+    const listener = () => undefined
+
+    subscribable.subscribe(listener)
+    subscribable.subscribe(listener)
+
+    expect(subscribable.hasListeners()).toBe(true)
+
+    const unsubscribe = subscribable.subscribe(listener)
+    unsubscribe()
+
+    expect(subscribable.hasListeners()).toBe(false)
+  })
+
+  it('should keep a stable subscribe reference when destructured', () => {
+    const subscribable = new SubscribableTest()
+    const { subscribe } = subscribable
+
+    const unsubscribe = subscribe(() => undefined)
+
+    expect(subscribable.onSubscribeSpy).toHaveBeenCalledTimes(1)
+    expect(subscribable.hasListeners()).toBe(true)
+
+    unsubscribe()
+
+    expect(subscribable.hasListeners()).toBe(false)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Add a dedicated unit test file for the `Subscribable` base class in `query-core`.

`Subscribable` is the base class that `QueryCache`, `MutationCache`, `QueryObserver`, `MutationObserver`, `QueriesObserver`, `FocusManager`, and `OnlineManager` all extend, but it had no test file of its own — its behavior was only exercised indirectly through those subclasses. This PR tests the class directly so the core subscribe/unsubscribe contract is pinned down in one place.

The new `subscribable.test.tsx` uses a minimal test subclass that spies on the protected `onSubscribe`/`onUnsubscribe` hooks, and covers:

- `onSubscribe` fires once per `subscribe()` call
- `onUnsubscribe` fires when the returned unsubscribe function is called
- `hasListeners()` transitions correctly across subscribe/unsubscribe, including when multiple listeners are registered and only some unsubscribe
- the same listener reference is de-duplicated (the underlying `Set` semantics)
- the `subscribe` method stays bound to the instance when destructured (the `this.subscribe = this.subscribe.bind(this)` in the constructor)

No source code is changed — this only adds test coverage.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for subscription behavior, including listener lifecycle hooks, listener state tracking, duplicate listener handling, and stable subscription references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->