### PR TITLE
test(query-core/removable): add unit tests for 'Removable' base class

### DIFF
--- a/packages/query-core/src/__tests__/removable.test.tsx
+++ b/packages/query-core/src/__tests__/removable.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Removable } from '../removable'
+import { defaultTimeoutProvider, timeoutManager } from '../timeoutManager'
+import { setIsServer } from './utils'
+import type { TimeoutCallback } from '../timeoutManager'
+
+class RemovableTest extends Removable {
+  optionalRemoveSpy = vi.fn()
+
+  // Expose the protected members so they can be exercised directly.
+  callScheduleGc(): void {
+    this.scheduleGc()
+  }
+
+  callUpdateGcTime(newGcTime: number | undefined): void {
+    this.updateGcTime(newGcTime)
+  }
+
+  callClearGcTimeout(): void {
+    this.clearGcTimeout()
+  }
+
+  protected optionalRemove(): void {
+    this.optionalRemoveSpy()
+  }
+}
+
+describe('Removable', () => {
+  function createMockProvider() {
+    return {
+      setTimeout: vi.fn((_callback: TimeoutCallback, _delay: number) => 123),
+      clearTimeout: vi.fn(),
+      setInterval: vi.fn((_callback: TimeoutCallback, _delay: number) => 456),
+      clearInterval: vi.fn(),
+    }
+  }
+
+  let provider: ReturnType<typeof createMockProvider>
+
+  beforeEach(() => {
+    provider = createMockProvider()
+    timeoutManager.setTimeoutProvider(provider)
+  })
+
+  afterEach(() => {
+    timeoutManager.setTimeoutProvider(defaultTimeoutProvider)
+    vi.restoreAllMocks()
+  })
+
+  describe('updateGcTime', () => {
+    it('should default to 5 minutes when no gcTime is provided on the client', () => {
+      const removable = new RemovableTest()
+
+      removable.callUpdateGcTime(undefined)
+
+      expect(removable.gcTime).toBe(5 * 60 * 1000)
+    })
+
+    it('should use the provided gcTime when it is larger than the default', () => {
+      const removable = new RemovableTest()
+
+      removable.callUpdateGcTime(10 * 60 * 1000)
+
+      expect(removable.gcTime).toBe(10 * 60 * 1000)
+    })
+
+    it('should use an explicit gcTime even when it is smaller than the default', () => {
+      const removable = new RemovableTest()
+
+      removable.callUpdateGcTime(1000)
+
+      expect(removable.gcTime).toBe(1000)
+    })
+
+    it('should never decrease an already larger gcTime', () => {
+      const removable = new RemovableTest()
+
+      removable.callUpdateGcTime(10 * 60 * 1000)
+      removable.callUpdateGcTime(1000)
+
+      expect(removable.gcTime).toBe(10 * 60 * 1000)
+    })
+
+    it('should default to Infinity on the server', () => {
+      const resetIsServer = setIsServer(true)
+      const removable = new RemovableTest()
+
+      removable.callUpdateGcTime(undefined)
+
+      expect(removable.gcTime).toBe(Infinity)
+
+      resetIsServer()
+    })
+  })
+
+  describe('scheduleGc', () => {
+    it('should schedule optionalRemove after a valid gcTime', () => {
+      const removable = new RemovableTest()
+      removable.callUpdateGcTime(1000)
+
+      removable.callScheduleGc()
+
+      expect(provider.setTimeout).toHaveBeenCalledTimes(1)
+      expect(provider.setTimeout).toHaveBeenCalledWith(
+        expect.any(Function),
+        1000,
+      )
+
+      // The scheduled callback should invoke optionalRemove.
+      const [scheduledCallback] = provider.setTimeout.mock.lastCall ?? []
+      expect(removable.optionalRemoveSpy).toHaveBeenCalledTimes(0)
+      scheduledCallback?.()
+      expect(removable.optionalRemoveSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not schedule when gcTime is not a valid timeout', () => {
+      const removable = new RemovableTest()
+      removable.gcTime = Infinity
+
+      removable.callScheduleGc()
+
+      expect(provider.setTimeout).not.toHaveBeenCalled()
+    })
+
+    it('should clear a previously scheduled timeout before scheduling a new one', () => {
+      const removable = new RemovableTest()
+      removable.callUpdateGcTime(1000)
+
+      removable.callScheduleGc()
+      removable.callScheduleGc()
+
+      // The second schedule clears the first timer before setting a new one.
+      expect(provider.clearTimeout).toHaveBeenCalledWith(123)
+      expect(provider.setTimeout).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('clearGcTimeout', () => {
+    it('should clear a scheduled timeout', () => {
+      const removable = new RemovableTest()
+      removable.callUpdateGcTime(1000)
+      removable.callScheduleGc()
+
+      removable.callClearGcTimeout()
+
+      expect(provider.clearTimeout).toHaveBeenCalledWith(123)
+    })
+
+    it('should do nothing when no timeout is scheduled', () => {
+      const removable = new RemovableTest()
+
+      removable.callClearGcTimeout()
+
+      expect(provider.clearTimeout).not.toHaveBeenCalled()
+    })
+
+    it('should not clear the same timeout twice', () => {
+      const removable = new RemovableTest()
+      removable.callUpdateGcTime(1000)
+      removable.callScheduleGc()
+
+      removable.callClearGcTimeout()
+      removable.callClearGcTimeout()
+
+      expect(provider.clearTimeout).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('destroy', () => {
+    it('should clear the scheduled gc timeout', () => {
+      const removable = new RemovableTest()
+      removable.callUpdateGcTime(1000)
+      removable.callScheduleGc()
+
+      removable.destroy()
+
+      expect(provider.clearTimeout).toHaveBeenCalledWith(123)
+    })
+  })
+})

--- a/packages/query-core/src/__tests__/removable.test.tsx
+++ b/packages/query-core/src/__tests__/removable.test.tsx
@@ -83,13 +83,15 @@ describe('Removable', () => {
 
     it('should default to Infinity on the server', () => {
       const resetIsServer = setIsServer(true)
-      const removable = new RemovableTest()
+      try {
+        const removable = new RemovableTest()
 
-      removable.callUpdateGcTime(undefined)
+        removable.callUpdateGcTime(undefined)
 
-      expect(removable.gcTime).toBe(Infinity)
-
-      resetIsServer()
+        expect(removable.gcTime).toBe(Infinity)
+      } finally {
+        resetIsServer()
+      }
     })
   })
 


### PR DESCRIPTION
## 🎯 Changes

Add a dedicated unit test file for the `Removable` base class in `query-core`.

`Removable` is the abstract base class that both `Query` and `Mutation` extend to manage their garbage-collection lifecycle, but it had no test file of its own — its behavior was only exercised indirectly through query/mutation tests. This PR tests the class directly so its gc-timer contract is pinned down in one place.

The new `removable.test.tsx` uses a minimal test subclass that exposes the protected members and spies on `optionalRemove`. Timer behavior is asserted through a mock `TimeoutProvider` (the same approach as `timeoutManager.test.tsx`), and the server case uses the existing `setIsServer` helper. It covers:

- `updateGcTime`: keeps the larger of the current and incoming value, uses an explicit `gcTime` as-is, and falls back to `5 * 60 * 1000` on the client / `Infinity` on the server
- `scheduleGc`: schedules `optionalRemove` after a valid `gcTime`, does nothing when `gcTime` is not a valid timeout, and clears any previously scheduled timer before scheduling a new one
- `clearGcTimeout`: clears a scheduled timer, is a no-op when nothing is scheduled, and does not clear the same timer twice
- `destroy`: clears the scheduled gc timer

The server-side `scheduleGc` behavior is intentionally left untouched here to avoid overlapping with #11321.

No source code is changed — this only adds test coverage.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for removable resource lifecycle behavior, including garbage-collection scheduling, timeout updates, timer cleanup, destruction, and client/server defaults.
  - Added validation for explicit timeout values, timer replacement, and handling of non-schedulable timeouts.
  - Improved test reliability by using controlled timeout providers and ensuring server-mode state is restored after test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->