### PR TITLE
fix(query-persist-client-core/createPersister): await 'storage.setItem' when persisting a query

### DIFF
--- a/.changeset/persister-await-storage-write.md
+++ b/.changeset/persister-await-storage-write.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-persist-client-core': patch
+---
+
+fix(query-persist-client-core/createPersister): await the storage write in `persistQuery`, so `persistQueryByKey` resolves only once the entry has actually been written and rejects when the write fails instead of leaving an unhandled rejection

--- a/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
+++ b/packages/query-persist-client-core/src/__tests__/createPersister.test.ts
@@ -521,6 +521,64 @@ describe('createPersister', () => {
         },
       })
     })
+
+    it('should not resolve until an asynchronous write has finished', async () => {
+      const storage = getFreshStorage()
+      let releaseWrite!: () => void
+      const writeGate = new Promise<void>((resolve) => {
+        releaseWrite = resolve
+      })
+      const { persister, client, queryKey, storageKey } = setupPersister(
+        ['foo'],
+        {
+          storage: {
+            ...storage,
+            setItem: async (key, value) => {
+              await writeGate
+              await storage.setItem(key, value)
+            },
+          },
+        },
+      )
+
+      client.setQueryData(queryKey, 'baz')
+
+      let settled = false
+      const persisted = persister
+        .persistQueryByKey(queryKey, client)
+        .then(() => {
+          settled = true
+        })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(settled).toBe(false)
+      expect(await storage.getItem(storageKey)).toBeUndefined()
+
+      releaseWrite()
+      await persisted
+
+      expect(settled).toBe(true)
+      expect(JSON.parse(await storage.getItem(storageKey))).toMatchObject({
+        state: { data: 'baz' },
+      })
+    })
+
+    it('should reject when the write fails', async () => {
+      const storage = getFreshStorage()
+      const { persister, client, queryKey } = setupPersister(['foo'], {
+        storage: {
+          ...storage,
+          setItem: () => Promise.reject(new Error('storage is full')),
+        },
+      })
+
+      client.setQueryData(queryKey, 'baz')
+
+      await expect(
+        persister.persistQueryByKey(queryKey, client),
+      ).rejects.toThrow('storage is full')
+    })
   })
 
   describe('retrieveQuery', () => {

--- a/packages/query-persist-client-core/src/createPersister.ts
+++ b/packages/query-persist-client-core/src/createPersister.ts
@@ -188,7 +188,7 @@ export function experimental_createQueryPersister<TStorageValue = string>({
   async function persistQuery(query: Query) {
     if (storage != null) {
       const storageKey = `${prefix}-${query.queryHash}`
-      storage.setItem(
+      await storage.setItem(
         storageKey,
         await serialize({
           state: query.state,


### PR DESCRIPTION
## 🎯 Changes

`persistQuery` in `packages/query-persist-client-core/src/createPersister.ts` awaits `serialize` but not `storage.setItem`, so the promise it returns resolves as soon as the write is started rather than when it finishes. This adds the missing `await`.

Two things go wrong with an asynchronous storage such as React Native AsyncStorage or `idb-keyval`. First, `await persister.persistQueryByKey(queryKey, queryClient)` returns before the entry is actually in storage, which matters because the createPersister docs show that call being used inside `onMutate` to persist an optimistic update. Second, a write that rejects, a quota error for example, becomes an unhandled promise rejection instead of rejecting the promise the caller is awaiting.

`createAsyncStoragePersister` already awaits its `storage.setItem` call in `packages/query-async-storage-persister/src/index.ts`, so this makes the two persisters agree.

The existing tests miss this because their mock storage writes into a `Map` synchronously and then returns an already resolved promise, which hides the difference. The two tests I added to `createPersister.test.ts` use a storage whose write is gated on a promise the test resolves, and a storage whose write rejects. Both fail on `main` and pass with the one line change.

Verification, all from the repo root: `pnpm nx run @tanstack/query-persist-client-core:test:lib` goes from 55 passing to 57 passing, and the two new tests fail on unmodified `main` (the rejection one also surfaces the unhandled rejection there). `pnpm nx run @tanstack/query-persist-client-core:test:eslint` reports 0 errors and the 2 pre-existing `no-shadow` warnings on lines 275 and 323, which this change does not touch. `pnpm nx run @tanstack/query-persist-client-core:test:types` passes on TS 5.6 through 7.0. `pnpm run test:lib`, `pnpm run test:types`, `pnpm run test:build`, `pnpm run build`, `pnpm run test:sherif`, `pnpm run test:knip` and `pnpm run test:docs` all pass. `pnpm exec prettier --check` is clean on the three changed files.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Persistence operations now complete only after data is successfully written to storage.
  * Storage write failures are now correctly reported to callers instead of becoming unhandled errors.

* **Tests**
  * Added coverage for delayed storage writes and write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->