### PR TITLE
test(solid-query/useInfiniteQuery): add test for 'initialData' with a failed refetch

### DIFF
--- a/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1351,6 +1351,47 @@ describe('useInfiniteQuery', () => {
     })
   })
 
+  it('should keep initialData visible alongside the error when a refetch fails', async () => {
+    const key = queryKey()
+    const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =
+      []
+
+    function Page() {
+      const state = useInfiniteQuery(() => ({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+        initialData: { pages: [1], pageParams: [1] },
+        getNextPageParam: (lastPage: number) => lastPage + 1,
+        initialPageParam: 0,
+        retry: false,
+      }))
+
+      createRenderEffect(() => {
+        states.push({
+          data: JSON.parse(JSON.stringify(state.data)),
+          isError: state.isError,
+        })
+      })
+
+      return null
+    }
+
+    renderWithClient(queryClient, () => <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(states.length).toBe(2)
+    expect(states[0]).toMatchObject({
+      data: { pages: [1] },
+      isError: false,
+    })
+    expect(states[1]).toMatchObject({
+      data: { pages: [1] },
+      isError: true,
+    })
+  })
+
   it('should only refetch the first page when initialData is provided', async () => {
     const key = queryKey()
     const states: Array<Partial<UseInfiniteQueryResult<InfiniteData<number>>>> =


### PR DESCRIPTION
## Summary
- Add a test verifying `useInfiniteQuery` keeps `initialData` visible alongside the error state when a background refetch fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring initial data remains visible when an infinite query’s initial refetch fails.
  * Verified the query transitions to an error state without clearing the previously available data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->