### PR TITLE
docs(preact-query): add 'Suspense' and 'Testing' guides

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -949,6 +949,14 @@
               "to": "framework/preact/guides/default-query-function"
             },
             {
+              "label": "Suspense",
+              "to": "framework/preact/guides/suspense"
+            },
+            {
+              "label": "Testing",
+              "to": "framework/preact/guides/testing"
+            },
+            {
               "label": "Does this replace [Redux, MobX, etc]?",
               "to": "framework/preact/guides/does-this-replace-client-state"
             }

--- a/docs/framework/preact/guides/suspense.md
+++ b/docs/framework/preact/guides/suspense.md
@@ -1,0 +1,87 @@
+---
+id: suspense
+title: Suspense
+ref: docs/framework/react/guides/suspense.md
+replace: { 'react-query': 'preact-query', 'React': 'Preact' }
+---
+
+[//]: # 'Info'
+
+When using suspense mode, `status` states and `error` objects are not needed and are then replaced by usage of the `Suspense` component from `preact/compat` (including the use of the `fallback` prop and error boundaries for catching errors). Please read the [Resetting Error Boundaries](#resetting-error-boundaries) section for more information on how to set up suspense mode.
+
+[//]: # 'Info'
+[//]: # 'PlaceholderData'
+
+`placeholderData` also doesn't exist for this Query.
+
+[//]: # 'PlaceholderData'
+[//]: # 'ExampleResetComponent'
+
+Preact does not ship an error boundary component, but one can be built with the [`useErrorBoundary`](https://preactjs.com/guide/v10/hooks/#useerrorboundary) hook:
+
+```tsx
+import { QueryErrorResetBoundary } from '@tanstack/preact-query'
+import { useErrorBoundary } from 'preact/hooks'
+
+function ErrorBoundary({ children, onReset, fallbackRender }) {
+  const [error, resetError] = useErrorBoundary()
+
+  if (error) {
+    return fallbackRender({
+      error,
+      resetErrorBoundary: () => {
+        onReset()
+        resetError()
+      },
+    })
+  }
+
+  return children
+}
+
+const App = () => (
+  <QueryErrorResetBoundary>
+    {({ reset }) => (
+      <ErrorBoundary
+        onReset={reset}
+        fallbackRender={({ resetErrorBoundary }) => (
+          <div>
+            There was an error!
+            <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>
+    )}
+  </QueryErrorResetBoundary>
+)
+```
+
+[//]: # 'ExampleResetComponent'
+[//]: # 'ExampleResetHook'
+
+```tsx
+import { useQueryErrorResetBoundary } from '@tanstack/preact-query'
+
+const App = () => {
+  const { reset } = useQueryErrorResetBoundary()
+  return (
+    <ErrorBoundary
+      onReset={reset}
+      fallbackRender={({ resetErrorBoundary }) => (
+        <div>
+          There was an error!
+          <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+        </div>
+      )}
+    >
+      <Page />
+    </ErrorBoundary>
+  )
+}
+```
+
+[//]: # 'ExampleResetHook'
+[//]: # 'Streaming'
+[//]: # 'Streaming'

--- a/docs/framework/preact/guides/testing.md
+++ b/docs/framework/preact/guides/testing.md
@@ -1,0 +1,43 @@
+---
+id: testing
+title: Testing
+ref: docs/framework/react/guides/testing.md
+replace: { 'react-query': 'preact-query', 'React': 'Preact' }
+---
+
+[//]: # 'Install'
+
+Writing unit tests for these custom hooks can be done by means of the [Preact Testing Library](https://github.com/testing-library/preact-testing-library), which provides `renderHook` and re-exports the `@testing-library/dom` helpers such as `waitFor`.
+
+Install this by running:
+
+```sh
+npm install @testing-library/preact --save-dev
+```
+
+[//]: # 'Install'
+[//]: # 'ExampleFirstTest'
+
+```tsx
+import { renderHook, waitFor } from '@testing-library/preact'
+
+const queryClient = new QueryClient()
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+const { result } = renderHook(() => useCustomHook(), { wrapper })
+
+await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+expect(result.current.data).toEqual('Hello')
+```
+
+[//]: # 'ExampleFirstTest'
+[//]: # 'NoteWaitFor1'
+
+Here we are making use of `waitFor` and waiting until the query status indicates that the request has succeeded. This way we know that our hook has finished and should have the correct data.
+
+[//]: # 'NoteWaitFor1'
+[//]: # 'NoteWaitFor2'
+[//]: # 'NoteWaitFor2'

--- a/docs/framework/react/guides/suspense.md
+++ b/docs/framework/react/guides/suspense.md
@@ -9,7 +9,10 @@ React Query can also be used with React's Suspense for Data Fetching APIs. For t
 - [useSuspenseInfiniteQuery](../reference/functions/useSuspenseInfiniteQuery.md)
 - [useSuspenseQueries](../reference/functions/useSuspenseQueries.md)
 
+[//]: # 'Info'
+
 When using suspense mode, `status` states and `error` objects are not needed and are then replaced by usage of the `React.Suspense` component (including the use of the `fallback` prop and React error boundaries for catching errors). Please read the [Resetting Error Boundaries](#resetting-error-boundaries) and look at the [Suspense Example](../examples/suspense) for more information on how to set up suspense mode.
+[//]: # 'Info'
 
 If you want mutations to propagate errors to the nearest error boundary (similar to queries), you can set the `throwOnError` option to `true` as well.
 
@@ -25,7 +28,10 @@ This works nicely in TypeScript, because `data` is guaranteed to be defined (as 
 
 On the flip side, you therefore can't conditionally enable / disable the Query. This generally shouldn't be necessary for dependent Queries because with suspense, all your Queries inside one component are fetched in serial.
 
+[//]: # 'PlaceholderData'
+
 `placeholderData` also doesn't exist for this Query. To prevent the UI from being replaced by a fallback during an update, wrap your updates that change the QueryKey into [startTransition](https://react.dev/reference/react/Suspense#preventing-unwanted-fallbacks).
+[//]: # 'PlaceholderData'
 
 ### throwOnError default
 
@@ -57,6 +63,8 @@ Query errors can be reset with the `QueryErrorResetBoundary` component or with t
 
 When using the component it will reset any query errors within the boundaries of the component:
 
+[//]: # 'ExampleResetComponent'
+
 ```tsx
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -80,7 +88,11 @@ const App = () => (
 )
 ```
 
+[//]: # 'ExampleResetComponent'
+
 When using the hook it will reset any query errors within the closest `QueryErrorResetBoundary`. If there is no boundary defined it will reset them globally:
+
+[//]: # 'ExampleResetHook'
 
 ```tsx
 import { useQueryErrorResetBoundary } from '@tanstack/react-query'
@@ -104,9 +116,13 @@ const App = () => {
 }
 ```
 
+[//]: # 'ExampleResetHook'
+
 ## Fetch-on-render vs Render-as-you-fetch
 
 Out of the box, React Query in `suspense` mode works really well as a **Fetch-on-render** solution with no additional configuration. This means that when your components attempt to mount, they will trigger query fetching and suspend, but only once you have imported them and mounted them. If you want to take it to the next level and implement a **Render-as-you-fetch** model, we recommend implementing [Prefetching](./prefetching.md) on routing callbacks and/or user interactions events to start loading queries before they are mounted and hopefully even before you start importing or mounting their parent components.
+
+[//]: # 'Streaming'
 
 ## Suspense on the Server with streaming
 
@@ -172,3 +188,4 @@ export function Providers(props: { children: React.ReactNode }) {
 ```
 
 For more information, check out the [NextJs Suspense Streaming Example](../examples/nextjs-suspense-streaming) and the [Advanced Rendering & Hydration](./advanced-ssr.md) guide.
+[//]: # 'Streaming'

--- a/docs/framework/react/guides/testing.md
+++ b/docs/framework/react/guides/testing.md
@@ -5,6 +5,8 @@ title: Testing
 
 React Query works by means of hooks - either the ones we offer or custom ones that wrap around them.
 
+[//]: # 'Install'
+
 With React 17 or earlier, writing unit tests for these custom hooks can be done by means of the [React Hooks Testing Library](https://react-hooks-testing-library.com/) library.
 
 Install this by running:
@@ -16,6 +18,7 @@ npm install @testing-library/react-hooks react-test-renderer --save-dev
 (The `react-test-renderer` library is needed as a peer dependency of `@testing-library/react-hooks`, and needs to correspond to the version of React that you are using.)
 
 _Note_: when using React 18 or later, `renderHook` is available directly through the `@testing-library/react` package, and `@testing-library/react-hooks` is no longer required.
+[//]: # 'Install'
 
 ## Our First Test
 
@@ -28,6 +31,8 @@ export function useCustomHook() {
 ```
 
 We can write a test for this as follows:
+
+[//]: # 'ExampleFirstTest'
 
 ```tsx
 import { renderHook, waitFor } from '@testing-library/react'
@@ -43,6 +48,8 @@ await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
 expect(result.current.data).toEqual('Hello')
 ```
+
+[//]: # 'ExampleFirstTest'
 
 Note that we provide a custom wrapper that builds the `QueryClient` and `QueryClientProvider`. This helps to ensure that our test is completely isolated from any other tests.
 
@@ -108,7 +115,10 @@ await waitFor(() => expect(result.current.isSuccess).toBe(true))
 expect(result.current.data).toEqual({ answer: 42 })
 ```
 
+[//]: # 'NoteWaitFor1'
+
 Here we are making use of `waitFor` and waiting until the query status indicates that the request has succeeded. This way we know that our hook has finished and should have the correct data. _Note_: when using React 18, the semantics of `waitFor` have changed as noted above.
+[//]: # 'NoteWaitFor1'
 
 ## Testing Load More / Infinite Scroll
 
@@ -163,7 +173,10 @@ await waitFor(() =>
 expectation.done()
 ```
 
+[//]: # 'NoteWaitFor2'
+
 _Note_: when using React 18, the semantics of `waitFor` have changed as noted above.
+[//]: # 'NoteWaitFor2'
 
 ## Further reading
 


### PR DESCRIPTION
## 🎯 Changes

Adds the **Suspense** and **Testing** guides to the Preact docs. Both pages exist for React but had no Preact counterpart, even though `@tanstack/preact-query` ships `useSuspenseQuery` / `useSuspenseInfiniteQuery` / `useSuspenseQueries` and `QueryErrorResetBoundary`, and its reference docs already link to them.

### Changes

- `docs/framework/preact/guides/suspense.md`, `docs/framework/preact/guides/testing.md`: new pages following the existing Preact docs convention (`ref:` to the React guide + `replace:` + section overrides), so the shared prose stays in one place.
- `docs/framework/react/guides/suspense.md`, `docs/framework/react/guides/testing.md`: add `[//]: # 'Section'` markers around the React-specific parts so they can be overridden. No wording changes to the React pages.
- Preact overrides:
  - Suspense: `Suspense` from `preact/compat`, an `ErrorBoundary` built on `useErrorBoundary` instead of `react-error-boundary`, drops the `startTransition` note and the Next.js streaming section.
  - Testing: `@testing-library/preact` (`renderHook` + `waitFor`) instead of the React 17/18 testing-library notes.
- `docs/config.json`: register both pages under the Preact guides, in the same position as the React menu.

### Test plan

- `pnpm nx run-many --target=test:docs` (`scripts/verify-links.ts`) passes.
- `pnpm prettier --check` on the changed files.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
