### PR TITLE
feat(query-core): allow overriding dehydration timestamp 🤖🤖🤖

### DIFF
--- a/.changeset/calm-plums-hydrate.md
+++ b/.changeset/calm-plums-hydrate.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': minor
+---
+
+Allow callers to provide the timestamp recorded on dehydrated queries.

--- a/docs/framework/react/guides/advanced-ssr.md
+++ b/docs/framework/react/guides/advanced-ssr.md
@@ -432,6 +432,17 @@ export function getQueryClient() {
 
 > Note: This works in NextJs and Server Components because React can serialize Promises over the wire when you pass them down to Client Components.
 
+By default, `dehydrate` records the current time on each dehydrated query. If your framework provides a stable timestamp for a cached data snapshot, pass it as `dehydratedAt` so hydration uses the same timestamp without reading the current time again:
+
+```tsx
+const { data, updatedAt } = await getCachedPostsSnapshot()
+const queryClient = new QueryClient()
+
+queryClient.setQueryData(['posts'], data, { updatedAt })
+
+const dehydratedState = dehydrate(queryClient, { dehydratedAt })
+```
+
 Then, all we need to do is provide a `HydrationBoundary`, but we don't need to `await` prefetches anymore:
 
 ```tsx

--- a/packages/query-core/src/__tests__/hydration.test.tsx
+++ b/packages/query-core/src/__tests__/hydration.test.tsx
@@ -40,6 +40,22 @@ describe('dehydration and rehydration', () => {
       queryClient.clear()
     })
 
+    it('should use a provided dehydration timestamp', () => {
+      const key = queryKey()
+      const queryClient = new QueryClient()
+      queryClient.setQueryData(key, 'data')
+      const query = queryClient.getQueryCache().find({ queryKey: key })!
+      const dateNowSpy = vi.spyOn(Date, 'now')
+
+      const dehydrated = dehydrateQuery(query, undefined, undefined, 123)
+
+      expect(dehydrated.dehydratedAt).toBe(123)
+      expect(dateNowSpy).not.toHaveBeenCalled()
+
+      dateNowSpy.mockRestore()
+      queryClient.clear()
+    })
+
     it('should serialize data when dehydrating a query directly', () => {
       const key = queryKey()
       const data = new Date('2024-01-01T00:00:00.000Z')
@@ -79,6 +95,21 @@ describe('dehydration and rehydration', () => {
 
       queryClient.clear()
     })
+  })
+
+  it('should use dehydratedAt specified in dehydrate options', () => {
+    const key = queryKey()
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(key, 'data')
+    const dateNowSpy = vi.spyOn(Date, 'now')
+
+    const dehydrated = dehydrate(queryClient, { dehydratedAt: 123 })
+
+    expect(dehydrated.queries[0]?.dehydratedAt).toBe(123)
+    expect(dateNowSpy).not.toHaveBeenCalled()
+
+    dateNowSpy.mockRestore()
+    queryClient.clear()
   })
 
   it('should work with serializable values', async () => {

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -40,6 +40,11 @@ export interface DehydrateOptions {
   shouldDehydrateMutation?: (mutation: Mutation) => boolean
   shouldDehydrateQuery?: (query: Query) => boolean
   shouldRedactErrors?: (error: unknown) => boolean
+  /**
+   * The timestamp to store on dehydrated queries.
+   * Defaults to `Date.now()`.
+   */
+  dehydratedAt?: number
 }
 
 export interface HydrateOptions {
@@ -122,9 +127,10 @@ export function dehydrateQuery(
   query: Query,
   serializeData?: TransformerFn,
   shouldRedactErrors?: (error: unknown) => boolean,
+  dehydratedAt = Date.now(),
 ): DehydratedQuery {
   return {
-    dehydratedAt: Date.now(),
+    dehydratedAt,
     state: {
       ...query.state,
       ...(query.state.data !== undefined && {
@@ -179,12 +185,22 @@ export function dehydrate(
   const serializeData =
     options.serializeData ?? client.getDefaultOptions().dehydrate?.serializeData
 
+  const dehydratedAt =
+    options.dehydratedAt ?? client.getDefaultOptions().dehydrate?.dehydratedAt
+
   const queries = client
     .getQueryCache()
     .getAll()
     .flatMap((query) =>
       filterQuery(query)
-        ? [dehydrateQuery(query, serializeData, shouldRedactErrors)]
+        ? [
+            dehydrateQuery(
+              query,
+              serializeData,
+              shouldRedactErrors,
+              dehydratedAt,
+            ),
+          ]
         : [],
     )
 


### PR DESCRIPTION
## 🎯 Changes

Next.js Cache Components cannot prerender `dehydrate()` because `dehydrateQuery()` reads `Date.now()`.

The [Next.js client-side fetching guide](https://nextjs.org/docs/app/guides/client-side-data-fetching/tanstack-query#build-a-prerenderable-hydration-state) works around this by caching a timestamp with the same tags as the data, then manually mapping the query cache into a `DehydratedState`:

```ts
const updatedAt = await getHydrationUpdatedAt(tags)

queryClient.setQueryData(queryKey, data, { updatedAt })

return {
  mutations: [],
  queries: queryClient.getQueryCache().getAll().map((query) => ({
    dehydratedAt: updatedAt,
    queryHash: query.queryHash,
    queryKey: query.queryKey,
    state: query.state,
  })),
}
```

This PR adds `dehydratedAt` to `DehydrateOptions`, so applications can use the normal dehydration logic instead:

```ts
return dehydrate(queryClient, { dehydratedAt: updatedAt })
```

The caller is still responsible for keeping the timestamp in the same cache lifecycle as the data. When omitted, `dehydratedAt` continues to default to `Date.now()`.

Includes tests, documentation, and a query-core changeset. Related to #9457.

## ✅ Checklist

- [x] I have followed the steps in the Contributing Guide
- [x] I have tested the code changes locally with `pnpm run test:pr`, or does not apply
- [x] I fully understand how the code works, including any changes generated by or with the assistance of AI

Local verification passed for query-core tests, its TypeScript matrix, lint, package build, formatting, and documentation links. The only remaining repository-wide failure was a Next.js example whose build-time PokeAPI request is unavailable in the restricted environment.

## 🚀 Release Impact

- [x] This change affects code that is released to users, and I have added a changeset
- [ ] This is a documentation, CI, or development-only change, and no changeset is needed