### PR TITLE
docs(config): reorder solid-query 'Functions' entries to match react grouping

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1355,36 +1355,20 @@
               "to": "framework/solid/reference/functions/useQuery"
             },
             {
-              "label": "Functions / queryOptions",
-              "to": "framework/solid/reference/functions/queryOptions"
-            },
-            {
-              "label": "Functions / QueryClientProvider",
-              "to": "framework/solid/reference/functions/QueryClientProvider"
-            },
-            {
-              "label": "Functions / useQueryClient",
-              "to": "framework/solid/reference/functions/useQueryClient"
-            },
-            {
-              "label": "Functions / useIsFetching",
-              "to": "framework/solid/reference/functions/useIsFetching"
+              "label": "Functions / useQueries",
+              "to": "framework/solid/reference/functions/useQueries"
             },
             {
               "label": "Functions / useInfiniteQuery",
               "to": "framework/solid/reference/functions/useInfiniteQuery"
             },
             {
-              "label": "Functions / infiniteQueryOptions",
-              "to": "framework/solid/reference/functions/infiniteQueryOptions"
-            },
-            {
               "label": "Functions / useMutation",
               "to": "framework/solid/reference/functions/useMutation"
             },
             {
-              "label": "Functions / mutationOptions",
-              "to": "framework/solid/reference/functions/mutationOptions"
+              "label": "Functions / useIsFetching",
+              "to": "framework/solid/reference/functions/useIsFetching"
             },
             {
               "label": "Functions / useIsMutating",
@@ -1395,8 +1379,24 @@
               "to": "framework/solid/reference/functions/useMutationState"
             },
             {
-              "label": "Functions / useQueries",
-              "to": "framework/solid/reference/functions/useQueries"
+              "label": "Functions / QueryClientProvider",
+              "to": "framework/solid/reference/functions/QueryClientProvider"
+            },
+            {
+              "label": "Functions / useQueryClient",
+              "to": "framework/solid/reference/functions/useQueryClient"
+            },
+            {
+              "label": "Functions / queryOptions",
+              "to": "framework/solid/reference/functions/queryOptions"
+            },
+            {
+              "label": "Functions / infiniteQueryOptions",
+              "to": "framework/solid/reference/functions/infiniteQueryOptions"
+            },
+            {
+              "label": "Functions / mutationOptions",
+              "to": "framework/solid/reference/functions/mutationOptions"
             },
             {
               "label": "Functions / useIsRestoring",


### PR DESCRIPTION
## 🎯 Changes

Reorders the `Functions` entries under `solid` in the API Reference section of `docs/config.json` to group by concept (core query hooks → fetching/mutating → provider/client → options factories → restoring) — the same convention `react` and `preact` already use, instead of the current interleaved order where each hook is immediately followed by its options factory.

`angular` was also checked but left unchanged: it turned out to already follow alphabetical order with deprecated functions (`injectQueryClient`, `provideAngularQuery` — both marked `## Deprecated` in their generated docs) intentionally pushed to the end, which is a different but equally deliberate convention.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).