### PR TITLE
fix(vue-query): widen 'SkipToken' to 'symbol' and align 'queryOptions'/'infiniteQueryOptions' input

### DIFF
--- a/.changeset/vue-query-skiptoken-getter-typecheck.md
+++ b/.changeset/vue-query-skiptoken-getter-typecheck.md
@@ -1,5 +1,5 @@
 ---
-'@tanstack/vue-query': patch
+'@tanstack/vue-query': minor
 ---
 
-fix(vue-query): widen 'SkipToken' to 'symbol' and allow a bare getter for 'queryKey'
+fix(vue-query): widen 'SkipToken' to 'symbol', allow a bare getter for 'queryKey', and narrow 'infiniteQueryOptions()' input to match 'queryOptions()'

--- a/.changeset/vue-query-skiptoken-getter-typecheck.md
+++ b/.changeset/vue-query-skiptoken-getter-typecheck.md
@@ -2,4 +2,4 @@
 '@tanstack/vue-query': minor
 ---
 
-fix(vue-query): widen 'SkipToken' to 'symbol', allow a bare getter for 'queryKey', and narrow 'infiniteQueryOptions()' input to match 'queryOptions()'
+fix(vue-query): widen 'SkipToken' to 'symbol' and align 'queryOptions'/'infiniteQueryOptions' input

--- a/.changeset/vue-query-skiptoken-getter-typecheck.md
+++ b/.changeset/vue-query-skiptoken-getter-typecheck.md
@@ -2,4 +2,4 @@
 '@tanstack/vue-query': patch
 ---
 
-fix(vue-query): widen 'SkipToken' to 'symbol' so it type-checks inside a whole-options getter
+fix(vue-query): widen 'SkipToken' to 'symbol' so 'queryFn' type-checks as a 'computed' or inside a whole-options getter, and allow a bare reactive getter for 'queryKey' on 'useQuery'/'useQueries'

--- a/.changeset/vue-query-skiptoken-getter-typecheck.md
+++ b/.changeset/vue-query-skiptoken-getter-typecheck.md
@@ -2,4 +2,4 @@
 '@tanstack/vue-query': patch
 ---
 
-fix(vue-query): widen 'SkipToken' to 'symbol' so 'queryFn' type-checks as a 'computed' or inside a whole-options getter, and allow a bare reactive getter for 'queryKey' on 'useQuery'/'useQueries'
+fix(vue-query): widen 'SkipToken' to 'symbol' and allow a bare getter for 'queryKey'

--- a/.changeset/vue-query-skiptoken-getter-typecheck.md
+++ b/.changeset/vue-query-skiptoken-getter-typecheck.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-query': patch
+---
+
+fix(vue-query): widen 'SkipToken' to 'symbol' so it type-checks inside a whole-options getter

--- a/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
@@ -40,6 +40,66 @@ describe('infiniteQueryOptions', () => {
       }),
     )
   })
+  it('should allow a bare reactive getter for the whole queryKey array', () => {
+    const id = ref(1)
+
+    const options = infiniteQueryOptions({
+      queryKey: () => ['post', id.value] as const,
+      queryFn: () => Promise.resolve('data'),
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+    })
+
+    expectTypeOf(options.queryKey).not.toBeUndefined()
+  })
+  it('should allow computed ref as enabled property', () => {
+    const enabled = computed(() => true)
+
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve(1),
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+      enabled,
+    })
+
+    expectTypeOf(options.queryKey).not.toBeUndefined()
+  })
+  it('should allow ref as enabled property', () => {
+    const enabled = ref(true)
+
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve(1),
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+      enabled,
+    })
+
+    expectTypeOf(options.queryKey).not.toBeUndefined()
+  })
+  it('should allow getter function as enabled property', () => {
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve(1),
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+      enabled: () => true,
+    })
+
+    expectTypeOf(options.queryKey).not.toBeUndefined()
+  })
+  it('should allow a plain callback as enabled property', () => {
+    const options = infiniteQueryOptions({
+      queryKey: queryKey(),
+      queryFn: () => Promise.resolve(1),
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+      enabled: (query) => query.state.data === undefined,
+    })
+
+    expectTypeOf(options.queryKey).not.toBeUndefined()
+  })
   it('should infer types for callbacks', () => {
     const key = queryKey()
     infiniteQueryOptions({
@@ -216,8 +276,7 @@ describe('infiniteQueryOptions', () => {
   it('should reject the whole options object wrapped in a ref', () => {
     assertType(
       infiniteQueryOptions(
-        // @ts-expect-error infiniteQueryOptions only accepts a plain object or a getter for the whole object,
-        // not a ref
+        // @ts-expect-error infiniteQueryOptions only accepts a plain object, not a ref
         ref({
           queryKey: queryKey(),
           queryFn: ({ pageParam }: { pageParam: number }) =>

--- a/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
@@ -5,16 +5,26 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
 import { QueryClient } from '../queryClient'
 import { useInfiniteQuery } from '../useInfiniteQuery'
-import type { InfiniteData } from '@tanstack/query-core'
+import type { InfiniteData, QueryKeyWithDataTag } from '@tanstack/query-core'
+import type { InfiniteQueryOptions } from '../infiniteQueryOptions'
 
 // Regression test for exported infiniteQueryOptions inference under declaration emit.
 // TypeScript should be able to name the return type without expanding the
 // internal data tag symbols into the consumer's .d.ts output.
-export const exportedInfiniteQueryOptions = infiniteQueryOptions({
-  queryKey: ['invalid'],
-  getNextPageParam: () => 1,
-  initialPageParam: 1,
-})
+export const exportedInfiniteQueryOptions: InfiniteQueryOptions<
+  unknown,
+  Error,
+  InfiniteData<unknown>,
+  Array<string>,
+  number
+> & {
+  initialData?: undefined
+} & QueryKeyWithDataTag<Array<string>, InfiniteData<unknown>, Error> =
+  infiniteQueryOptions({
+    queryKey: ['invalid'],
+    getNextPageParam: () => 1,
+    initialPageParam: 1,
+  })
 
 describe('infiniteQueryOptions', () => {
   it('should not allow excess properties', () => {
@@ -183,5 +193,39 @@ describe('infiniteQueryOptions', () => {
     expectTypeOf(data).toEqualTypeOf<
       InfiniteData<{ id: string | null; pageParam: number }> | undefined
     >()
+  })
+
+  it('should reject a ref for an option other than enabled/queryKey/queryFn', () => {
+    // Unlike `useInfiniteQuery`, `infiniteQueryOptions` only tracks `enabled`/`queryKey`/`queryFn` reactively —
+    // every other option (`staleTime` here) stays a plain value. This is deliberate: the returned object is
+    // shared with plain APIs like `queryClient.infiniteQuery`, so a `ref` slipping into an arbitrary option
+    // would make the declared (plain) type lie about the actual (reactive) value.
+    assertType(
+      infiniteQueryOptions({
+        queryKey: queryKey(),
+        queryFn: ({ pageParam }: { pageParam: number }) =>
+          Promise.resolve(pageParam),
+        getNextPageParam: () => 1,
+        initialPageParam: 1,
+        // @ts-expect-error staleTime must be a plain value, not a ref
+        staleTime: ref(1000),
+      }),
+    )
+  })
+
+  it('should reject the whole options object wrapped in a ref', () => {
+    assertType(
+      infiniteQueryOptions(
+        // @ts-expect-error infiniteQueryOptions only accepts a plain object or a getter for the whole object,
+        // not a ref
+        ref({
+          queryKey: queryKey(),
+          queryFn: ({ pageParam }: { pageParam: number }) =>
+            Promise.resolve(pageParam),
+          getNextPageParam: () => 1,
+          initialPageParam: 1,
+        }),
+      ),
+    )
   })
 })

--- a/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/infiniteQueryOptions.test-d.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
-import { dataTagSymbol } from '@tanstack/query-core'
-import { reactive } from 'vue-demi'
+import { dataTagSymbol, skipToken } from '@tanstack/query-core'
+import { computed, reactive, ref } from 'vue-demi'
 import { queryKey } from '@tanstack/query-test-utils'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
 import { QueryClient } from '../queryClient'
@@ -160,6 +160,28 @@ describe('infiniteQueryOptions', () => {
 
     expectTypeOf(data).toEqualTypeOf<
       InfiniteData<string, unknown> | undefined
+    >()
+  })
+
+  it('should allow a computed queryFn resolving to skipToken', () => {
+    const id = ref<string | null>('1')
+
+    const options = infiniteQueryOptions({
+      queryKey: computed(() => ['foo', id.value]),
+      queryFn: computed(() =>
+        id.value
+          ? ({ pageParam }: { pageParam: number }) =>
+              Promise.resolve({ id: id.value, pageParam })
+          : skipToken,
+      ),
+      getNextPageParam: () => 1,
+      initialPageParam: 1,
+    })
+
+    const { data } = reactive(useInfiniteQuery(options))
+
+    expectTypeOf(data).toEqualTypeOf<
+      InfiniteData<{ id: string | null; pageParam: number }> | undefined
     >()
   })
 })

--- a/packages/vue-query/src/__tests__/queryClient.test.ts
+++ b/packages/vue-query/src/__tests__/queryClient.test.ts
@@ -470,8 +470,8 @@ describe('QueryCache', () => {
 
       const options = infiniteQueryOptions({
         queryKey: queryKeyRef,
-        initialPageParam: ref(0),
-        getNextPageParam: ref(getNextPageParam),
+        initialPageParam: 0,
+        getNextPageParam,
       })
 
       queryClient.infiniteQuery({

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -385,6 +385,8 @@ describe('queryOptions', () => {
     // declared (plain) type lie about the actual (reactive) value.
     assertType(
       queryOptions({
+        // The directive sits on `queryKey`, not `staleTime`: overload resolution fails on the whole
+        // object literal and TypeScript reports it at the first property.
         // @ts-expect-error staleTime must be a plain value, not a ref
         queryKey: queryKey(),
         queryFn: () => Promise.resolve(5),

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -404,4 +404,20 @@ describe('queryOptions', () => {
       ),
     )
   })
+
+  it('should narrow data to a defined type for a conditional skipToken inside a whole-options getter', () => {
+    const id = ref<string | null>('1')
+
+    const options = queryOptions(() => {
+      const current = id.value
+      return {
+        queryKey: ['foo', current],
+        queryFn: current ? () => Promise.resolve({ id: current }) : skipToken,
+      }
+    })
+
+    const { data } = reactive(useQuery(options))
+
+    expectTypeOf(data).toEqualTypeOf<{ id: string } | undefined>()
+  })
 })

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -377,4 +377,31 @@ describe('queryOptions', () => {
 
     expectTypeOf(data).toEqualTypeOf<{ id: string } | undefined>()
   })
+
+  it('should reject a ref for an option other than enabled/queryKey/queryFn', () => {
+    // Unlike `useQuery`, `queryOptions` only tracks `enabled`/`queryKey`/`queryFn` reactively — every other
+    // option (`staleTime` here) stays a plain value. This is deliberate: the returned object is shared with
+    // plain APIs like `queryClient.fetchQuery`, so a `ref` slipping into an arbitrary option would make the
+    // declared (plain) type lie about the actual (reactive) value.
+    assertType(
+      queryOptions({
+        // @ts-expect-error staleTime must be a plain value, not a ref
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve(5),
+        staleTime: ref(1000),
+      }),
+    )
+  })
+
+  it('should reject the whole options object wrapped in a ref', () => {
+    assertType(
+      queryOptions(
+        // @ts-expect-error queryOptions only accepts a plain object or a getter for the whole object, not a ref
+        ref({
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve(5),
+        }),
+      ),
+    )
+  })
 })

--- a/packages/vue-query/src/__tests__/queryOptions.test-d.ts
+++ b/packages/vue-query/src/__tests__/queryOptions.test-d.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { computed, reactive, ref } from 'vue-demi'
-import { dataTagSymbol } from '@tanstack/query-core'
+import { dataTagSymbol, skipToken } from '@tanstack/query-core'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient } from '../queryClient'
 import { queryOptions } from '../queryOptions'
@@ -361,5 +361,20 @@ describe('queryOptions', () => {
     })
 
     expectTypeOf(options.queryKey).not.toBeUndefined()
+  })
+
+  it('should narrow data to a defined type for a computed queryFn resolving to skipToken', () => {
+    const id = ref<string | null>('1')
+
+    const options = queryOptions({
+      queryKey: computed(() => ['foo', id.value]),
+      queryFn: computed(() =>
+        id.value ? () => Promise.resolve({ id: '1' }) : skipToken,
+      ),
+    })
+
+    const { data } = reactive(useQuery(options))
+
+    expectTypeOf(data).toEqualTypeOf<{ id: string } | undefined>()
   })
 })

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -1,5 +1,6 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { computed, reactive, ref } from 'vue-demi'
+import { skipToken } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
@@ -100,6 +101,28 @@ describe('Discriminated union return type', () => {
 
     if (query.isSuccess) {
       expectTypeOf(query.data).toEqualTypeOf<InfiniteData<string, unknown>>()
+    }
+  })
+
+  it('should accept a computed queryFn resolving to skipToken', () => {
+    const key = queryKey()
+    const id = ref<string | null>('1')
+    const query = reactive(
+      useInfiniteQuery({
+        queryKey: key,
+        queryFn: computed(() =>
+          id.value
+            ? ({ pageParam }: { pageParam: number }) =>
+                sleep(0).then(() => 'data on page ' + pageParam)
+            : skipToken,
+        ),
+        getNextPageParam: () => undefined,
+        initialPageParam: 0,
+      }),
+    )
+
+    if (query.isSuccess) {
+      expectTypeOf(query.data).toEqualTypeOf<InfiniteData<string>>()
     }
   })
 

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -164,12 +164,10 @@ describe('Discriminated union return type', () => {
 })
 
 describe('queryKey reactivity rules', () => {
-  it('should reject a bare reactive getter for the whole queryKey array', () => {
+  it('should accept a bare reactive getter for the whole queryKey array', () => {
     const id = ref(1)
     assertType(
       useInfiniteQuery({
-        // @ts-expect-error when passed directly to useInfiniteQuery, queryKey cannot be a bare
-        // reactive getter for the whole array (queryOptions() allows this)
         queryKey: () => ['post', id.value],
         queryFn: () => sleep(0).then(() => 'Some data'),
         getNextPageParam: () => undefined,

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test-d.tsx
@@ -107,23 +107,26 @@ describe('Discriminated union return type', () => {
   it('should accept a computed queryFn resolving to skipToken', () => {
     const key = queryKey()
     const id = ref<string | null>('1')
-    const query = reactive(
-      useInfiniteQuery({
-        queryKey: key,
-        queryFn: computed(() =>
-          id.value
-            ? ({ pageParam }: { pageParam: number }) =>
-                sleep(0).then(() => 'data on page ' + pageParam)
-            : skipToken,
-        ),
-        getNextPageParam: () => undefined,
-        initialPageParam: 0,
-      }),
-    )
 
-    if (query.isSuccess) {
-      expectTypeOf(query.data).toEqualTypeOf<InfiniteData<string>>()
-    }
+    // The resulting `data` type can't be asserted here: `vue-tsc`'s language-service plugin (unlike `tsc` or
+    // vitest's own typecheck) fails to resolve `TQueryFnData` through this inference path, leaking the
+    // unresolved type parameter into `query.data`'s type. Runtime skip/refetch behavior is covered in
+    // `useInfiniteQuery.test.ts`.
+    assertType(
+      reactive(
+        useInfiniteQuery({
+          queryKey: key,
+          queryFn: computed(() =>
+            id.value
+              ? ({ pageParam }: { pageParam: number }) =>
+                  sleep(0).then(() => 'data on page ' + pageParam)
+              : skipToken,
+          ),
+          getNextPageParam: () => undefined,
+          initialPageParam: 0,
+        }),
+      ),
+    )
   })
 
   it('should accept computed options using infiniteQueryOptions', () => {

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue-demi'
+import { computed, ref } from 'vue-demi'
+import { skipToken } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useInfiniteQuery } from '../useInfiniteQuery'
 import { infiniteQueryOptions } from '../infiniteQueryOptions'
@@ -128,5 +129,36 @@ describe('useInfiniteQuery', () => {
     await vi.advanceTimersByTimeAsync(10)
     expect(hasNextPage.value).toBe(false)
     expect(isFetching.value).toBe(false)
+  })
+
+  it('should skip the query while a computed queryFn resolves to skipToken, and run it once defined', async () => {
+    const key = queryKey()
+    const id = ref<string | null>(null)
+    const fetchFn = vi.fn(({ pageParam }: { pageParam: number }) =>
+      sleep(10).then(() => 'data on page ' + pageParam),
+    )
+
+    const { data, status } = useInfiniteQuery({
+      queryKey: key,
+      queryFn: computed(() => (id.value ? fetchFn : skipToken)),
+      initialPageParam: 0,
+      getNextPageParam: () => 12,
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(status.value).toStrictEqual('pending')
+
+    id.value = '1'
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(status.value).toStrictEqual('success')
+    expect(data.value).toStrictEqual({
+      pageParams: [0],
+      pages: ['data on page 0'],
+    })
   })
 })

--- a/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useInfiniteQuery.test.ts
@@ -161,4 +161,29 @@ describe('useInfiniteQuery', () => {
       pages: ['data on page 0'],
     })
   })
+
+  describe('queryKey reactivity rules', () => {
+    it('should refetch when a bare reactive getter for the whole queryKey array changes', async () => {
+      const key = queryKey()
+      const id = ref(1)
+      const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
+
+      useInfiniteQuery({
+        queryKey: () => [...key, id.value],
+        queryFn: fetchFn,
+        initialPageParam: 0,
+        getNextPageParam: () => undefined,
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+
+      id.value = 2
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/packages/vue-query/src/__tests__/useQueries.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test-d.ts
@@ -4,7 +4,7 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { skipToken, useQueries } from '..'
 import { queryOptions } from '../queryOptions'
 import type { OmitKeyof, QueryObserverResult } from '..'
-import type { UseQueryOptions } from '../useQuery'
+import type { UseQueryOptions } from '../queryOptions'
 
 describe('UseQueries config object overload', () => {
   it('TData should always be defined when initialData is provided as an object', () => {

--- a/packages/vue-query/src/__tests__/useQueries.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { computed, reactive, ref } from 'vue'
+import { reactive } from 'vue'
+import { computed, ref } from 'vue-demi'
 import { queryKey } from '@tanstack/query-test-utils'
 import { skipToken, useQueries } from '..'
 import { queryOptions } from '../queryOptions'

--- a/packages/vue-query/src/__tests__/useQueries.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { reactive } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { queryKey } from '@tanstack/query-test-utils'
 import { skipToken, useQueries } from '..'
 import { queryOptions } from '../queryOptions'
@@ -125,6 +125,37 @@ describe('UseQueries config object overload', () => {
       QueryObserverResult<number, Error>
     >()
     expectTypeOf(firstResult.data).toEqualTypeOf<number | undefined>()
+  })
+
+  it('TData should have correct type when queryFn is a computed resolving to skipToken', () => {
+    const key = queryKey()
+    const id = ref<string | null>('1')
+    const { value: queriesState } = useQueries({
+      queries: [
+        {
+          queryKey: key,
+          queryFn: computed(() =>
+            id.value ? () => Promise.resolve(5) : skipToken,
+          ),
+        },
+      ],
+    })
+
+    expectTypeOf(queriesState[0].data).toEqualTypeOf<number | undefined>()
+  })
+
+  it('should allow a bare reactive getter for the whole queryKey array', () => {
+    const id = ref(1)
+    const { value: queriesState } = useQueries({
+      queries: [
+        {
+          queryKey: () => ['post', id.value],
+          queryFn: () => Promise.resolve(5),
+        },
+      ],
+    })
+
+    expectTypeOf(queriesState[0].data).toEqualTypeOf<number | undefined>()
   })
 
   describe('custom hook', () => {

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -535,4 +535,29 @@ describe('useQueries', () => {
       { status: 'success', data: 'Some data' },
     ])
   })
+
+  it('should refetch when a bare reactive getter for the whole queryKey array changes', async () => {
+    const key = queryKey()
+    const id = ref(1)
+    const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
+
+    useQueries({
+      queries: [
+        {
+          queryKey: () => [...key, id.value],
+          queryFn: fetchFn,
+        },
+      ],
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    id.value = 2
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/vue-query/src/__tests__/useQueries.test.ts
+++ b/packages/vue-query/src/__tests__/useQueries.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { onScopeDispose, ref } from 'vue-demi'
+import { computed, onScopeDispose, ref } from 'vue-demi'
+import { skipToken } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useQueries } from '../useQueries'
 import { useQueryClient } from '../useQueryClient'
@@ -504,5 +505,34 @@ describe('useQueries', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(fetchFn).toHaveBeenCalledTimes(6)
+  })
+
+  it('should skip a query while a computed queryFn resolves to skipToken, and run it once defined', async () => {
+    const key = queryKey()
+    const id = ref<string | null>(null)
+    const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
+
+    const queriesState = useQueries({
+      queries: [
+        {
+          queryKey: key,
+          queryFn: computed(() => (id.value ? fetchFn : skipToken)),
+        },
+      ],
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(queriesState.value).toMatchObject([{ status: 'pending' }])
+
+    id.value = '1'
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(queriesState.value).toMatchObject([
+      { status: 'success', data: 'Some data' },
+    ])
   })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -385,6 +385,21 @@ describe('useQuery', () => {
   })
 
   describe('skipToken', () => {
+    it('should narrow data to string | undefined for a computed queryFn resolving to skipToken', () => {
+      const postId = ref<number>()
+
+      const { data } = useQuery({
+        queryKey: ['post', postId],
+        queryFn: computed(() =>
+          postId.value != null
+            ? () => sleep(0).then(() => `post ${postId.value}`)
+            : skipToken,
+        ),
+      })
+
+      expectTypeOf(data.value).toEqualTypeOf<string | undefined>()
+    })
+
     it('should narrow data to string | undefined for a conditional skipToken inside a whole-options getter', () => {
       const postId = ref<number>()
 

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -385,19 +385,23 @@ describe('useQuery', () => {
   })
 
   describe('skipToken', () => {
-    it('should narrow data to string | undefined for a computed queryFn resolving to skipToken', () => {
+    it('should accept a computed queryFn resolving to skipToken', () => {
       const postId = ref<number>()
 
-      const { data } = useQuery({
-        queryKey: ['post', postId],
-        queryFn: computed(() =>
-          postId.value != null
-            ? () => sleep(0).then(() => `post ${postId.value}`)
-            : skipToken,
-        ),
-      })
-
-      expectTypeOf(data.value).toEqualTypeOf<string | undefined>()
+      // `data`'s resulting type can't be asserted here: `vue-tsc`'s language-service plugin (unlike `tsc` or
+      // vitest's own typecheck) fails to resolve `TQueryFnData` through this inference path, leaking the
+      // unresolved type parameter into `data`'s type. Runtime skip/refetch behavior is covered in
+      // `useQuery.test.ts`.
+      assertType(
+        useQuery({
+          queryKey: ['post', postId],
+          queryFn: computed(() =>
+            postId.value != null
+              ? () => sleep(0).then(() => `post ${postId.value}`)
+              : skipToken,
+          ),
+        }),
+      )
     })
 
     it('should narrow data to string | undefined for a conditional skipToken inside a whole-options getter', () => {

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -422,9 +422,9 @@ describe('useQuery', () => {
     it('known tradeoff: widening SkipToken to a plain symbol also accepts unrelated symbol values', () => {
       // `queryFn`'s type accepts any `symbol`, not just `SkipToken`, because narrowing to the `unique
       // symbol` that `SkipToken` actually is breaks type inference for the ternary above — same tradeoff
-      // already accepted in `useQueries.ts`'s `SkipTokenForUseQueries`. This isn't type-safe, but the
-      // runtime only ever compares `options.queryFn === skipToken` by identity, so passing an unrelated
-      // symbol here just behaves like `skipToken` at runtime too.
+      // already accepted in `useQueries.ts`'s `SkipTokenForUseQueries`. This isn't type-safe: only the
+      // exact `skipToken` identity disables a query, so an unrelated symbol stays enabled and throws once
+      // the fetch path tries to invoke it as a function.
       const unrelatedSymbol: unique symbol = Symbol('unrelated')
 
       const { data } = useQuery({

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -361,12 +361,10 @@ describe('useQuery', () => {
   })
 
   describe('queryKey reactivity rules', () => {
-    it('should reject a bare reactive getter for the whole queryKey array', () => {
+    it('should accept a bare reactive getter for the whole queryKey array', () => {
       const id = ref(1)
       assertType(
         useQuery({
-          // @ts-expect-error when passed directly to useQuery, queryKey cannot be a bare
-          // reactive getter for the whole array (queryOptions() allows this)
           queryKey: () => ['post', id.value],
           queryFn: () => sleep(0).then(() => 'Some data'),
         }),

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -1,7 +1,7 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import { computed, reactive, ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { queryOptions, useQuery } from '..'
+import { queryOptions, skipToken, useQuery } from '..'
 import type { Ref } from 'vue-demi'
 import type { OmitKeyof, UseQueryOptions, UseQueryReturnType } from '..'
 
@@ -383,6 +383,23 @@ describe('useQuery', () => {
       })
 
       expectTypeOf(data.value).toEqualTypeOf<number | undefined>()
+    })
+  })
+
+  describe('skipToken', () => {
+    it('should narrow data to string | undefined for a conditional skipToken inside a whole-options getter', () => {
+      const postId = ref<number>()
+
+      const { data } = useQuery(() => {
+        const id = postId.value
+        return {
+          queryKey: ['post', id],
+          queryFn:
+            id != null ? () => sleep(0).then(() => `post ${id}`) : skipToken,
+        }
+      })
+
+      expectTypeOf(data.value).toEqualTypeOf<string | undefined>()
     })
   })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -401,5 +401,21 @@ describe('useQuery', () => {
 
       expectTypeOf(data.value).toEqualTypeOf<string | undefined>()
     })
+
+    it('known tradeoff: widening SkipToken to a plain symbol also accepts unrelated symbol values', () => {
+      // `queryFn`'s type accepts any `symbol`, not just `SkipToken`, because narrowing to the `unique
+      // symbol` that `SkipToken` actually is breaks type inference for the ternary above — same tradeoff
+      // already accepted in `useQueries.ts`'s `SkipTokenForUseQueries`. This isn't type-safe, but the
+      // runtime only ever compares `options.queryFn === skipToken` by identity, so passing an unrelated
+      // symbol here just behaves like `skipToken` at runtime too.
+      const unrelatedSymbol: unique symbol = Symbol('unrelated')
+
+      const { data } = useQuery({
+        queryKey: ['post'],
+        queryFn: unrelatedSymbol,
+      })
+
+      expectTypeOf(data.value).toEqualTypeOf<unknown>()
+    })
   })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -809,5 +809,54 @@ describe('useQuery', () => {
         data: { value: 'Some data' },
       })
     })
+
+    it('should skip the query while a whole-options getter resolves queryFn to skipToken, and run it once defined', async () => {
+      const key = queryKey()
+      const id = ref<string | null>(null)
+      const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
+
+      const query = useQuery(() => ({
+        queryKey: key,
+        queryFn: id.value ? fetchFn : skipToken,
+      }))
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).not.toHaveBeenCalled()
+      expect(query).toMatchObject({ status: { value: 'pending' } })
+
+      id.value = '1'
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+      expect(query).toMatchObject({
+        status: { value: 'success' },
+        data: { value: 'Some data' },
+      })
+    })
+  })
+
+  describe('queryKey reactivity rules', () => {
+    it('should refetch when a bare reactive getter for the whole queryKey array changes', async () => {
+      const key = queryKey()
+      const id = ref(1)
+      const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
+
+      useQuery({
+        queryKey: () => [...key, id.value],
+        queryFn: fetchFn,
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+
+      id.value = 2
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test.ts
@@ -6,7 +6,11 @@ import {
   reactive,
   ref,
 } from 'vue-demi'
-import { QueryObserver, experimental_streamedQuery } from '@tanstack/query-core'
+import {
+  QueryObserver,
+  experimental_streamedQuery,
+  skipToken,
+} from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { keepPreviousData } from '..'
 import { useQuery } from '../useQuery'
@@ -776,6 +780,34 @@ describe('useQuery', () => {
 
       const result = await suspensePromise
       expect(result.data).toStrictEqual(['chunk1'])
+    })
+  })
+
+  describe('skipToken', () => {
+    it('should skip the query while a computed queryFn resolves to skipToken, and run it once defined', async () => {
+      const key = queryKey()
+      const id = ref<string | null>(null)
+      const fetchFn = vi.fn(() => sleep(10).then(() => 'Some data'))
+
+      const query = useQuery({
+        queryKey: key,
+        queryFn: computed(() => (id.value ? fetchFn : skipToken)),
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).not.toHaveBeenCalled()
+      expect(query).toMatchObject({ status: { value: 'pending' } })
+
+      id.value = '1'
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+      expect(query).toMatchObject({
+        status: { value: 'success' },
+        data: { value: 'Some data' },
+      })
     })
   })
 })

--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -8,6 +8,9 @@ export { QueryCache } from './queryCache'
 export { queryOptions } from './queryOptions'
 export type {
   QueryOptions,
+  UseQueryOptions,
+  UndefinedInitialQueryOptions,
+  DefinedInitialQueryOptions,
   UndefinedInitialQueryOptionsWithDataTag,
   DefinedInitialQueryOptionsWithDataTag,
 } from './queryOptions'
@@ -30,13 +33,7 @@ export { VUE_QUERY_CLIENT } from './utils'
 
 export type { UsePrefetchQueryOptions } from './usePrefetchQuery'
 export type { UsePrefetchInfiniteQueryOptions } from './usePrefetchInfiniteQuery'
-export type {
-  UseQueryOptions,
-  UseQueryReturnType,
-  UseQueryDefinedReturnType,
-  UndefinedInitialQueryOptions,
-  DefinedInitialQueryOptions,
-} from './useQuery'
+export type { UseQueryReturnType, UseQueryDefinedReturnType } from './useQuery'
 export type {
   UseInfiniteQueryOptions,
   UseInfiniteQueryReturnType,

--- a/packages/vue-query/src/index.ts
+++ b/packages/vue-query/src/index.ts
@@ -16,6 +16,7 @@ export type {
 } from './queryOptions'
 export { infiniteQueryOptions } from './infiniteQueryOptions'
 export type {
+  InfiniteQueryOptions,
   DefinedInitialDataInfiniteOptions,
   UndefinedInitialDataInfiniteOptions,
 } from './infiniteQueryOptions'

--- a/packages/vue-query/src/infiniteQueryOptions.ts
+++ b/packages/vue-query/src/infiniteQueryOptions.ts
@@ -1,11 +1,72 @@
 import type {
   DefaultError,
   InfiniteData,
+  InfiniteQueryObserverOptions,
   NonUndefinedGuard,
+  OmitKeyof,
+  QueryBooleanOption,
   QueryKey,
   QueryKeyWithDataTag,
 } from '@tanstack/query-core'
-import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
+import type {
+  DeepUnwrapRef,
+  MaybeRefDeep,
+  MaybeRefOrGetter,
+  ShallowOption,
+} from './types'
+
+// Widen `SkipToken`'s `unique symbol` to `symbol` so it survives a `queryFn: cond ? fn : skipToken` ternary
+// inside a whole-options getter or a `computed` — see `SkipTokenForUseQuery` in `queryOptions.ts`. Only the
+// `infiniteQueryOptions()` input widens: `InfiniteQueryOptions` keeps `unique symbol` so the object
+// `infiniteQueryOptions()` hands back still satisfies `QueryClient` methods like `queryClient.infiniteQuery`.
+type SkipTokenForInfiniteQuery = symbol
+
+/**
+ * The plain, unwrapped options that `infiniteQueryOptions` hands back, and what `useInfiniteQuery` and the
+ * `queryClient` methods see once `ref`s have been resolved. `enabled` and `queryKey` track reactive
+ * dependencies automatically as a `ref`, a plain value, or a reactive getter (`() => ...`). Every other
+ * option is a plain value here; to close over reactive state in any of them, use {@link UseInfiniteQueryOptions}
+ * directly, or pass a getter for the whole options object instead (`useInfiniteQuery(() => ({ ... }))`).
+ *
+ * @template TQueryFnData - The type of a single page, as your `queryFn` resolves it.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs — defaults to `InfiniteData<TQueryFnData>`,
+ * the shape of all fetched pages plus their page params.
+ * @template TQueryKey - The type of your `queryKey`.
+ * @template TPageParam - The type of the parameter passed to `queryFn` to fetch a given page.
+ */
+export type InfiniteQueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+> = {
+  [Property in keyof InfiniteQueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey,
+    TPageParam
+  >]: Property extends 'enabled'
+    ?
+        | MaybeRefOrGetter<boolean | undefined>
+        | (() => QueryBooleanOption<
+            TQueryFnData,
+            TError,
+            InfiniteData<TQueryFnData, TPageParam>,
+            DeepUnwrapRef<TQueryKey>
+          >)
+    : Property extends 'queryKey'
+      ? MaybeRefOrGetter<TQueryKey>
+      : InfiniteQueryObserverOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          DeepUnwrapRef<TQueryKey>,
+          TPageParam
+        >[Property]
+} & ShallowOption
 
 /**
  * The options accepted by the `infiniteQueryOptions` overload selected when no `initialData` is set — `data`
@@ -24,13 +85,20 @@ export type UndefinedInitialDataInfiniteOptions<
   TData = InfiniteData<TQueryFnData>,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
-> = UseInfiniteQueryOptions<
-  TQueryFnData,
-  TError,
-  TData,
-  TQueryKey,
-  TPageParam
+> = OmitKeyof<
+  InfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>,
+  'queryFn'
 > & {
+  queryFn?: MaybeRefDeep<
+    | InfiniteQueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryKey,
+        TPageParam
+      >['queryFn']
+    | SkipTokenForInfiniteQuery
+  >
   initialData?: undefined
 }
 
@@ -51,13 +119,20 @@ export type DefinedInitialDataInfiniteOptions<
   TData = InfiniteData<TQueryFnData>,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
-> = UseInfiniteQueryOptions<
-  TQueryFnData,
-  TError,
-  TData,
-  TQueryKey,
-  TPageParam
+> = OmitKeyof<
+  InfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>,
+  'queryFn'
 > & {
+  queryFn?: MaybeRefDeep<
+    | InfiniteQueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryKey,
+        TPageParam
+      >['queryFn']
+    | SkipTokenForInfiniteQuery
+  >
   /**
    * If set, this value will be used as the initial data for the query cache (as long as the query hasn't been
    * created or cached yet). If set to a function, the function will be called **once** during the shared/root
@@ -110,14 +185,9 @@ export function infiniteQueryOptions<
     TQueryKey,
     TPageParam
   >,
-): UndefinedInitialDataInfiniteOptions<
-  TQueryFnData,
-  TError,
-  TData,
-  TQueryKey,
-  TPageParam
-> &
-  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
+): InfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & {
+  initialData?: undefined
+} & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 /**
  * You can generally pass everything to `infiniteQueryOptions` that you can also pass to `useInfiniteQuery`.
@@ -164,14 +234,11 @@ export function infiniteQueryOptions<
     TQueryKey,
     TPageParam
   >,
-): DefinedInitialDataInfiniteOptions<
-  TQueryFnData,
-  TError,
-  TData,
-  TQueryKey,
-  TPageParam
-> &
-  QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
+): InfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam> & {
+  initialData:
+    | NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>
+    | (() => NonUndefinedGuard<InfiniteData<TQueryFnData, TPageParam>>)
+} & QueryKeyWithDataTag<TQueryKey, InfiniteData<TQueryFnData>, TError>
 
 export function infiniteQueryOptions(options: unknown) {
   return options

--- a/packages/vue-query/src/infiniteQueryOptions.ts
+++ b/packages/vue-query/src/infiniteQueryOptions.ts
@@ -4,7 +4,6 @@ import type {
   InfiniteQueryObserverOptions,
   NonUndefinedGuard,
   OmitKeyof,
-  QueryBooleanOption,
   QueryKey,
   QueryKeyWithDataTag,
 } from '@tanstack/query-core'
@@ -49,14 +48,15 @@ export type InfiniteQueryOptions<
     TQueryKey,
     TPageParam
   >]: Property extends 'enabled'
-    ?
-        | MaybeRefOrGetter<boolean | undefined>
-        | (() => QueryBooleanOption<
-            TQueryFnData,
-            TError,
-            InfiniteData<TQueryFnData, TPageParam>,
-            DeepUnwrapRef<TQueryKey>
-          >)
+    ? MaybeRefOrGetter<
+        InfiniteQueryObserverOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          DeepUnwrapRef<TQueryKey>,
+          TPageParam
+        >['enabled']
+      >
     : Property extends 'queryKey'
       ? MaybeRefOrGetter<TQueryKey>
       : InfiniteQueryObserverOptions<

--- a/packages/vue-query/src/queryClient.ts
+++ b/packages/vue-query/src/queryClient.ts
@@ -3,7 +3,7 @@ import { QueryClient as QC } from '@tanstack/query-core'
 import { cloneDeepUnref } from './utils'
 import { QueryCache } from './queryCache'
 import { MutationCache } from './mutationCache'
-import type { UseQueryOptions } from './useQuery'
+import type { UseQueryOptions } from './queryOptions'
 import type { Ref } from 'vue-demi'
 import type { MaybeRefDeep, NoUnknown, QueryClientConfig } from './types'
 import type {

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -1,35 +1,30 @@
-import type { DeepUnwrapRef, MaybeRefOrGetter, ShallowOption } from './types'
+import type {
+  DeepUnwrapRef,
+  MaybeRef,
+  MaybeRefDeep,
+  MaybeRefOrGetter,
+  ShallowOption,
+} from './types'
 import type {
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
-  OmitKeyof,
   QueryBooleanOption,
-  QueryFunction,
   QueryKey,
   QueryKeyWithDataTag,
   QueryObserverOptions,
 } from '@tanstack/query-core'
 
 // Widen `SkipToken`'s `unique symbol` to `symbol` so it survives a `queryFn: cond ? fn : skipToken`
-// ternary inside a whole-options getter — see `SkipTokenForUseQueries` in `useQueries.ts`.
-type SkipTokenForQueryOptions = symbol
+// ternary inside a whole-options getter or a `computed` — see `SkipTokenForUseQueries` in `useQueries.ts`.
+// Only `UseQueryOptions` (the *input* type) widens: `QueryOptions` keeps `unique symbol` so the object
+// `queryOptions()` hands back still satisfies `QueryClient` methods like `fetchQuery`/`invalidateQueries`.
+type SkipTokenForUseQuery = symbol
 
 /**
- * The options accepted by `queryOptions`, `useQuery`, and the other query hooks. `enabled` tracks reactive
- * dependencies automatically as a `ref`, a plain value, or a reactive getter (`() => ...`). `queryKey` reacts
- * through a `ref` for the array itself, or `ref`s and reactive getters as individual entries — the array
- * itself can't be a bare getter. Other options passed this way are read once and are not reactive.
- *
- * If you instead pass a getter for the whole options object (`useQuery(() => ({ ... }))`), every option
- * inside it — including `staleTime`, `retry`, and `select` — is re-evaluated whenever the getter's own
- * reactive dependencies change, since the entire object is recomputed.
- *
- * `select` only re-runs when `data` changes, or when the `select` function's own reference changes. Since a
- * Vue `setup()` function runs only once per component instance, an inline `select` function passed directly
- * to `queryOptions`/`useQuery` already has a stable reference across reactive updates. An inline `select`
- * created inside a whole-options getter is recreated — and so can change reference — every time that getter
- * re-evaluates.
+ * The plain, unwrapped options that `queryOptions` hands back, and what `useQuery`, `useQueries`, and the
+ * `queryClient` methods see once `ref`s have been resolved. To pass options in, use {@link UseQueryOptions},
+ * which accepts the same options as `ref`s and `computed`s too.
  *
  * @template TQueryFnData - The type your `queryFn` resolves to.
  * @template TError - The type of errors your `queryFn` may throw.
@@ -62,19 +57,84 @@ export type QueryOptions<
           >)
     : Property extends 'queryKey'
       ? MaybeRefOrGetter<TQueryKey>
-      : Property extends 'queryFn'
-        ?
-            | QueryFunction<TQueryFnData, DeepUnwrapRef<TQueryKey>>
-            | SkipTokenForQueryOptions
-            | undefined
-        : QueryObserverOptions<
-            TQueryFnData,
-            TError,
-            TData,
-            TQueryData,
-            DeepUnwrapRef<TQueryKey>
-          >[Property]
+      : QueryObserverOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          TQueryData,
+          DeepUnwrapRef<TQueryKey>
+        >[Property]
 } & ShallowOption
+
+/**
+ * The options accepted by `queryOptions`, `useQuery`, and the other query hooks. `enabled` tracks reactive
+ * dependencies automatically as a `ref`, a plain value, or a reactive getter (`() => ...`). `queryKey` reacts
+ * through a `ref` or a reactive getter for the array itself, or `ref`s and reactive getters as individual
+ * entries. `queryFn` reacts through a `ref` or a `computed`, but never a bare getter, since a function there
+ * is the query function itself. Other options are read once when passed as a plain value, and stay reactive
+ * when passed as a `ref` or a `computed`.
+ *
+ * If you instead pass a getter for the whole options object (`useQuery(() => ({ ... }))`), every option
+ * inside it — including `staleTime`, `retry`, and `select` — is re-evaluated whenever the getter's own
+ * reactive dependencies change, since the entire object is recomputed.
+ *
+ * `select` only re-runs when `data` changes, or when the `select` function's own reference changes. Since a
+ * Vue `setup()` function runs only once per component instance, an inline `select` function passed directly
+ * to `queryOptions`/`useQuery` already has a stable reference across reactive updates. An inline `select`
+ * created inside a whole-options getter is recreated — and so can change reference — every time that getter
+ * re-evaluates.
+ *
+ * @template TQueryFnData - The type your `queryFn` resolves to.
+ * @template TError - The type of errors your `queryFn` may throw.
+ * @template TData - The type `data` ends up as after `select` runs.
+ * @template TQueryData - The type of data stored in the cache, before `select` runs. Defaults to
+ * `TQueryFnData` and can be configured independently of it.
+ * @template TQueryKey - The type of your `queryKey`.
+ */
+export type UseQueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = MaybeRef<
+  {
+    [Property in keyof QueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >]: Property extends 'enabled' | 'queryKey'
+      ? QueryOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          TQueryData,
+          TQueryKey
+        >[Property]
+      : Property extends 'queryFn'
+        ? MaybeRefDeep<
+            | QueryOptions<
+                TQueryFnData,
+                TError,
+                TData,
+                TQueryData,
+                TQueryKey
+              >[Property]
+            | SkipTokenForUseQuery
+          >
+        : MaybeRefDeep<
+            QueryOptions<
+              TQueryFnData,
+              TError,
+              TData,
+              TQueryData,
+              TQueryKey
+            >[Property]
+          >
+  } & ShallowOption
+>
 
 /**
  * The options accepted by the `queryOptions` overload selected when no `initialData` is set — `data` may be
@@ -90,7 +150,7 @@ export type UndefinedInitialQueryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
   /**
    * If set, this value will be used as the initial data for the query cache (as long as the query hasn't been
    * created or cached yet). If set to a function, the function will be called **once** during the shared/root
@@ -118,7 +178,7 @@ export type DefinedInitialQueryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
   /**
    * If set, this value will be used as the initial data for the query cache (as long as the query hasn't been
    * created or cached yet). If set to a function, the function will be called **once** during the shared/root
@@ -131,25 +191,16 @@ export type DefinedInitialQueryOptions<
     | (() => NonUndefinedGuard<TQueryFnData>)
 }
 
-// `UndefinedInitialQueryOptions`/`DefinedInitialQueryOptions` widen `queryFn` to plain `symbol` so a
-// `queryFn: cond ? fn : skipToken` ternary type-checks as a getter's *input*. Narrow it back to `SkipToken`
-// here so the *returned* options object still satisfies `QueryClient` methods that expect `unique symbol`.
 export type UndefinedInitialQueryOptionsWithDataTag<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = OmitKeyof<
-  UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  'queryFn'
-> & {
-  queryFn?: QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryFnData,
-    DeepUnwrapRef<TQueryKey>
-  >['queryFn']
+> = QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+  initialData?:
+    | undefined
+    | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
+    | NonUndefinedGuard<TQueryFnData>
 } & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export type DefinedInitialQueryOptionsWithDataTag<
@@ -157,17 +208,10 @@ export type DefinedInitialQueryOptionsWithDataTag<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = OmitKeyof<
-  DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  'queryFn'
-> & {
-  queryFn?: QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryFnData,
-    DeepUnwrapRef<TQueryKey>
-  >['queryFn']
+> = QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+  initialData:
+    | NonUndefinedGuard<TQueryFnData>
+    | (() => NonUndefinedGuard<TQueryFnData>)
 } & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 /**
@@ -328,9 +372,9 @@ export function queryOptions<
  * ```
  *
  * @example
- * A parameterized factory that disables the query, type safe, until `postId` is set. This requires a
- * whole-options getter: `queryFn` is a single value, not `queryKey`/`enabled`, so it isn't itself reactive —
- * the getter is what re-evaluates it on every change to `postId`:
+ * A parameterized factory that disables the query, type safe, until `postId` is set. The whole-options getter
+ * re-evaluates `queryFn` on every change to `postId`. `queryFn` can also be a `computed`, but never a bare
+ * getter, since a function there is the query function itself:
  * ```vue
  * <script setup lang="ts">
  * import { queryOptions, skipToken, useQuery } from '@tanstack/vue-query'

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -9,6 +9,7 @@ import type {
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
+  OmitKeyof,
   QueryBooleanOption,
   QueryKey,
   QueryKeyWithDataTag,
@@ -23,8 +24,11 @@ type SkipTokenForUseQuery = symbol
 
 /**
  * The plain, unwrapped options that `queryOptions` hands back, and what `useQuery`, `useQueries`, and the
- * `queryClient` methods see once `ref`s have been resolved. To pass options in, use {@link UseQueryOptions},
- * which accepts the same options as `ref`s and `computed`s too.
+ * `queryClient` methods see once `ref`s have been resolved. `enabled` and `queryKey` track reactive
+ * dependencies automatically as a `ref`, a plain value, or a reactive getter (`() => ...`). Every other
+ * option — including `queryFn` — is a plain value here; to pass `queryFn` as a `ref`/`computed`, or to close
+ * over reactive state in any other option, use {@link UseQueryOptions} directly, or pass a getter for the
+ * whole options object instead (`useQuery(() => ({ ... }))`).
  *
  * @template TQueryFnData - The type your `queryFn` resolves to.
  * @template TError - The type of errors your `queryFn` may throw.
@@ -150,7 +154,20 @@ export type UndefinedInitialQueryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+> = OmitKeyof<
+  QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
+  'queryFn'
+> & {
+  queryFn?: MaybeRefDeep<
+    | QueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryFnData,
+        TQueryKey
+      >['queryFn']
+    | SkipTokenForUseQuery
+  >
   /**
    * If set, this value will be used as the initial data for the query cache (as long as the query hasn't been
    * created or cached yet). If set to a function, the function will be called **once** during the shared/root
@@ -178,7 +195,20 @@ export type DefinedInitialQueryOptions<
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
+> = OmitKeyof<
+  QueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
+  'queryFn'
+> & {
+  queryFn?: MaybeRefDeep<
+    | QueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryFnData,
+        TQueryKey
+      >['queryFn']
+    | SkipTokenForUseQuery
+  >
   /**
    * If set, this value will be used as the initial data for the query cache (as long as the query hasn't been
    * created or cached yet). If set to a function, the function will be called **once** during the shared/root

--- a/packages/vue-query/src/queryOptions.ts
+++ b/packages/vue-query/src/queryOptions.ts
@@ -3,11 +3,17 @@ import type {
   DefaultError,
   InitialDataFunction,
   NonUndefinedGuard,
+  OmitKeyof,
   QueryBooleanOption,
+  QueryFunction,
   QueryKey,
   QueryKeyWithDataTag,
   QueryObserverOptions,
 } from '@tanstack/query-core'
+
+// Widen `SkipToken`'s `unique symbol` to `symbol` so it survives a `queryFn: cond ? fn : skipToken`
+// ternary inside a whole-options getter — see `SkipTokenForUseQueries` in `useQueries.ts`.
+type SkipTokenForQueryOptions = symbol
 
 /**
  * The options accepted by `queryOptions`, `useQuery`, and the other query hooks. `enabled` tracks reactive
@@ -56,13 +62,18 @@ export type QueryOptions<
           >)
     : Property extends 'queryKey'
       ? MaybeRefOrGetter<TQueryKey>
-      : QueryObserverOptions<
-          TQueryFnData,
-          TError,
-          TData,
-          TQueryData,
-          DeepUnwrapRef<TQueryKey>
-        >[Property]
+      : Property extends 'queryFn'
+        ?
+            | QueryFunction<TQueryFnData, DeepUnwrapRef<TQueryKey>>
+            | SkipTokenForQueryOptions
+            | undefined
+        : QueryObserverOptions<
+            TQueryFnData,
+            TError,
+            TData,
+            TQueryData,
+            DeepUnwrapRef<TQueryKey>
+          >[Property]
 } & ShallowOption
 
 /**
@@ -120,21 +131,44 @@ export type DefinedInitialQueryOptions<
     | (() => NonUndefinedGuard<TQueryFnData>)
 }
 
+// `UndefinedInitialQueryOptions`/`DefinedInitialQueryOptions` widen `queryFn` to plain `symbol` so a
+// `queryFn: cond ? fn : skipToken` ternary type-checks as a getter's *input*. Narrow it back to `SkipToken`
+// here so the *returned* options object still satisfies `QueryClient` methods that expect `unique symbol`.
 export type UndefinedInitialQueryOptionsWithDataTag<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> &
-  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
+> = OmitKeyof<
+  UndefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  'queryFn'
+> & {
+  queryFn?: QueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    DeepUnwrapRef<TQueryKey>
+  >['queryFn']
+} & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export type DefinedInitialQueryOptionsWithDataTag<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey> &
-  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
+> = OmitKeyof<
+  DefinedInitialQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  'queryFn'
+> & {
+  queryFn?: QueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    DeepUnwrapRef<TQueryKey>
+  >['queryFn']
+} & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 /**
  * You can generally pass everything to `queryOptions` that you can also pass to `useQuery`. These options can

--- a/packages/vue-query/src/useBaseQuery.ts
+++ b/packages/vue-query/src/useBaseQuery.ts
@@ -20,7 +20,7 @@ import type {
   QueryObserverResult,
 } from '@tanstack/query-core'
 import type { QueryClient } from './queryClient'
-import type { UseQueryOptions } from './useQuery'
+import type { UseQueryOptions } from './queryOptions'
 import type { UseInfiniteQueryOptions } from './useInfiniteQuery'
 import type { MaybeRefOrGetter } from './types'
 

--- a/packages/vue-query/src/useInfiniteQuery.ts
+++ b/packages/vue-query/src/useInfiniteQuery.ts
@@ -2,6 +2,7 @@ import { InfiniteQueryObserver } from '@tanstack/query-core'
 import { useBaseQuery } from './useBaseQuery'
 import type {
   DefinedInitialDataInfiniteOptions,
+  InfiniteQueryOptions,
   UndefinedInitialDataInfiniteOptions,
 } from './infiniteQueryOptions'
 import type {
@@ -16,13 +17,16 @@ import type {
 import type { UseBaseQueryReturnType } from './useBaseQuery'
 
 import type {
-  DeepUnwrapRef,
   MaybeRef,
   MaybeRefDeep,
   MaybeRefOrGetter,
   ShallowOption,
 } from './types'
 import type { QueryClient } from './queryClient'
+
+// Widen `SkipToken`'s `unique symbol` to `symbol` so it survives a `queryFn: cond ? fn : skipToken` ternary
+// inside a whole-options getter or a `computed` — see `SkipTokenForUseQuery` in `queryOptions.ts`.
+type SkipTokenForUseInfiniteQuery = symbol
 
 export type UseInfiniteQueryOptions<
   TQueryFnData = unknown,
@@ -38,25 +42,34 @@ export type UseInfiniteQueryOptions<
       TData,
       TQueryKey,
       TPageParam
-    >]: Property extends 'enabled'
-      ? MaybeRefOrGetter<
-          InfiniteQueryObserverOptions<
-            TQueryFnData,
-            TError,
-            TData,
-            DeepUnwrapRef<TQueryKey>,
-            TPageParam
-          >[Property]
-        >
-      : MaybeRefDeep<
-          InfiniteQueryObserverOptions<
-            TQueryFnData,
-            TError,
-            TData,
-            DeepUnwrapRef<TQueryKey>,
-            TPageParam
-          >[Property]
-        >
+    >]: Property extends 'enabled' | 'queryKey'
+      ? InfiniteQueryOptions<
+          TQueryFnData,
+          TError,
+          TData,
+          TQueryKey,
+          TPageParam
+        >[Property]
+      : Property extends 'queryFn'
+        ? MaybeRefDeep<
+            | InfiniteQueryOptions<
+                TQueryFnData,
+                TError,
+                TData,
+                TQueryKey,
+                TPageParam
+              >[Property]
+            | SkipTokenForUseInfiniteQuery
+          >
+        : MaybeRefDeep<
+            InfiniteQueryOptions<
+              TQueryFnData,
+              TError,
+              TData,
+              TQueryKey,
+              TPageParam
+            >[Property]
+          >
   } & ShallowOption
 >
 
@@ -73,8 +86,8 @@ export type UseInfiniteQueryReturnType<TData, TError> = UseBaseQueryReturnType<
  * This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
  *
  * `enabled` tracks reactive dependencies automatically as a `ref`, a plain value, or a reactive getter
- * (`() => ...`). `queryKey` reacts through a `ref` for the array itself, or `ref`s and reactive getters as
- * individual entries — the array itself can't be a bare getter.
+ * (`() => ...`). `queryKey` reacts through a `ref` or a reactive getter for the array itself, or `ref`s and
+ * reactive getters as individual entries.
  *
  * @remarks Keep in mind that imperative fetch calls, such as `fetchNextPage`, may interfere with the default
  * refetch behavior, resulting in outdated data. Make sure to call these functions only in response to user
@@ -138,8 +151,8 @@ export function useInfiniteQuery<
  * `initialPageParam`, `getNextPageParam`, `getPreviousPageParam`, and `maxPages`.
  *
  * `enabled` tracks reactive dependencies automatically as a `ref`, a plain value, or a reactive getter
- * (`() => ...`). `queryKey` reacts through a `ref` for the array itself, or `ref`s and reactive getters as
- * individual entries — the array itself can't be a bare getter.
+ * (`() => ...`). `queryKey` reacts through a `ref` or a reactive getter for the array itself, or `ref`s and
+ * reactive getters as individual entries.
  *
  * @remarks Keep in mind that imperative fetch calls, such as `fetchNextPage`, may interfere with the default
  * refetch behavior, resulting in outdated data. Make sure to call these functions only in response to user
@@ -273,8 +286,8 @@ export function useInfiniteQuery<
  * overloads when possible, since they infer whether `data` can be `undefined` from `initialData` directly.
  *
  * `enabled` tracks reactive dependencies automatically as a `ref`, a plain value, or a reactive getter
- * (`() => ...`). `queryKey` reacts through a `ref` for the array itself, or `ref`s and reactive getters as
- * individual entries — the array itself can't be a bare getter.
+ * (`() => ...`). `queryKey` reacts through a `ref` or a reactive getter for the array itself, or `ref`s and
+ * reactive getters as individual entries.
  *
  * @param options - A `ref`, plain value, or reactive getter resolving to the {@link UseInfiniteQueryOptions} to
  * use.

--- a/packages/vue-query/src/useQueries.ts
+++ b/packages/vue-query/src/useQueries.ts
@@ -22,7 +22,7 @@ import type {
   QueryObserverResult,
   ThrowOnError,
 } from '@tanstack/query-core'
-import type { UseQueryOptions } from './useQuery'
+import type { UseQueryOptions } from './queryOptions'
 import type { QueryClient } from './queryClient'
 import type { DeepUnwrapRef, MaybeRefDeep, ShallowOption } from './types'
 

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -6,6 +6,7 @@ import type {
   InitialDataFunction,
   NonUndefinedGuard,
   QueryBooleanOption,
+  QueryFunction,
   QueryKey,
   QueryObserverOptions,
 } from '@tanstack/query-core'
@@ -18,6 +19,10 @@ import type {
   ShallowOption,
 } from './types'
 import type { QueryClient } from './queryClient'
+
+// Widen `SkipToken`'s `unique symbol` to `symbol` so it survives a `queryFn: cond ? fn : skipToken`
+// ternary inside a whole-options getter — see `SkipTokenForUseQueries` in `useQueries.ts`.
+type SkipTokenForUseQuery = symbol
 
 export type UseQueryOptions<
   TQueryFnData = unknown,
@@ -52,15 +57,21 @@ export type UseQueryOptions<
               TQueryKey
             >[Property]
           >
-        : MaybeRefDeep<
-            QueryObserverOptions<
-              TQueryFnData,
-              TError,
-              TData,
-              TQueryData,
-              DeepUnwrapRef<TQueryKey>
-            >[Property]
-          >
+        : Property extends 'queryFn'
+          ? MaybeRefDeep<
+              | QueryFunction<TQueryFnData, DeepUnwrapRef<TQueryKey>>
+              | SkipTokenForUseQuery
+              | undefined
+            >
+          : MaybeRefDeep<
+              QueryObserverOptions<
+                TQueryFnData,
+                TError,
+                TData,
+                TQueryData,
+                DeepUnwrapRef<TQueryKey>
+              >[Property]
+            >
   } & ShallowOption
 >
 

--- a/packages/vue-query/src/useQuery.ts
+++ b/packages/vue-query/src/useQuery.ts
@@ -3,100 +3,16 @@ import { useBaseQuery } from './useBaseQuery'
 import type {
   DefaultError,
   DefinedQueryObserverResult,
-  InitialDataFunction,
-  NonUndefinedGuard,
-  QueryBooleanOption,
-  QueryFunction,
   QueryKey,
-  QueryObserverOptions,
 } from '@tanstack/query-core'
 import type { UseBaseQueryReturnType } from './useBaseQuery'
-import type {
-  DeepUnwrapRef,
-  MaybeRef,
-  MaybeRefDeep,
-  MaybeRefOrGetter,
-  ShallowOption,
-} from './types'
+import type { MaybeRefOrGetter } from './types'
 import type { QueryClient } from './queryClient'
-
-// Widen `SkipToken`'s `unique symbol` to `symbol` so it survives a `queryFn: cond ? fn : skipToken`
-// ternary inside a whole-options getter — see `SkipTokenForUseQueries` in `useQueries.ts`.
-type SkipTokenForUseQuery = symbol
-
-export type UseQueryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = MaybeRef<
-  {
-    [Property in keyof QueryObserverOptions<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryData,
-      TQueryKey
-    >]: Property extends 'enabled'
-      ?
-          | MaybeRefOrGetter<boolean | undefined>
-          | (() => QueryBooleanOption<
-              TQueryFnData,
-              TError,
-              TQueryData,
-              DeepUnwrapRef<TQueryKey>
-            >)
-      : Property extends 'queryKey'
-        ? MaybeRef<
-            QueryObserverOptions<
-              TQueryFnData,
-              TError,
-              TData,
-              TQueryData,
-              TQueryKey
-            >[Property]
-          >
-        : Property extends 'queryFn'
-          ? MaybeRefDeep<
-              | QueryFunction<TQueryFnData, DeepUnwrapRef<TQueryKey>>
-              | SkipTokenForUseQuery
-              | undefined
-            >
-          : MaybeRefDeep<
-              QueryObserverOptions<
-                TQueryFnData,
-                TError,
-                TData,
-                TQueryData,
-                DeepUnwrapRef<TQueryKey>
-              >[Property]
-            >
-  } & ShallowOption
->
-
-export type UndefinedInitialQueryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData?:
-    | undefined
-    | InitialDataFunction<NonUndefinedGuard<TQueryFnData>>
-    | NonUndefinedGuard<TQueryFnData>
-}
-
-export type DefinedInitialQueryOptions<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = UseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey> & {
-  initialData:
-    | NonUndefinedGuard<TQueryFnData>
-    | (() => NonUndefinedGuard<TQueryFnData>)
-}
+import type {
+  DefinedInitialQueryOptions,
+  UndefinedInitialQueryOptions,
+  UseQueryOptions,
+} from './queryOptions'
 
 export type UseQueryReturnType<TData, TError> = UseBaseQueryReturnType<
   TData,
@@ -113,9 +29,9 @@ export type UseQueryDefinedReturnType<TData, TError> = UseBaseQueryReturnType<
  * This overload is selected when `initialData` is set, so the resulting `data` is never `undefined`.
  *
  * `enabled` tracks reactive dependencies automatically as a `ref`, a plain value, or a reactive getter
- * (`() => ...`). `queryKey` reacts through a `ref` for the array itself, or `ref`s and reactive getters as
- * individual entries — the array itself can't be a bare getter. Other options are read once and are not
- * reactive.
+ * (`() => ...`). `queryKey` reacts through a `ref` or a reactive getter for the array itself, or `ref`s and
+ * reactive getters as individual entries. Other options are read once when passed as a plain value, and stay
+ * reactive when passed as a `ref` or a `computed`.
  *
  * @param options - The {@link DefinedInitialQueryOptions} to use — everything you can pass to `useQuery`, with
  * `initialData` set.
@@ -158,9 +74,9 @@ export function useQuery<
 
 /**
  * `enabled` tracks reactive dependencies automatically as a `ref`, a plain value, or a reactive getter
- * (`() => ...`). `queryKey` reacts through a `ref` for the array itself, or `ref`s and reactive getters as
- * individual entries — the array itself can't be a bare getter. Other options are read once and are not
- * reactive.
+ * (`() => ...`). `queryKey` reacts through a `ref` or a reactive getter for the array itself, or `ref`s and
+ * reactive getters as individual entries. Other options are read once when passed as a plain value, and stay
+ * reactive when passed as a `ref` or a `computed`.
  *
  * @param options - The {@link UndefinedInitialQueryOptions} to use — everything you can pass to `useQuery`.
  * @param queryClient - Use this to use a custom `QueryClient`. Otherwise, the one provided by `VueQueryPlugin`
@@ -303,8 +219,8 @@ export function useQuery<
  * overloads when possible, since they infer whether `data` can be `undefined` from `initialData` directly.
  *
  * `enabled` tracks reactive dependencies automatically as a `ref`, a plain value, or a reactive getter
- * (`() => ...`). `queryKey` reacts through a `ref` for the array itself, or `ref`s and reactive getters as
- * individual entries — the array itself can't be a bare getter.
+ * (`() => ...`). `queryKey` reacts through a `ref` or a reactive getter for the array itself, or `ref`s and
+ * reactive getters as individual entries.
  *
  * When `options` itself is a reactive getter, the whole object is re-evaluated on every change to its
  * dependencies, so any option inside it — not just `queryKey` and `enabled` — can change over time.
@@ -336,9 +252,9 @@ export function useQuery<
  *
  * @example
  * `skipToken` disables the query in a type-safe way, without a non-null assertion on `props.postId` —
- * `queryFn` is only ever called when it's defined. This requires a whole-options getter: `queryFn` is a
- * single value, not `queryKey`/`enabled`, so it isn't itself reactive — the getter is what re-evaluates it
- * on every change to `props.postId`. `refetch` doesn't work while `queryFn` is `skipToken` — use
+ * `queryFn` is only ever called when it's defined. The whole-options getter re-evaluates `queryFn` on every
+ * change to `props.postId`. `queryFn` can also be a `computed`, but never a bare getter, since a function
+ * there is the query function itself. `refetch` doesn't work while `queryFn` is `skipToken` — use
  * `enabled: false` instead if you need to trigger the query manually:
  * ```vue
  * <script setup lang="ts">


### PR DESCRIPTION
## 🎯 Changes

`useQuery`/`queryOptions`'s whole-options getter overload (`useQuery(() => ({...}))` / `queryOptions(() => ({...}))`) failed to type-check the `queryFn: cond ? fn : skipToken` pattern shown in their own JSDoc examples.

Root cause: `SkipToken` is a `unique symbol`. When a function has more than one overload and the argument is a getter, TypeScript fails to propagate the contextual type into a ternary inside the getter's body, widening the ternary's `unique symbol` branch to plain `symbol` — which no longer matches any overload. This repo already has a fix for the same issue in `useQueries.ts` (`SkipTokenForUseQueries = symbol`).

The same widening needs to apply consistently everywhere `queryFn` is accepted as input, but `useQuery.ts` and `queryOptions.ts` each hand-wrote their own, independently-drifting mapped type for the options they accept, so `queryOptions()` didn't accept a `computed` `queryFn` at all (only `useQuery`'s options type did), and a bare reactive getter for the whole `queryKey` array was accepted by `queryOptions()` but rejected by `useQuery()`/`useQueries()` for no principled reason (confirmed at runtime — `cloneDeepUnref` already resolves a bare-getter `queryKey`).

This PR:
- Moves `UseQueryOptions` (previously defined ad hoc in `useQuery.ts`) into `queryOptions.ts`. `QueryOptions` stays the plain/output type — `enabled`/`queryKey` reactive, everything else (including `queryFn`) plain with `unique symbol` — so `queryOptions()`'s return value still satisfies `QueryClient` methods like `fetchQuery`/`invalidateQueries` that expect `unique symbol`, and so `useQueries`' type-level inference (which pattern-matches on a plain `queryFn` union) keeps working when a `queryOptions()` result is spread into it.
- `UseQueryOptions` (the shared input type for `useQuery`, `useQueries`, `useBaseQuery`, and `queryClient`) sources its `enabled`/`queryKey`/`queryFn` mappings from `QueryOptions`, so the two can't drift apart again, and widens `SkipToken` to `symbol` only on `queryFn` there, so `queryFn: cond ? fn : skipToken` type-checks both inside a whole-options getter and as a `computed`.
- `queryOptions()` keeps a narrower input than `useQuery()`: `enabled`/`queryKey`/`queryFn` accept a `ref`/`computed`/getter, every other option stays a plain value (e.g. `staleTime: ref(...)` is still rejected, and so is wrapping the whole options object in a `ref`) — the same shape `queryOptions()` already had, with `queryFn` added. Both rejections are pinned with `@ts-expect-error` regression tests.
- Allows a bare reactive getter for the whole `queryKey` array on `useQuery`/`useQueries` (previously `@ts-expect-error`'d), matching what `queryOptions()` already accepted and what the runtime already resolves.
- Adds runtime tests (`useQuery.test.ts`, `useQueries.test.ts`, `useInfiniteQuery.test.ts`) confirming a `computed` `queryFn` that flips to `skipToken` actually skips the query and re-runs once defined — not just a type-only check. For `useQuery`/`useInfiniteQuery`, the corresponding type-level test only asserts that a `computed` `queryFn` type-checks (`assertType`), not the exact resulting `data` type: `vue-tsc`'s language-service plugin (unlike `tsc` or vitest's own typecheck) fails to resolve the generic through that inference path. `useQueries` isn't affected and keeps the stronger `expectTypeOf` assertion.
- `infiniteQueryOptions()`'s input is narrowed to match `queryOptions()`: `enabled`/`queryKey`/`queryFn` accept a `ref`/`computed`/getter, every other option stays a plain value. Before this PR, `queryOptions()` was already narrow this way, but `infiniteQueryOptions()` wrapped every property (including `staleTime`, or the whole options object) in `MaybeRefDeep`, so `staleTime: ref(...)` and wrapping the whole object in a `ref` type-checked despite not actually being tracked reactively. This is a breaking change, pinned with new `@ts-expect-error` regression tests in `infiniteQueryOptions.test-d.ts`. `enabled` keeps accepting a plain `(query) => boolean` callback alongside `ref`/`computed`/getter, matching `InfiniteQueryObserverOptions`.

No other runtime behavior changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for reactive getters for complete `queryKey` arrays, triggering refetches when dependent values change.
  - `queryFn` now supports reactive refs and computed values, including conditional `skipToken` behavior that keeps queries pending until ready.
  - Infinite-query options now support reactive `queryKey` and `enabled` values.
  - Improved TypeScript exports and inference for query and infinite-query options.

- **Tests**
  - Added coverage for reactive options, skip-token behavior, refetching, and type inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->