### PR TITLE
test(angular-query-experimental/inject-mutation): add tests for optimistic update rollback, concurrent 'mutate'/'mutateAsync' calls, and 'TOnMutateResult' type inference

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
@@ -73,6 +73,23 @@ describe('injectMutation', () => {
     })
   })
 
+  it('should infer TOnMutateResult from onMutate return type', () => {
+    injectMutation(() => ({
+      mutationFn: () => sleep(0).then(() => 'string'),
+      onMutate: () => {
+        return { token: 'abc' }
+      },
+      onSuccess: (_data, _variables, onMutateResult) => {
+        expectTypeOf(onMutateResult).toEqualTypeOf<{ token: string }>()
+      },
+      onError: (_error, _variables, onMutateResult) => {
+        expectTypeOf(onMutateResult).toEqualTypeOf<
+          { token: string } | undefined
+        >()
+      },
+    }))
+  })
+
   it('should allow calling mutate with no arguments when TVariables is optional undefinable', () => {
     const mutation = injectMutation(() => ({
       mutationFn: (_variables: number | undefined) => sleep(0).then(() => 1),

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -755,4 +755,157 @@ describe('injectMutation', () => {
       expect(mutation.data()).toBe('processed: test')
     })
   })
+
+  describe('optimistic updates', () => {
+    it('should update the cache in onMutate and roll back via onMutateResult in onError', async () => {
+      const key = queryKey()
+      queryClient.setQueryData<Array<string>>(key, ['Todo 1'])
+
+      @Component({
+        template: `<div>isError: {{ mutation.isError() }}</div>`,
+      })
+      class Page {
+        readonly mutation = injectMutation(() => ({
+          mutationFn: () =>
+            sleep(10).then(() => Promise.reject(new Error('Some error'))),
+          onMutate: async (newTodo: string) => {
+            await queryClient.cancelQueries({ queryKey: key })
+            const previousTodos = queryClient.getQueryData<Array<string>>(key)
+
+            queryClient.setQueryData<Array<string>>(key, (old) => [
+              ...(old ?? []),
+              newTodo,
+            ])
+
+            return { previousTodos }
+          },
+          onError: (_err, _newTodo, onMutateResult) => {
+            queryClient.setQueryData(key, onMutateResult?.previousTodos)
+          },
+        }))
+      }
+
+      const rendered = await render(Page)
+
+      rendered.fixture.componentInstance.mutation.mutate('Todo 2')
+      // onMutate runs synchronously up to its first await, so the optimistic
+      // value is visible immediately, before the mutationFn settles.
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(queryClient.getQueryData(key)).toEqual(['Todo 1', 'Todo 2'])
+
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+
+      expect(rendered.getByText('isError: true')).toBeInTheDocument()
+      expect(queryClient.getQueryData(key)).toEqual(['Todo 1'])
+    })
+
+    it('should keep the optimistic update in place when the mutation succeeds', async () => {
+      const key = queryKey()
+      queryClient.setQueryData<Array<string>>(key, ['Todo 1'])
+
+      @Component({
+        template: `<div>isSuccess: {{ mutation.isSuccess() }}</div>`,
+      })
+      class Page {
+        readonly mutation = injectMutation(() => ({
+          mutationFn: (newTodo: string) => sleep(10).then(() => newTodo),
+          onMutate: async (newTodo: string) => {
+            await queryClient.cancelQueries({ queryKey: key })
+            const previousTodos = queryClient.getQueryData<Array<string>>(key)
+
+            queryClient.setQueryData<Array<string>>(key, (old) => [
+              ...(old ?? []),
+              newTodo,
+            ])
+
+            return { previousTodos }
+          },
+          onError: (_err, _newTodo, onMutateResult) => {
+            queryClient.setQueryData(key, onMutateResult?.previousTodos)
+          },
+        }))
+      }
+
+      const rendered = await render(Page)
+
+      rendered.fixture.componentInstance.mutation.mutate('Todo 2')
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+
+      expect(rendered.getByText('isSuccess: true')).toBeInTheDocument()
+      expect(queryClient.getQueryData(key)).toEqual(['Todo 1', 'Todo 2'])
+    })
+  })
+
+  describe('concurrent mutate calls', () => {
+    it('should report each mutateAsync call result independently when some fail', async () => {
+      @Component({
+        template: `<div>isPending: {{ mutation.isPending() }}</div>`,
+      })
+      class Page {
+        readonly mutation = injectMutation(() => ({
+          mutationFn: (todo: string) =>
+            todo === 'bad'
+              ? sleep(10).then(() => Promise.reject(new Error('Some error')))
+              : sleep(10).then(() => todo),
+        }))
+      }
+
+      const rendered = await render(Page)
+      const todos = ['Todo 1', 'bad', 'Todo 3']
+
+      expect(rendered.getByText('isPending: false')).toBeInTheDocument()
+
+      const settledPromise = Promise.allSettled(
+        todos.map((todo) =>
+          rendered.fixture.componentInstance.mutation.mutateAsync(todo),
+        ),
+      )
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+      const results = await settledPromise
+
+      expect(results).toEqual([
+        { status: 'fulfilled', value: 'Todo 1' },
+        { status: 'rejected', reason: Error('Some error') },
+        { status: 'fulfilled', value: 'Todo 3' },
+      ])
+      expect(rendered.getByText('isPending: false')).toBeInTheDocument()
+    })
+
+    it('should only fire the per-call onSuccess for the last mutate() call', async () => {
+      const onSuccessPerCall = vi.fn()
+
+      @Component({
+        template: `<div>data: {{ mutation.data() ?? 'none' }}</div>`,
+      })
+      class Page {
+        readonly mutation = injectMutation(() => ({
+          mutationFn: (todo: string) => sleep(10).then(() => todo),
+        }))
+      }
+
+      const rendered = await render(Page)
+
+      rendered.fixture.componentInstance.mutation.mutate('Todo 1', {
+        onSuccess: onSuccessPerCall,
+      })
+      rendered.fixture.componentInstance.mutation.mutate('Todo 2', {
+        onSuccess: onSuccessPerCall,
+      })
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+
+      expect(onSuccessPerCall).toHaveBeenCalledTimes(1)
+      expect(onSuccessPerCall).toHaveBeenCalledWith(
+        'Todo 2',
+        'Todo 2',
+        undefined,
+        expect.anything(),
+      )
+      expect(rendered.getByText('data: Todo 2')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -863,6 +863,11 @@ describe('injectMutation', () => {
           rendered.fixture.componentInstance.mutation.mutateAsync(todo),
         ),
       )
+      await vi.advanceTimersByTimeAsync(0)
+      rendered.fixture.detectChanges()
+
+      expect(rendered.getByText('isPending: true')).toBeInTheDocument()
+
       await vi.advanceTimersByTimeAsync(11)
       rendered.fixture.detectChanges()
       const results = await settledPromise


### PR DESCRIPTION
## 🎯 Changes

Add test coverage for `injectMutation` scenarios that had no coverage in this file (mirroring vue-query's #11403):

- `optimistic updates`: cache is updated in `onMutate` and rolled back via `onMutateResult` in `onError`; the optimistic value stays in place when the mutation succeeds instead.
- `concurrent mutate calls`: `mutateAsync` calls settle independently when some fail; only the per-call `onSuccess` of the last `mutate()` call fires.
- Type test (`inject-mutation.test-d.ts`): `TOnMutateResult` (the return type of `onMutate`) is correctly inferred as the third argument of `onSuccess`/`onError`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for optimistic updates, including query-cache updates, rollback behavior after errors, and persistence after successful mutations.
  - Added coverage for concurrent mutation calls, confirming independent results, accurate pending-state transitions, and per-call success callback behavior.
  - Added type inference checks to ensure mutation lifecycle callbacks receive the context returned by the mutation’s preparation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->