### PR TITLE
chore(scripts/generate-docs): add vue-query entry point

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -169,6 +169,12 @@ for (const pkg of [
     exclude: ['./packages/query-core/**/*'],
   },
   {
+    entryPoints: [resolve(__dirname, '../packages/vue-query/src/index.ts')],
+    tsconfig: resolve(__dirname, '../packages/vue-query/tsconfig.json'),
+    outputDir: resolve(__dirname, '../docs/framework/vue/reference'),
+    exclude: ['./packages/query-core/**/*'],
+  },
+  {
     entryPoints: [resolve(__dirname, '../packages/react-query/src/index.ts')],
     tsconfig: resolve(__dirname, '../packages/react-query/tsconfig.json'),
     outputDir: resolve(__dirname, '../docs/framework/react/reference'),


### PR DESCRIPTION
## 🎯 Changes

Adds a `vue-query` entry to `scripts/generate-docs.ts`, matching the config already used for angular/svelte/solid/react/preact/lit — same `@tanstack/query-core` exclude, output pointed at `docs/framework/vue/reference`.

**Deliberately not run yet.** `packages/vue-query/src/` has JSDoc on only 3 of 19 source files today (`types.ts`, `useQueries.ts`, `queryClient.ts` — the rest have none). Running `pnpm run generate-docs` with this entry point active would delete the hand-written pages currently under `docs/framework/vue/reference/` (`rm(outputDir, { recursive: true, force: true })`) and replace them with mostly-empty TypeDoc output. This PR only wires up the entry point so it's ready; actually regenerating vue's reference docs is a separate PR, gated on writing JSDoc across `packages/vue-query/src/` first.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added automated reference documentation generation for the Vue Query package.
  * Vue Query API documentation is now generated from its public entry point and published under the Vue framework reference docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->