### PR TITLE
fix(query-devtools): honor hideDisabledQueries option

### DIFF
--- a/.changeset/friendly-queries-hide.md
+++ b/.changeset/friendly-queries-hide.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/query-devtools": patch
+---
+
+Honor the hideDisabledQueries option when no saved visibility preference exists. Keep the settings menu consistent with the effective preference.

--- a/docs/framework/angular/devtools.md
+++ b/docs/framework/angular/devtools.md
@@ -161,7 +161,7 @@ Of these options `loadDevtools`, `client`, `position`, `errorTypes`, `buttonPosi
   - Default behavior will apply the devtool's styles to the head tag within the DOM.
   - Use this to pass a shadow DOM target to the devtools so that the styles will be applied within the shadow DOM instead of within the head tag in the light DOM.
 - `hideDisabledQueries?: boolean`
-  - Set this to true to hide disabled queries from the devtools panel.
+  - Set this to true to hide disabled queries from the devtools panel by default. A saved Show/Hide preference from the devtools settings takes precedence.
 - `theme?: "light" | "dark" | "system"`
   - Defaults to `system`.
   - Set this to change the theme of the devtools panel.

--- a/packages/query-devtools/src/Devtools.tsx
+++ b/packages/query-devtools/src/Devtools.tsx
@@ -694,6 +694,12 @@ export const ContentView: Component<ContentViewProps> = (props) => {
     () => Number(props.localStore.sortOrder) || DEFAULT_SORT_ORDER,
   ) as () => 1 | -1
 
+  const hideDisabledQueries = createMemo(() =>
+    props.localStore.hideDisabledQueries == null
+      ? (useQueryDevtoolsContext().hideDisabledQueries ?? false)
+      : props.localStore.hideDisabledQueries === 'true',
+  )
+
   const mutationSort = createMemo(
     () => props.localStore.mutationSort || DEFAULT_MUTATION_SORT_FN_NAME,
   )
@@ -729,7 +735,7 @@ export const ContentView: Component<ContentViewProps> = (props) => {
         props.localStore.filter,
         sort(),
         sortOrder(),
-        props.localStore.hideDisabledQueries,
+        hideDisabledQueries(),
       ],
       () => {
         const curr = query_cache().getAll()
@@ -742,7 +748,7 @@ export const ContentView: Component<ContentViewProps> = (props) => {
           : [...curr]
 
         // Filter out disabled queries if hideDisabledQueries is enabled
-        if (props.localStore.hideDisabledQueries === 'true') {
+        if (hideDisabledQueries()) {
           filtered = filtered.filter((item) => !item.isDisabled())
         }
 
@@ -1282,7 +1288,7 @@ export const ContentView: Component<ContentViewProps> = (props) => {
                         )}
                       >
                         <DropdownMenu.RadioGroup
-                          value={props.localStore.hideDisabledQueries}
+                          value={String(hideDisabledQueries())}
                           aria-label="Hide disabled queries setting"
                           onChange={(value) =>
                             props.setLocalStore('hideDisabledQueries', value)
@@ -1297,11 +1303,7 @@ export const ContentView: Component<ContentViewProps> = (props) => {
                             )}
                           >
                             <span>Show</span>
-                            <Show
-                              when={
-                                props.localStore.hideDisabledQueries !== 'true'
-                              }
-                            >
+                            <Show when={!hideDisabledQueries()}>
                               <CheckCircle />
                             </Show>
                           </DropdownMenu.RadioItem>
@@ -1314,11 +1316,7 @@ export const ContentView: Component<ContentViewProps> = (props) => {
                             )}
                           >
                             <span>Hide</span>
-                            <Show
-                              when={
-                                props.localStore.hideDisabledQueries === 'true'
-                              }
-                            >
+                            <Show when={hideDisabledQueries()}>
                               <CheckCircle />
                             </Show>
                           </DropdownMenu.RadioItem>

--- a/packages/query-devtools/src/__tests__/Devtools.test.tsx
+++ b/packages/query-devtools/src/__tests__/Devtools.test.tsx
@@ -998,6 +998,43 @@ describe('Devtools', () => {
       )
     })
 
+    it.each([
+      { option: true, saved: undefined, hidden: true },
+      { option: false, saved: undefined, hidden: false },
+      { option: undefined, saved: undefined, hidden: false },
+      { option: true, saved: 'false', hidden: false },
+      { option: false, saved: 'true', hidden: true },
+    ])(
+      'uses hideDisabledQueries=$option with saved preference $saved',
+      ({ option, saved, hidden }) => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: ['disabled-option'],
+          queryFn: () => 'disabled',
+          enabled: false,
+        })
+        const unsubscribe = observer.subscribe(() => {})
+        queryClient.setQueryData(['disabled-option'], 'disabled')
+        queryClient.setQueryData(['visible-option'], 'visible')
+
+        try {
+          const rendered = renderDevtools(
+            { initialIsOpen: true, hideDisabledQueries: option },
+            saved === undefined
+              ? {}
+              : { 'TanstackQueryDevtools.hideDisabledQueries': saved },
+          )
+          expect(
+            rendered.queryByLabelText(/Query key \["disabled-option"\]/) === null,
+          ).toBe(hidden)
+          expect(
+            rendered.getByLabelText(/Query key \["visible-option"\]/),
+          ).toBeInTheDocument()
+        } finally {
+          unsubscribe()
+        }
+      },
+    )
+
     it('should hide disabled queries when "hideDisabledQueries" is enabled in localStorage', () => {
       const disabled = new QueryObserver(queryClient, {
         queryKey: ['hide-test-disabled'],


### PR DESCRIPTION
## 🎯 Changes

`TanstackQueryDevtools` forwards `hideDisabledQueries` into the devtools context, but the query list filtering in `Devtools.tsx` was only reading `props.localStore.hideDisabledQueries`. Consequently, passing `hideDisabledQueries: true` was ignored when no preference was previously saved to `localStore`.

- Fall back to the context `hideDisabledQueries` option when no preference is saved in `localStore`.
- Preserve user preference priority: any saved Show/Hide selection in the devtools settings dropdown takes precedence.
- Synchronize the settings menu state with the effective visibility preference.
- Update devtools documentation to describe the option default and saved preference precedence.
- Add unit tests verifying both initial option states and localStorage override behavior.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Devtools now consistently honors the saved Show/Hide Disabled Queries preference.
  * When no saved preference exists, the configured `hideDisabledQueries` option is applied across query filtering and settings indicators.

* **Documentation**
  * Clarified that a saved Show/Hide preference takes precedence over the default `hideDisabledQueries` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->