### PR TITLE
fix(vue-query): skip hydration when Nuxt state is null

### DIFF
--- a/docs/framework/vue/guides/ssr.md
+++ b/docs/framework/vue/guides/ssr.md
@@ -42,7 +42,7 @@ export default defineNuxtPlugin((nuxt) => {
     })
   }
 
-  if (import.meta.client) {
+  if (import.meta.client && vueQueryState.value !== null) {
     hydrate(queryClient, vueQueryState.value)
   }
 })

--- a/examples/vue/nuxt3/plugins/vue-query.ts
+++ b/examples/vue/nuxt3/plugins/vue-query.ts
@@ -28,7 +28,7 @@ export default defineNuxtPlugin((nuxt) => {
     })
   }
 
-  if (import.meta.client) {
+  if (import.meta.client && vueQueryState.value !== null) {
     nuxt.hooks.hook('app:created', () => {
       hydrate(queryClient, vueQueryState.value)
     })


### PR DESCRIPTION
## 🎯 Changes

Prevent Nuxt client hydration when no dehydrated query state exists. Updates the Vue SSR guide and Nuxt 3 example to guard against `null`.

See #11260

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nuxt 3 server-side rendering hydration by skipping hydration when no dehydrated query state is available.
  * Prevents unnecessary or invalid client-side hydration in affected scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->