### PR TITLE
test(svelte-query/createQuery): add test for 'initialData' with a failed refetch

### DIFF
--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -271,6 +271,30 @@ describe('createQuery', () => {
     )
   })
 
+  it('should keep initialData visible alongside the error when a refetch fails', async () => {
+    const key = queryKey()
+
+    const rendered = render(Base, {
+      props: {
+        queryClient,
+        options: () => ({
+          queryKey: key,
+          queryFn: () =>
+            sleep(10).then(() => Promise.reject(new Error('Some error'))),
+          initialData: 'initial',
+          retry: false,
+        }),
+      },
+    })
+
+    expect(rendered.getByTestId('data')).toHaveTextContent('initial')
+    expect(rendered.getByTestId('status')).toHaveTextContent('success')
+
+    await vi.advanceTimersByTimeAsync(11)
+    expect(rendered.getByTestId('data')).toHaveTextContent('initial')
+    expect(rendered.getByTestId('status')).toHaveTextContent('error')
+  })
+
   it('should not cancel an ongoing fetch when refetch is called with cancelRefetch=false if we have data already', async () => {
     const key = queryKey()
     let fetchCount = 0


### PR DESCRIPTION
## Summary
- Add a test verifying `createQuery` keeps `initialData` visible alongside the error state when a background refetch fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming that initial data remains visible when a refetch fails.
  - Verified that the query transitions from a successful state to an error state while retaining the previously displayed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->