### PR TITLE
docs(svelte-query): regenerate reference docs to fix stale source line numbers

### DIFF
--- a/docs/framework/svelte/reference/type-aliases/Accessor.md
+++ b/docs/framework/svelte/reference/type-aliases/Accessor.md
@@ -7,7 +7,7 @@ title: Accessor
 type Accessor<T> = () => T;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:21](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L21)
+Defined in: [packages/svelte-query/src/types.ts:22](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L22)
 
 ## Type Parameters
 

--- a/docs/framework/svelte/reference/type-aliases/CreateBaseMutationResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateBaseMutationResult.md
@@ -9,7 +9,7 @@ type CreateBaseMutationResult<TData, TError, TVariables, TOnMutateResult> = Over
 }> & object;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:114](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L114)
+Defined in: [packages/svelte-query/src/types.ts:121](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L121)
 
 ## Type Declaration
 

--- a/docs/framework/svelte/reference/type-aliases/CreateBaseQueryOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateBaseQueryOptions.md
@@ -7,7 +7,7 @@ title: CreateBaseQueryOptions
 type CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:24](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L24)
+Defined in: [packages/svelte-query/src/types.ts:25](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L25)
 
 Options for createBaseQuery
 

--- a/docs/framework/svelte/reference/type-aliases/CreateBaseQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateBaseQueryResult.md
@@ -7,7 +7,7 @@ title: CreateBaseQueryResult
 type CreateBaseQueryResult<TData, TError> = QueryObserverResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:33](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L33)
+Defined in: [packages/svelte-query/src/types.ts:34](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L34)
 
 Result from createBaseQuery
 

--- a/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryOptions.md
@@ -7,7 +7,7 @@ title: CreateInfiniteQueryOptions
 type CreateInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:53](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L53)
+Defined in: [packages/svelte-query/src/types.ts:54](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L54)
 
 Options for createInfiniteQuery
 

--- a/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateInfiniteQueryResult.md
@@ -7,7 +7,7 @@ title: CreateInfiniteQueryResult
 type CreateInfiniteQueryResult<TData, TError> = InfiniteQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:68](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L68)
+Defined in: [packages/svelte-query/src/types.ts:69](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L69)
 
 Result from createInfiniteQuery
 

--- a/docs/framework/svelte/reference/type-aliases/CreateMutateAsyncFunction.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutateAsyncFunction.md
@@ -7,7 +7,7 @@ title: CreateMutateAsyncFunction
 type CreateMutateAsyncFunction<TData, TError, TVariables, TOnMutateResult> = MutateFunction<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:107](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L107)
+Defined in: [packages/svelte-query/src/types.ts:114](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L114)
 
 ## Type Parameters
 

--- a/docs/framework/svelte/reference/type-aliases/CreateMutateFunction.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutateFunction.md
@@ -7,7 +7,7 @@ title: CreateMutateFunction
 type CreateMutateFunction<TData, TError, TVariables, TOnMutateResult> = (...args) => void;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:96](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L96)
+Defined in: [packages/svelte-query/src/types.ts:103](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L103)
 
 ## Type Parameters
 

--- a/docs/framework/svelte/reference/type-aliases/CreateMutationOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutationOptions.md
@@ -7,7 +7,7 @@ title: CreateMutationOptions
 type CreateMutationOptions<TData, TError, TVariables, TOnMutateResult> = OmitKeyof<MutationObserverOptions<TData, TError, TVariables, TOnMutateResult>, "_defaulted">;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:86](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L86)
+Defined in: [packages/svelte-query/src/types.ts:93](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L93)
 
 Options for createMutation
 

--- a/docs/framework/svelte/reference/type-aliases/CreateMutationResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateMutationResult.md
@@ -7,7 +7,7 @@ title: CreateMutationResult
 type CreateMutationResult<TData, TError, TVariables, TOnMutateResult> = CreateBaseMutationResult<TData, TError, TVariables, TOnMutateResult>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:132](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L132)
+Defined in: [packages/svelte-query/src/types.ts:139](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L139)
 
 Result from createMutation
 

--- a/docs/framework/svelte/reference/type-aliases/CreateQueryOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateQueryOptions.md
@@ -7,7 +7,7 @@ title: CreateQueryOptions
 type CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> = CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:39](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L39)
+Defined in: [packages/svelte-query/src/types.ts:40](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L40)
 
 Options for createQuery
 

--- a/docs/framework/svelte/reference/type-aliases/CreateQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/CreateQueryResult.md
@@ -7,7 +7,7 @@ title: CreateQueryResult
 type CreateQueryResult<TData, TError> = CreateBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:47](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L47)
+Defined in: [packages/svelte-query/src/types.ts:48](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L48)
 
 Result from createQuery
 

--- a/docs/framework/svelte/reference/type-aliases/DefinedCreateBaseQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/DefinedCreateBaseQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedCreateBaseQueryResult
 type DefinedCreateBaseQueryResult<TData, TError> = DefinedQueryObserverResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:74](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L74)
+Defined in: [packages/svelte-query/src/types.ts:81](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L81)
 
 Options for createBaseQuery with initialData
 

--- a/docs/framework/svelte/reference/type-aliases/DefinedCreateQueryResult.md
+++ b/docs/framework/svelte/reference/type-aliases/DefinedCreateQueryResult.md
@@ -7,7 +7,7 @@ title: DefinedCreateQueryResult
 type DefinedCreateQueryResult<TData, TError> = DefinedCreateBaseQueryResult<TData, TError>;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:80](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L80)
+Defined in: [packages/svelte-query/src/types.ts:87](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L87)
 
 Options for createQuery with initialData
 

--- a/docs/framework/svelte/reference/type-aliases/MutationStateOptions.md
+++ b/docs/framework/svelte/reference/type-aliases/MutationStateOptions.md
@@ -7,7 +7,7 @@ title: MutationStateOptions
 type MutationStateOptions<TResult, TMutation> = object;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:151](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L151)
+Defined in: [packages/svelte-query/src/types.ts:158](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L158)
 
 Options for useMutationState
 
@@ -29,7 +29,7 @@ Options for useMutationState
 optional filters: MutationFilters;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:156](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L156)
+Defined in: [packages/svelte-query/src/types.ts:163](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L163)
 
 ***
 
@@ -39,7 +39,7 @@ Defined in: [packages/svelte-query/src/types.ts:156](https://github.com/TanStack
 optional select: (mutation) => TResult;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:157](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L157)
+Defined in: [packages/svelte-query/src/types.ts:164](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L164)
 
 #### Parameters
 

--- a/docs/framework/svelte/reference/type-aliases/MutationTypeFromResult.md
+++ b/docs/framework/svelte/reference/type-aliases/MutationTypeFromResult.md
@@ -7,7 +7,7 @@ title: MutationTypeFromResult
 type MutationTypeFromResult<TResult> = [TResult] extends [MutationState<infer TData, infer TError, infer TVariables, infer TOnMutateResult>] ? Mutation<TData, TError, TVariables, TOnMutateResult> : Mutation;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:139](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L139)
+Defined in: [packages/svelte-query/src/types.ts:146](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L146)
 
 ## Type Parameters
 

--- a/docs/framework/svelte/reference/type-aliases/QueryClientProviderProps.md
+++ b/docs/framework/svelte/reference/type-aliases/QueryClientProviderProps.md
@@ -7,7 +7,7 @@ title: QueryClientProviderProps
 type QueryClientProviderProps = object;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:160](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L160)
+Defined in: [packages/svelte-query/src/types.ts:167](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L167)
 
 ## Properties
 
@@ -17,7 +17,7 @@ Defined in: [packages/svelte-query/src/types.ts:160](https://github.com/TanStack
 children: Snippet;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:162](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L162)
+Defined in: [packages/svelte-query/src/types.ts:169](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L169)
 
 ***
 
@@ -27,4 +27,4 @@ Defined in: [packages/svelte-query/src/types.ts:162](https://github.com/TanStack
 client: QueryClient;
 ```
 
-Defined in: [packages/svelte-query/src/types.ts:161](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L161)
+Defined in: [packages/svelte-query/src/types.ts:168](https://github.com/TanStack/query/blob/main/packages/svelte-query/src/types.ts#L168)


### PR DESCRIPTION
## 🎯 Changes

`packages/svelte-query/src/types.ts` gained 7 lines in #11356 (`feat(svelte-query): add 'DefinedInitialDataInfiniteOptions' overload for 'createInfiniteQuery'/'infiniteQueryOptions'`), but that PR's own history shows the generated reference docs were deliberately reverted (`docs(svelte-query): drop generated reference doc changes from this type-only PR`), leaving `docs/framework/svelte/reference/type-aliases/*.md` pointing at source line numbers that no longer match `types.ts`.

Since then, every `pnpm run generate-docs` run picks this up as a diff even on an unrelated branch — confirmed by running it on a clean `main` checkout with no other changes. This PR is just that regeneration: 17 files, all `Defined in: .../types.ts#L<N>` line numbers corrected to match current source, no content changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated source-reference links across Svelte type-alias documentation to point to the current definition locations.
  - Corrected links for several type aliases and their documented properties, including mutation state options and provider props.
  - No functional behavior, public APIs, or type definitions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->