### PR TITLE
docs(preact-query): correct inaccurate JSDoc statements

### DIFF
--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -9,7 +9,7 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:169](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L169)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:171](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L171)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -95,7 +95,7 @@ function Projects() {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:231](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L231)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:233](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L233)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -178,7 +178,7 @@ function Comments({ postId }: { postId: string }) {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:293](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L293)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:295](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L295)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.

--- a/docs/framework/preact/reference/functions/mutationOptions.md
+++ b/docs/framework/preact/reference/functions/mutationOptions.md
@@ -78,7 +78,7 @@ function SavingIndicator() {
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): Omit<UseMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [preact-query/src/mutationOptions.ts:74](https://github.com/TanStack/query/blob/main/packages/preact-query/src/mutationOptions.ts#L74)
+Defined in: [preact-query/src/mutationOptions.ts:75](https://github.com/TanStack/query/blob/main/packages/preact-query/src/mutationOptions.ts#L75)
 
 You can generally pass everything to `mutationOptions` that you can also pass to `useMutation`. No
 `mutationKey` is required on this overload — use this when you don't need to look the mutation up later
@@ -123,8 +123,9 @@ The same options object, unchanged.
 
 ### Remarks
 
-Without a `mutationKey`, the mutation can't be looked up elsewhere via `useMutationState` — see
-the other overload's example for that.
+Without a `mutationKey`, the mutation can't be targeted via a `mutationKey` filter in
+`useMutationState` — it can still be observed through other filters, such as `status` — see the other
+overload's example for that.
 
 ### Example
 

--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -9,7 +9,7 @@ title: queryOptions
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:140](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L140)
+Defined in: [preact-query/src/queryOptions.ts:142](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L142)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -84,7 +84,7 @@ function Posts() {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:180](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L180)
+Defined in: [preact-query/src/queryOptions.ts:182](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L182)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -152,7 +152,7 @@ function Post({ id }: { id: string }) {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:243](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L243)
+Defined in: [preact-query/src/queryOptions.ts:245](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L245)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and

--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -11,7 +11,7 @@ function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(op
 
 Defined in: [preact-query/src/useInfiniteQuery.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L64)
 
-The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
+The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
 
 This overload is selected when `initialData` is set.
@@ -106,7 +106,7 @@ function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(op
 
 Defined in: [preact-query/src/useInfiniteQuery.ts:189](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L189)
 
-The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
+The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
 
 ### Type Parameters
@@ -265,7 +265,7 @@ function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(op
 
 Defined in: [preact-query/src/useInfiniteQuery.ts:344](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L344)
 
-The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
+The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
 
 ### Type Parameters

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -7,7 +7,7 @@ title: useMutation
 function useMutation<TData, TError, TVariables, TOnMutateResult>(options, queryClient?): UseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [preact-query/src/useMutation.ts:191](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutation.ts#L191)
+Defined in: [preact-query/src/useMutation.ts:192](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutation.ts#L192)
 
 Unlike queries, mutations are typically used to create/update/delete data or perform server side-effects.
 `useMutation` is the hook for that.
@@ -51,8 +51,9 @@ be used.
 
 `mutate`/`mutateAsync` also accept per-call `onSuccess`/`onError`/`onSettled` callbacks as a second
 argument, useful for triggering call-site side effects (e.g. navigation) without coupling them to the shared
-mutation definition. If you make multiple requests, `onSuccess` will fire only after the latest call you've
-made.
+mutation definition. Hook-level callbacks (passed to `options`) fire for every mutation; per-call callbacks
+fire only for the latest call you've made, and only while the component is still mounted — unmounting before
+the mutation settles removes the subscription and prevents them from firing.
 
 ## See
 

--- a/docs/framework/preact/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/preact/reference/functions/useSuspenseQueries.md
@@ -11,8 +11,8 @@ function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombine
 
 Defined in: [preact-query/src/useSuspenseQueries.ts:409](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L409)
 
-The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
-`throwOnError`, `enabled`, or `placeholderData`.
+The options for `useSuspenseQueries` are the same as for `useQueries`, except that the top-level `subscribed`
+option isn't supported, and each `query` can't have `throwOnError`, `enabled`, or `placeholderData`.
 
 ### Type Parameters
 
@@ -281,8 +281,8 @@ function useSuspenseQueries<T, TCombinedResult>(options, queryClient?): TCombine
 
 Defined in: [preact-query/src/useSuspenseQueries.ts:589](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useSuspenseQueries.ts#L589)
 
-The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
-`throwOnError`, `enabled`, or `placeholderData`.
+The options for `useSuspenseQueries` are the same as for `useQueries`, except that the top-level `subscribed`
+option isn't supported, and each `query` can't have `throwOnError`, `enabled`, or `placeholderData`.
 
 ### Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -7,7 +7,7 @@ title: DefinedInitialDataInfiniteOptions
 type DefinedInitialDataInfiniteOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:102](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L102)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:104](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L104)
 
 The options accepted by the `infiniteQueryOptions` overload selected when `initialData` is set — `data` is
 never `undefined`.

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataOptions.md
@@ -7,7 +7,7 @@ title: DefinedInitialDataOptions
 type DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:79](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L79)
+Defined in: [preact-query/src/queryOptions.ts:81](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L81)
 
 The options accepted by the `queryOptions` overload selected when `initialData` is set — `data` is never
 `undefined`.

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenInfiniteOptions.md
@@ -22,7 +22,9 @@ optional queryFn: Exclude<UseInfiniteQueryOptions<TQueryFnData, TError, TData, T
 ```
 
 `skipToken` is not allowed as a value here — this overload is selected when no `initialData` is set. If
-you don't intend to run the query yet, omit `queryFn` or use a default query function instead.
+you don't intend to run the query yet, set `enabled: false` — omitting `queryFn` alone still triggers a
+fetch that fails with "Missing queryFn" unless `enabled` is `false` or a default query function has been
+defined. A default query function only supplies `queryFn`; it doesn't defer the fetch on its own.
 
 ## Type Parameters
 

--- a/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
+++ b/docs/framework/preact/reference/type-aliases/UnusedSkipTokenOptions.md
@@ -21,7 +21,9 @@ optional queryFn: Exclude<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey
 ```
 
 `skipToken` is not allowed as a value here — this overload is selected when no `initialData` is set. If
-you don't intend to run the query yet, omit `queryFn` or use a default query function instead.
+you don't intend to run the query yet, set `enabled: false` — omitting `queryFn` alone still triggers a
+fetch that fails with "Missing queryFn" unless `enabled` is `false` or a default query function has been
+defined. A default query function only supplies `queryFn`; it doesn't defer the fetch on its own.
 
 ## Type Parameters
 

--- a/packages/preact-query/src/infiniteQueryOptions.ts
+++ b/packages/preact-query/src/infiniteQueryOptions.ts
@@ -74,7 +74,9 @@ export type UnusedSkipTokenInfiniteOptions<
 > & {
   /**
    * `skipToken` is not allowed as a value here — this overload is selected when no `initialData` is set. If
-   * you don't intend to run the query yet, omit `queryFn` or use a default query function instead.
+   * you don't intend to run the query yet, set `enabled: false` — omitting `queryFn` alone still triggers a
+   * fetch that fails with "Missing queryFn" unless `enabled` is `false` or a default query function has been
+   * defined. A default query function only supplies `queryFn`; it doesn't defer the fetch on its own.
    */
   queryFn?: Exclude<
     UseInfiniteQueryOptions<

--- a/packages/preact-query/src/mutationOptions.ts
+++ b/packages/preact-query/src/mutationOptions.ts
@@ -54,8 +54,9 @@ export function mutationOptions<
  * @param options - The mutation options to use, identical to what you'd pass to `useMutation`, without a
  * `mutationKey`.
  * @returns The same options object, unchanged.
- * @remarks Without a `mutationKey`, the mutation can't be looked up elsewhere via `useMutationState` — see
- * the other overload's example for that.
+ * @remarks Without a `mutationKey`, the mutation can't be targeted via a `mutationKey` filter in
+ * `useMutationState` — it can still be observed through other filters, such as `status` — see the other
+ * overload's example for that.
  *
  * @example
  * ```tsx

--- a/packages/preact-query/src/queryOptions.ts
+++ b/packages/preact-query/src/queryOptions.ts
@@ -59,7 +59,9 @@ export type UnusedSkipTokenOptions<
 > & {
   /**
    * `skipToken` is not allowed as a value here — this overload is selected when no `initialData` is set. If
-   * you don't intend to run the query yet, omit `queryFn` or use a default query function instead.
+   * you don't intend to run the query yet, set `enabled: false` — omitting `queryFn` alone still triggers a
+   * fetch that fails with "Missing queryFn" unless `enabled` is `false` or a default query function has been
+   * defined. A default query function only supplies `queryFn`; it doesn't defer the fetch on its own.
    */
   queryFn?: Exclude<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>['queryFn'],

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -19,7 +19,7 @@ import type {
 import { useBaseQuery } from './useBaseQuery'
 
 /**
- * The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
+ * The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
  * `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
  *
  * This overload is selected when `initialData` is set.
@@ -79,7 +79,7 @@ export function useInfiniteQuery<
 ): DefinedUseInfiniteQueryResult<TData, TError>
 
 /**
- * The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
+ * The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
  * `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
  *
  * @remarks Keep in mind that imperative fetch calls, such as `fetchNextPage`, may interfere with the default
@@ -204,7 +204,7 @@ export function useInfiniteQuery<
 ): UseInfiniteQueryResult<TData, TError>
 
 /**
- * The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of `queryFn`,
+ * The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
  * `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
  *
  * @remarks Keep in mind that imperative fetch calls, such as `fetchNextPage`, may interfere with the default

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -28,8 +28,9 @@ import { useSyncExternalStore } from './utils'
  * be used.
  * @returns `mutate`/`mutateAsync` also accept per-call `onSuccess`/`onError`/`onSettled` callbacks as a second
  * argument, useful for triggering call-site side effects (e.g. navigation) without coupling them to the shared
- * mutation definition. If you make multiple requests, `onSuccess` will fire only after the latest call you've
- * made.
+ * mutation definition. Hook-level callbacks (passed to `options`) fire for every mutation; per-call callbacks
+ * fire only for the latest call you've made, and only while the component is still mounted — unmounting before
+ * the mutation settles removes the subscription and prevents them from firing.
  *
  * @example
  * ```tsx

--- a/packages/preact-query/src/useSuspenseQueries.ts
+++ b/packages/preact-query/src/useSuspenseQueries.ts
@@ -181,8 +181,8 @@ export type SuspenseQueriesResults<
         : { [K in keyof T]: GetUseSuspenseQueryResult<T[K]> }
 
 /**
- * The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
- * `throwOnError`, `enabled`, or `placeholderData`.
+ * The options for `useSuspenseQueries` are the same as for `useQueries`, except that the top-level `subscribed`
+ * option isn't supported, and each `query` can't have `throwOnError`, `enabled`, or `placeholderData`.
  *
  * @param options - The `queries` array to run in Suspense, and an optional `combine` function.
  * @param queryClient - Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context
@@ -427,8 +427,8 @@ export function useSuspenseQueries<
 ): TCombinedResult
 
 /**
- * The options for `useSuspenseQueries` are the same as for `useQueries`, except that each `query` can't have
- * `throwOnError`, `enabled`, or `placeholderData`.
+ * The options for `useSuspenseQueries` are the same as for `useQueries`, except that the top-level `subscribed`
+ * option isn't supported, and each `query` can't have `throwOnError`, `enabled`, or `placeholderData`.
  *
  * @param options - The `queries` array to run in Suspense, and an optional `combine` function.
  * @param queryClient - Use this to provide a custom `QueryClient`. Otherwise, the one from the nearest context


### PR DESCRIPTION
## 🎯 Changes

Corrects 6 inaccurate JSDoc statements in `packages/preact-query/src/`, and regenerates the affected reference docs under `docs/framework/preact/reference/` to match.

- `mutationOptions.ts`: without a `mutationKey`, a mutation can still be targeted via other `useMutationState` filters (e.g. `status`) — it's only a `mutationKey` filter that can't reach it.
- `queryOptions.ts` / `infiniteQueryOptions.ts`: the `queryFn`-omission guidance no longer implies a default query function defers a fetch the way `enabled: false` does — omitting `queryFn` alone still triggers a fetch that fails with "Missing queryFn" unless `enabled` is `false` or a default query function has been defined.
- `useInfiniteQuery.ts` (3 overloads): `queryFn` is also accepted by `useQuery`, so it isn't something `useInfiniteQuery` "adds" — removed from that list.
- `useMutation.ts`: `mutate`'s `@returns` docs now distinguish hook-level callbacks (fire on every mutation) from per-call callbacks (fire only for the latest call, and only while still mounted).
- `useSuspenseQueries.ts` (2 overloads): the top-level `subscribed` option from `useQueries` isn't supported here either — added to the list of unsupported options alongside `throwOnError`/`enabled`/`placeholderData`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified query behavior when `queryFn` is omitted, including failed fetches and the use of `enabled: false`.
  - Clarified mutation filtering and the behavior of per-call callbacks during concurrent mutations or component unmounting.
  - Documented that `useSuspenseQueries` does not support the top-level `subscribed` option.
  - Updated API reference source links and option descriptions for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->