### PR TITLE
docs(react-query, preact-query): use 'button' instead of undefined 'Button' in suspense guide examples

### DIFF
--- a/docs/framework/preact/guides/suspense.md
+++ b/docs/framework/preact/guides/suspense.md
@@ -47,7 +47,7 @@ const App = () => (
         fallbackRender={({ resetErrorBoundary }) => (
           <div>
             There was an error!
-            <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+            <button onClick={() => resetErrorBoundary()}>Try again</button>
           </div>
         )}
       >
@@ -72,7 +72,7 @@ const App = () => {
       fallbackRender={({ resetErrorBoundary }) => (
         <div>
           There was an error!
-          <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+          <button onClick={() => resetErrorBoundary()}>Try again</button>
         </div>
       )}
     >

--- a/docs/framework/react/guides/suspense.md
+++ b/docs/framework/react/guides/suspense.md
@@ -77,7 +77,7 @@ const App = () => (
         fallbackRender={({ resetErrorBoundary }) => (
           <div>
             There was an error!
-            <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+            <button onClick={() => resetErrorBoundary()}>Try again</button>
           </div>
         )}
       >
@@ -106,7 +106,7 @@ const App = () => {
       fallbackRender={({ resetErrorBoundary }) => (
         <div>
           There was an error!
-          <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+          <button onClick={() => resetErrorBoundary()}>Try again</button>
         </div>
       )}
     >


### PR DESCRIPTION
## 🎯 Changes

The "Resetting Error Boundaries" examples in `guides/suspense.md` use `<Button onClick={...}>Try again</Button>`, but `Button` is never imported or defined — copying the example as-is throws `Button is not defined`. Replaced with the plain `<button>` element the rest of the docs' examples consistently use (e.g. `disabling-queries.md`, `mutations.md`, `paginated-queries.md`).

- `docs/framework/react/guides/suspense.md`: fixes both occurrences (component-based and hook-based reset examples).
- `docs/framework/preact/guides/suspense.md`: the same two occurrences in its `ExampleResetComponent`/`ExampleResetHook` override sections (added in #11377, which inherited the bug from react's original via `ref:`).

Found while reviewing #11377 for a related issue (#11389).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Preact Suspense guide’s error-boundary examples to use the native HTML `<button>` element for “Try again” actions.
  - Updated the React Suspense guide’s `QueryErrorResetBoundary` and `useQueryErrorResetBoundary` examples with the same native button usage.
  - These documentation examples now provide more consistent, directly applicable markup for retry actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->