### PR TITLE
test(solid-query/useQuery): add tests for 'initialData' with a failed refetch and 'skipToken' dependent query

### DIFF
--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -30,6 +30,7 @@ import {
   QueryClient,
   keepPreviousData,
   noop,
+  skipToken,
   useQuery,
 } from '..'
 import {
@@ -2579,6 +2580,33 @@ describe('useQuery', () => {
       isStale: true,
       isFetching: false,
     })
+  })
+
+  it('should keep initialData visible alongside the error when a refetch fails', async () => {
+    const key = queryKey()
+    const states: Array<DefinedUseQueryResult<string>> = []
+
+    function Page() {
+      const state = useQuery(() => ({
+        queryKey: key,
+        queryFn: () =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+        initialData: 'initial',
+        retry: false,
+      }))
+      createRenderEffect(() => {
+        states.push({ ...state })
+      })
+      return null
+    }
+
+    renderWithClient(queryClient, () => <Page />)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(states.length).toBe(2)
+    expect(states[0]).toMatchObject({ data: 'initial', isError: false })
+    expect(states[1]).toMatchObject({ data: 'initial', isError: true })
   })
 
   it('should not fetch if initial data is set with a stale time', async () => {
@@ -5769,5 +5797,39 @@ describe('useQuery', () => {
     expect(rendered.getByText('status: success')).toBeInTheDocument()
     expect(queryClient2.getQueryCache().find({ queryKey: key })).toBeDefined()
     expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not fetch when queryFn is skipToken, and fetch once postId is set', async () => {
+    const key = queryKey()
+
+    function Page() {
+      const [postId, setPostId] = createSignal<number>()
+
+      const state = useQuery(() => ({
+        queryKey: key,
+        queryFn:
+          postId() != null
+            ? () => sleep(10).then(() => `post ${postId()}`)
+            : skipToken,
+      }))
+
+      return (
+        <div>
+          <div>data: {state.data ?? 'none'}</div>
+          <button onClick={() => setPostId(1)}>set postId</button>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    expect(rendered.getByText('data: none')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('data: none')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: 'set postId' }))
+    await vi.advanceTimersByTimeAsync(10)
+    expect(rendered.getByText('data: post 1')).toBeInTheDocument()
   })
 })

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -5801,16 +5801,14 @@ describe('useQuery', () => {
 
   it('should not fetch when queryFn is skipToken, and fetch once postId is set', async () => {
     const key = queryKey()
+    const queryFn = vi.fn(() => sleep(10).then(() => 'post 1'))
 
     function Page() {
       const [postId, setPostId] = createSignal<number>()
 
       const state = useQuery(() => ({
         queryKey: key,
-        queryFn:
-          postId() != null
-            ? () => sleep(10).then(() => `post ${postId()}`)
-            : skipToken,
+        queryFn: postId() != null ? queryFn : skipToken,
       }))
 
       return (
@@ -5826,10 +5824,12 @@ describe('useQuery', () => {
     expect(rendered.getByText('data: none')).toBeInTheDocument()
 
     await vi.advanceTimersByTimeAsync(10)
+    expect(queryFn).not.toHaveBeenCalled()
     expect(rendered.getByText('data: none')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: 'set postId' }))
     await vi.advanceTimersByTimeAsync(10)
+    expect(queryFn).toHaveBeenCalledTimes(1)
     expect(rendered.getByText('data: post 1')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Add a test verifying `useQuery` keeps `initialData` visible alongside the error state when a background refetch fails
- Add a test verifying `useQuery` skips fetching while `queryFn` is `skipToken` and fetches once it is replaced with a real query function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage ensuring previously loaded data remains available when a refresh fails.
  - Added coverage verifying that queries remain paused until required input is available, then retrieve the corresponding data exactly once.
  - Improved validation of conditional query behavior and error handling, helping confirm that users see stable existing results during failed refreshes and receive the correct content once required information becomes available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->