### PR TITLE
docs(preact-query): add 'The Query Options API' link, matching react's queryOptions JSDoc

### DIFF
--- a/docs/framework/preact/reference/functions/queryOptions.md
+++ b/docs/framework/preact/reference/functions/queryOptions.md
@@ -9,7 +9,7 @@ title: queryOptions
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:142](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L142)
+Defined in: [preact-query/src/queryOptions.ts:143](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L143)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -49,7 +49,8 @@ The same options object, typed so that `queryKey` carries the inferred data type
 
 ### See
 
-[useQuery](useQuery.md) to run a query with these options.
+ - [useQuery](useQuery.md) to run a query with these options.
+ - [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
 
 ### Example
 
@@ -84,7 +85,7 @@ function Posts() {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): OmitKeyof<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "queryFn"> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:182](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L182)
+Defined in: [preact-query/src/queryOptions.ts:184](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L184)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -122,7 +123,8 @@ The same options object, typed so that `queryKey` carries the inferred data type
 
 ### See
 
-[useQuery](useQuery.md) to run a query with these options.
+ - [useQuery](useQuery.md) to run a query with these options.
+ - [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
 
 ### Example
 
@@ -152,7 +154,7 @@ function Post({ id }: { id: string }) {
 function queryOptions<TQueryFnData, TError, TData, TQueryKey>(options): UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & object & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>;
 ```
 
-Defined in: [preact-query/src/queryOptions.ts:245](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L245)
+Defined in: [preact-query/src/queryOptions.ts:248](https://github.com/TanStack/query/blob/main/packages/preact-query/src/queryOptions.ts#L248)
 
 You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can
 be shared across hooks and imperative APIs such as `queryClient.query`. `options.queryKey` is required and
@@ -190,7 +192,8 @@ The same options object, typed so that `queryKey` carries the inferred data type
 
 ### See
 
-[useQuery](useQuery.md) to run a query with these options.
+ - [useQuery](useQuery.md) to run a query with these options.
+ - [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
 
 ### Remarks
 

--- a/packages/preact-query/src/queryOptions.ts
+++ b/packages/preact-query/src/queryOptions.ts
@@ -110,6 +110,7 @@ export type DefinedInitialDataOptions<
  * This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
  *
  * @see {@link useQuery} to run a query with these options.
+ * @see [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
  * @param options - The {@link DefinedInitialDataOptions} to use — everything you can pass to `useQuery`, with `initialData` set.
  * @returns The same options object, typed so that `queryKey` carries the inferred data type.
  *
@@ -155,6 +156,7 @@ export function queryOptions<
  * is the query key to generate options for.
  *
  * @see {@link useQuery} to run a query with these options.
+ * @see [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
  * @param options - The {@link UnusedSkipTokenOptions} to use — everything you can pass to `useQuery`.
  * @returns The same options object, typed so that `queryKey` carries the inferred data type.
  *
@@ -195,6 +197,7 @@ export function queryOptions<
  * is the query key to generate options for.
  *
  * @see {@link useQuery} to run a query with these options.
+ * @see [The Query Options API](https://tkdodo.eu/blog/the-query-options-api) for more on this pattern.
  * @param options - The {@link UndefinedInitialDataOptions} to use — everything you can pass to `useQuery`.
  * @returns The same options object, typed so that `queryKey` carries the inferred data type.
  * @remarks This is the only overload that accepts `queryFn: skipToken`, shown below.


### PR DESCRIPTION
## 🎯 Changes

Adds the `@see [The Query Options API](https://tkdodo.eu/blog/the-query-options-api)` link to `queryOptions`'s JSDoc, matching `react-query`'s.

`packages/preact-query/src/queryOptions.ts` is otherwise a near-exact mirror of `packages/react-query/src/queryOptions.ts` (same hook-based API, same JSX examples — diffing the two files shows only import path and this link as the differences), so the linked article's React code examples apply directly here too. This complements #11387, which removed the same link from `solid-query` where the reactive-getter API and examples don't carry over.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to the Query Options API article in the `queryOptions` reference documentation.
  * Updated source-reference line numbers for all documented `queryOptions` call signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->