### PR TITLE
test(angular-query-experimental/inject-infinite-query): assert 'queryFn' call count in skipToken test

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -145,9 +145,8 @@ describe('injectInfiniteQuery', () => {
   describe('skipToken', () => {
     it('should not fetch when queryFn is skipToken, and fetch once it is replaced', async () => {
       const key = queryKey()
-      const queryFn = vi.fn(
-        ({ pageParam }: { pageParam: number }, postId: string) =>
-          sleep(10).then(() => `comments for ${postId} page ${pageParam}`),
+      const queryFn = vi.fn(({ pageParam }: { pageParam: number }) =>
+        sleep(10).then(() => `comments for 1 page ${pageParam}`),
       )
 
       @Component({
@@ -162,11 +161,7 @@ describe('injectInfiniteQuery', () => {
 
         readonly query = injectInfiniteQuery(() => ({
           queryKey: key,
-          queryFn:
-            this.postId() != null
-              ? ({ pageParam }: { pageParam: number }) =>
-                  queryFn({ pageParam }, this.postId()!)
-              : skipToken,
+          queryFn: this.postId() != null ? queryFn : skipToken,
           initialPageParam: 0,
           getNextPageParam: () => 12,
         }))

--- a/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-infinite-query.test.ts
@@ -145,6 +145,10 @@ describe('injectInfiniteQuery', () => {
   describe('skipToken', () => {
     it('should not fetch when queryFn is skipToken, and fetch once it is replaced', async () => {
       const key = queryKey()
+      const queryFn = vi.fn(
+        ({ pageParam }: { pageParam: number }, postId: string) =>
+          sleep(10).then(() => `comments for ${postId} page ${pageParam}`),
+      )
 
       @Component({
         template: `
@@ -161,9 +165,7 @@ describe('injectInfiniteQuery', () => {
           queryFn:
             this.postId() != null
               ? ({ pageParam }: { pageParam: number }) =>
-                  sleep(10).then(
-                    () => `comments for ${this.postId()} page ${pageParam}`,
-                  )
+                  queryFn({ pageParam }, this.postId()!)
               : skipToken,
           initialPageParam: 0,
           getNextPageParam: () => 12,
@@ -177,6 +179,7 @@ describe('injectInfiniteQuery', () => {
 
       await vi.advanceTimersByTimeAsync(11)
       rendered.fixture.detectChanges()
+      expect(queryFn).not.toHaveBeenCalled()
       expect(rendered.getByText('status: pending')).toBeInTheDocument()
       expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
 
@@ -186,6 +189,7 @@ describe('injectInfiniteQuery', () => {
 
       await vi.advanceTimersByTimeAsync(11)
       rendered.fixture.detectChanges()
+      expect(queryFn).toHaveBeenCalledTimes(1)
       expect(rendered.getByText('status: success')).toBeInTheDocument()
       expect(
         rendered.getByText('pages: comments for 1 page 0'),


### PR DESCRIPTION
## 🎯 Changes

CodeRabbit flagged the same gap on #11423 (solid-query): `should not fetch when queryFn is skipToken, and fetch once it is replaced` only asserted the final rendered data, so multiple fetches after the `postId` signal is set would still pass.

Wraps `queryFn` in `vi.fn` and asserts it is not called before `postId` is set, and called exactly once after.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for skipped infinite queries.
  * Added verification that the query function is not called while `skipToken` is active and runs once when a valid post ID is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->