### PR TITLE
docs({react,preact,solid}-query): correct inaccurate JSDoc statements

### DIFF
--- a/docs/framework/preact/reference/functions/mutationOptions.md
+++ b/docs/framework/preact/reference/functions/mutationOptions.md
@@ -78,11 +78,12 @@ function SavingIndicator() {
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): Omit<UseMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [preact-query/src/mutationOptions.ts:75](https://github.com/TanStack/query/blob/main/packages/preact-query/src/mutationOptions.ts#L75)
+Defined in: [preact-query/src/mutationOptions.ts:74](https://github.com/TanStack/query/blob/main/packages/preact-query/src/mutationOptions.ts#L74)
 
 You can generally pass everything to `mutationOptions` that you can also pass to `useMutation`. No
-`mutationKey` is required on this overload — use this when you don't need to look the mutation up later
-(e.g. with `useMutationState`).
+`mutationKey` is required on this overload — use this when you don't need to target the mutation via a
+`mutationKey` filter later (e.g. with `useMutationState`); it can still be observed through other filters,
+such as `status`.
 
 ### Type Parameters
 
@@ -123,9 +124,7 @@ The same options object, unchanged.
 
 ### Remarks
 
-Without a `mutationKey`, the mutation can't be targeted via a `mutationKey` filter in
-`useMutationState` — it can still be observed through other filters, such as `status` — see the other
-overload's example for that.
+See the other overload's example for looking a mutation up via `useMutationState`.
 
 ### Example
 

--- a/docs/framework/preact/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/preact/reference/functions/useInfiniteQuery.md
@@ -9,7 +9,7 @@ title: useInfiniteQuery
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): DefinedUseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:64](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L64)
+Defined in: [preact-query/src/useInfiniteQuery.ts:65](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L65)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -57,9 +57,10 @@ be used.
 
 [`DefinedUseInfiniteQueryResult`](../type-aliases/DefinedUseInfiniteQueryResult.md)\<`TData`, `TError`\>
 
-The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
-`fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
-`isFetchingPreviousPage`.
+The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+`hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+`data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+`InfiniteData<TQueryFnData>` shape.
 
 ### Remarks
 
@@ -104,7 +105,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:189](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L189)
+Defined in: [preact-query/src/useInfiniteQuery.ts:191](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L191)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -150,9 +151,10 @@ be used.
 
 [`UseInfiniteQueryResult`](../type-aliases/UseInfiniteQueryResult.md)\<`TData`, `TError`\>
 
-The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
-`fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
-`isFetchingPreviousPage`.
+The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+`hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+`data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+`InfiniteData<TQueryFnData>` shape.
 
 ### Remarks
 
@@ -263,7 +265,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [preact-query/src/useInfiniteQuery.ts:344](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L344)
+Defined in: [preact-query/src/useInfiniteQuery.ts:347](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useInfiniteQuery.ts#L347)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -309,9 +311,10 @@ be used.
 
 [`UseInfiniteQueryResult`](../type-aliases/UseInfiniteQueryResult.md)\<`TData`, `TError`\>
 
-The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
-`fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
-`isFetchingPreviousPage`.
+The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+`hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+`data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+`InfiniteData<TQueryFnData>` shape.
 
 ### Remarks
 

--- a/docs/framework/preact/reference/functions/useIsFetching.md
+++ b/docs/framework/preact/reference/functions/useIsFetching.md
@@ -9,8 +9,8 @@ function useIsFetching(filters?, queryClient?): number;
 
 Defined in: [preact-query/src/useIsFetching.ts:44](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useIsFetching.ts#L44)
 
-`useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or
-fetching in the background (useful for app-wide loading indicators).
+The `useIsFetching` hook returns the `number` of the queries that your application is loading or fetching in
+the background (useful for app-wide loading indicators).
 
 ## Parameters
 

--- a/docs/framework/preact/reference/functions/useIsMutating.md
+++ b/docs/framework/preact/reference/functions/useIsMutating.md
@@ -9,7 +9,7 @@ function useIsMutating(filters?, queryClient?): number;
 
 Defined in: [preact-query/src/useMutationState.ts:35](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useMutationState.ts#L35)
 
-`useIsMutating` is an optional hook that returns the `number` of mutations that your application is fetching
+The `useIsMutating` hook returns the `number` of mutations that your application currently has `pending`
 (useful for app-wide loading indicators).
 
 ## Parameters
@@ -31,7 +31,7 @@ be used.
 
 `number`
 
-Will be the `number` of the mutations that your application is currently fetching.
+Will be the `number` of the mutations that your application currently has `pending`.
 
 ## Example
 

--- a/docs/framework/preact/reference/functions/useMutationState.md
+++ b/docs/framework/preact/reference/functions/useMutationState.md
@@ -88,9 +88,9 @@ function Posts() {
 }
 ```
 
-Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
-mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
-latest invocation:
+Access the latest successful mutation data via the `mutationKey`. Each invocation of `mutate` adds a new
+entry to the mutation cache for `gcTime` milliseconds — with the `status: 'success'` filter below, check the
+last item that `useMutationState` returns to get the latest successful invocation:
 ```tsx
 import { useMutationState } from '@tanstack/preact-query'
 

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -7,12 +7,13 @@ title: useQueries
 function useQueries<T, TCombinedResult>(__namedParameters, queryClient?): TCombinedResult;
 ```
 
-Defined in: [preact-query/src/useQueries.ts:301](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L301)
+Defined in: [preact-query/src/useQueries.ts:302](https://github.com/TanStack/query/blob/main/packages/preact-query/src/useQueries.ts#L302)
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 
-The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
-is supplied once, as `useQueries`' own top-level second argument, rather than per query.
+The `queries` key accepts an array with query option objects mostly identical to `useQuery` — see the
+`queries` parameter below for the differences. A custom `QueryClient` is supplied once, as `useQueries`' own
+top-level second argument, rather than per query.
 
 Having the same query key more than once in the array of query objects may cause some data to be shared
 between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/docs/framework/preact/reference/functions/useQueries.md
+++ b/docs/framework/preact/reference/functions/useQueries.md
@@ -11,8 +11,8 @@ Defined in: [preact-query/src/useQueries.ts:301](https://github.com/TanStack/que
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 
-The `queries` key accepts an array with query option objects identical to `useQuery` (excluding the
-`queryClient` option - because the `QueryClient` can be passed in on the top level).
+The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
+is supplied once, as `useQueries`' own top-level second argument, rather than per query.
 
 Having the same query key more than once in the array of query objects may cause some data to be shared
 between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/docs/framework/react/reference/functions/mutationOptions.md
+++ b/docs/framework/react/reference/functions/mutationOptions.md
@@ -78,11 +78,12 @@ function SavingIndicator() {
 function mutationOptions<TData, TError, TVariables, TOnMutateResult>(options): Omit<UseMutationOptions<TData, TError, TVariables, TOnMutateResult>, "mutationKey">;
 ```
 
-Defined in: [react-query/src/mutationOptions.ts:74](https://github.com/TanStack/query/blob/main/packages/react-query/src/mutationOptions.ts#L74)
+Defined in: [react-query/src/mutationOptions.ts:73](https://github.com/TanStack/query/blob/main/packages/react-query/src/mutationOptions.ts#L73)
 
 You can generally pass everything to `mutationOptions` that you can also pass to `useMutation`. No
-`mutationKey` is required on this overload — use this when you don't need to look the mutation up later
-(e.g. with `useMutationState`).
+`mutationKey` is required on this overload — use this when you don't need to target the mutation via a
+`mutationKey` filter later (e.g. with `useMutationState`); it can still be observed through other filters,
+such as `status`.
 
 ### Type Parameters
 
@@ -123,9 +124,7 @@ The same options object, unchanged.
 
 ### Remarks
 
-Without a `mutationKey`, the mutation can't be targeted via a `mutationKey` filter in
-`useMutationState` — it can still be observed through other filters, such as `status` — see the other
-overload's example for that.
+See the other overload's example for looking a mutation up via `useMutationState`.
 
 ### Example
 

--- a/docs/framework/react/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/react/reference/functions/useInfiniteQuery.md
@@ -9,7 +9,7 @@ title: useInfiniteQuery
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): DefinedUseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [react-query/src/useInfiniteQuery.ts:64](https://github.com/TanStack/query/blob/main/packages/react-query/src/useInfiniteQuery.ts#L64)
+Defined in: [react-query/src/useInfiniteQuery.ts:65](https://github.com/TanStack/query/blob/main/packages/react-query/src/useInfiniteQuery.ts#L65)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -57,9 +57,10 @@ be used.
 
 [`DefinedUseInfiniteQueryResult`](../type-aliases/DefinedUseInfiniteQueryResult.md)\<`TData`, `TError`\>
 
-The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
-`fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
-`isFetchingPreviousPage`.
+The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+`hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+`data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+`InfiniteData<TQueryFnData>` shape.
 
 ### Remarks
 
@@ -104,7 +105,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [react-query/src/useInfiniteQuery.ts:189](https://github.com/TanStack/query/blob/main/packages/react-query/src/useInfiniteQuery.ts#L189)
+Defined in: [react-query/src/useInfiniteQuery.ts:191](https://github.com/TanStack/query/blob/main/packages/react-query/src/useInfiniteQuery.ts#L191)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -150,9 +151,10 @@ be used.
 
 [`UseInfiniteQueryResult`](../type-aliases/UseInfiniteQueryResult.md)\<`TData`, `TError`\>
 
-The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
-`fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
-`isFetchingPreviousPage`.
+The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+`hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+`data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+`InfiniteData<TQueryFnData>` shape.
 
 ### Remarks
 
@@ -263,7 +265,7 @@ function Projects() {
 function useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options, queryClient?): UseInfiniteQueryResult<TData, TError>;
 ```
 
-Defined in: [react-query/src/useInfiniteQuery.ts:344](https://github.com/TanStack/query/blob/main/packages/react-query/src/useInfiniteQuery.ts#L344)
+Defined in: [react-query/src/useInfiniteQuery.ts:347](https://github.com/TanStack/query/blob/main/packages/react-query/src/useInfiniteQuery.ts#L347)
 
 The options for `useInfiniteQuery` are identical to `useQuery`, with the addition of
 `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
@@ -309,9 +311,10 @@ be used.
 
 [`UseInfiniteQueryResult`](../type-aliases/UseInfiniteQueryResult.md)\<`TData`, `TError`\>
 
-The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
-`fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
-`isFetchingPreviousPage`.
+The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+`hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+`data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+`InfiniteData<TQueryFnData>` shape.
 
 ### Remarks
 

--- a/docs/framework/react/reference/functions/useIsFetching.md
+++ b/docs/framework/react/reference/functions/useIsFetching.md
@@ -9,8 +9,8 @@ function useIsFetching(filters?, queryClient?): number;
 
 Defined in: [react-query/src/useIsFetching.ts:44](https://github.com/TanStack/query/blob/main/packages/react-query/src/useIsFetching.ts#L44)
 
-`useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or
-fetching in the background (useful for app-wide loading indicators).
+The `useIsFetching` hook returns the `number` of the queries that your application is loading or fetching in
+the background (useful for app-wide loading indicators).
 
 ## Parameters
 

--- a/docs/framework/react/reference/functions/useIsMutating.md
+++ b/docs/framework/react/reference/functions/useIsMutating.md
@@ -9,7 +9,7 @@ function useIsMutating(filters?, queryClient?): number;
 
 Defined in: [react-query/src/useMutationState.ts:35](https://github.com/TanStack/query/blob/main/packages/react-query/src/useMutationState.ts#L35)
 
-`useIsMutating` is an optional hook that returns the `number` of mutations that your application is fetching
+The `useIsMutating` hook returns the `number` of mutations that your application currently has `pending`
 (useful for app-wide loading indicators).
 
 ## Parameters
@@ -31,7 +31,7 @@ be used.
 
 `number`
 
-Will be the `number` of the mutations that your application is currently fetching.
+Will be the `number` of the mutations that your application currently has `pending`.
 
 ## Example
 

--- a/docs/framework/react/reference/functions/useMutationState.md
+++ b/docs/framework/react/reference/functions/useMutationState.md
@@ -88,9 +88,9 @@ function Posts() {
 }
 ```
 
-Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
-mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
-latest invocation:
+Access the latest successful mutation data via the `mutationKey`. Each invocation of `mutate` adds a new
+entry to the mutation cache for `gcTime` milliseconds — with the `status: 'success'` filter below, check the
+last item that `useMutationState` returns to get the latest successful invocation:
 ```tsx
 import { useMutationState } from '@tanstack/react-query'
 

--- a/docs/framework/react/reference/functions/useQueries.md
+++ b/docs/framework/react/reference/functions/useQueries.md
@@ -11,8 +11,8 @@ Defined in: [react-query/src/useQueries.ts:354](https://github.com/TanStack/quer
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 
-The `queries` key accepts an array with query option objects identical to `useQuery` (excluding the
-`queryClient` option - because the `QueryClient` can be passed in on the top level).
+The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
+is supplied once, as `useQueries`' own top-level second argument, rather than per query.
 
 Having the same query key more than once in the array of query objects may cause some data to be shared
 between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/docs/framework/react/reference/functions/useQueries.md
+++ b/docs/framework/react/reference/functions/useQueries.md
@@ -7,12 +7,13 @@ title: useQueries
 function useQueries<T, TCombinedResult>(__namedParameters, queryClient?): TCombinedResult;
 ```
 
-Defined in: [react-query/src/useQueries.ts:354](https://github.com/TanStack/query/blob/main/packages/react-query/src/useQueries.ts#L354)
+Defined in: [react-query/src/useQueries.ts:355](https://github.com/TanStack/query/blob/main/packages/react-query/src/useQueries.ts#L355)
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 
-The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
-is supplied once, as `useQueries`' own top-level second argument, rather than per query.
+The `queries` key accepts an array with query option objects mostly identical to `useQuery` — the top-level
+`subscribed` option isn't accepted per query (see `placeholderData` below for another difference). A custom
+`QueryClient` is supplied once, as `useQueries`' own top-level second argument, rather than per query.
 
 Having the same query key more than once in the array of query objects may cause some data to be shared
 between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/docs/framework/solid/reference/functions/useQueries.md
+++ b/docs/framework/solid/reference/functions/useQueries.md
@@ -7,12 +7,13 @@ title: useQueries
 function useQueries<T, TCombinedResult>(queriesOptions, queryClient?): TCombinedResult;
 ```
 
-Defined in: [useQueries.ts:273](https://github.com/TanStack/query/blob/main/packages/solid-query/src/useQueries.ts#L273)
+Defined in: [useQueries.ts:274](https://github.com/TanStack/query/blob/main/packages/solid-query/src/useQueries.ts#L274)
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 
-The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
-is supplied once, as `useQueries`' own top-level second argument, rather than per query.
+The `queries` key accepts an array with query option objects mostly identical to `useQuery` — see
+`placeholderData` below for the one difference. A custom `QueryClient` is supplied once, as `useQueries`'
+own top-level second argument, rather than per query.
 
 Having the same query key more than once in the array of query objects may cause some data to be shared
 between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/docs/framework/solid/reference/variables/createQueries.md
+++ b/docs/framework/solid/reference/variables/createQueries.md
@@ -11,8 +11,9 @@ Defined in: [index.ts:86](https://github.com/TanStack/query/blob/main/packages/s
 
 The `useQueries` hook can be used to fetch a variable number of queries.
 
-The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
-is supplied once, as `useQueries`' own top-level second argument, rather than per query.
+The `queries` key accepts an array with query option objects mostly identical to `useQuery` — see
+`placeholderData` below for the one difference. A custom `QueryClient` is supplied once, as `useQueries`'
+own top-level second argument, rather than per query.
 
 Having the same query key more than once in the array of query objects may cause some data to be shared
 between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/packages/preact-query/src/mutationOptions.ts
+++ b/packages/preact-query/src/mutationOptions.ts
@@ -47,16 +47,15 @@ export function mutationOptions<
 >
 /**
  * You can generally pass everything to `mutationOptions` that you can also pass to `useMutation`. No
- * `mutationKey` is required on this overload — use this when you don't need to look the mutation up later
- * (e.g. with `useMutationState`).
+ * `mutationKey` is required on this overload — use this when you don't need to target the mutation via a
+ * `mutationKey` filter later (e.g. with `useMutationState`); it can still be observed through other filters,
+ * such as `status`.
  *
  * @see {@link useMutation} to run the mutation these options describe.
  * @param options - The mutation options to use, identical to what you'd pass to `useMutation`, without a
  * `mutationKey`.
  * @returns The same options object, unchanged.
- * @remarks Without a `mutationKey`, the mutation can't be targeted via a `mutationKey` filter in
- * `useMutationState` — it can still be observed through other filters, such as `status` — see the other
- * overload's example for that.
+ * @remarks See the other overload's example for looking a mutation up via `useMutationState`.
  *
  * @example
  * ```tsx

--- a/packages/preact-query/src/useInfiniteQuery.ts
+++ b/packages/preact-query/src/useInfiniteQuery.ts
@@ -31,9 +31,10 @@ import { useBaseQuery } from './useBaseQuery'
  * @param options - The {@link DefinedInitialDataInfiniteOptions} to use — everything you can pass to `useInfiniteQuery`, with `initialData` set.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
- * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
- * `isFetchingPreviousPage`.
+ * @returns The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+ * `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+ * `data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+ * `InfiniteData<TQueryFnData>` shape.
  *
  * @example
  * ```tsx
@@ -89,9 +90,10 @@ export function useInfiniteQuery<
  * @param options - The {@link UndefinedInitialDataInfiniteOptions} to use — everything you can pass to `useInfiniteQuery`.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
- * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
- * `isFetchingPreviousPage`.
+ * @returns The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+ * `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+ * `data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+ * `InfiniteData<TQueryFnData>` shape.
  *
  * @example
  * Fetching the next page from a "Load More" button click:
@@ -214,9 +216,10 @@ export function useInfiniteQuery<
  * @param options - The {@link UseInfiniteQueryOptions} to use — everything you can pass to `useInfiniteQuery`.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
- * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
- * `isFetchingPreviousPage`.
+ * @returns The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+ * `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+ * `data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+ * `InfiniteData<TQueryFnData>` shape.
  *
  * @example
  * Fetching the next page from a "Load More" button click:

--- a/packages/preact-query/src/useIsFetching.ts
+++ b/packages/preact-query/src/useIsFetching.ts
@@ -6,8 +6,8 @@ import { useQueryClient } from './QueryClientProvider'
 import { useSyncExternalStore } from './utils'
 
 /**
- * `useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or
- * fetching in the background (useful for app-wide loading indicators).
+ * The `useIsFetching` hook returns the `number` of the queries that your application is loading or fetching in
+ * the background (useful for app-wide loading indicators).
  *
  * @param filters - The {@link QueryFilters} to narrow down the matched queries.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will

--- a/packages/preact-query/src/useMutationState.ts
+++ b/packages/preact-query/src/useMutationState.ts
@@ -12,13 +12,13 @@ import { useQueryClient } from './QueryClientProvider'
 import { useSyncExternalStore } from './utils'
 
 /**
- * `useIsMutating` is an optional hook that returns the `number` of mutations that your application is fetching
+ * The `useIsMutating` hook returns the `number` of mutations that your application currently has `pending`
  * (useful for app-wide loading indicators).
  *
  * @param filters - The {@link MutationFilters} to narrow down the matched mutations.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns Will be the `number` of the mutations that your application is currently fetching.
+ * @returns Will be the `number` of the mutations that your application currently has `pending`.
  *
  * @example
  * ```tsx
@@ -136,9 +136,9 @@ function getResult<
  * ```
  *
  * @example
- * Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
- * mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
- * latest invocation:
+ * Access the latest successful mutation data via the `mutationKey`. Each invocation of `mutate` adds a new
+ * entry to the mutation cache for `gcTime` milliseconds — with the `status: 'success'` filter below, check the
+ * last item that `useMutationState` returns to get the latest successful invocation:
  * ```tsx
  * import { useMutationState } from '@tanstack/preact-query'
  *

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -225,8 +225,8 @@ export type QueriesResults<
 /**
  * The `useQueries` hook can be used to fetch a variable number of queries.
  *
- * The `queries` key accepts an array with query option objects identical to `useQuery` (excluding the
- * `queryClient` option - because the `QueryClient` can be passed in on the top level).
+ * The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
+ * is supplied once, as `useQueries`' own top-level second argument, rather than per query.
  *
  * Having the same query key more than once in the array of query objects may cause some data to be shared
  * between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/packages/preact-query/src/useQueries.ts
+++ b/packages/preact-query/src/useQueries.ts
@@ -225,8 +225,9 @@ export type QueriesResults<
 /**
  * The `useQueries` hook can be used to fetch a variable number of queries.
  *
- * The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
- * is supplied once, as `useQueries`' own top-level second argument, rather than per query.
+ * The `queries` key accepts an array with query option objects mostly identical to `useQuery` — see the
+ * `queries` parameter below for the differences. A custom `QueryClient` is supplied once, as `useQueries`' own
+ * top-level second argument, rather than per query.
  *
  * Having the same query key more than once in the array of query objects may cause some data to be shared
  * between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/packages/react-query/src/mutationOptions.ts
+++ b/packages/react-query/src/mutationOptions.ts
@@ -46,16 +46,15 @@ export function mutationOptions<
 >
 /**
  * You can generally pass everything to `mutationOptions` that you can also pass to `useMutation`. No
- * `mutationKey` is required on this overload — use this when you don't need to look the mutation up later
- * (e.g. with `useMutationState`).
+ * `mutationKey` is required on this overload — use this when you don't need to target the mutation via a
+ * `mutationKey` filter later (e.g. with `useMutationState`); it can still be observed through other filters,
+ * such as `status`.
  *
  * @see {@link useMutation} to run the mutation these options describe.
  * @param options - The mutation options to use, identical to what you'd pass to `useMutation`, without a
  * `mutationKey`.
  * @returns The same options object, unchanged.
- * @remarks Without a `mutationKey`, the mutation can't be targeted via a `mutationKey` filter in
- * `useMutationState` — it can still be observed through other filters, such as `status` — see the other
- * overload's example for that.
+ * @remarks See the other overload's example for looking a mutation up via `useMutationState`.
  *
  * @example
  * ```tsx

--- a/packages/react-query/src/useInfiniteQuery.ts
+++ b/packages/react-query/src/useInfiniteQuery.ts
@@ -31,9 +31,10 @@ import type {
  * @param options - The {@link DefinedInitialDataInfiniteOptions} to use — everything you can pass to `useInfiniteQuery`, with `initialData` set.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
- * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
- * `isFetchingPreviousPage`.
+ * @returns The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+ * `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+ * `data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+ * `InfiniteData<TQueryFnData>` shape.
  *
  * @example
  * ```tsx
@@ -89,9 +90,10 @@ export function useInfiniteQuery<
  * @param options - The {@link UndefinedInitialDataInfiniteOptions} to use — everything you can pass to `useInfiniteQuery`.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
- * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
- * `isFetchingPreviousPage`.
+ * @returns The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+ * `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+ * `data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+ * `InfiniteData<TQueryFnData>` shape.
  *
  * @example
  * Fetching the next page from a "Load More" button click:
@@ -214,9 +216,10 @@ export function useInfiniteQuery<
  * @param options - The {@link UseInfiniteQueryOptions} to use — everything you can pass to `useInfiniteQuery`.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns The same properties as `useQuery`, with the addition of `data.pages`, `data.pageParams`,
- * `fetchNextPage`, `fetchPreviousPage`, `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and
- * `isFetchingPreviousPage`.
+ * @returns The same properties as `useQuery`, with the addition of `fetchNextPage`, `fetchPreviousPage`,
+ * `hasNextPage`, `hasPreviousPage`, `isFetchingNextPage`, and `isFetchingPreviousPage`. `data.pages` and
+ * `data.pageParams` are also added, as long as a `select` doesn't change `TData` away from its default
+ * `InfiniteData<TQueryFnData>` shape.
  *
  * @example
  * Fetching the next page from a "Load More" button click:

--- a/packages/react-query/src/useIsFetching.ts
+++ b/packages/react-query/src/useIsFetching.ts
@@ -6,8 +6,8 @@ import { useQueryClient } from './QueryClientProvider'
 import type { QueryClient, QueryFilters } from '@tanstack/query-core'
 
 /**
- * `useIsFetching` is an optional hook that returns the `number` of the queries that your application is loading or
- * fetching in the background (useful for app-wide loading indicators).
+ * The `useIsFetching` hook returns the `number` of the queries that your application is loading or fetching in
+ * the background (useful for app-wide loading indicators).
  *
  * @param filters - The {@link QueryFilters} to narrow down the matched queries.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will

--- a/packages/react-query/src/useMutationState.ts
+++ b/packages/react-query/src/useMutationState.ts
@@ -12,13 +12,13 @@ import type {
 } from '@tanstack/query-core'
 
 /**
- * `useIsMutating` is an optional hook that returns the `number` of mutations that your application is fetching
+ * The `useIsMutating` hook returns the `number` of mutations that your application currently has `pending`
  * (useful for app-wide loading indicators).
  *
  * @param filters - The {@link MutationFilters} to narrow down the matched mutations.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one from the nearest context will
  * be used.
- * @returns Will be the `number` of the mutations that your application is currently fetching.
+ * @returns Will be the `number` of the mutations that your application currently has `pending`.
  *
  * @example
  * ```tsx
@@ -136,9 +136,9 @@ function getResult<
  * ```
  *
  * @example
- * Access the latest mutation data via the `mutationKey`. Each invocation of `mutate` adds a new entry to the
- * mutation cache for `gcTime` milliseconds — check the last item that `useMutationState` returns to get the
- * latest invocation:
+ * Access the latest successful mutation data via the `mutationKey`. Each invocation of `mutate` adds a new
+ * entry to the mutation cache for `gcTime` milliseconds — with the `status: 'success'` filter below, check the
+ * last item that `useMutationState` returns to get the latest successful invocation:
  * ```tsx
  * import { useMutationState } from '@tanstack/react-query'
  *

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -225,8 +225,8 @@ export type QueriesResults<
 /**
  * The `useQueries` hook can be used to fetch a variable number of queries.
  *
- * The `queries` key accepts an array with query option objects identical to `useQuery` (excluding the
- * `queryClient` option - because the `QueryClient` can be passed in on the top level).
+ * The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
+ * is supplied once, as `useQueries`' own top-level second argument, rather than per query.
  *
  * Having the same query key more than once in the array of query objects may cause some data to be shared
  * between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/packages/react-query/src/useQueries.ts
+++ b/packages/react-query/src/useQueries.ts
@@ -225,8 +225,9 @@ export type QueriesResults<
 /**
  * The `useQueries` hook can be used to fetch a variable number of queries.
  *
- * The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
- * is supplied once, as `useQueries`' own top-level second argument, rather than per query.
+ * The `queries` key accepts an array with query option objects mostly identical to `useQuery` — the top-level
+ * `subscribed` option isn't accepted per query (see `placeholderData` below for another difference). A custom
+ * `QueryClient` is supplied once, as `useQueries`' own top-level second argument, rather than per query.
  *
  * Having the same query key more than once in the array of query objects may cause some data to be shared
  * between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired

--- a/packages/solid-query/src/useQueries.ts
+++ b/packages/solid-query/src/useQueries.ts
@@ -187,8 +187,9 @@ type QueriesResults<
 /**
  * The `useQueries` hook can be used to fetch a variable number of queries.
  *
- * The `queries` key accepts an array with query option objects identical to `useQuery`. A custom `QueryClient`
- * is supplied once, as `useQueries`' own top-level second argument, rather than per query.
+ * The `queries` key accepts an array with query option objects mostly identical to `useQuery` — see
+ * `placeholderData` below for the one difference. A custom `QueryClient` is supplied once, as `useQueries`'
+ * own top-level second argument, rather than per query.
  *
  * Having the same query key more than once in the array of query objects may cause some data to be shared
  * between queries. To avoid this, consider de-duplicating the queries and map the results back to the desired


### PR DESCRIPTION
## 🎯 Changes

Applies to react-query, preact-query, and solid-query the same JSDoc corrections. solid-query's JSDoc was originally written by referencing react-query's, so several inaccuracies CodeRabbit caught during #11369's review turned out to be pre-existing in the react-query/preact-query source, not new mistakes introduced while porting to solid — and one further inaccuracy, caught during this PR's own review, turned out to affect all three packages including solid-query.

- `mutationOptions.ts`: the no-`mutationKey` overload's description implied a mutation becomes entirely unobservable via `useMutationState` without one, contradicting its own `@remarks` one line below (which correctly says other filters like `status` still work). Reworded to state the `mutationKey`-filter limitation directly, and trimmed the now-redundant `@remarks`.
- `useInfiniteQuery.ts` (3 overloads each): `@returns` listed `data.pages`/`data.pageParams` as unconditional, but they only exist while `select` leaves `TData` at its default `InfiniteData<TQueryFnData>` shape — a custom `select` can change that.
- `useIsFetching.ts`: "is an optional hook" misapplies "optional" to the hook itself instead of its (optional) parameters. Reworded to "The `useIsFetching` hook...".
- `useIsMutating` (inside `useMutationState.ts` in both packages): same "optional hook" wording fixed, plus "currently fetching" corrected to "currently `pending`" — core's `isMutating()` filters on `status: 'pending'`, so "fetching" doesn't match what the count actually reflects.
- `useMutationState.ts`: the "access the latest mutation data" example filters on `status: 'success'`, so the last returned item is the latest *successful* invocation, not simply the latest one (a failed or in-flight call wouldn't be in the filtered results). Reworded to say "successful" throughout that example.
- `useQueries.ts` (react-query, preact-query, and solid-query): claimed the per-query option objects are "identical" to `useQuery`'s, but they aren't — the top-level `subscribed` option isn't accepted per query (react/preact only; solid-query has no `subscribed` option to begin with), and `placeholderData` doesn't receive information from previously rendered queries the way `useQuery`'s does. Reworded to "mostly identical" and pointed at the existing explanation of that difference instead of asserting an equivalence that doesn't hold. (Also touches the regenerated `docs/framework/solid/reference/` pages already shipped in #11369, since solid-query's `useQueries.ts` had the same inaccurate wording.)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified when mutations can be observed without a mutation key and how to identify the latest successful mutation results.
  - Updated infinite-query return documentation, including when `data.pages` and `data.pageParams` are available.
  - Clarified pending mutation counts and background-fetching behavior.
  - Documented differences between `useQueries` and `useQuery`, including `placeholderData`, and clarified top-level custom query client usage.
  - Corrected source references and refined wording across React, Preact, and Solid references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->