### PR TITLE
docs: redirect flat reference URLs broken by the TypeDoc migration

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -1,6 +1,8 @@
 ---
 id: ssr
 title: Server Rendering & Hydration
+redirect_from:
+  - framework/react/reference/hydration
 ---
 
 In this guide you'll learn how to use React Query with server rendering.

--- a/docs/framework/react/reference/functions/QueryClientProvider.md
+++ b/docs/framework/react/reference/functions/QueryClientProvider.md
@@ -1,6 +1,8 @@
 ---
 id: QueryClientProvider
 title: QueryClientProvider
+redirect_from:
+  - framework/react/reference/QueryClientProvider
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/QueryErrorResetBoundary.md
+++ b/docs/framework/react/reference/functions/QueryErrorResetBoundary.md
@@ -1,6 +1,8 @@
 ---
 id: QueryErrorResetBoundary
 title: QueryErrorResetBoundary
+redirect_from:
+  - framework/react/reference/QueryErrorResetBoundary
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/react/reference/functions/infiniteQueryOptions.md
@@ -1,6 +1,8 @@
 ---
 id: infiniteQueryOptions
 title: infiniteQueryOptions
+redirect_from:
+  - framework/react/reference/infiniteQueryOptions
 ---
 
 ## Call Signature

--- a/docs/framework/react/reference/functions/mutationOptions.md
+++ b/docs/framework/react/reference/functions/mutationOptions.md
@@ -1,6 +1,8 @@
 ---
 id: mutationOptions
 title: mutationOptions
+redirect_from:
+  - framework/react/reference/mutationOptions
 ---
 
 ## Call Signature

--- a/docs/framework/react/reference/functions/queryOptions.md
+++ b/docs/framework/react/reference/functions/queryOptions.md
@@ -1,6 +1,8 @@
 ---
 id: queryOptions
 title: queryOptions
+redirect_from:
+  - framework/react/reference/queryOptions
 ---
 
 ## Call Signature

--- a/docs/framework/react/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/react/reference/functions/useInfiniteQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useInfiniteQuery
 title: useInfiniteQuery
+redirect_from:
+  - framework/react/reference/useInfiniteQuery
 ---
 
 ## Call Signature

--- a/docs/framework/react/reference/functions/useIsFetching.md
+++ b/docs/framework/react/reference/functions/useIsFetching.md
@@ -1,6 +1,8 @@
 ---
 id: useIsFetching
 title: useIsFetching
+redirect_from:
+  - framework/react/reference/useIsFetching
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useIsMutating.md
+++ b/docs/framework/react/reference/functions/useIsMutating.md
@@ -1,6 +1,8 @@
 ---
 id: useIsMutating
 title: useIsMutating
+redirect_from:
+  - framework/react/reference/useIsMutating
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useMutation.md
+++ b/docs/framework/react/reference/functions/useMutation.md
@@ -1,6 +1,8 @@
 ---
 id: useMutation
 title: useMutation
+redirect_from:
+  - framework/react/reference/useMutation
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useMutationState.md
+++ b/docs/framework/react/reference/functions/useMutationState.md
@@ -1,6 +1,8 @@
 ---
 id: useMutationState
 title: useMutationState
+redirect_from:
+  - framework/react/reference/useMutationState
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/usePrefetchInfiniteQuery.md
+++ b/docs/framework/react/reference/functions/usePrefetchInfiniteQuery.md
@@ -1,6 +1,8 @@
 ---
 id: usePrefetchInfiniteQuery
 title: usePrefetchInfiniteQuery
+redirect_from:
+  - framework/react/reference/usePrefetchInfiniteQuery
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/usePrefetchQuery.md
+++ b/docs/framework/react/reference/functions/usePrefetchQuery.md
@@ -1,6 +1,8 @@
 ---
 id: usePrefetchQuery
 title: usePrefetchQuery
+redirect_from:
+  - framework/react/reference/usePrefetchQuery
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useQueries.md
+++ b/docs/framework/react/reference/functions/useQueries.md
@@ -1,6 +1,8 @@
 ---
 id: useQueries
 title: useQueries
+redirect_from:
+  - framework/react/reference/useQueries
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useQuery.md
+++ b/docs/framework/react/reference/functions/useQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useQuery
 title: useQuery
+redirect_from:
+  - framework/react/reference/useQuery
 ---
 
 ## Call Signature

--- a/docs/framework/react/reference/functions/useQueryClient.md
+++ b/docs/framework/react/reference/functions/useQueryClient.md
@@ -1,6 +1,8 @@
 ---
 id: useQueryClient
 title: useQueryClient
+redirect_from:
+  - framework/react/reference/useQueryClient
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useQueryErrorResetBoundary.md
+++ b/docs/framework/react/reference/functions/useQueryErrorResetBoundary.md
@@ -1,6 +1,8 @@
 ---
 id: useQueryErrorResetBoundary
 title: useQueryErrorResetBoundary
+redirect_from:
+  - framework/react/reference/useQueryErrorResetBoundary
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useSuspenseInfiniteQuery.md
+++ b/docs/framework/react/reference/functions/useSuspenseInfiniteQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useSuspenseInfiniteQuery
 title: useSuspenseInfiniteQuery
+redirect_from:
+  - framework/react/reference/useSuspenseInfiniteQuery
 ---
 
 ```ts

--- a/docs/framework/react/reference/functions/useSuspenseQueries.md
+++ b/docs/framework/react/reference/functions/useSuspenseQueries.md
@@ -1,6 +1,8 @@
 ---
 id: useSuspenseQueries
 title: useSuspenseQueries
+redirect_from:
+  - framework/react/reference/useSuspenseQueries
 ---
 
 ## Call Signature

--- a/docs/framework/react/reference/functions/useSuspenseQuery.md
+++ b/docs/framework/react/reference/functions/useSuspenseQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useSuspenseQuery
 title: useSuspenseQuery
+redirect_from:
+  - framework/react/reference/useSuspenseQuery
 ---
 
 ```ts

--- a/docs/framework/solid/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/solid/reference/functions/infiniteQueryOptions.md
@@ -1,6 +1,8 @@
 ---
 id: infiniteQueryOptions
 title: infiniteQueryOptions
+redirect_from:
+  - framework/solid/reference/infiniteQueryOptions
 ---
 
 ## Call Signature

--- a/docs/framework/solid/reference/functions/mutationOptions.md
+++ b/docs/framework/solid/reference/functions/mutationOptions.md
@@ -1,6 +1,8 @@
 ---
 id: mutationOptions
 title: mutationOptions
+redirect_from:
+  - framework/solid/reference/mutationOptions
 ---
 
 ## Call Signature

--- a/docs/framework/solid/reference/functions/queryOptions.md
+++ b/docs/framework/solid/reference/functions/queryOptions.md
@@ -1,6 +1,8 @@
 ---
 id: queryOptions
 title: queryOptions
+redirect_from:
+  - framework/solid/reference/queryOptions
 ---
 
 ## Call Signature

--- a/docs/framework/solid/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/solid/reference/functions/useInfiniteQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useInfiniteQuery
 title: useInfiniteQuery
+redirect_from:
+  - framework/solid/reference/useInfiniteQuery
 ---
 
 ## Call Signature

--- a/docs/framework/solid/reference/functions/useIsFetching.md
+++ b/docs/framework/solid/reference/functions/useIsFetching.md
@@ -1,6 +1,8 @@
 ---
 id: useIsFetching
 title: useIsFetching
+redirect_from:
+  - framework/solid/reference/useIsFetching
 ---
 
 ```ts

--- a/docs/framework/solid/reference/functions/useIsMutating.md
+++ b/docs/framework/solid/reference/functions/useIsMutating.md
@@ -1,6 +1,8 @@
 ---
 id: useIsMutating
 title: useIsMutating
+redirect_from:
+  - framework/solid/reference/useIsMutating
 ---
 
 ```ts

--- a/docs/framework/solid/reference/functions/useMutation.md
+++ b/docs/framework/solid/reference/functions/useMutation.md
@@ -1,6 +1,8 @@
 ---
 id: useMutation
 title: useMutation
+redirect_from:
+  - framework/solid/reference/useMutation
 ---
 
 ```ts

--- a/docs/framework/solid/reference/functions/useMutationState.md
+++ b/docs/framework/solid/reference/functions/useMutationState.md
@@ -1,6 +1,8 @@
 ---
 id: useMutationState
 title: useMutationState
+redirect_from:
+  - framework/solid/reference/useMutationState
 ---
 
 ```ts

--- a/docs/framework/solid/reference/functions/useQueries.md
+++ b/docs/framework/solid/reference/functions/useQueries.md
@@ -1,6 +1,8 @@
 ---
 id: useQueries
 title: useQueries
+redirect_from:
+  - framework/solid/reference/useQueries
 ---
 
 ```ts

--- a/docs/framework/solid/reference/functions/useQuery.md
+++ b/docs/framework/solid/reference/functions/useQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useQuery
 title: useQuery
+redirect_from:
+  - framework/solid/reference/useQuery
 ---
 
 ## Call Signature

--- a/docs/reference/InfiniteQueryObserver.md
+++ b/docs/reference/InfiniteQueryObserver.md
@@ -1,6 +1,8 @@
 ---
 id: InfiniteQueryObserver
 title: InfiniteQueryObserver
+redirect_from:
+  - framework/react/reference/InfiniteQueryObserver
 ---
 
 The `InfiniteQueryObserver` can be used to observe and switch between infinite queries.

--- a/docs/reference/MutationCache.md
+++ b/docs/reference/MutationCache.md
@@ -1,6 +1,8 @@
 ---
 id: MutationCache
 title: MutationCache
+redirect_from:
+  - framework/react/reference/MutationCache
 ---
 
 The `MutationCache` is the storage for mutations.

--- a/docs/reference/QueriesObserver.md
+++ b/docs/reference/QueriesObserver.md
@@ -1,6 +1,8 @@
 ---
 id: QueriesObserver
 title: QueriesObserver
+redirect_from:
+  - framework/react/reference/QueriesObserver
 ---
 
 The `QueriesObserver` can be used to observe multiple queries.

--- a/docs/reference/QueryCache.md
+++ b/docs/reference/QueryCache.md
@@ -1,6 +1,8 @@
 ---
 id: QueryCache
 title: QueryCache
+redirect_from:
+  - framework/react/reference/QueryCache
 ---
 
 The `QueryCache` is the storage mechanism for TanStack Query. It stores all the data, meta information and state of queries it contains.

--- a/docs/reference/QueryClient.md
+++ b/docs/reference/QueryClient.md
@@ -1,6 +1,8 @@
 ---
 id: QueryClient
 title: QueryClient
+redirect_from:
+  - framework/react/reference/QueryClient
 ---
 
 The `QueryClient` can be used to interact with a cache:

--- a/docs/reference/QueryObserver.md
+++ b/docs/reference/QueryObserver.md
@@ -1,6 +1,8 @@
 ---
 id: QueryObserver
 title: QueryObserver
+redirect_from:
+  - framework/react/reference/QueryObserver
 ---
 
 The `QueryObserver` can be used to observe and switch between queries.

--- a/docs/reference/focusManager.md
+++ b/docs/reference/focusManager.md
@@ -1,6 +1,8 @@
 ---
 id: FocusManager
 title: FocusManager
+redirect_from:
+  - framework/react/reference/focusManager
 ---
 
 The `FocusManager` manages the focus state within TanStack Query.

--- a/docs/reference/notifyManager.md
+++ b/docs/reference/notifyManager.md
@@ -1,6 +1,8 @@
 ---
 id: NotifyManager
 title: NotifyManager
+redirect_from:
+  - framework/react/reference/notifyManager
 ---
 
 The `notifyManager` handles scheduling and batching callbacks in TanStack Query.

--- a/docs/reference/onlineManager.md
+++ b/docs/reference/onlineManager.md
@@ -1,6 +1,8 @@
 ---
 id: OnlineManager
 title: OnlineManager
+redirect_from:
+  - framework/react/reference/onlineManager
 ---
 
 The `OnlineManager` manages the online state within TanStack Query. It can be used to change the default event listeners or to manually change the online state.

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -19,6 +19,10 @@ type PackageReferenceDocsConfig = {
   excludeExternals?: boolean
   simplifyLitQueriesControllerTypes?: boolean
   trimGeneratedMarkdown?: boolean
+  // Maps a generated page's path (relative to outputDir, no extension) to the flat
+  // `docs/framework/<framework>/reference/<name>.md` URLs it replaced, so old links/bookmarks redirect
+  // instead of falling through to the framework docs index. See https://github.com/TanStack/query/issues/11371
+  redirectFrom?: Record<string, Array<string>>
 }
 
 type TypeDocReflectionWithSignatures = {
@@ -99,6 +103,40 @@ async function trimTrailingWhitespaceInMarkdown(outputDir: string) {
   )
 }
 
+async function addRedirectFromToFileFrontmatter(
+  filePath: string,
+  fromPaths: Array<string>,
+) {
+  const markdown = await readFile(filePath, 'utf8')
+
+  const frontmatterMatch = markdown.match(/^---\n([\s\S]*?)\n---\n/)
+  if (!frontmatterMatch) {
+    throw new Error(`Expected frontmatter in ${filePath}`)
+  }
+
+  const redirectLines = fromPaths
+    .map((fromPath) => `  - ${fromPath}`)
+    .join('\n')
+  const updatedFrontmatter = `---\n${frontmatterMatch[1]}\nredirect_from:\n${redirectLines}\n---\n`
+
+  await writeFile(
+    filePath,
+    updatedFrontmatter + markdown.slice(frontmatterMatch[0].length),
+  )
+}
+
+async function addRedirectFromToFrontmatter(
+  outputDir: string,
+  redirectFrom: Record<string, Array<string>>,
+) {
+  for (const [pagePath, fromPaths] of Object.entries(redirectFrom)) {
+    await addRedirectFromToFileFrontmatter(
+      resolve(outputDir, `${pagePath}.md`),
+      fromPaths,
+    )
+  }
+}
+
 async function generatePackageReferenceDocs(pkg: PackageReferenceDocsConfig) {
   const outputDir = pkg.outputDir
   await rm(outputDir, { recursive: true, force: true })
@@ -141,10 +179,14 @@ async function generatePackageReferenceDocs(pkg: PackageReferenceDocsConfig) {
     if (pkg.trimGeneratedMarkdown) {
       await trimTrailingWhitespaceInMarkdown(outputDir)
     }
+
+    if (pkg.redirectFrom) {
+      await addRedirectFromToFrontmatter(outputDir, pkg.redirectFrom)
+    }
   }
 }
 
-for (const pkg of [
+const packages: Array<PackageReferenceDocsConfig> = [
   {
     entryPoints: [
       resolve(__dirname, '../packages/angular-query-experimental/src/index.ts'),
@@ -167,6 +209,26 @@ for (const pkg of [
     tsconfig: resolve(__dirname, '../packages/solid-query/tsconfig.json'),
     outputDir: resolve(__dirname, '../docs/framework/solid/reference'),
     exclude: ['./packages/query-core/**/*'],
+    redirectFrom: {
+      'functions/infiniteQueryOptions': [
+        'framework/solid/reference/infiniteQueryOptions',
+      ],
+      'functions/mutationOptions': [
+        'framework/solid/reference/mutationOptions',
+      ],
+      'functions/queryOptions': ['framework/solid/reference/queryOptions'],
+      'functions/useInfiniteQuery': [
+        'framework/solid/reference/useInfiniteQuery',
+      ],
+      'functions/useIsFetching': ['framework/solid/reference/useIsFetching'],
+      'functions/useIsMutating': ['framework/solid/reference/useIsMutating'],
+      'functions/useMutation': ['framework/solid/reference/useMutation'],
+      'functions/useMutationState': [
+        'framework/solid/reference/useMutationState',
+      ],
+      'functions/useQueries': ['framework/solid/reference/useQueries'],
+      'functions/useQuery': ['framework/solid/reference/useQuery'],
+    },
   },
   {
     entryPoints: [resolve(__dirname, '../packages/vue-query/src/index.ts')],
@@ -179,6 +241,51 @@ for (const pkg of [
     tsconfig: resolve(__dirname, '../packages/react-query/tsconfig.json'),
     outputDir: resolve(__dirname, '../docs/framework/react/reference'),
     exclude: ['./packages/query-core/**/*'],
+    redirectFrom: {
+      'functions/infiniteQueryOptions': [
+        'framework/react/reference/infiniteQueryOptions',
+      ],
+      'functions/mutationOptions': [
+        'framework/react/reference/mutationOptions',
+      ],
+      'functions/QueryClientProvider': [
+        'framework/react/reference/QueryClientProvider',
+      ],
+      'functions/QueryErrorResetBoundary': [
+        'framework/react/reference/QueryErrorResetBoundary',
+      ],
+      'functions/queryOptions': ['framework/react/reference/queryOptions'],
+      'functions/useInfiniteQuery': [
+        'framework/react/reference/useInfiniteQuery',
+      ],
+      'functions/useIsFetching': ['framework/react/reference/useIsFetching'],
+      'functions/useIsMutating': ['framework/react/reference/useIsMutating'],
+      'functions/useMutation': ['framework/react/reference/useMutation'],
+      'functions/useMutationState': [
+        'framework/react/reference/useMutationState',
+      ],
+      'functions/usePrefetchInfiniteQuery': [
+        'framework/react/reference/usePrefetchInfiniteQuery',
+      ],
+      'functions/usePrefetchQuery': [
+        'framework/react/reference/usePrefetchQuery',
+      ],
+      'functions/useQueries': ['framework/react/reference/useQueries'],
+      'functions/useQuery': ['framework/react/reference/useQuery'],
+      'functions/useQueryClient': ['framework/react/reference/useQueryClient'],
+      'functions/useQueryErrorResetBoundary': [
+        'framework/react/reference/useQueryErrorResetBoundary',
+      ],
+      'functions/useSuspenseInfiniteQuery': [
+        'framework/react/reference/useSuspenseInfiniteQuery',
+      ],
+      'functions/useSuspenseQueries': [
+        'framework/react/reference/useSuspenseQueries',
+      ],
+      'functions/useSuspenseQuery': [
+        'framework/react/reference/useSuspenseQuery',
+      ],
+    },
   },
   {
     entryPoints: [resolve(__dirname, '../packages/preact-query/src/index.ts')],
@@ -195,7 +302,9 @@ for (const pkg of [
     simplifyLitQueriesControllerTypes: true,
     trimGeneratedMarkdown: true,
   },
-] satisfies Array<PackageReferenceDocsConfig>) {
+]
+
+for (const pkg of packages) {
   await generatePackageReferenceDocs(pkg)
 }
 


### PR DESCRIPTION
## 🎯 Changes

Fixes broken links for `docs/framework/{react,solid}/reference/*.md` URLs that returned a flat page before the TypeDoc migration (react: #11205/#11366, solid: #11368/#11369) moved them under `functions/`. Requests to the old flat URLs currently fall through to the framework docs index instead of resolving. Reported in #11371.

Adds `redirect_from` frontmatter (per tanstack.com's redirect convention) to the affected pages, split into two kinds:

- **Generated pages** (`functions/*.md`, 19 react + 10 solid): `scripts/generate-docs.ts` now injects `redirect_from` into each package's TypeDoc output as a post-processing step, keyed off a per-package mapping. This runs on every `pnpm run generate-docs`, so the redirects survive regeneration without manual upkeep.
- **Hand-maintained pages** (10 files): `docs/reference/*.md` (9 files — `QueryClient`, `QueryCache`, `MutationCache`, `QueryObserver`, `QueriesObserver`, `InfiniteQueryObserver`, `focusManager`, `notifyManager`, `onlineManager`) and `docs/framework/react/guides/ssr.md`. These pages aren't generated by the script (query-core is excluded from every framework's TypeDoc entry point, and `hydration.md`'s content lives in the SSR guide), so their `redirect_from` was added directly and isn't part of the generation pipeline.

`docs/framework/solid/reference/hydration.md` is not redirected — its content was never anything but a react-guide clone (`ref:`/`replace:`) and `docs/framework/solid/guides/ssr.md` is currently a stub, so there's no real target to send readers to.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added redirects from legacy React and Solid reference URLs to their current documentation pages.
  * Added a redirect from the former hydration guide URL to the SSR guide.
  * Added redirects for legacy core reference pages, including query, mutation, cache, observer, and manager documentation.
  * Updated documentation generation to preserve redirects automatically for future reference pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->