### PR TITLE
test(angular-query-experimental/inject-query): add tests for 'enabled' signal transitions and 'initialData' with a failed refetch

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -467,6 +467,35 @@ describe('injectQuery', () => {
     expect(query.status()).toBe('success')
   })
 
+  it('should not fetch while the enabled signal is false, and fetch again once it is truthy', async () => {
+    const key = queryKey()
+    const spy = vi.fn(() => sleep(10).then(() => 'Some data'))
+    const filter = signal('a')
+
+    const query = TestBed.runInInjectionContext(() => {
+      return injectQuery(() => ({
+        queryKey: [...key, filter()],
+        queryFn: spy,
+        enabled: !!filter(),
+      }))
+    })
+
+    await vi.advanceTimersByTimeAsync(11)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(query.status()).toBe('success')
+
+    filter.set('')
+
+    await vi.advanceTimersByTimeAsync(11)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(query.isFetching()).toBe(false)
+
+    filter.set('b')
+
+    await vi.advanceTimersByTimeAsync(11)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
   it('should properly execute dependent queries', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
@@ -551,6 +580,36 @@ describe('injectQuery', () => {
     })
 
     await vi.advanceTimersByTimeAsync(11)
+  })
+
+  it('should keep initialData visible alongside the error when a refetch fails', async () => {
+    const key = queryKey()
+
+    @Component({
+      template: `
+        <div>data: {{ query.data() }}</div>
+        <div>isError: {{ query.isError() }}</div>
+      `,
+    })
+    class Page {
+      readonly query = injectQuery(() => ({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+        initialData: 'initial',
+        retry: false,
+      }))
+    }
+
+    const rendered = await render(Page)
+
+    expect(rendered.getByText('data: initial')).toBeInTheDocument()
+    expect(rendered.getByText('isError: false')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(11)
+    rendered.fixture.detectChanges()
+    expect(rendered.getByText('data: initial')).toBeInTheDocument()
+    expect(rendered.getByText('isError: true')).toBeInTheDocument()
   })
 
   describe('throwOnError', () => {


### PR DESCRIPTION
## Summary
- Add a test verifying `injectQuery` skips fetching while the `enabled` signal is falsy and resumes fetching once it becomes truthy again
- Add a test verifying `initialData` stays visible alongside the error state when a background refetch fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming queries pause and resume fetching as a signal-controlled `enabled` value changes.
  - Added coverage confirming initial data remains visible when a refetch results in an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->