### PR TITLE
test(vue-query/useInfiniteQuery): add tests for 'maxPages' getter reactivity, 'hasNextPage' transitions, and 'queryKey' getter rejection

### DIFF
--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -1,5 +1,5 @@
-import { describe, expectTypeOf, it } from 'vitest'
-import { computed, reactive } from 'vue-demi'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
+import { computed, reactive, ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
@@ -134,5 +134,21 @@ describe('Discriminated union return type', () => {
     if (query.isSuccess) {
       expectTypeOf(query.data).toEqualTypeOf<InfiniteData<string, unknown>>()
     }
+  })
+})
+
+describe('queryKey reactivity rules', () => {
+  it('should reject a bare reactive getter for the whole queryKey array', () => {
+    const id = ref(1)
+    assertType(
+      useInfiniteQuery({
+        // @ts-expect-error when passed directly to useInfiniteQuery, queryKey cannot be a bare
+        // reactive getter for the whole array (queryOptions() allows this)
+        queryKey: () => ['post', id.value],
+        queryFn: () => sleep(0).then(() => 'Some data'),
+        getNextPageParam: () => undefined,
+        initialPageParam: 0,
+      }),
+    )
   })
 })

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
@@ -77,5 +78,55 @@ describe('useInfiniteQuery', () => {
       pages: ['data on page 0', 'data on page 12'],
     })
     expect(status.value).toStrictEqual('success')
+  })
+
+  it('should react to maxPages changing via a whole-options getter', async () => {
+    const key = queryKey()
+    const maxPages = ref(1)
+    const { data, fetchNextPage } = useInfiniteQuery(() => ({
+      queryKey: key,
+      queryFn: ({ pageParam }) =>
+        sleep(10).then(() => 'data on page ' + pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage, _allPages, lastPageParam) =>
+        lastPageParam + 1,
+      maxPages: maxPages.value,
+    }))
+
+    await vi.advanceTimersByTimeAsync(10)
+    fetchNextPage()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(data.value?.pages).toStrictEqual(['data on page 1'])
+
+    maxPages.value = 2
+    await vi.advanceTimersByTimeAsync(0)
+    fetchNextPage()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(data.value?.pages).toStrictEqual([
+      'data on page 1',
+      'data on page 2',
+    ])
+  })
+
+  it('should reflect hasNextPage becoming false once the last page is reached', async () => {
+    const key = queryKey()
+    const { hasNextPage, fetchNextPage, isFetching } = useInfiniteQuery({
+      queryKey: key,
+      queryFn: ({ pageParam }) =>
+        sleep(10).then(() => 'data on page ' + pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage, _allPages, lastPageParam) =>
+        lastPageParam < 12 ? lastPageParam + 12 : undefined,
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(hasNextPage.value).toBe(true)
+
+    fetchNextPage()
+    await vi.advanceTimersByTimeAsync(10)
+    expect(hasNextPage.value).toBe(false)
+    expect(isFetching.value).toBe(false)
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds runtime and type-level test coverage for `useInfiniteQuery` behaviors that had no dedicated tests:

- `maxPages` reacting to changes when passed through a whole-options getter
- `hasNextPage` becoming `false` (and `isFetching` settling to `false`) once the last page is reached
- Type-level: `queryKey` passed directly to `useInfiniteQuery` cannot be a bare reactive getter for the whole array (`@ts-expect-error`)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for infinite queries configured through reactive options, including updates to the maximum page limit.
  * Added validation for pagination state at the final page, ensuring next-page availability and loading status are reported correctly.
  * Added type-safety checks to prevent invalid reactive query key usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->