### PR TITLE
test(query-core): expand notifyManager unit tests 🤖🤖🤖

### DIFF
--- a/packages/query-core/src/__tests__/notifyManager.test.tsx
+++ b/packages/query-core/src/__tests__/notifyManager.test.tsx
@@ -130,4 +130,98 @@ describe('notifyManager', () => {
 
     expect(callbackSpy).toHaveBeenCalledWith(1, 'test')
   })
+
+  it('should not schedule anything when a batch is empty', () => {
+    const notifyManagerTest = createNotifyManager()
+    const schedulerSpy = vi.fn((cb) => queueMicrotask(cb))
+    notifyManagerTest.setScheduler(schedulerSpy)
+
+    notifyManagerTest.batch(() => {})
+
+    expect(schedulerSpy).not.toHaveBeenCalled()
+  })
+
+  it('should notify scheduled callbacks individually outside of a batch', async () => {
+    const notifyManagerTest = createNotifyManager()
+    const notifySpy = vi.fn()
+    const batchNotifySpy = vi.fn((cb) => cb())
+    notifyManagerTest.setNotifyFunction(notifySpy)
+    notifyManagerTest.setBatchNotifyFunction(batchNotifySpy)
+
+    notifyManagerTest.schedule(vi.fn())
+    notifyManagerTest.schedule(vi.fn())
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(notifySpy).toHaveBeenCalledTimes(2)
+    expect(batchNotifySpy).not.toHaveBeenCalled()
+  })
+
+  it('should only flush after the outermost batch ends', async () => {
+    const notifyManagerTest = createNotifyManager()
+    const schedulerSpy = vi.fn((cb) => queueMicrotask(cb))
+    notifyManagerTest.setScheduler(schedulerSpy)
+    const innerCallback = vi.fn()
+    const outerCallback = vi.fn()
+
+    notifyManagerTest.batch(() => {
+      notifyManagerTest.batch(() => {
+        notifyManagerTest.schedule(innerCallback)
+      })
+
+      // the inner batch ending must not flush the queue yet
+      expect(schedulerSpy).not.toHaveBeenCalled()
+
+      notifyManagerTest.schedule(outerCallback)
+    })
+
+    expect(schedulerSpy).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(innerCallback).toHaveBeenCalledTimes(1)
+    expect(outerCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return the result of the batched callback', () => {
+    const notifyManagerTest = createNotifyManager()
+
+    const result = notifyManagerTest.batch(() => 42)
+
+    expect(result).toBe(42)
+  })
+
+  it('should dispatch schedules immediately after a batch threw', async () => {
+    const notifyManagerTest = createNotifyManager()
+    const schedulerSpy = vi.fn((cb) => queueMicrotask(cb))
+    notifyManagerTest.setScheduler(schedulerSpy)
+    const callbackSpy = vi.fn()
+
+    expect(() =>
+      notifyManagerTest.batch(() => {
+        throw new Error('Foo')
+      }),
+    ).toThrow('Foo')
+
+    // the transaction must be released, otherwise this schedule would be
+    // queued forever instead of being dispatched
+    notifyManagerTest.schedule(callbackSpy)
+    expect(schedulerSpy).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(callbackSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should defer notifications scheduled with the default scheduler to a macrotask', async () => {
+    const notifyManagerTest = createNotifyManager()
+    const callbackSpy = vi.fn()
+
+    notifyManagerTest.schedule(callbackSpy)
+
+    // the default scheduler is based on setTimeout(0), so draining microtasks
+    // alone must not run the notification
+    await Promise.resolve()
+    expect(callbackSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(callbackSpy).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Expands the unit test coverage for `notifyManager` in `packages/query-core`. The existing suite covered the happy paths of batching and custom `notifyFn`/`batchNotifyFn`/scheduler configuration; this PR adds behavioral coverage for the gaps that were not exercised:

- **Empty batches**: a `batch()` call that schedules nothing does not invoke the scheduler at all (the flush no-op path).
- **Scheduling outside of a batch**: each `schedule()` notifies its callback individually and does not route through `batchNotifyFn`, pinning the two distinct code paths of `schedule`.
- **Nested batches**: ending an inner batch does not flush; queued callbacks are dispatched only after the outermost batch ends.
- **Return value**: `batch()` passes the callback's return value through to the caller.
- **Error recovery**: after a batch throws, the transaction counter is released, so a subsequent `schedule()` is dispatched immediately instead of being queued forever.
- **Default scheduler semantics**: notifications scheduled with the default scheduler run on a macrotask (`setTimeout(0)`) — draining microtasks alone does not flush them.

Key assertions were verified against intentionally broken implementations (empty-batch flush guard, nested-batch flush guard) and go red, so they test behavior rather than implementation details.

Test-only change: no production source is modified.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for notification batching, including nested batches and empty batches.
  - Verified scheduler behavior for notifications made inside and outside batches.
  - Confirmed batched callbacks return their results and recover correctly after errors.
  - Added coverage ensuring default notifications run on a later task rather than during microtask processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->