### PR TITLE
docs(angular-query-experimental): add 'readonly' to class fields in JSDoc examples

### DIFF
--- a/docs/framework/angular/reference/functions/infiniteQueryOptions.md
+++ b/docs/framework/angular/reference/functions/infiniteQueryOptions.md
@@ -90,7 +90,7 @@ export const projectsOptions = infiniteQueryOptions({
   `,
 })
 export class Projects {
-  projectsQuery = injectInfiniteQuery(() => projectsOptions)
+  readonly projectsQuery = injectInfiniteQuery(() => projectsOptions)
 }
 ```
 
@@ -180,8 +180,8 @@ export const commentsOptions = (postId: string) =>
   `,
 })
 export class Comments {
-  postId = signal('1')
-  commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
+  readonly postId = signal('1')
+  readonly commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
 }
 ```
 
@@ -275,8 +275,8 @@ export const commentsOptions = (postId: string) =>
   `,
 })
 export class Comments {
-  postId = signal('1')
-  commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
+  readonly postId = signal('1')
+  readonly commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
 }
 ```
 

--- a/docs/framework/angular/reference/functions/injectInfiniteQuery.md
+++ b/docs/framework/angular/reference/functions/injectInfiniteQuery.md
@@ -94,7 +94,7 @@ like `queryClient.fetchInfiniteQuery`.
   `,
 })
 export class Projects {
-  projectsQuery = injectInfiniteQuery(() => ({
+  readonly projectsQuery = injectInfiniteQuery(() => ({
     queryKey: ['projects'],
     queryFn: ({ pageParam }) => fetchProjects(pageParam),
     initialPageParam: 0,
@@ -198,7 +198,7 @@ Fetching the next page from a button click:
   `,
 })
 export class ProjectsList {
-  projectsQuery = injectInfiniteQuery(() => ({
+  readonly projectsQuery = injectInfiniteQuery(() => ({
     queryKey: ['projects'],
     queryFn: ({ pageParam }) => fetchProjects(pageParam),
     initialPageParam: 0,
@@ -224,9 +224,9 @@ element after the list:
   `,
 })
 export class ProjectsList {
-  sentinel = viewChild<ElementRef<HTMLElement>>('sentinel')
+  readonly sentinel = viewChild<ElementRef<HTMLElement>>('sentinel')
 
-  projectsQuery = injectInfiniteQuery(() => ({
+  readonly projectsQuery = injectInfiniteQuery(() => ({
     queryKey: ['projects'],
     queryFn: ({ pageParam }) => fetchProjects(pageParam),
     initialPageParam: 0,
@@ -279,9 +279,9 @@ setting `enabled: false`:
   `,
 })
 export class Comments {
-  postId = signal<string | undefined>(undefined)
+  readonly postId = signal<string | undefined>(undefined)
 
-  commentsQuery = injectInfiniteQuery(() => ({
+  readonly commentsQuery = injectInfiniteQuery(() => ({
     queryKey: ['post', this.postId(), 'comments'],
     queryFn:
       this.postId() != null

--- a/docs/framework/angular/reference/functions/injectIsFetching.md
+++ b/docs/framework/angular/reference/functions/injectIsFetching.md
@@ -46,7 +46,7 @@ the background.
 })
 export class PostsFetchingIndicator {
   // How many queries matching the posts prefix are fetching?
-  isFetchingPosts = injectIsFetching({ queryKey: ['posts'] })
+  readonly isFetchingPosts = injectIsFetching({ queryKey: ['posts'] })
 }
 ```
 
@@ -61,6 +61,6 @@ A global loading indicator for any query fetching in the background, not just th
   `,
 })
 export class GlobalLoadingIndicator {
-  isFetching = injectIsFetching()
+  readonly isFetching = injectIsFetching()
 }
 ```

--- a/docs/framework/angular/reference/functions/injectIsMutating.md
+++ b/docs/framework/angular/reference/functions/injectIsMutating.md
@@ -45,6 +45,6 @@ A `Signal` with the number of mutations that your application currently has `pen
 })
 export class PostsMutatingIndicator {
   // How many mutations matching the posts prefix are in progress?
-  isMutatingPosts = injectIsMutating({ mutationKey: ['posts'] })
+  readonly isMutatingPosts = injectIsMutating({ mutationKey: ['posts'] })
 }
 ```

--- a/docs/framework/angular/reference/functions/injectMutation.md
+++ b/docs/framework/angular/reference/functions/injectMutation.md
@@ -82,9 +82,9 @@ the mutation up elsewhere via its `mutationKey` (e.g. with `injectMutationState`
   `,
 })
 export class Todos {
-  #queryClient = inject(QueryClient)
+  readonly #queryClient = inject(QueryClient)
 
-  addMutation = injectMutation(() => ({
+  readonly addMutation = injectMutation(() => ({
     mutationFn: addTodo,
     onSuccess: () => this.#queryClient.invalidateQueries({ queryKey: ['todos'] }),
   }))
@@ -98,9 +98,9 @@ Optimistic update via `onMutate`, rolling back on `onError`:
   template: `<button (click)="addMutation.mutate('Item')">Add</button>`,
 })
 export class Todos {
-  #queryClient = inject(QueryClient)
+  readonly #queryClient = inject(QueryClient)
 
-  addMutation = injectMutation(() => ({
+  readonly addMutation = injectMutation(() => ({
     mutationFn: addTodo,
     onMutate: async (newTodo) => {
       await this.#queryClient.cancelQueries({ queryKey: ['todos'] })
@@ -134,9 +134,9 @@ call instead, so you can wait for all of them:
   `,
 })
 export class Todos {
-  #queryClient = inject(QueryClient)
+  readonly #queryClient = inject(QueryClient)
 
-  addMutation = injectMutation(() => ({
+  readonly addMutation = injectMutation(() => ({
     mutationFn: addTodo,
     onSuccess: () => this.#queryClient.invalidateQueries({ queryKey: ['todos'] }),
   }))
@@ -162,9 +162,9 @@ rather than losing that information the moment the first one rejects — swap `P
   `,
 })
 export class Todos {
-  #queryClient = inject(QueryClient)
+  readonly #queryClient = inject(QueryClient)
 
-  addMutation = injectMutation(() => ({
+  readonly addMutation = injectMutation(() => ({
     mutationFn: addTodo,
     onSuccess: () => this.#queryClient.invalidateQueries({ queryKey: ['todos'] }),
   }))

--- a/docs/framework/angular/reference/functions/injectMutationState.md
+++ b/docs/framework/angular/reference/functions/injectMutationState.md
@@ -49,7 +49,7 @@ Get all variables of all running mutations:
   template: `{{ pendingVariables().length }} posts saving...`,
 })
 export class PendingPosts {
-  pendingVariables = injectMutationState(() => ({
+  readonly pendingVariables = injectMutationState(() => ({
     filters: { status: 'pending' },
     select: (mutation) => mutation.state.variables,
   }))
@@ -70,12 +70,12 @@ const mutationKey = ['posts']
 })
 export class Posts {
   // Some mutation that we want to get the state for
-  createPostMutation = injectMutation(() => ({
+  readonly createPostMutation = injectMutation(() => ({
     mutationKey,
     mutationFn: createPosts,
   }))
 
-  savedPosts = injectMutationState(() => ({
+  readonly savedPosts = injectMutationState(() => ({
     // this mutation key needs to match the mutation key of the given mutation (see above)
     filters: { mutationKey, status: 'success' },
     select: (mutation) => mutation.state.data,

--- a/docs/framework/angular/reference/functions/injectQuery.md
+++ b/docs/framework/angular/reference/functions/injectQuery.md
@@ -80,7 +80,7 @@ include `undefined`).
   `,
 })
 export class Posts {
-  postsQuery = injectQuery(() => ({
+  readonly postsQuery = injectQuery(() => ({
     queryKey: ['posts'],
     queryFn: fetchPosts,
     initialData: [],
@@ -166,7 +166,7 @@ the last fetch attempt failed, or `'success'` if the query has data to display. 
   `,
 })
 export class Posts {
-  postsQuery = injectQuery(() => ({
+  readonly postsQuery = injectQuery(() => ({
     queryKey: ['posts'],
     queryFn: fetchPosts,
   }))
@@ -195,9 +195,9 @@ truthy value. When the filter signal changes back to a falsy value, the query is
   `,
 })
 export class Posts {
-  filter = signal('')
+  readonly filter = signal('')
 
-  postsQuery = injectQuery(() => ({
+  readonly postsQuery = injectQuery(() => ({
     queryKey: ['posts', this.filter()],
     queryFn: () => fetchPosts(this.filter()),
     // Signals can be combined with expressions

--- a/docs/framework/angular/reference/functions/mutationOptions.md
+++ b/docs/framework/angular/reference/functions/mutationOptions.md
@@ -72,10 +72,10 @@ const createPostOptions = mutationOptions({
   `,
 })
 export class SavingIndicator {
-  #pendingCreates = injectMutationState(() => ({
+  readonly #pendingCreates = injectMutationState(() => ({
     filters: { mutationKey: createPostOptions.mutationKey, status: 'pending' },
   }))
-  isCreatingPost = computed(() => this.#pendingCreates().length > 0)
+  readonly isCreatingPost = computed(() => this.#pendingCreates().length > 0)
 }
 ```
 
@@ -141,7 +141,7 @@ import { mutationOptions, injectMutation } from '@tanstack/angular-query-experim
 
 @Injectable({ providedIn: 'root' })
 export class QueriesService {
-  #queryClient = inject(QueryClient)
+  readonly #queryClient = inject(QueryClient)
 
   updatePost(id: number) {
     return mutationOptions({
@@ -156,9 +156,9 @@ export class QueriesService {
   template: `<button (click)="save()">Save</button>`,
 })
 export class Post {
-  queries = inject(QueriesService)
-  id = signal(0)
-  updatePostMutation = injectMutation(() => this.queries.updatePost(this.id()))
+  readonly queries = inject(QueriesService)
+  readonly id = signal(0)
+  readonly updatePostMutation = injectMutation(() => this.queries.updatePost(this.id()))
 
   save() {
     this.updatePostMutation.mutate({ title: 'New Title' })

--- a/docs/framework/angular/reference/functions/queryOptions.md
+++ b/docs/framework/angular/reference/functions/queryOptions.md
@@ -81,7 +81,7 @@ export const postsOptions = queryOptions({
   `,
 })
 export class Posts {
-  postsQuery = injectQuery(() => postsOptions)
+  readonly postsQuery = injectQuery(() => postsOptions)
 }
 ```
 
@@ -157,8 +157,8 @@ export const postOptions = (id: string) =>
   `,
 })
 export class Post {
-  id = signal('1')
-  postQuery = injectQuery(() => postOptions(this.id()))
+  readonly id = signal('1')
+  readonly postQuery = injectQuery(() => postOptions(this.id()))
 }
 ```
 
@@ -238,8 +238,8 @@ export const postOptions = (id: string) =>
   `,
 })
 export class Post {
-  id = signal('1')
-  postQuery = injectQuery(() => postOptions(this.id()))
+  readonly id = signal('1')
+  readonly postQuery = injectQuery(() => postOptions(this.id()))
 }
 ```
 
@@ -268,7 +268,7 @@ export const postOptions = (postId: number | undefined) =>
   `,
 })
 export class Post {
-  postId = signal<number | undefined>(undefined)
-  postQuery = injectQuery(() => postOptions(this.postId()))
+  readonly postId = signal<number | undefined>(undefined)
+  readonly postQuery = injectQuery(() => postOptions(this.postId()))
 }
 ```

--- a/packages/angular-query-experimental/src/infinite-query-options.ts
+++ b/packages/angular-query-experimental/src/infinite-query-options.ts
@@ -174,7 +174,7 @@ export type DefinedInitialDataInfiniteOptions<
  *   `,
  * })
  * export class Projects {
- *   projectsQuery = injectInfiniteQuery(() => projectsOptions)
+ *   readonly projectsQuery = injectInfiniteQuery(() => projectsOptions)
  * }
  * ```
  */
@@ -243,8 +243,8 @@ export function infiniteQueryOptions<
  *   `,
  * })
  * export class Comments {
- *   postId = signal('1')
- *   commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
+ *   readonly postId = signal('1')
+ *   readonly commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
  * }
  * ```
  *
@@ -317,8 +317,8 @@ export function infiniteQueryOptions<
  *   `,
  * })
  * export class Comments {
- *   postId = signal('1')
- *   commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
+ *   readonly postId = signal('1')
+ *   readonly commentsQuery = injectInfiniteQuery(() => commentsOptions(this.postId()))
  * }
  * ```
  *

--- a/packages/angular-query-experimental/src/inject-infinite-query.ts
+++ b/packages/angular-query-experimental/src/inject-infinite-query.ts
@@ -70,7 +70,7 @@ export interface InjectInfiniteQueryOptions {
  *   `,
  * })
  * export class Projects {
- *   projectsQuery = injectInfiniteQuery(() => ({
+ *   readonly projectsQuery = injectInfiniteQuery(() => ({
  *     queryKey: ['projects'],
  *     queryFn: ({ pageParam }) => fetchProjects(pageParam),
  *     initialPageParam: 0,
@@ -139,7 +139,7 @@ export function injectInfiniteQuery<
  *   `,
  * })
  * export class ProjectsList {
- *   projectsQuery = injectInfiniteQuery(() => ({
+ *   readonly projectsQuery = injectInfiniteQuery(() => ({
  *     queryKey: ['projects'],
  *     queryFn: ({ pageParam }) => fetchProjects(pageParam),
  *     initialPageParam: 0,
@@ -166,9 +166,9 @@ export function injectInfiniteQuery<
  *   `,
  * })
  * export class ProjectsList {
- *   sentinel = viewChild<ElementRef<HTMLElement>>('sentinel')
+ *   readonly sentinel = viewChild<ElementRef<HTMLElement>>('sentinel')
  *
- *   projectsQuery = injectInfiniteQuery(() => ({
+ *   readonly projectsQuery = injectInfiniteQuery(() => ({
  *     queryKey: ['projects'],
  *     queryFn: ({ pageParam }) => fetchProjects(pageParam),
  *     initialPageParam: 0,
@@ -222,9 +222,9 @@ export function injectInfiniteQuery<
  *   `,
  * })
  * export class Comments {
- *   postId = signal<string | undefined>(undefined)
+ *   readonly postId = signal<string | undefined>(undefined)
  *
- *   commentsQuery = injectInfiniteQuery(() => ({
+ *   readonly commentsQuery = injectInfiniteQuery(() => ({
  *     queryKey: ['post', this.postId(), 'comments'],
  *     queryFn:
  *       this.postId() != null

--- a/packages/angular-query-experimental/src/inject-is-fetching.ts
+++ b/packages/angular-query-experimental/src/inject-is-fetching.ts
@@ -40,7 +40,7 @@ export interface InjectIsFetchingOptions {
  * })
  * export class PostsFetchingIndicator {
  *   // How many queries matching the posts prefix are fetching?
- *   isFetchingPosts = injectIsFetching({ queryKey: ['posts'] })
+ *   readonly isFetchingPosts = injectIsFetching({ queryKey: ['posts'] })
  * }
  * ```
  *
@@ -56,7 +56,7 @@ export interface InjectIsFetchingOptions {
  *   `,
  * })
  * export class GlobalLoadingIndicator {
- *   isFetching = injectIsFetching()
+ *   readonly isFetching = injectIsFetching()
  * }
  * ```
  */

--- a/packages/angular-query-experimental/src/inject-is-mutating.ts
+++ b/packages/angular-query-experimental/src/inject-is-mutating.ts
@@ -39,7 +39,7 @@ export interface InjectIsMutatingOptions {
  * })
  * export class PostsMutatingIndicator {
  *   // How many mutations matching the posts prefix are in progress?
- *   isMutatingPosts = injectIsMutating({ mutationKey: ['posts'] })
+ *   readonly isMutatingPosts = injectIsMutating({ mutationKey: ['posts'] })
  * }
  * ```
  */

--- a/packages/angular-query-experimental/src/inject-mutation-state.ts
+++ b/packages/angular-query-experimental/src/inject-mutation-state.ts
@@ -64,7 +64,7 @@ export interface InjectMutationStateOptions {
  *   template: `{{ pendingVariables().length }} posts saving...`,
  * })
  * export class PendingPosts {
- *   pendingVariables = injectMutationState(() => ({
+ *   readonly pendingVariables = injectMutationState(() => ({
  *     filters: { status: 'pending' },
  *     select: (mutation) => mutation.state.variables,
  *   }))
@@ -86,12 +86,12 @@ export interface InjectMutationStateOptions {
  * })
  * export class Posts {
  *   // Some mutation that we want to get the state for
- *   createPostMutation = injectMutation(() => ({
+ *   readonly createPostMutation = injectMutation(() => ({
  *     mutationKey,
  *     mutationFn: createPosts,
  *   }))
  *
- *   savedPosts = injectMutationState(() => ({
+ *   readonly savedPosts = injectMutationState(() => ({
  *     // this mutation key needs to match the mutation key of the given mutation (see above)
  *     filters: { mutationKey, status: 'success' },
  *     select: (mutation) => mutation.state.data,

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -67,9 +67,9 @@ export interface InjectMutationOptions {
  *   `,
  * })
  * export class Todos {
- *   #queryClient = inject(QueryClient)
+ *   readonly #queryClient = inject(QueryClient)
  *
- *   addMutation = injectMutation(() => ({
+ *   readonly addMutation = injectMutation(() => ({
  *     mutationFn: addTodo,
  *     onSuccess: () => this.#queryClient.invalidateQueries({ queryKey: ['todos'] }),
  *   }))
@@ -84,9 +84,9 @@ export interface InjectMutationOptions {
  *   template: `<button (click)="addMutation.mutate('Item')">Add</button>`,
  * })
  * export class Todos {
- *   #queryClient = inject(QueryClient)
+ *   readonly #queryClient = inject(QueryClient)
  *
- *   addMutation = injectMutation(() => ({
+ *   readonly addMutation = injectMutation(() => ({
  *     mutationFn: addTodo,
  *     onMutate: async (newTodo) => {
  *       await this.#queryClient.cancelQueries({ queryKey: ['todos'] })
@@ -121,9 +121,9 @@ export interface InjectMutationOptions {
  *   `,
  * })
  * export class Todos {
- *   #queryClient = inject(QueryClient)
+ *   readonly #queryClient = inject(QueryClient)
  *
- *   addMutation = injectMutation(() => ({
+ *   readonly addMutation = injectMutation(() => ({
  *     mutationFn: addTodo,
  *     onSuccess: () => this.#queryClient.invalidateQueries({ queryKey: ['todos'] }),
  *   }))
@@ -150,9 +150,9 @@ export interface InjectMutationOptions {
  *   `,
  * })
  * export class Todos {
- *   #queryClient = inject(QueryClient)
+ *   readonly #queryClient = inject(QueryClient)
  *
- *   addMutation = injectMutation(() => ({
+ *   readonly addMutation = injectMutation(() => ({
  *     mutationFn: addTodo,
  *     onSuccess: () => this.#queryClient.invalidateQueries({ queryKey: ['todos'] }),
  *   }))

--- a/packages/angular-query-experimental/src/inject-queries.ts
+++ b/packages/angular-query-experimental/src/inject-queries.ts
@@ -278,9 +278,9 @@ export interface InjectQueriesOptions<
  *   `,
  * })
  * export class Posts {
- *   ids = signal([1, 2, 3])
+ *   readonly ids = signal([1, 2, 3])
  *
- *   postQueries = injectQueries(() => ({
+ *   readonly postQueries = injectQueries(() => ({
  *     queries: this.ids().map((id) => ({
  *       queryKey: ['post', id],
  *       queryFn: () => fetchPost(id),
@@ -310,9 +310,9 @@ export interface InjectQueriesOptions<
  *   `,
  * })
  * export class Posts {
- *   ids = signal([1, 2, 3])
+ *   readonly ids = signal([1, 2, 3])
  *
- *   combined = injectQueries(() => ({
+ *   readonly combined = injectQueries(() => ({
  *     queries: this.ids().map((id) => ({
  *       queryKey: ['post', id],
  *       queryFn: () => fetchPost(id),
@@ -342,9 +342,9 @@ export interface InjectQueriesOptions<
  *   template: `<h1>{{ fixed()[0].data() }}</h1>`,
  * })
  * export class PostTitle {
- *   id = signal(1)
+ *   readonly id = signal(1)
  *
- *   broken = injectQueries(() => ({
+ *   readonly broken = injectQueries(() => ({
  *     queries: [
  *       {
  *         ...postOptions(this.id()),
@@ -354,7 +354,7 @@ export interface InjectQueriesOptions<
  *     ],
  *   }))
  *
- *   fixed = injectQueries(() => ({
+ *   readonly fixed = injectQueries(() => ({
  *     queries: [
  *       queryOptions({
  *         ...postOptions(this.id()),

--- a/packages/angular-query-experimental/src/inject-query.ts
+++ b/packages/angular-query-experimental/src/inject-query.ts
@@ -58,7 +58,7 @@ export interface InjectQueryOptions {
  *   `,
  * })
  * export class Posts {
- *   postsQuery = injectQuery(() => ({
+ *   readonly postsQuery = injectQuery(() => ({
  *     queryKey: ['posts'],
  *     queryFn: fetchPosts,
  *     initialData: [],
@@ -114,7 +114,7 @@ export function injectQuery<
  *   `,
  * })
  * export class Posts {
- *   postsQuery = injectQuery(() => ({
+ *   readonly postsQuery = injectQuery(() => ({
  *     queryKey: ['posts'],
  *     queryFn: fetchPosts,
  *   }))
@@ -144,9 +144,9 @@ export function injectQuery<
  *   `,
  * })
  * export class Posts {
- *   filter = signal('')
+ *   readonly filter = signal('')
  *
- *   postsQuery = injectQuery(() => ({
+ *   readonly postsQuery = injectQuery(() => ({
  *     queryKey: ['posts', this.filter()],
  *     queryFn: () => fetchPosts(this.filter()),
  *     // Signals can be combined with expressions

--- a/packages/angular-query-experimental/src/mutation-options.ts
+++ b/packages/angular-query-experimental/src/mutation-options.ts
@@ -30,10 +30,10 @@ import type { CreateMutationOptions } from './types'
  *   `,
  * })
  * export class SavingIndicator {
- *   #pendingCreates = injectMutationState(() => ({
+ *   readonly #pendingCreates = injectMutationState(() => ({
  *     filters: { mutationKey: createPostOptions.mutationKey, status: 'pending' },
  *   }))
- *   isCreatingPost = computed(() => this.#pendingCreates().length > 0)
+ *   readonly isCreatingPost = computed(() => this.#pendingCreates().length > 0)
  * }
  * ```
  */
@@ -70,7 +70,7 @@ export function mutationOptions<
  *
  * @Injectable({ providedIn: 'root' })
  * export class QueriesService {
- *   #queryClient = inject(QueryClient)
+ *   readonly #queryClient = inject(QueryClient)
  *
  *   updatePost(id: number) {
  *     return mutationOptions({
@@ -85,9 +85,9 @@ export function mutationOptions<
  *   template: `<button (click)="save()">Save</button>`,
  * })
  * export class Post {
- *   queries = inject(QueriesService)
- *   id = signal(0)
- *   updatePostMutation = injectMutation(() => this.queries.updatePost(this.id()))
+ *   readonly queries = inject(QueriesService)
+ *   readonly id = signal(0)
+ *   readonly updatePostMutation = injectMutation(() => this.queries.updatePost(this.id()))
  *
  *   save() {
  *     this.updatePostMutation.mutate({ title: 'New Title' })

--- a/packages/angular-query-experimental/src/query-options.ts
+++ b/packages/angular-query-experimental/src/query-options.ts
@@ -144,7 +144,7 @@ export type DefinedInitialDataOptions<
  *   `,
  * })
  * export class Posts {
- *   postsQuery = injectQuery(() => postsOptions)
+ *   readonly postsQuery = injectQuery(() => postsOptions)
  * }
  * ```
  */
@@ -192,8 +192,8 @@ export function queryOptions<
  *   `,
  * })
  * export class Post {
- *   id = signal('1')
- *   postQuery = injectQuery(() => postOptions(this.id()))
+ *   readonly id = signal('1')
+ *   readonly postQuery = injectQuery(() => postOptions(this.id()))
  * }
  * ```
  */
@@ -242,8 +242,8 @@ export function queryOptions<
  *   `,
  * })
  * export class Post {
- *   id = signal('1')
- *   postQuery = injectQuery(() => postOptions(this.id()))
+ *   readonly id = signal('1')
+ *   readonly postQuery = injectQuery(() => postOptions(this.id()))
  * }
  * ```
  *
@@ -273,8 +273,8 @@ export function queryOptions<
  *   `,
  * })
  * export class Post {
- *   postId = signal<number | undefined>(undefined)
- *   postQuery = injectQuery(() => postOptions(this.postId()))
+ *   readonly postId = signal<number | undefined>(undefined)
+ *   readonly postQuery = injectQuery(() => postOptions(this.postId()))
  * }
  * ```
  */


### PR DESCRIPTION
## 🎯 Changes

Add `readonly` to component class fields in JSDoc `@example` blocks across `angular-query-experimental`.

The [Angular style guide](https://angular.dev/style-guide) explicitly recommends marking properties initialized by `input`/`model`/`output`/queries as `readonly`, which covers the `signal`, `viewChild`, and `computed` fields here. For the remaining fields — `inject(QueryClient)`, `injectQuery`, `injectMutation`, `injectInfiniteQuery`, `injectQueries`, `injectIsFetching`, `injectIsMutating`, `injectMutationState` — the style guide doesn't call these out specifically, but they're never reassigned after initialization either, so `readonly` reflects actual usage there too. Reference docs regenerated with `pnpm run generate-docs` to match.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).