### PR TITLE
fix(preact-query): retry on mount for falsy errors when throwOnError returns false

### DIFF
--- a/.changeset/preact-falsy-error-retry-on-mount.md
+++ b/.changeset/preact-falsy-error-retry-on-mount.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/preact-query': patch
+---
+
+Allow queries with falsy errors to retry on mount when `throwOnError` returns false.

--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -6951,4 +6951,33 @@ describe('useQuery', () => {
     expect(fetchCount).toBe(initialFetchCount + 1)
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
+
+  it('should retry on mount when throwOnError returns false for a falsy error', async () => {
+    const key = queryKey()
+    const queryFn = vi.fn(() => Promise.reject())
+
+    function Component() {
+      const { status } = useQuery({
+        queryKey: key,
+        queryFn,
+        throwOnError: () => false,
+        retryOnMount: () => true,
+        staleTime: Infinity,
+        retry: false,
+      })
+
+      return <div data-testid="status">{status}</div>
+    }
+
+    const rendered1 = renderWithClient(queryClient, <Component />)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered1.getByTestId('status')).toHaveTextContent('error')
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    rendered1.unmount()
+
+    const rendered2 = renderWithClient(queryClient, <Component />)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(rendered2.getByTestId('status')).toHaveTextContent('error')
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/preact-query/src/errorBoundaryUtils.ts
+++ b/packages/preact-query/src/errorBoundaryUtils.ts
@@ -27,10 +27,14 @@ export const ensurePreventErrorBoundaryRetry = <
   errorResetBoundary: QueryErrorResetBoundaryValue,
   query: Query<TQueryFnData, TError, TQueryData, TQueryKey> | undefined,
 ) => {
-  const throwOnError =
-    query?.state.error && typeof options.throwOnError === 'function'
-      ? shouldThrowError(options.throwOnError, [query.state.error, query])
-      : options.throwOnError
+  let throwOnError = options.throwOnError
+
+  if (query?.state.status === 'error' && typeof throwOnError === 'function') {
+    throwOnError = shouldThrowError(throwOnError, [
+      query.state.error as TError,
+      query,
+    ])
+  }
 
   if (options.suspense || throwOnError) {
     // Prevent retrying failed query if the error boundary has not been reset yet


### PR DESCRIPTION
## 🎯 Changes

Ports #11328 (react-query) to `preact-query`.

### Summary

`ensurePreventErrorBoundaryRetry` in `preact-query` has the same check as the one fixed for react-query in #11328: a function-valued `throwOnError` was only evaluated when `query.state.error` was truthy. For a query that rejected with a falsy value (e.g. `Promise.reject()` / `undefined`), the callback was skipped, the function itself was treated as truthy, and `retryOnMount` was disabled even though `throwOnError` would have returned `false`. This is the preact side of #11327.

### Changes

- `packages/preact-query/src/errorBoundaryUtils.ts`: check `query.state.status === 'error'` instead of the truthiness of `query.state.error`, so the `throwOnError` callback runs for every failed query.
- `packages/preact-query/src/__tests__/useQuery.test.tsx`: regression test — a query that rejects with `undefined`, `throwOnError: () => false`, `retryOnMount: () => true` must refetch on remount (`queryFn` called twice).
- changeset (`@tanstack/preact-query` patch).

### Test plan

- The new test fails on `main` (`expected "vi.fn()" to be called 2 times, but got 1 times`) and passes with the fix.
- `pnpm nx run @tanstack/preact-query:test:lib` — 529 passed.
- `pnpm run test:pr --base=upstream/main` for the affected projects.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
