### PR TITLE
docs(react-query): fix run-on sentence and subject-verb agreement in SSR guide

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -160,7 +160,7 @@ function Posts() {
 The setup is minimal and this can be a quick solution for some cases, but there are a **few tradeoffs to consider** when compared to the full approach:
 
 - If you are calling `useQuery` in a component deeper down in the tree you need to pass the `initialData` down to that point
-- If you are calling `useQuery` with the same query in multiple locations, passing `initialData` to only one of them can be brittle and break when your app changes since. If you remove or move the component that has the `useQuery` with `initialData`, the more deeply nested `useQuery` might no longer have any data. Passing `initialData` to **all** queries that needs it can also be cumbersome.
+- If you are calling `useQuery` with the same query in multiple locations, passing `initialData` to only one of them can be brittle and break when your app changes. If you remove or move the component that has the `useQuery` with `initialData`, the more deeply nested `useQuery` might no longer have any data. Passing `initialData` to **all** queries that need it can also be cumbersome.
 - There is no way to know at what time the query was fetched on the server, so `dataUpdatedAt` and determining if the query needs refetching is based on when the page loaded instead
 - If there is already data in the cache for a query, `initialData` will never overwrite this data, **even if the new data is fresher than the old one**.
   - To understand why this is especially bad, consider the `getServerSideProps` example above. If you navigate back and forth to a page several times, `getServerSideProps` would get called each time and fetch new data, but because we are using the `initialData` option, the client cache and data would never be updated.


### PR DESCRIPTION
## 🎯 Changes

Fixes a grammar issue in `docs/framework/react/guides/ssr.md`, found while porting this guide to `preact-query` in #11380 (where CodeRabbit flagged the same copied sentence).

- Removed a dangling "since." that left the sentence unfinished: "...can be brittle and break when your app changes since. If you remove..." → "...can be brittle and break when your app changes. If you remove..."
- Fixed a subject-verb agreement error: "queries that needs it" → "queries that need it"

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected grammar and punctuation in the server-rendering guide’s `initialData` section.
  - Clarified wording about queries that require the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->