### PR TITLE
docs(persister): document asynchronous serialization callbacks

### DIFF
--- a/docs/framework/react/plugins/createAsyncStoragePersister.md
+++ b/docs/framework/react/plugins/createAsyncStoragePersister.md
@@ -93,9 +93,9 @@ interface CreateAsyncStoragePersisterOptions {
    * pass a time in ms to throttle saving the cache to disk */
   throttleTime?: number
   /** How to serialize the data to storage */
-  serialize?: (client: PersistedClient) => string
+  serialize?: (client: PersistedClient) => MaybePromise<string>
   /** How to deserialize the data from storage */
-  deserialize?: (cachedString: string) => PersistedClient
+  deserialize?: (cachedString: string) => MaybePromise<PersistedClient>
   /** How to retry persistence on error **/
   retry?: AsyncPersistRetryer
 }
@@ -107,6 +107,8 @@ interface AsyncStorage<TStorageValue = string> {
   entries?: () => MaybePromise<Array<[key: string, value: TStorageValue]>>
 }
 ```
+
+The `serialize` and `deserialize` callbacks can return their results synchronously or asynchronously as promises.
 
 The default options are:
 


### PR DESCRIPTION
## 🎯 Changes

The `createAsyncStoragePersister` options documentation currently lists `serialize` and `deserialize` as synchronous functions returning `string` and `PersistedClient`.

In the implementation (`packages/query-async-storage-persister/src/index.ts`), both options accept and await `MaybePromise<string>` and `MaybePromise<PersistedClient>`. This update aligns the documented TypeScript interface signatures and adds a note explaining that both callbacks support synchronous and asynchronous (Promise) returns.

Documentation only. Verified against `createAsyncStoragePersister` implementation and types; `git diff --check` passes cleanly.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that asynchronous storage serialization and deserialization callbacks may return results either synchronously or asynchronously.
  - Updated the documented callback types to reflect support for promises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->