### PR TITLE
fix(vue-query): throw falsy errors from useMutation to the error boundary

### DIFF
--- a/.changeset/vue-mutation-falsy-error.md
+++ b/.changeset/vue-mutation-falsy-error.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query': patch
+---
+
+fix(vue-query): throw falsy errors from `useMutation` to the error boundary

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -450,6 +450,27 @@ describe('useMutation', () => {
       expect(throwOnErrorFn).toHaveBeenCalledTimes(1)
       expect(throwOnErrorFn).toHaveBeenCalledWith(Error('Some error'))
     })
+
+    it('should evaluate throwOnError for a falsy error', async () => {
+      const throwOnErrorFn = vi.fn().mockReturnValue(true)
+      const { mutate } = useMutation<string, undefined>({
+        mutationFn: () => sleep(10).then(() => Promise.reject(undefined)),
+        throwOnError: throwOnErrorFn,
+      })
+
+      mutate()
+
+      // Suppress the Unhandled Rejection caused by watcher throw in Vue 3
+      const rejectionHandler = () => {}
+      process.on('unhandledRejection', rejectionHandler)
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      process.off('unhandledRejection', rejectionHandler)
+
+      expect(throwOnErrorFn).toHaveBeenCalledTimes(1)
+      expect(throwOnErrorFn).toHaveBeenCalledWith(undefined)
+    })
   })
 
   describe('optimistic updates', () => {

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -451,8 +451,11 @@ describe('useMutation', () => {
       expect(throwOnErrorFn).toHaveBeenCalledWith(Error('Some error'))
     })
 
-    it('should evaluate throwOnError for a falsy error', async () => {
-      const throwOnErrorFn = vi.fn().mockReturnValue(true)
+    // These tests let throwOnError return false on purpose: under vitest,
+    // throwing a falsy value from the watcher breaks every watcher created
+    // later in this file, while the throw path is already covered above.
+    it('should evaluate throwOnError when the mutation rejects with undefined', async () => {
+      const throwOnErrorFn = vi.fn().mockReturnValue(false)
       const { mutate } = useMutation<string, undefined>({
         mutationFn: () => sleep(10).then(() => Promise.reject(undefined)),
         throwOnError: throwOnErrorFn,
@@ -460,16 +463,25 @@ describe('useMutation', () => {
 
       mutate()
 
-      // Suppress the Unhandled Rejection caused by watcher throw in Vue 3
-      const rejectionHandler = () => {}
-      process.on('unhandledRejection', rejectionHandler)
-
       await vi.advanceTimersByTimeAsync(10)
-
-      process.off('unhandledRejection', rejectionHandler)
 
       expect(throwOnErrorFn).toHaveBeenCalledTimes(1)
       expect(throwOnErrorFn).toHaveBeenCalledWith(undefined)
+    })
+
+    it('should evaluate throwOnError when the mutation rejects with null', async () => {
+      const throwOnErrorFn = vi.fn().mockReturnValue(false)
+      const { mutate } = useMutation<string, null>({
+        mutationFn: () => sleep(10).then(() => Promise.reject(null)),
+        throwOnError: throwOnErrorFn,
+      })
+
+      mutate()
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(throwOnErrorFn).toHaveBeenCalledTimes(1)
+      expect(throwOnErrorFn).toHaveBeenCalledWith(null)
     })
   })
 

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -285,17 +285,14 @@ export function useMutation<
     Readonly<MutationResult<TData, TError, TVariables, TOnMutateResult>>
   >
 
-  watch(
-    () => state.error,
-    (error) => {
-      if (
-        state.isError &&
-        shouldThrowError(defaultedOptions.value.throwOnError, [error as TError])
-      ) {
-        throw error
-      }
-    },
-  )
+  watch([() => state.isError, () => state.error], ([isError, error]) => {
+    if (
+      isError &&
+      shouldThrowError(defaultedOptions.value.throwOnError, [error as TError])
+    ) {
+      throw error
+    }
+  })
 
   return {
     ...resultRefs,

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -289,7 +289,7 @@ export function useMutation<
     () => state.error,
     (error) => {
       if (
-        error &&
+        state.isError &&
         shouldThrowError(defaultedOptions.value.throwOnError, [error as TError])
       ) {
         throw error


### PR DESCRIPTION
## 🎯 Changes

vue-query counterpart of #11311 (react-query) / #11312 (preact-query), following #11305.

### Summary

The `useMutation` error watcher in `vue-query` guards `throwOnError` with the truthiness of the error value:

```ts
watch(() => state.error, (error) => {
  if (error && shouldThrowError(options.value.throwOnError, [error as TError])) {
    throw error
  }
})
```

A mutation that rejects with a falsy value (e.g. `Promise.reject(undefined)`) therefore never evaluates `throwOnError` and is never propagated, even with `throwOnError: true`.

### Changes

- `packages/vue-query/src/useMutation.ts`: watch `state.isError` together with `state.error`, and gate on `isError` instead of the truthiness of `error`, so `throwOnError` is evaluated for every failed mutation. Watching `isError` too matters for a `null` rejection, which leaves `state.error` at its initial `null` and would otherwise never trigger the watcher.
- `packages/vue-query/src/__tests__/useMutation.test.ts`: regression tests — a mutation rejecting with `undefined` or `null` must have `throwOnError` evaluated once with that value.
- changeset (`@tanstack/vue-query` patch).

### Test plan

- Both new tests fail on `main` (`expected "vi.fn()" to be called 1 times, but got 0 times`) and pass with the fix.
- `pnpm nx run @tanstack/vue-query:test:lib` — 318 passed, `test:eslint`, `test:types`, prettier.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `useMutation` so errors with falsy values, such as `null` or `undefined`, are correctly recognized and can be propagated to the error boundary.
  - Preserved accurate mutation error-state handling regardless of the error value.
  - Ensured error handling responds consistently when mutation error status changes, including cases where the error value itself is falsy.

- **Tests**
  - Added regression coverage for mutations that reject with `null` or `undefined`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->