### PR TITLE
docs(config): register redirect_from mappings for vue-query reference pages

### DIFF
--- a/docs/framework/vue/guides/ssr.md
+++ b/docs/framework/vue/guides/ssr.md
@@ -1,6 +1,8 @@
 ---
 id: ssr
 title: SSR
+redirect_from:
+  - framework/vue/reference/hydration
 ---
 
 Vue Query supports prefetching multiple queries on the server and then _dehydrating_ those queries to the queryClient. This means the server can prerender markup that is immediately available on page load and as soon as JS is available, Vue Query can upgrade or _hydrate_ those queries with the full functionality of the library. This includes refetching those queries on the client if they have become stale since the time they were rendered on the server.

--- a/docs/framework/vue/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/vue/reference/functions/infiniteQueryOptions.md
@@ -1,6 +1,8 @@
 ---
 id: infiniteQueryOptions
 title: infiniteQueryOptions
+redirect_from:
+  - framework/vue/reference/infiniteQueryOptions
 ---
 
 ## Call Signature

--- a/docs/framework/vue/reference/functions/mutationOptions.md
+++ b/docs/framework/vue/reference/functions/mutationOptions.md
@@ -1,6 +1,8 @@
 ---
 id: mutationOptions
 title: mutationOptions
+redirect_from:
+  - framework/vue/reference/mutationOptions
 ---
 
 ## Call Signature

--- a/docs/framework/vue/reference/functions/queryOptions.md
+++ b/docs/framework/vue/reference/functions/queryOptions.md
@@ -1,6 +1,8 @@
 ---
 id: queryOptions
 title: queryOptions
+redirect_from:
+  - framework/vue/reference/queryOptions
 ---
 
 ## Call Signature

--- a/docs/framework/vue/reference/functions/useInfiniteQuery.md
+++ b/docs/framework/vue/reference/functions/useInfiniteQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useInfiniteQuery
 title: useInfiniteQuery
+redirect_from:
+  - framework/vue/reference/useInfiniteQuery
 ---
 
 ## Call Signature

--- a/docs/framework/vue/reference/functions/useIsFetching.md
+++ b/docs/framework/vue/reference/functions/useIsFetching.md
@@ -1,6 +1,8 @@
 ---
 id: useIsFetching
 title: useIsFetching
+redirect_from:
+  - framework/vue/reference/useIsFetching
 ---
 
 ```ts

--- a/docs/framework/vue/reference/functions/useIsMutating.md
+++ b/docs/framework/vue/reference/functions/useIsMutating.md
@@ -1,6 +1,8 @@
 ---
 id: useIsMutating
 title: useIsMutating
+redirect_from:
+  - framework/vue/reference/useIsMutating
 ---
 
 ```ts

--- a/docs/framework/vue/reference/functions/useMutation.md
+++ b/docs/framework/vue/reference/functions/useMutation.md
@@ -1,6 +1,8 @@
 ---
 id: useMutation
 title: useMutation
+redirect_from:
+  - framework/vue/reference/useMutation
 ---
 
 ```ts

--- a/docs/framework/vue/reference/functions/useMutationState.md
+++ b/docs/framework/vue/reference/functions/useMutationState.md
@@ -1,6 +1,8 @@
 ---
 id: useMutationState
 title: useMutationState
+redirect_from:
+  - framework/vue/reference/useMutationState
 ---
 
 ```ts

--- a/docs/framework/vue/reference/functions/usePrefetchInfiniteQuery.md
+++ b/docs/framework/vue/reference/functions/usePrefetchInfiniteQuery.md
@@ -1,6 +1,8 @@
 ---
 id: usePrefetchInfiniteQuery
 title: usePrefetchInfiniteQuery
+redirect_from:
+  - framework/vue/reference/usePrefetchInfiniteQuery
 ---
 
 ```ts

--- a/docs/framework/vue/reference/functions/usePrefetchQuery.md
+++ b/docs/framework/vue/reference/functions/usePrefetchQuery.md
@@ -1,6 +1,8 @@
 ---
 id: usePrefetchQuery
 title: usePrefetchQuery
+redirect_from:
+  - framework/vue/reference/usePrefetchQuery
 ---
 
 ```ts

--- a/docs/framework/vue/reference/functions/useQueries.md
+++ b/docs/framework/vue/reference/functions/useQueries.md
@@ -1,6 +1,8 @@
 ---
 id: useQueries
 title: useQueries
+redirect_from:
+  - framework/vue/reference/useQueries
 ---
 
 ```ts

--- a/docs/framework/vue/reference/functions/useQuery.md
+++ b/docs/framework/vue/reference/functions/useQuery.md
@@ -1,6 +1,8 @@
 ---
 id: useQuery
 title: useQuery
+redirect_from:
+  - framework/vue/reference/useQuery
 ---
 
 ## Call Signature

--- a/docs/framework/vue/reference/functions/useQueryClient.md
+++ b/docs/framework/vue/reference/functions/useQueryClient.md
@@ -1,6 +1,8 @@
 ---
 id: useQueryClient
 title: useQueryClient
+redirect_from:
+  - framework/vue/reference/useQueryClient
 ---
 
 ```ts

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -235,6 +235,31 @@ const packages: Array<PackageReferenceDocsConfig> = [
     tsconfig: resolve(__dirname, '../packages/vue-query/tsconfig.json'),
     outputDir: resolve(__dirname, '../docs/framework/vue/reference'),
     exclude: ['./packages/query-core/**/*'],
+    redirectFrom: {
+      'functions/infiniteQueryOptions': [
+        'framework/vue/reference/infiniteQueryOptions',
+      ],
+      'functions/mutationOptions': ['framework/vue/reference/mutationOptions'],
+      'functions/queryOptions': ['framework/vue/reference/queryOptions'],
+      'functions/useInfiniteQuery': [
+        'framework/vue/reference/useInfiniteQuery',
+      ],
+      'functions/useIsFetching': ['framework/vue/reference/useIsFetching'],
+      'functions/useIsMutating': ['framework/vue/reference/useIsMutating'],
+      'functions/useMutation': ['framework/vue/reference/useMutation'],
+      'functions/useMutationState': [
+        'framework/vue/reference/useMutationState',
+      ],
+      'functions/usePrefetchInfiniteQuery': [
+        'framework/vue/reference/usePrefetchInfiniteQuery',
+      ],
+      'functions/usePrefetchQuery': [
+        'framework/vue/reference/usePrefetchQuery',
+      ],
+      'functions/useQueries': ['framework/vue/reference/useQueries'],
+      'functions/useQuery': ['framework/vue/reference/useQuery'],
+      'functions/useQueryClient': ['framework/vue/reference/useQueryClient'],
+    },
   },
   {
     entryPoints: [resolve(__dirname, '../packages/react-query/src/index.ts')],


### PR DESCRIPTION
## 🎯 Changes

PR #11378 switched `docs/framework/vue/reference/` from 14 hand-written flat files to TypeDoc-generated output under `functions/`, deleting the old flat URLs. Same as the react (#11379) and solid migrations, this registers `redirectFrom` mappings in `scripts/generate-docs.ts`'s vue-query entry so the old URLs 301 to their new locations instead of 404ing.

- Added `redirectFrom` for the 13 functions that map 1:1 to a new `functions/` page (`infiniteQueryOptions`, `mutationOptions`, `queryOptions`, `useInfiniteQuery`, `useIsFetching`, `useIsMutating`, `useMutation`, `useMutationState`, `usePrefetchInfiniteQuery`, `usePrefetchQuery`, `useQueries`, `useQuery`, `useQueryClient`).
- `hydration.md` has no direct replacement — its content was folded into `guides/ssr.md`'s new "dehydrate/hydrate options" subsection in #11378, so `redirect_from: - framework/vue/reference/hydration` was added directly to `ssr.md`'s frontmatter instead (same pattern as react's `guides/ssr.md`).
- Ran `pnpm run generate-docs` to regenerate the 13 reference pages with the new `redirect_from` frontmatter.

Checked for duplicate `redirect_from` sources across all of `docs/` before adding (a duplicate `from` pointing at different `to` targets breaks the site-wide redirect manifest build) — none found.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added redirects from legacy Vue documentation URLs to their current reference pages.
  * Preserved access to moved query, mutation, prefetch, and QueryClient documentation.
  * Added a redirect from the former hydration reference URL to the SSR guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->