### PR TITLE
feat(solid-query): sweep X-Revalidate keys in the single-flight consumer

### DIFF
--- a/.changeset/flight-revalidate-sweep.md
+++ b/.changeset/flight-revalidate-sweep.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-query': patch
+---
+
+Sweep `X-Revalidate` keys in the single-flight consumer. A mutation can declare its invalidation scope with Solid's `reload`/`redirect` `revalidate` option; the flight payload covers what the server recomputed, and whatever a declared key matches beyond it (parameterized instances only the client holds, queries no loader owns) is now invalidated client-side — active queries refetch in the background, inactive ones are marked stale. Keys match by queryKey prefix, mirroring Solid Router's consumption of the same header.

--- a/packages/solid-query/src/QueryClientProvider.tsx
+++ b/packages/solid-query/src/QueryClientProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, onCleanup, sharedConfig, useContext } from 'solid-js'
+import { REVALIDATE_HEADER } from '@solidjs/web'
 import { hydrate } from '@tanstack/query-core'
 import { subscribeFlightData } from '@solidjs/web/server-functions'
 import type { DehydratedState, Query } from '@tanstack/query-core'
@@ -35,8 +36,52 @@ export const HYDRATION_KEY_PREFIX = 'sq:'
  * The slice's payload is a `DehydratedState`; the provider consumes it
  * with `hydrate()`, so every mounted query on those keys updates before
  * the mutation's promise resolves — no follow-up refetches.
+ *
+ * A mutation can additionally declare its invalidation SCOPE with
+ * `X-Revalidate` keys (the `revalidate` option of Solid's `reload`/
+ * `redirect` response helpers). The payload covers the slice of that scope
+ * the server could recompute; whatever a declared key matches beyond it is
+ * swept client-side (see the consumer below). For the sweep to be
+ * delivered, the collector must contribute a slice — return the dehydrated
+ * state even when it holds no queries if `outcome.revalidateKeys` is
+ * present, rather than skipping the source.
  */
 export const FLIGHT_DATA_SOURCE = 'sq'
+
+/**
+ * The client half of key-scoped invalidation. A mutation declares its
+ * invalidation scope with `X-Revalidate` keys; the flight payload covers
+ * the part of that scope the server's collector recomputed (typically the
+ * target page's loader graph). Whatever a declared key matches BEYOND the
+ * payload — parameterized instances only this client holds, queries no
+ * loader owns — is invalidated here: active queries refetch in the
+ * background, inactive ones are marked stale for their next mount. This
+ * mirrors how Solid Router consumes the same header for its own cache.
+ *
+ * A key matches by queryKey prefix — `revalidate: 'users'` sweeps every
+ * query whose key begins with `'users'`. Payload-covered hashes are exempt:
+ * they hydrated with fresh data a moment ago, and refetching them would
+ * spend the round trip single flight just saved.
+ */
+function sweepRevalidatedQueries(
+  client: QueryClient,
+  payload: DehydratedState,
+  response: Response,
+): void {
+  const keys = response.headers.get(REVALIDATE_HEADER)?.split(',')
+  if (!keys) return
+  const covered = new Set(payload.queries.map((query) => query.queryHash))
+  for (const key of keys) {
+    client
+      .invalidateQueries({
+        queryKey: [key],
+        predicate: (query) => !covered.has(query.queryHash),
+      })
+      // Background refetch failures surface through the queries' own error
+      // states; an unhandled rejection here would fail the mutation instead.
+      .catch(() => undefined)
+  }
+}
 
 export const QueryClientContext = createContext<(() => QueryClient) | null>(
   null,
@@ -160,9 +205,16 @@ export const QueryClientProvider = (
     // Client-only: the server's consumer registry is module state shared
     // across requests — registering there would leak between them.
     onCleanup(
-      subscribeFlightData<DehydratedState>(FLIGHT_DATA_SOURCE, (data) => {
-        hydrate(props.client, data)
-      }),
+      subscribeFlightData<DehydratedState>(
+        FLIGHT_DATA_SOURCE,
+        (data, context) => {
+          hydrate(props.client, data)
+          // Fresh data first, then the declared-scope sweep: stale marks
+          // land synchronously, refetches run in the background — the
+          // mutation's promise never waits on them.
+          sweepRevalidatedQueries(props.client, data, context.response)
+        },
+      ),
     )
   }
 

--- a/packages/solid-query/src/__tests__/flightData.test.tsx
+++ b/packages/solid-query/src/__tests__/flightData.test.tsx
@@ -107,4 +107,130 @@ describe('single-flight data source', () => {
 
     expect(queryClient.getQueryData(key)).toBe('prefetched')
   })
+
+  // The declared-scope sweep: a mutation names its invalidation scope with
+  // `X-Revalidate` keys (Solid's reload/redirect `revalidate` option); the
+  // payload covers what the server recomputed, and whatever a declared key
+  // matches beyond it is invalidated client-side — active queries refetch,
+  // inactive ones are marked stale. Keys match by queryKey prefix.
+  describe('X-Revalidate sweep', () => {
+    function revalidateResponse(keys: string) {
+      return new Response(null, { headers: { 'X-Revalidate': keys } })
+    }
+
+    it('refetches active queries a declared key matches beyond the payload', async () => {
+      let fetches = 0
+
+      function Page() {
+        const state = useQuery(() => ({
+          queryKey: ['users', 1],
+          queryFn: () => {
+            fetches++
+            return Promise.resolve(`user-${fetches}`)
+          },
+          staleTime: Infinity,
+        }))
+        return <span>{state.data}</span>
+      }
+
+      const rendered = render(() => (
+        <QueryClientProvider client={queryClient}>
+          <Page />
+        </QueryClientProvider>
+      ))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(rendered.getByText('user-1')).toBeInTheDocument()
+
+      // The payload covers ['users'] (the list); the mounted instance
+      // ['users', 1] is only this client's — the sweep picks it up.
+      const consumer = getFlightDataConsumer(FLIGHT_DATA_SOURCE)!
+      await consumer(flightSlice(['users'], 'fresh-list'), {
+        response: revalidateResponse('users'),
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(fetches).toBe(2)
+      expect(rendered.getByText('user-2')).toBeInTheDocument()
+    })
+
+    it('exempts payload-covered queries from the sweep', async () => {
+      const key = ['users', 1]
+      let fetches = 0
+
+      function Page() {
+        const state = useQuery(() => ({
+          queryKey: key,
+          queryFn: () => {
+            fetches++
+            return Promise.resolve('stale')
+          },
+          staleTime: Infinity,
+        }))
+        return <span>{state.data}</span>
+      }
+
+      const rendered = render(() => (
+        <QueryClientProvider client={queryClient}>
+          <Page />
+        </QueryClientProvider>
+      ))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(rendered.getByText('stale')).toBeInTheDocument()
+      // hydrate() only adopts fresher timestamps.
+      await vi.advanceTimersByTimeAsync(10)
+
+      // The payload itself covers the declared key's only match: the fresh
+      // data seeds it, and the sweep must not spend a refetch on top.
+      const consumer = getFlightDataConsumer(FLIGHT_DATA_SOURCE)!
+      await consumer(flightSlice(key, 'fresh'), {
+        response: revalidateResponse('users'),
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(rendered.getByText('fresh')).toBeInTheDocument()
+      expect(fetches).toBe(1)
+      expect(queryClient.getQueryState(key)!.isInvalidated).toBe(false)
+    })
+
+    it('stale-marks inactive matches instead of refetching', async () => {
+      render(() => (
+        <QueryClientProvider client={queryClient}>
+          <div />
+        </QueryClientProvider>
+      ))
+      queryClient.setQueryData(['users', 2], 'cached')
+      queryClient.setQueryData(['posts', 1], 'unrelated')
+
+      const consumer = getFlightDataConsumer(FLIGHT_DATA_SOURCE)!
+      await consumer(flightSlice(['users'], 'fresh-list'), {
+        response: revalidateResponse('users'),
+      })
+
+      expect(queryClient.getQueryState(['users', 2])!.isInvalidated).toBe(true)
+      // Covered by the payload: hydrated fresh, not invalidated.
+      expect(queryClient.getQueryState(['users'])!.isInvalidated).toBe(false)
+      // Outside every declared key: untouched.
+      expect(queryClient.getQueryState(['posts', 1])!.isInvalidated).toBe(false)
+    })
+
+    it('sweeps each declared key of a comma-separated list', async () => {
+      render(() => (
+        <QueryClientProvider client={queryClient}>
+          <div />
+        </QueryClientProvider>
+      ))
+      queryClient.setQueryData(['users', 2], 'cached')
+      queryClient.setQueryData(['posts', 1], 'cached')
+      queryClient.setQueryData(['tags'], 'cached')
+
+      const consumer = getFlightDataConsumer(FLIGHT_DATA_SOURCE)!
+      await consumer(flightSlice(['other'], 'x'), {
+        response: revalidateResponse('users,posts'),
+      })
+
+      expect(queryClient.getQueryState(['users', 2])!.isInvalidated).toBe(true)
+      expect(queryClient.getQueryState(['posts', 1])!.isInvalidated).toBe(true)
+      expect(queryClient.getQueryState(['tags'])!.isInvalidated).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Key-scoped invalidation for the single-flight consumer, completing the scope a mutation declares.

A mutation can declare its invalidation scope with `X-Revalidate` keys (the `revalidate` option of Solid's `reload`/`redirect` response helpers). The flight payload covers the part of that scope the server's collector recomputed — typically the target page's loader graph — but a declared key can match more than any loader knows about: parameterized instances only the client holds (`['users', 2]` behind a paginated list), or queries no loader owns (a layout's notification count). Those previously stayed stale until their own `staleTime` brought them back.

The provider's flight consumer now finishes the job client-side. After hydrating the payload, each declared key is invalidated by queryKey prefix:

- **Active queries** refetch in the background (the mutation's promise never waits on them).
- **Inactive queries** are marked stale for their next mount.
- **Payload-covered hashes are exempt** — they hydrated with fresh data a moment ago; refetching them would spend the round trip single flight just saved.

This mirrors how Solid Router consumes the same header for its own cache, so one `revalidate` declaration on a mutation scopes both caches consistently:

```ts
async function updateUser(id: number, data: UserData) {
  'use server'
  await db.users.update(id, data)
  return reload({ revalidate: 'users' })
}
```

## Notes

- **No wire or protocol changes.** The keys already ride the response headers the consumer receives as envelope context (`FlightDataContext.response`); `REVALIDATE_HEADER` comes from the universal `@solidjs/web` entry.
- **Collector convention** (documented on `FLIGHT_DATA_SOURCE`): contribute the slice even when it holds no queries if `outcome.revalidateKeys` is present — the sweep is delivered with the slice, and a source that skips folding skips the delivery.
- Mutations that declare no keys behave exactly as before.

## Tests

Four new cases in `flightData.test.tsx`: sweep-beyond-payload refetch, payload-covered exemption, inactive stale-marking, and comma-separated key lists. Full solid-query suite green (358 passed).

Made with [Cursor](https://cursor.com)