### PR TITLE
test(svelte-query/createMutation): add tests for optimistic update rollback and success paths using cache-based 'onMutateResult'

### DIFF
--- a/packages/svelte-query/tests/createMutation/OptimisticUpdate.svelte
+++ b/packages/svelte-query/tests/createMutation/OptimisticUpdate.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { QueryClient } from '@tanstack/query-core'
+  import { createMutation, setQueryClientContext } from '../../src/index.js'
+  import { sleep } from '@tanstack/query-test-utils'
+
+  type Props = {
+    queryClient: QueryClient
+    queryKey: Array<string>
+    shouldSucceed: boolean
+  }
+
+  const { queryClient, queryKey, shouldSucceed }: Props = $props()
+
+  setQueryClientContext(queryClient)
+
+  const mutation = createMutation(() => ({
+    mutationFn: (newTodo: string) =>
+      shouldSucceed
+        ? sleep(10).then(() => newTodo)
+        : sleep(10).then(() => Promise.reject(new Error('Some error'))),
+    onMutate: async (newTodo: string) => {
+      await queryClient.cancelQueries({ queryKey })
+      const previousTodos = queryClient.getQueryData<Array<string>>(queryKey)
+
+      queryClient.setQueryData<Array<string>>(queryKey, (old) => [
+        ...(old ?? []),
+        newTodo,
+      ])
+
+      return { previousTodos }
+    },
+    onError: (_err, _newTodo, onMutateResult) => {
+      queryClient.setQueryData(queryKey, onMutateResult?.previousTodos)
+    },
+  }))
+</script>
+
+<button onclick={() => mutation.mutate('Todo 2')}>add</button>

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushSync } from 'svelte'
 import { fireEvent, render } from '@testing-library/svelte'
 import { QueryClient } from '@tanstack/query-core'
-import { sleep } from '@tanstack/query-test-utils'
+import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { createMutation } from '../../src/index.js'
 import { withEffectRoot } from '../utils.svelte.js'
 import Reset from './Reset.svelte'
 import Success from './Success.svelte'
 import Failure from './Failure.svelte'
+import OptimisticUpdate from './OptimisticUpdate.svelte'
 
 describe('createMutation', () => {
   let queryClient: QueryClient
@@ -136,4 +137,38 @@ describe('createMutation', () => {
       expect(mutation.data).toBeUndefined()
     }),
   )
+
+  it('should update the cache in onMutate and roll back via onMutateResult in onError', async () => {
+    const key = queryKey()
+    queryClient.setQueryData<Array<string>>(key, ['Todo 1'])
+
+    const rendered = render(OptimisticUpdate, {
+      props: { queryClient, queryKey: key, shouldSucceed: false },
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: /add/i }))
+    // The optimistic value lands after onMutate's first await, so flush
+    // microtasks before asserting.
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(queryClient.getQueryData(key)).toEqual(['Todo 1', 'Todo 2'])
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(queryClient.getQueryData(key)).toEqual(['Todo 1'])
+  })
+
+  it('should keep the optimistic update in place when the mutation succeeds', async () => {
+    const key = queryKey()
+    queryClient.setQueryData<Array<string>>(key, ['Todo 1'])
+
+    const rendered = render(OptimisticUpdate, {
+      props: { queryClient, queryKey: key, shouldSucceed: true },
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: /add/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(queryClient.getQueryData(key)).toEqual(['Todo 1', 'Todo 2'])
+  })
 })


### PR DESCRIPTION
## Summary
- Add a test verifying `createMutation`'s `onMutate` cache update is rolled back via `onMutateResult` in `onError`
- Add a test verifying the optimistic cache update stays in place when the mutation succeeds
- Add the `OptimisticUpdate.svelte` fixture used by both tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for optimistic updates during mutations.
  - Verified that failed mutations restore previous data.
  - Verified that successful mutations retain the optimistic update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->