### PR TITLE
test({react,preact}-query/useInfiniteQuery): assert 'queryFn' call count in skipToken test

### DIFF
--- a/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/preact-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1730,17 +1730,16 @@ describe('useInfiniteQuery', () => {
 
   it('should not fetch when queryFn is skipToken, and fetch once it is replaced', async () => {
     const key = queryKey()
+    const queryFn = vi.fn(({ pageParam }: { pageParam: number }) =>
+      sleep(10).then(() => `comments for 1 page ${pageParam}`),
+    )
 
     function Page() {
       const [postId, setPostId] = useState<string>()
 
       const { data, isFetching } = useInfiniteQuery({
         queryKey: key,
-        queryFn:
-          postId != null
-            ? ({ pageParam }: { pageParam: number }) =>
-                sleep(10).then(() => `comments for ${postId} page ${pageParam}`)
-            : skipToken,
+        queryFn: postId != null ? queryFn : skipToken,
         initialPageParam: 0,
         getNextPageParam: () => 12,
       })
@@ -1759,11 +1758,13 @@ describe('useInfiniteQuery', () => {
     expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
 
     await vi.advanceTimersByTimeAsync(11)
+    expect(queryFn).not.toHaveBeenCalled()
     expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
     expect(rendered.getByText('pages: none')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: 'set postId' }))
     await vi.advanceTimersByTimeAsync(11)
+    expect(queryFn).toHaveBeenCalledTimes(1)
     expect(
       rendered.getByText('pages: comments for 1 page 0'),
     ).toBeInTheDocument()

--- a/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
+++ b/packages/react-query/src/__tests__/useInfiniteQuery.test.tsx
@@ -1806,17 +1806,16 @@ describe('useInfiniteQuery', () => {
 
   it('should not fetch when queryFn is skipToken, and fetch once it is replaced', async () => {
     const key = queryKey()
+    const queryFn = vi.fn(({ pageParam }: { pageParam: number }) =>
+      sleep(10).then(() => `comments for 1 page ${pageParam}`),
+    )
 
     function Page() {
       const [postId, setPostId] = React.useState<string>()
 
       const { data, isFetching } = useInfiniteQuery({
         queryKey: key,
-        queryFn:
-          postId != null
-            ? ({ pageParam }: { pageParam: number }) =>
-                sleep(10).then(() => `comments for ${postId} page ${pageParam}`)
-            : skipToken,
+        queryFn: postId != null ? queryFn : skipToken,
         initialPageParam: 0,
         getNextPageParam: () => 12,
       })
@@ -1835,11 +1834,13 @@ describe('useInfiniteQuery', () => {
     expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
 
     await vi.advanceTimersByTimeAsync(11)
+    expect(queryFn).not.toHaveBeenCalled()
     expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
     expect(rendered.getByText('pages: none')).toBeInTheDocument()
 
     fireEvent.click(rendered.getByRole('button', { name: 'set postId' }))
     await vi.advanceTimersByTimeAsync(11)
+    expect(queryFn).toHaveBeenCalledTimes(1)
     expect(
       rendered.getByText('pages: comments for 1 page 0'),
     ).toBeInTheDocument()


### PR DESCRIPTION
## 🎯 Changes

CodeRabbit flagged the same gap on #11423 (solid-query): `should not fetch when queryFn is skipToken, and fetch once it is replaced` only asserted the final rendered data, so multiple fetches after `postId` is set would still pass.

Wraps `queryFn` in `vi.fn` and asserts it is not called before `postId` is set, and called exactly once after, in both `react-query`'s and `preact-query`'s `useInfiniteQuery.test.tsx`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage for infinite-query behavior when execution is skipped.
  - Verified that the query function is not called while skipping is active and runs exactly once when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->