### PR TITLE
docs(solid-query): correct devtools development-mode explanation

### DIFF
--- a/docs/framework/solid/devtools.md
+++ b/docs/framework/solid/devtools.md
@@ -45,7 +45,7 @@ You can import the devtools like this:
 import { SolidQueryDevtools } from '@tanstack/solid-query-devtools'
 ```
 
-By default, Solid Query Devtools are only included in bundles when `isServer === true` ([`isServer`](https://github.com/solidjs/solid/blob/a72d393a07b22f9b7496e5eb93712188ccce0d28/packages/solid/web/src/index.ts#L37) comes from the `solid-js/web` package), so you don't need to worry about excluding them during a production build.
+By default, Solid Query Devtools are only enabled in development mode (`isDev` from `solid-js/web`). In production, the devtools components render nothing. During development, the devtools are loaded only on the client and are not rendered on the server.
 
 ## Floating Mode
 


### PR DESCRIPTION
## 🎯 Changes

The devtools documentation incorrectly describes `isServer === true` as the condition for including devtools.

Update it to reflect the implementation: `isDev` enables the devtools in development, the components render nothing in production, and loading happens only on the client.

Documentation only. Verified against the entry point and client-only wrapper; `git diff --check` passes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Solid Query Devtools behavior across environments.
  * Clarified that devtools are enabled only in development, load on the client, and render nothing in production or during server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->