### PR TITLE
fix({react,preact,angular}-query): remove erroneous '| undefined' from 'DefinedInitialDataInfiniteOptions'

### DIFF
--- a/.changeset/fix-defined-initial-data-infinite-undefined.md
+++ b/.changeset/fix-defined-initial-data-infinite-undefined.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-query': patch
+'@tanstack/preact-query': patch
+'@tanstack/angular-query-experimental': patch
+---
+
+fix({react,preact,angular}-query): remove erroneous '| undefined' from 'DefinedInitialDataInfiniteOptions'

--- a/docs/framework/angular/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/angular/reference/functions/infiniteQueryOptions.md
@@ -17,7 +17,7 @@ The infinite query options to tag with the type from `queryFn`.
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [infinite-query-options.ts:88](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L88)
+Defined in: [infinite-query-options.ts:87](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L87)
 
 Allows sharing and re-using infinite query options in a type-safe way.
 
@@ -65,7 +65,7 @@ The tagged infinite query options.
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [infinite-query-options.ts:118](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L118)
+Defined in: [infinite-query-options.ts:117](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L117)
 
 Allows sharing and re-using infinite query options in a type-safe way.
 
@@ -113,7 +113,7 @@ The tagged infinite query options.
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [infinite-query-options.ts:148](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L148)
+Defined in: [infinite-query-options.ts:147](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/infinite-query-options.ts#L147)
 
 Allows sharing and re-using infinite query options in a type-safe way.
 

--- a/docs/framework/angular/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/angular/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -16,8 +16,7 @@ Defined in: [infinite-query-options.ts:62](https://github.com/TanStack/query/blo
 ```ts
 initialData: 
   | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
-  | () => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
-  | undefined;
+| () => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>;
 ```
 
 ## Type Parameters

--- a/docs/framework/preact/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/preact/reference/functions/infiniteQueryOptions.md
@@ -9,7 +9,7 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:171](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L171)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:170](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L170)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -95,7 +95,7 @@ function Projects() {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:233](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L233)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:232](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L232)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -178,7 +178,7 @@ function Comments({ postId }: { postId: string }) {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [preact-query/src/infiniteQueryOptions.ts:295](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L295)
+Defined in: [preact-query/src/infiniteQueryOptions.ts:294](https://github.com/TanStack/query/blob/main/packages/preact-query/src/infiniteQueryOptions.ts#L294)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.

--- a/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/preact/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -19,8 +19,7 @@ never `undefined`.
 ```ts
 initialData: 
   | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
-  | () => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
-  | undefined;
+| () => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>;
 ```
 
 If set, this value will be used as the initial data for the query cache (as long as the query hasn't been

--- a/docs/framework/react/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/react/reference/functions/infiniteQueryOptions.md
@@ -9,7 +9,7 @@ title: infiniteQueryOptions
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [react-query/src/infiniteQueryOptions.ts:170](https://github.com/TanStack/query/blob/main/packages/react-query/src/infiniteQueryOptions.ts#L170)
+Defined in: [react-query/src/infiniteQueryOptions.ts:169](https://github.com/TanStack/query/blob/main/packages/react-query/src/infiniteQueryOptions.ts#L169)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -95,7 +95,7 @@ function Projects() {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): OmitKeyof<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [react-query/src/infiniteQueryOptions.ts:232](https://github.com/TanStack/query/blob/main/packages/react-query/src/infiniteQueryOptions.ts#L232)
+Defined in: [react-query/src/infiniteQueryOptions.ts:231](https://github.com/TanStack/query/blob/main/packages/react-query/src/infiniteQueryOptions.ts#L231)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.
@@ -178,7 +178,7 @@ function Comments({ postId }: { postId: string }) {
 function infiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>(options): UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & object & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData, unknown>, TError>;
 ```
 
-Defined in: [react-query/src/infiniteQueryOptions.ts:294](https://github.com/TanStack/query/blob/main/packages/react-query/src/infiniteQueryOptions.ts#L294)
+Defined in: [react-query/src/infiniteQueryOptions.ts:293](https://github.com/TanStack/query/blob/main/packages/react-query/src/infiniteQueryOptions.ts#L293)
 
 You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
 These options can be shared across hooks and imperative APIs such as `queryClient.infiniteQuery`.

--- a/docs/framework/react/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
+++ b/docs/framework/react/reference/type-aliases/DefinedInitialDataInfiniteOptions.md
@@ -19,8 +19,7 @@ never `undefined`.
 ```ts
 initialData: 
   | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
-  | () => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
-  | undefined;
+| () => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>;
 ```
 
 If set, this value will be used as the initial data for the query cache (as long as the query hasn't been

--- a/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/infinite-query-options.test-d.ts
@@ -268,6 +268,25 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
+  it('keeps data possibly undefined when initialData is a ternary that can be undefined', () => {
+    const key = queryKey()
+    const hasInitialData = false
+    const options = infiniteQueryOptions({
+      queryKey: key,
+      queryFn: () => Promise.resolve({ example: true }),
+      initialData: hasInitialData
+        ? { pages: [{ example: true }], pageParams: [1] }
+        : undefined,
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+    })
+
+    const { data } = injectInfiniteQuery(() => options)
+    expectTypeOf(data()).toEqualTypeOf<
+      InfiniteData<{ example: boolean }, unknown> | undefined
+    >()
+  })
+
   it('should return a custom query key type', () => {
     type MyQueryKey = [Array<string>, { type: 'foo' }]
 

--- a/packages/angular-query-experimental/src/infinite-query-options.ts
+++ b/packages/angular-query-experimental/src/infinite-query-options.ts
@@ -75,7 +75,6 @@ export type DefinedInitialDataInfiniteOptions<
   initialData:
     | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
     | (() => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>)
-    | undefined
 }
 
 /**

--- a/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/preact-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -276,6 +276,24 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
+  it('keeps data possibly undefined when initialData is a ternary that can be undefined', () => {
+    const hasInitialData = false
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ example: true }),
+      initialData: hasInitialData
+        ? { pages: [{ example: true }], pageParams: [1] }
+        : undefined,
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+    })
+
+    const { data } = useInfiniteQuery(options)
+    expectTypeOf(data).toEqualTypeOf<
+      InfiniteData<{ example: boolean }, unknown> | undefined
+    >()
+  })
+
   it('should return a custom query key type', () => {
     type MyQueryKey = [Array<string>, { type: 'foo' }]
 

--- a/packages/preact-query/src/infiniteQueryOptions.ts
+++ b/packages/preact-query/src/infiniteQueryOptions.ts
@@ -124,7 +124,6 @@ export type DefinedInitialDataInfiniteOptions<
   initialData:
     | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
     | (() => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>)
-    | undefined
 }
 
 /**

--- a/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
+++ b/packages/react-query/src/__tests__/infiniteQueryOptions.test-d.tsx
@@ -315,6 +315,24 @@ describe('infiniteQueryOptions', () => {
     >()
   })
 
+  it('keeps data possibly undefined when initialData is a ternary that can be undefined', () => {
+    const hasInitialData = false
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve({ example: true }),
+      initialData: hasInitialData
+        ? { pages: [{ example: true }], pageParams: [1] }
+        : undefined,
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+    })
+
+    const { data } = useInfiniteQuery(options)
+    expectTypeOf(data).toEqualTypeOf<
+      InfiniteData<{ example: boolean }, unknown> | undefined
+    >()
+  })
+
   it('should return a custom query key type', () => {
     type MyQueryKey = [Array<string>, { type: 'foo' }]
 

--- a/packages/react-query/src/infiniteQueryOptions.ts
+++ b/packages/react-query/src/infiniteQueryOptions.ts
@@ -123,7 +123,6 @@ export type DefinedInitialDataInfiniteOptions<
   initialData:
     | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
     | (() => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>)
-    | undefined
 }
 
 /**


### PR DESCRIPTION
## 🎯 Changes

`DefinedInitialDataInfiniteOptions['initialData']` (the overload selected when `initialData` is set, meant to guarantee `data` is never `undefined`) incorrectly included `| undefined` in `packages/react-query/src/infiniteQueryOptions.ts`, `packages/preact-query/src/infiniteQueryOptions.ts`, and `packages/angular-query-experimental/src/infinite-query-options.ts`.

This let expressions like `initialData: id ? {...} : undefined` match the `Defined` overload, causing `useInfiniteQuery`/`injectInfiniteQuery` to infer `data` as never `undefined` even though it could be `undefined` at runtime.

Root cause: `initialData?: undefined | NonUndefinedGuard<...> | InitialDataFunction<...>` was already added to `UndefinedInitialDataInfiniteOptions` (the correct overload for this case) in an earlier PR. A later PR aiming to support the same ternary pattern missed that and added `| undefined` to the `Defined` overload instead, where it didn't belong.

Verified by removing `| undefined` and confirming, via `tsc --build`, that `initialData: id ? {...} : undefined` now falls through to `UndefinedInitialDataInfiniteOptions` as intended, and `data` is correctly typed as possibly `undefined`. Existing `.test-d` suites in all three packages still pass unmodified.

`solid-query`, `svelte-query`, and `vue-query` don't have this `| undefined` on their `Defined` overload — only these three packages needed the fix. `lit-query`'s `infiniteQueryOptions` has no `Defined`/`Undefined` overload split, so it isn't affected.

Added a regression test to each package's `infiniteQueryOptions.test-d` suite asserting `data` stays `T | undefined` when `initialData` is a ternary that can evaluate to `undefined`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected infinite-query type definitions across React, Preact, and Angular integrations so options guaranteeing initial data no longer accept `undefined`.
  - Preserved accurate typing for conditional initial data, ensuring query results remain recognized as potentially `undefined` when appropriate.

- **Tests**
  - Added type-level coverage for defined and conditionally undefined infinite-query initial data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->