### PR TITLE
test(angular-query-experimental/inject-infinite-query): add runtime and type tests for 'skipToken' dependent query

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test-d.ts
@@ -2,7 +2,12 @@ import { TestBed } from '@angular/core/testing'
 import { afterEach, beforeEach, describe, expectTypeOf, it, vi } from 'vitest'
 import { provideZonelessChangeDetection } from '@angular/core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryClient, injectInfiniteQuery, provideTanStackQuery } from '..'
+import {
+  QueryClient,
+  injectInfiniteQuery,
+  provideTanStackQuery,
+  skipToken,
+} from '..'
 import type { InfiniteData } from '@tanstack/query-core'
 
 describe('injectInfiniteQuery', () => {
@@ -39,5 +44,23 @@ describe('injectInfiniteQuery', () => {
       const data = query.data()
       expectTypeOf(data).toEqualTypeOf<InfiniteData<string, unknown>>()
     }
+  })
+
+  it('should work when queryFn is skipToken', () => {
+    const key = queryKey()
+    const query = TestBed.runInInjectionContext(() => {
+      return injectInfiniteQuery(() => ({
+        queryKey: key,
+        queryFn: skipToken,
+        initialPageParam: 0,
+        getNextPageParam: () => 1,
+      }))
+    })
+
+    // TPageParam falls back to `unknown` here (unlike `infiniteQueryOptions`, which infers
+    // `number` for the same options) because there's no skipToken-specific overload to carry it.
+    expectTypeOf(query.data()).toEqualTypeOf<
+      InfiniteData<unknown, unknown> | undefined
+    >()
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -125,7 +125,7 @@ describe('injectInfiniteQuery', () => {
         postId = signal<string | undefined>(undefined)
 
         readonly query = injectInfiniteQuery(() => ({
-          queryKey: [...key, this.postId()],
+          queryKey: key,
           queryFn:
             this.postId() != null
               ? ({ pageParam }: { pageParam: number }) =>

--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -4,10 +4,16 @@ import {
   Component,
   Injector,
   provideZonelessChangeDetection,
+  signal,
 } from '@angular/core'
 import { render } from '@testing-library/angular'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { QueryClient, injectInfiniteQuery, provideTanStackQuery } from '..'
+import {
+  QueryClient,
+  injectInfiniteQuery,
+  provideTanStackQuery,
+  skipToken,
+} from '..'
 
 describe('injectInfiniteQuery', () => {
   let queryClient: QueryClient
@@ -102,6 +108,57 @@ describe('injectInfiniteQuery', () => {
     expect(rendered.getByText('error: Some error')).toBeInTheDocument()
     expect(rendered.getByText('isError: true')).toBeInTheDocument()
     expect(rendered.getByText('failureCount: 1')).toBeInTheDocument()
+  })
+
+  describe('skipToken', () => {
+    it('should not fetch when queryFn is skipToken, and fetch once it is replaced', async () => {
+      const key = queryKey()
+
+      @Component({
+        template: `
+          <div>status: {{ query.status() }}</div>
+          <div>isFetching: {{ query.isFetching() }}</div>
+          <div>pages: {{ query.data()?.pages?.join(', ') ?? 'none' }}</div>
+        `,
+      })
+      class Page {
+        postId = signal<string | undefined>(undefined)
+
+        readonly query = injectInfiniteQuery(() => ({
+          queryKey: [...key, this.postId()],
+          queryFn:
+            this.postId() != null
+              ? ({ pageParam }: { pageParam: number }) =>
+                  sleep(10).then(
+                    () => `comments for ${this.postId()} page ${pageParam}`,
+                  )
+              : skipToken,
+          initialPageParam: 0,
+          getNextPageParam: () => 12,
+        }))
+      }
+
+      const rendered = await render(Page)
+
+      expect(rendered.getByText('status: pending')).toBeInTheDocument()
+      expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
+
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+      expect(rendered.getByText('status: pending')).toBeInTheDocument()
+      expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
+
+      rendered.fixture.componentInstance.postId.set('1')
+      rendered.fixture.detectChanges()
+      expect(rendered.getByText('isFetching: true')).toBeInTheDocument()
+
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+      expect(rendered.getByText('status: success')).toBeInTheDocument()
+      expect(
+        rendered.getByText('pages: comments for 1 page 0'),
+      ).toBeInTheDocument()
+    })
   })
 
   describe('injection context', () => {


### PR DESCRIPTION
## 🎯 Changes

Add test coverage for `injectInfiniteQuery` with `queryFn: skipToken`, which had no coverage in this file:

- Runtime test (`inject-infinite-query.test.ts`): a dependent infinite query stays `pending` and does not fetch while `queryFn` is `skipToken`, then fetches once it's replaced with a real query function.
- Type test (`inject-infinite-query.test-d.ts`): `data()` is typed as `InfiniteData<unknown, unknown> | undefined` when `queryFn` is `skipToken`. A comment notes that `TPageParam` falls back to `unknown` here (unlike `infiniteQueryOptions`, which infers a concrete `TPageParam` for the same options) because `injectInfiniteQuery` has no `skipToken`-specific overload to carry it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming infinite queries can remain disabled with `skipToken`.
  - Verified no fetch occurs while skipped, and fetching begins successfully when the required signal value becomes available.
  - Added type-level validation for skipped infinite queries and their resulting data type.
  - Confirmed the query transitions from pending to successful after the required value is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->