### PR TITLE
fix(angular-query): honor per-query 'throwOnError' in 'injectQueries' 🤖🤖🤖

### DIFF
--- a/.changeset/angular-inject-queries-throw-on-error.md
+++ b/.changeset/angular-inject-queries-throw-on-error.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-query-experimental': patch
+---
+
+fix(angular-query): honor per-query 'throwOnError' in 'injectQueries'

--- a/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-queries.test.ts
@@ -180,6 +180,103 @@ describe('injectQueries', () => {
     expect(rendered.getByText('status2: success, data2: 2')).toBeInTheDocument()
   })
 
+  describe('throwOnError', () => {
+    it('should throw when throwOnError is true', async () => {
+      const key1 = queryKey()
+      const key2 = queryKey()
+
+      TestBed.runInInjectionContext(() =>
+        injectQueries(() => ({
+          queries: [
+            {
+              queryKey: key1,
+              queryFn: () => sleep(0).then(() => 1),
+            },
+            {
+              queryKey: key2,
+              queryFn: () =>
+                sleep(0).then(() => Promise.reject(new Error('Some error'))),
+              throwOnError: true,
+            },
+          ],
+        })),
+      )
+
+      await expect(vi.runAllTimersAsync()).rejects.toThrow('Some error')
+    })
+
+    it('should keep the queries observable after throwing', async () => {
+      const key1 = queryKey()
+      const key2 = queryKey()
+
+      const result = TestBed.runInInjectionContext(() =>
+        injectQueries(() => ({
+          queries: [
+            {
+              queryKey: key1,
+              queryFn: () => sleep(10).then(() => 1),
+            },
+            {
+              queryKey: key2,
+              queryFn: () =>
+                sleep(20).then(() => Promise.reject(new Error('Some error'))),
+              retry: false,
+              throwOnError: true,
+            },
+          ],
+        })),
+      )
+
+      await vi.advanceTimersByTimeAsync(11)
+      expect(result()[0].data()).toBe(1)
+
+      await expect(vi.advanceTimersByTimeAsync(10)).rejects.toThrow(
+        'Some error',
+      )
+
+      // `throwOnError` means "also throw", so the results the caller renders
+      // from must still be updated - including the sibling that succeeded.
+      expect(result()[0].data()).toBe(1)
+      expect(result()[1].status()).toBe('error')
+      expect(result()[1].error()).toEqual(Error('Some error'))
+    })
+
+    it('should evaluate throwOnError with the error and query of the failing query only', async () => {
+      const key1 = queryKey()
+      const key2 = queryKey()
+      const boundaryFn = vi.fn().mockReturnValue(false)
+
+      TestBed.runInInjectionContext(() =>
+        injectQueries(() => ({
+          queries: [
+            {
+              queryKey: key1,
+              queryFn: () => sleep(10).then(() => 1),
+            },
+            {
+              queryKey: key2,
+              queryFn: () =>
+                sleep(10).then(() => Promise.reject(new Error('Some error'))),
+              retry: false,
+              throwOnError: boundaryFn,
+            },
+          ],
+        })),
+      )
+
+      await vi.advanceTimersByTimeAsync(11)
+
+      expect(boundaryFn).toHaveBeenCalledTimes(1)
+      expect(boundaryFn).toHaveBeenCalledWith(
+        Error('Some error'),
+        expect.objectContaining({
+          queryKey: key2,
+          state: expect.objectContaining({ status: 'error' }),
+        }),
+      )
+    })
+  })
+
   describe('isRestoring', () => {
     it('should not fetch for the duration of the restoring period when isRestoring is true', async () => {
       const key1 = queryKey()

--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -2,6 +2,7 @@ import {
   QueriesObserver,
   QueryClient,
   notifyManager,
+  shouldThrowError,
 } from '@tanstack/query-core'
 import {
   DestroyRef,
@@ -301,7 +302,32 @@ export function injectQueries<
           : ngZone.runOutsideAngular(() =>
               observer.subscribe(
                 notifyManager.batchCalls((state) => {
+                  // Publish first: `throwOnError` means "also throw", so the
+                  // results the caller renders from - the failing query's own
+                  // error state included - must still be updated. Nothing below
+                  // may leave the signal holding a stale notification.
                   resultFromSubscriberSignal.set(getCombinedResult(state))
+
+                  // Each query carries its own `throwOnError`, so the option is
+                  // resolved per query against that query's own error.
+                  const queryObservers = observer.getObservers()
+                  const resultToThrow = state.find((result, index) => {
+                    const queryObserver = queryObservers[index]
+                    return (
+                      result.isError &&
+                      !result.isFetching &&
+                      !!queryObserver &&
+                      shouldThrowError(queryObserver.options.throwOnError, [
+                        result.error,
+                        queryObserver.getCurrentQuery(),
+                      ])
+                    )
+                  })
+
+                  if (resultToThrow) {
+                    ngZone.onError.emit(resultToThrow.error)
+                    throw resultToThrow.error
+                  }
                 }),
               ),
             )


### PR DESCRIPTION
## 🎯 Changes

`injectQueries` never looked at `throwOnError`. Its `QueriesObserver` subscriber wrote every
notification straight into the result signal, so a query failing with `throwOnError: true` was
silently reduced to an error result — nothing was thrown, and nothing reached Angular's error
handling.

`injectQuery` already handles this in `create-base-query.ts`: it calls `shouldThrowError` with
the query's own `throwOnError`, emits on `NgZone.onError`, and rethrows. This applies the same
handling in `injectQueries`, resolving the option **per query** — each entry in the array carries
its own `throwOnError`, so the query that opts in is the one that throws, checked against its own
error and its own `Query`. `react-query`'s `useQueries` resolves it per query the same way.

The results are published to the signal *before* the throw. `throwOnError` means "also throw", so
the failing query's own `status()`/`error()` and its healthy siblings must still update; throwing
first would leave the whole array frozen at its previous value.

Behaviour without `throwOnError` is unchanged — the errored result still flows into the result
signal, which the existing `should reflect error state when one of the queries rejects` test covers.

This is one item from the `injectQueries` TODO list left on #8704 ("Should be able to throw an
error when `throwOnError` is true"). The other items there are untouched, so this does not close
the issue, and the "under development" note in the Angular parallel-queries guide still applies.

### Test verification (RED → GREEN)

Run the `angular-query-experimental` package's `test:lib` target from the repo root through
Nx, filtered to `inject-queries`.

RED — the three new tests against unmodified `main` (production file reverted, tests kept):

```
 ❯ src/__tests__/inject-queries.test.ts (7 tests | 3 failed)
       × should throw when throwOnError is true
       × should keep the queries observable after throwing
       × should evaluate throwOnError with the error and query of the failing query only

AssertionError: promise resolved "{ …(45) }" instead of rejecting
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times

 Test Files  1 failed | 1 passed (2)
      Tests  3 failed | 11 passed (14)
```

GREEN — same command with the change applied:

```
 Test Files  2 passed (2)
      Tests  14 passed (14)
Type Errors  no errors
```

### Full local suite

Replayed the `pr.yml` target set (`test:sherif`, `test:knip`, `test:docs`, `test:eslint`,
`test:lib`, `test:types`, `test:build`, `build`) over the affected projects, on `main` and on
this branch:

| | angular-query-experimental | angular-query-persist-client |
|---|---|---|
| `main` | 25 files / 227 passed | 5 passed, 1 todo |
| this branch | 25 files / 230 passed | 5 passed, 1 todo |

No type errors, no lint errors, no new failures. `test:types` passes on TS 5.6/5.7/5.8/5.9/
current/7.0.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `injectQueries` now honors each query’s `throwOnError` setting.
  - Configured errors are thrown correctly while query status and error details remain available.
  - Other queries continue updating normally when one query throws an error.

- **Documentation**
  - Added a patch release note for the Angular Query experimental package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->