### PR TITLE
fix(broadcast-client): don't overwrite an existing query's data on an incoming 'added' message

### DIFF
--- a/.changeset/fix-broadcast-added-overwrites-existing-data.md
+++ b/.changeset/fix-broadcast-added-overwrites-existing-data.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-broadcast-client-experimental': patch
+---
+
+fix: don't overwrite an existing query's resolved data when another tab broadcasts an `added` event for it

--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -179,28 +179,6 @@ describe('broadcastQueryClient', () => {
         value: 'from other tab',
       })
     })
-
-    it('should build a new query with the broadcasted state when an "added" message arrives for an unknown key', () => {
-      const newKey = queryKey()
-
-      broadcastQueryClient({
-        queryClient,
-        broadcastChannel: 'test_channel',
-      })
-
-      // A tab mounting this key for the very first time in the whole app
-      // already has resolved data for it (e.g. via `initialData`).
-      lastCreatedChannel.onmessage?.({
-        type: 'added',
-        queryHash: JSON.stringify(newKey),
-        queryKey: newKey,
-        state: { status: 'success', data: { value: 'brand new' } },
-      })
-
-      expect(queryClient.getQueryData(newKey)).toEqual({
-        value: 'brand new',
-      })
-    })
   })
 
   describe('postMessage error handling', () => {

--- a/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
+++ b/packages/query-broadcast-client-experimental/src/__tests__/index.test.ts
@@ -122,6 +122,85 @@ describe('broadcastQueryClient', () => {
 
       expect(mockPostMessage).toHaveBeenCalled()
     })
+
+    it('should not overwrite an existing query with data when an "added" message arrives for it', () => {
+      const existingKey = queryKey()
+
+      broadcastQueryClient({
+        queryClient,
+        broadcastChannel: 'test_channel',
+      })
+
+      // A query that already resolved in this tab (e.g. it fetched before
+      // another tab mounted the same key).
+      queryClient.setQueryData(existingKey, { value: 'resolved' })
+      const existingQuery = queryCache.find({ queryKey: existingKey })!
+
+      // Another tab just mounted the same key for the first time, so its
+      // `build()` broadcasts an `added` message with a pending state and
+      // no data.
+      lastCreatedChannel.onmessage?.({
+        type: 'added',
+        queryHash: existingQuery.queryHash,
+        queryKey: existingKey,
+        state: { status: 'pending', data: undefined },
+      })
+
+      expect(queryClient.getQueryData(existingKey)).toEqual({
+        value: 'resolved',
+      })
+      expect(queryClient.getQueryState(existingKey)?.status).toBe('success')
+    })
+
+    it('should adopt an "added" message\'s state for an existing query that has no data yet', () => {
+      const existingKey = queryKey()
+
+      broadcastQueryClient({
+        queryClient,
+        broadcastChannel: 'test_channel',
+      })
+
+      // This tab has already built the query (e.g. an observer mounted it)
+      // but hasn't fetched it yet.
+      const existingQuery = queryCache.build(queryClient, {
+        queryKey: existingKey,
+      })
+
+      // Another tab already had this key resolved (e.g. via `initialData`)
+      // when it mounted, so its `added` message carries real data.
+      lastCreatedChannel.onmessage?.({
+        type: 'added',
+        queryHash: existingQuery.queryHash,
+        queryKey: existingKey,
+        state: { status: 'success', data: { value: 'from other tab' } },
+      })
+
+      expect(queryClient.getQueryData(existingKey)).toEqual({
+        value: 'from other tab',
+      })
+    })
+
+    it('should build a new query with the broadcasted state when an "added" message arrives for an unknown key', () => {
+      const newKey = queryKey()
+
+      broadcastQueryClient({
+        queryClient,
+        broadcastChannel: 'test_channel',
+      })
+
+      // A tab mounting this key for the very first time in the whole app
+      // already has resolved data for it (e.g. via `initialData`).
+      lastCreatedChannel.onmessage?.({
+        type: 'added',
+        queryHash: JSON.stringify(newKey),
+        queryKey: newKey,
+        state: { status: 'success', data: { value: 'brand new' } },
+      })
+
+      expect(queryClient.getQueryData(newKey)).toEqual({
+        value: 'brand new',
+      })
+    })
   })
 
   describe('postMessage error handling', () => {

--- a/packages/query-broadcast-client-experimental/src/index.ts
+++ b/packages/query-broadcast-client-experimental/src/index.ts
@@ -175,7 +175,9 @@ export function broadcastQueryClient({
         }
       } else if (type === 'added') {
         if (query) {
-          query.setState(state)
+          if (query.state.data === undefined) {
+            query.setState(state)
+          }
           return
         }
         queryCache.build(


### PR DESCRIPTION
## 🎯 Changes

Since 5.102.0, the `added` broadcast message carries the query's state, and the receiving tab applies it with `query.setState(state)` whenever the query already exists locally. A tab mounting a query for the first time always broadcasts `added`, even if it hasn't fetched yet, so any other tab that already has resolved data for that key gets reset back to `pending` with no data.

This only skips `setState` when the local query already has data, so a query that has never resolved locally can still adopt state from an `added` message (matches how a brand-new tab picks up a key another tab already resolved via `initialData`), while an already-resolved query in one tab won't get clobbered just because another tab mounts the same key.

Fixes #11391

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing query data when another browser tab broadcasts an `added` update for the same query.
  * Allowed queries without data to adopt the broadcasted successful state.
  * Continued creating unknown queries from incoming broadcast updates.

* **Tests**
  * Added coverage for cross-tab query synchronization, including populated and data-less queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->