### PR TITLE
test(vue-query/useQuery): add tests for 'select', 'enabled' getter, 'initialData', 'keepPreviousData', and 'queryKey' getter reactivity rules

### DIFF
--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -359,4 +359,30 @@ describe('useQuery', () => {
       }
     })
   })
+
+  describe('queryKey reactivity rules', () => {
+    it('should reject a bare reactive getter for the whole queryKey array', () => {
+      const id = ref(1)
+      assertType(
+        useQuery({
+          // @ts-expect-error when passed directly to useQuery, queryKey cannot be a bare
+          // reactive getter for the whole array (queryOptions() allows this)
+          queryKey: () => ['post', id.value],
+          queryFn: () => sleep(0).then(() => 'Some data'),
+        }),
+      )
+    })
+  })
+
+  describe('select', () => {
+    it('should narrow data to the type select returns', () => {
+      const { data } = useQuery({
+        queryKey: queryKey(),
+        queryFn: () => sleep(0).then(() => ['a', 'b', 'c']),
+        select: (posts) => posts.length,
+      })
+
+      expectTypeOf(data.value).toEqualTypeOf<number | undefined>()
+    })
+  })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -504,7 +504,21 @@ describe('useQuery', () => {
     })
   })
 
-  it('should seed from initialData and skip the loading state', async () => {
+  it('should seed from initialData and skip the loading state', () => {
+    const key = queryKey()
+    const query = useQuery({
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => 'fetched data'),
+      initialData: 'seeded data',
+    })
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'seeded data' },
+    })
+  })
+
+  it('should still fetch in the background and replace initialData with the fetched value', async () => {
     const key = queryKey()
     const fetchFn = vi.fn(() => sleep(10).then(() => 'fetched data'))
 
@@ -512,11 +526,6 @@ describe('useQuery', () => {
       queryKey: key,
       queryFn: fetchFn,
       initialData: 'seeded data',
-    })
-
-    expect(query).toMatchObject({
-      status: { value: 'success' },
-      data: { value: 'seeded data' },
     })
 
     await vi.advanceTimersByTimeAsync(10)

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'vue-demi'
 import { QueryObserver, experimental_streamedQuery } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
+import { keepPreviousData } from '..'
 import { useQuery } from '../useQuery'
 import { useBaseQuery } from '../useBaseQuery'
 import { useQueryClient } from '../useQueryClient'
@@ -455,6 +456,113 @@ describe('useQuery', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(fetchFn).toHaveBeenCalledTimes(6)
+  })
+
+  it('should derive data via select without changing what is cached', async () => {
+    const key = queryKey()
+    const query = useQuery({
+      queryKey: key,
+      queryFn: () => sleep(10).then(() => ['a', 'b', 'c']),
+      select: (posts) => posts.length,
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 3 },
+    })
+
+    const queryClient = useQueryClient()
+    expect(queryClient.getQueryData(key)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should stay disabled until the dependent value is set', async () => {
+    const key = queryKey()
+    const postId = ref<number>()
+    const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
+
+    const query = useQuery({
+      queryKey: [...key, postId],
+      queryFn: fetchFn,
+      enabled: () => postId.value != null,
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(query).toMatchObject({ status: { value: 'pending' } })
+
+    postId.value = 1
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'Some data' },
+    })
+  })
+
+  it('should seed from initialData and skip the loading state', async () => {
+    const key = queryKey()
+    const fetchFn = vi.fn(() => sleep(10).then(() => 'fetched data'))
+
+    const query = useQuery({
+      queryKey: key,
+      queryFn: fetchFn,
+      initialData: 'seeded data',
+    })
+
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'seeded data' },
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(query).toMatchObject({
+      status: { value: 'success' },
+      data: { value: 'fetched data' },
+    })
+  })
+
+  it('should keep the previous page visible while the next page loads with keepPreviousData', async () => {
+    const key = queryKey()
+    const page = ref(0)
+    const fetchFn = vi.fn((pageParam: number) =>
+      sleep(10).then(() => `page-${pageParam}`),
+    )
+
+    const query = useQuery({
+      queryKey: [...key, page],
+      queryFn: () => fetchFn(page.value),
+      placeholderData: keepPreviousData,
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(query).toMatchObject({
+      data: { value: 'page-0' },
+      isPlaceholderData: { value: false },
+    })
+
+    page.value = 1
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query).toMatchObject({
+      data: { value: 'page-0' },
+      isPlaceholderData: { value: true },
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(query).toMatchObject({
+      data: { value: 'page-1' },
+      isPlaceholderData: { value: false },
+    })
   })
 
   describe('throwOnError', () => {


### PR DESCRIPTION
## 🎯 Changes

Adds runtime and type-level test coverage for `useQuery` behaviors that had no dedicated tests:

- `select`: derives `data` without mutating the cached query data
- `enabled` as a getter depending on another reactive value, gating the fetch until the dependency is set
- `initialData`: seeds `data` and skips the loading state, while the real fetch still runs in the background and replaces it
- `placeholderData: keepPreviousData`: keeps the previous page's data visible (`isPlaceholderData: true`) while the next page loads
- Type-level: `queryKey` passed directly to `useQuery` cannot be a bare reactive getter for the whole array (`@ts-expect-error`)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for derived query data using `select`, including accurate data type narrowing.
  - Added validation for getter-based enabled states with dependent values.
  - Added scenarios covering initial data seeding and replacement after background fetching.
  - Added placeholder data coverage for paginated queries while preserving previous results.
  - Added type-level checks to ensure query keys follow supported reactivity rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->