### PR TITLE
docs(solid-query): remove 'The Query Options API' link, solid's queryOptions API differs from react's

### DIFF
--- a/docs/framework/solid/reference/functions/queryOptions.md
+++ b/docs/framework/solid/reference/functions/queryOptions.md
@@ -11,7 +11,7 @@ redirect_from:
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): QueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [queryOptions.ts:90](https://github.com/TanStack/query/blob/main/packages/solid-query/src/queryOptions.ts#L90)
+Defined in: [queryOptions.ts:89](https://github.com/TanStack/query/blob/main/packages/solid-query/src/queryOptions.ts#L89)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -53,8 +53,7 @@ The same options object, typed so that `queryKey` carries the inferred data type
 
 ### See
 
- - [useQuery](useQuery.md) to run a query with these options.
- - [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
+[useQuery](useQuery.md) to run a query with these options.
 
 ### Example
 
@@ -90,7 +89,7 @@ function Posts() {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): QueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [queryOptions.ts:141](https://github.com/TanStack/query/blob/main/packages/solid-query/src/queryOptions.ts#L141)
+Defined in: [queryOptions.ts:139](https://github.com/TanStack/query/blob/main/packages/solid-query/src/queryOptions.ts#L139)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -130,8 +129,7 @@ The same options object, typed so that `queryKey` carries the inferred data type
 
 ### See
 
- - [useQuery](useQuery.md) to run a query with these options.
- - [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
+[useQuery](useQuery.md) to run a query with these options.
 
 ### Example
 

--- a/packages/solid-query/src/queryOptions.ts
+++ b/packages/solid-query/src/queryOptions.ts
@@ -56,7 +56,6 @@ export type DefinedInitialDataOptions<
  * This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
  *
  * @see {@link useQuery} to run a query with these options.
- * @see [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
  * @param options - The {@link DefinedInitialDataOptions} to use — everything you can pass to `useQuery`, with `initialData` set.
  * @returns The same options object, typed so that `queryKey` carries the inferred data type.
  *
@@ -107,7 +106,6 @@ export function queryOptions<
  * is the query key to generate options for.
  *
  * @see {@link useQuery} to run a query with these options.
- * @see [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
  * @param options - The {@link UndefinedInitialDataOptions} to use — everything you can pass to `useQuery`.
  * @returns The same options object, typed so that `queryKey` carries the inferred data type.
  *


### PR DESCRIPTION
## 🎯 Changes

Removes the `@see [The Query Options API](https://tkdodo.eu/blog/the-query-options-api)` link from `queryOptions`'s JSDoc (added in #11369).

The linked article's code examples are written in React (`useQuery`, JSX, `dataTagSymbol`), which don't carry over to solid's `queryOptions(() => ({...}))` reactive-getter API. `preact` keeps this link since it mirrors react's API/JSX closely enough for the examples to still apply directly; `solid`'s API differs enough that the link isn't useful there. `vue` never had this link for the same reason (caught during review before merging its own TypeDoc migration).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `queryOptions` API documentation with corrected source references.
  - Removed outdated external blog links from the related “See” sections.
  - Aligned inline API guidance with the current documentation references.
  - No functional or type-level behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->