### PR TITLE
chore(scripts/generate-docs): add solid-query entry point

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -163,6 +163,12 @@ for (const pkg of [
     exclude: ['./packages/query-core/**/*'],
   },
   {
+    entryPoints: [resolve(__dirname, '../packages/solid-query/src/index.ts')],
+    tsconfig: resolve(__dirname, '../packages/solid-query/tsconfig.json'),
+    outputDir: resolve(__dirname, '../docs/framework/solid/reference'),
+    exclude: ['./packages/query-core/**/*'],
+  },
+  {
     entryPoints: [resolve(__dirname, '../packages/react-query/src/index.ts')],
     tsconfig: resolve(__dirname, '../packages/react-query/tsconfig.json'),
     outputDir: resolve(__dirname, '../docs/framework/react/reference'),


### PR DESCRIPTION
## 🎯 Changes

Adds a `solid-query` entry to `scripts/generate-docs.ts`, matching the config already used for angular/svelte/react/preact/lit — same `@tanstack/query-core` exclude, output pointed at `docs/framework/solid/reference`.

**Deliberately not run yet.** `packages/solid-query/src/` has JSDoc on only ~2 of 15 source files today. Running `pnpm run generate-docs` with this entry point active would delete the 11 hand-written pages currently under `docs/framework/solid/reference/` (`rm(outputDir, { recursive: true, force: true })`) and replace them with mostly-empty TypeDoc output. This PR only wires up the entry point so it's ready; actually regenerating solid's reference docs is a separate PR, gated on writing JSDoc across `packages/solid-query/src/` first.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added generated reference documentation for the Solid Query package.
  - Documentation generation now reflects the package’s public entry point and excludes internal query-core details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->