### PR TITLE
test({react,preact}-query/useQuery): add test for 'initialData' with a failed refetch

### DIFF
--- a/packages/preact-query/src/__tests__/useQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test.tsx
@@ -3263,6 +3263,31 @@ describe('useQuery', () => {
     expect(states[1]).toMatchObject({ data: { count: 1 } })
   })
 
+  it('should keep initialData visible alongside the error when a refetch fails', async () => {
+    const key = queryKey()
+    const states: Array<DefinedUseQueryResult<string>> = []
+
+    function Page() {
+      const state = useQuery({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+        initialData: 'initial',
+        retry: false,
+      })
+      states.push(state)
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(states.length).toBe(2)
+    expect(states[0]).toMatchObject({ data: 'initial', isError: false })
+    expect(states[1]).toMatchObject({ data: 'initial', isError: true })
+  })
+
   it('should retry specified number of times', async () => {
     const key = queryKey()
 

--- a/packages/react-query/src/__tests__/useQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test.tsx
@@ -3251,6 +3251,31 @@ describe('useQuery', () => {
     expect(states[1]).toMatchObject({ data: { count: 1 } })
   })
 
+  it('should keep initialData visible alongside the error when a refetch fails', async () => {
+    const key = queryKey()
+    const states: Array<DefinedUseQueryResult<string>> = []
+
+    function Page() {
+      const state = useQuery({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+        initialData: 'initial',
+        retry: false,
+      })
+      states.push(state)
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(states.length).toBe(2)
+    expect(states[0]).toMatchObject({ data: 'initial', isError: false })
+    expect(states[1]).toMatchObject({ data: 'initial', isError: true })
+  })
+
   it('should retry specified number of times', async () => {
     const key = queryKey()
 


### PR DESCRIPTION
## Summary
- Add a test verifying `useQuery` keeps `initialData` visible alongside the error state when a background refetch fails (react-query, preact-query)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved initially loaded data when a query refetch fails and enters an error state.

- **Tests**
  - Added regression coverage for this behavior across supported query integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->