### PR TITLE
docs(preact-query): fix broken TkDodo link mangled by 'react-query'->'preact-query' replace

### DIFF
--- a/docs/framework/preact/guides/testing.md
+++ b/docs/framework/preact/guides/testing.md
@@ -41,3 +41,8 @@ Here we are making use of `waitFor` and waiting until the query status indicates
 [//]: # 'NoteWaitFor1'
 [//]: # 'NoteWaitFor2'
 [//]: # 'NoteWaitFor2'
+[//]: # 'FurtherReading'
+
+For additional tips and an alternative setup using `mock-service-worker`, have a look at [TkDodo's article on testing](https://tkdodo.eu/blog/testing-react%2Dquery). It's written for a different framework adapter, but the same approach applies here.
+
+[//]: # 'FurtherReading'

--- a/docs/framework/react/guides/testing.md
+++ b/docs/framework/react/guides/testing.md
@@ -180,4 +180,8 @@ _Note_: when using React 18, the semantics of `waitFor` have changed as noted ab
 
 ## Further reading
 
+[//]: # 'FurtherReading'
+
 For additional tips and an alternative setup using `mock-service-worker`, have a look at [this article by TkDodo on Testing React Query](https://tkdodo.eu/blog/testing-react-query).
+
+[//]: # 'FurtherReading'


### PR DESCRIPTION
## 🎯 Changes

The "Further reading" link on the deployed Preact Testing guide (https://tanstack.com/query/latest/docs/framework/preact/guides/testing) is currently a 404. Verified in-browser: the rendered page links to `https://tkdodo.eu/blog/testing-preact-query`, which doesn't exist — the real article is `https://tkdodo.eu/blog/testing-react-query`.

Root cause: `docs/framework/preact/guides/testing.md` inherits react's `docs/framework/react/guides/testing.md` via `ref:`, and applies `replace: { 'react-query': 'preact-query', 'React': 'Preact' }` over the whole rendered output. The "Further reading" section wasn't wrapped in a `[//]: # 'Section'` override marker (added in #11377), so the `react-query` → `preact-query` substitution mangled the substring inside the article's URL slug (`testing-react-query` → `testing-preact-query`).

- `docs/framework/react/guides/testing.md`: wraps the "Further reading" section in a `[//]: # 'FurtherReading'` marker so it can be overridden per-framework. No wording change to the React page.
- `docs/framework/preact/guides/testing.md`: overrides that section — rewords the sentence to note the article was written for a different adapter, and URL-encodes the hyphen in the slug (`react%2Dquery`) so the `react-query` substring substitution can no longer match it. Verified in-browser that the encoded URL resolves correctly to the original article.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added further reading for Preact testing, including guidance on applying mock service worker techniques.
  * Marked the React testing guide’s further reading section for documentation tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->