### PR TITLE
fix(angular-query-experimental): widen 'SkipToken' to 'symbol' so it type-checks inside a whole-options getter

### DIFF
--- a/.changeset/angular-query-injectquery-skiptoken-getter-typecheck.md
+++ b/.changeset/angular-query-injectquery-skiptoken-getter-typecheck.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-query-experimental': patch
+---
+
+fix(angular-query-experimental): widen 'SkipToken' to 'symbol' so it type-checks inside a whole-options getter

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
-import { injectQuery, queryOptions } from '..'
+import { injectQuery, queryOptions, skipToken } from '..'
 import type { Signal } from '@angular/core'
 
 describe('injectQuery', () => {
@@ -189,6 +189,20 @@ describe('injectQuery', () => {
       if (query.isError()) {
         expectTypeOf(query.error).toEqualTypeOf<Signal<Error>>()
       }
+    })
+  })
+
+  describe('skipToken', () => {
+    it('should narrow data to string | undefined for a conditional skipToken inside a whole-options getter', () => {
+      const key = queryKey()
+      const postId: number | undefined = 1
+      const query = injectQuery(() => ({
+        queryKey: [...key, postId],
+        queryFn:
+          postId != null ? () => sleep(0).then(() => `post ${postId}`) : skipToken,
+      }))
+
+      expectTypeOf(query.data).toEqualTypeOf<Signal<string | undefined>>()
     })
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -199,7 +199,9 @@ describe('injectQuery', () => {
       const query = injectQuery(() => ({
         queryKey: [...key, postId],
         queryFn:
-          postId != null ? () => sleep(0).then(() => `post ${postId}`) : skipToken,
+          postId != null
+            ? () => sleep(0).then(() => `post ${postId}`)
+            : skipToken,
       }))
 
       expectTypeOf(query.data).toEqualTypeOf<Signal<string | undefined>>()

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -32,6 +32,7 @@ import {
   injectQuery,
   provideIsRestoring,
   provideTanStackQuery,
+  skipToken,
 } from '..'
 import { setSignalInputs } from './test-utils'
 import type { CreateQueryOptions, OmitKeyof, QueryFunction } from '..'
@@ -918,6 +919,50 @@ describe('injectQuery', () => {
       expect(query.status()).toBe('success')
       expect(query.data()).toBe('sync-data-2')
       expect(callCount).toBe(2)
+    })
+  })
+
+  describe('skipToken', () => {
+    it('should not fetch when queryFn is skipToken, and fetch once it is replaced', async () => {
+      const key = queryKey()
+      const queryFn = vi.fn(() => sleep(10).then(() => 'post 1'))
+
+      @Component({
+        template: `
+          <div>status: {{ query.status() }}</div>
+          <div>isFetching: {{ query.isFetching() }}</div>
+          <div>data: {{ query.data() ?? 'none' }}</div>
+        `,
+      })
+      class Page {
+        postId = signal<string | undefined>(undefined)
+
+        readonly query = injectQuery(() => ({
+          queryKey: [...key, this.postId()],
+          queryFn: this.postId() != null ? queryFn : skipToken,
+        }))
+      }
+
+      const rendered = await render(Page)
+
+      expect(rendered.getByText('status: pending')).toBeInTheDocument()
+      expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
+
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+      expect(queryFn).not.toHaveBeenCalled()
+      expect(rendered.getByText('status: pending')).toBeInTheDocument()
+      expect(rendered.getByText('isFetching: false')).toBeInTheDocument()
+
+      rendered.fixture.componentInstance.postId.set('1')
+      rendered.fixture.detectChanges()
+      expect(rendered.getByText('isFetching: true')).toBeInTheDocument()
+
+      await vi.advanceTimersByTimeAsync(11)
+      rendered.fixture.detectChanges()
+      expect(queryFn).toHaveBeenCalledTimes(1)
+      expect(rendered.getByText('status: success')).toBeInTheDocument()
+      expect(rendered.getByText('data: post 1')).toBeInTheDocument()
     })
   })
 })

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -124,7 +124,12 @@ it('should work when passed to query with skipToken', () => {
 })
 
 it('should not allow skipToken on UnusedSkipTokenOptions', () => {
-  const options: UnusedSkipTokenOptions<number, Error, number, Array<string>> = {
+  const options: UnusedSkipTokenOptions<
+    number,
+    Error,
+    number,
+    Array<string>
+  > = {
     queryKey: ['key'],
     // @ts-expect-error skipToken should not be assignable here
     queryFn: skipToken,

--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -8,6 +8,7 @@ import {
   skipToken,
 } from '..'
 import type { Signal } from '@angular/core'
+import type { UnusedSkipTokenOptions } from '..'
 
 // Regression test for exported queryOptions inference under declaration emit.
 // TypeScript should be able to name the return type without expanding the
@@ -120,6 +121,15 @@ it('should work when passed to query with skipToken', () => {
 
   const data = new QueryClient().query(options)
   assertType<Promise<unknown>>(data)
+})
+
+it('should not allow skipToken on UnusedSkipTokenOptions', () => {
+  const options: UnusedSkipTokenOptions<number, Error, number, Array<string>> = {
+    queryKey: ['key'],
+    // @ts-expect-error skipToken should not be assignable here
+    queryFn: skipToken,
+  }
+  expectTypeOf(options.queryKey).toEqualTypeOf<Array<string>>()
 })
 
 it('should tag the queryKey with the result type of the QueryFn', () => {

--- a/packages/angular-query-experimental/src/inject-query.ts
+++ b/packages/angular-query-experimental/src/inject-query.ts
@@ -8,6 +8,7 @@ import {
 import { createBaseQuery } from './create-base-query'
 import type { DefaultError, QueryKey } from '@tanstack/query-core'
 import type {
+  CreateBaseQueryOptions,
   CreateQueryOptions,
   CreateQueryResult,
   DefinedCreateQueryResult,
@@ -203,6 +204,9 @@ export function injectQuery(
 ) {
   !options?.injector && assertInInjectionContext(injectQuery)
   return runInInjectionContext(options?.injector ?? inject(Injector), () =>
-    createBaseQuery(injectQueryFn, QueryObserver),
+    createBaseQuery(
+      injectQueryFn as () => CreateBaseQueryOptions,
+      QueryObserver,
+    ),
   ) as unknown as CreateQueryResult
 }

--- a/packages/angular-query-experimental/src/query-options.ts
+++ b/packages/angular-query-experimental/src/query-options.ts
@@ -62,10 +62,7 @@ export type UnusedSkipTokenOptions<
    * fetch that fails with "Missing queryFn" unless `enabled` is `false` or a default query function has been
    * defined. A default query function only supplies `queryFn`; it doesn't defer the fetch on its own.
    */
-  queryFn?: Exclude<
-    CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>['queryFn'],
-    SkipToken | undefined
-  >
+  queryFn?: QueryFunction<TQueryFnData, TQueryKey>
 }
 
 /**
@@ -285,8 +282,12 @@ export function queryOptions<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> &
-  QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
+): OmitKeyof<
+  UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  'queryFn'
+> & {
+  queryFn?: QueryFunction<TQueryFnData, TQueryKey> | SkipToken
+} & QueryKeyWithDataTag<TQueryKey, TQueryFnData, TError>
 
 export function queryOptions(options: unknown) {
   return options

--- a/packages/angular-query-experimental/src/types.ts
+++ b/packages/angular-query-experimental/src/types.ts
@@ -11,12 +11,16 @@ import type {
   MutationObserverResult,
   OmitKeyof,
   Override,
+  QueryFunction,
   QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
 } from '@tanstack/query-core'
 import type { Signal } from '@angular/core'
 import type { MapToSignals } from './signal-proxy'
+
+// Widen the type of the symbol to enable type inference even if skipToken is not immutable.
+type SkipTokenForCreateQueryOptions = symbol
 
 /**
  * The options shared across `angular-query-experimental`'s query functions. Extends
@@ -55,15 +59,19 @@ export interface CreateBaseQueryOptions<
  * `select` is used.
  * @template TQueryKey - The type of your `queryKey`.
  */
-export interface CreateQueryOptions<
+export type CreateQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> extends OmitKeyof<
+> = OmitKeyof<
   CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
-  'suspense'
-> {}
+  'suspense' | 'queryFn'
+> & {
+  queryFn?:
+    | QueryFunction<TQueryFnData, TQueryKey>
+    | SkipTokenForCreateQueryOptions
+}
 
 type CreateStatusBasedQueryResult<
   TStatus extends QueryObserverResult['status'],


### PR DESCRIPTION
## 🎯 Changes

Same root cause as #11427 (vue-query): `injectQuery`'s whole-options getter overload (`injectQuery(() => ({...}))`) failed to type-check the `queryFn: cond ? fn : skipToken` pattern, because `SkipToken` is a `unique symbol` and TypeScript fails to propagate the contextual type into a ternary inside a getter's body when the function has multiple overloads — widening the ternary's `unique symbol` branch to plain `symbol`, which then matches no overload.

Applies the same fix verified in #11427: widen `CreateQueryOptions`'s `queryFn` to accept `symbol` (parameter position), following the existing `SkipTokenForUseQueries` precedent in `@tanstack/vue-query`'s `useQueries.ts`. Since `CreateQueryOptions` is also the basis of `queryOptions()`'s return type, the `queryOptions()` overload that could leak the widened `symbol` narrows `queryFn` back with `OmitKeyof`. `UnusedSkipTokenOptions` (which already existed here, unlike vue) is changed from `Exclude<..., SkipToken | undefined>` to a direct `QueryFunction<...>` type, since `Exclude` no longer filters out the widened `symbol` — verified with a new regression test that it still rejects `skipToken`.

`injectQuery`'s implementation signature needed an explicit cast to `CreateBaseQueryOptions` when calling `createBaseQuery`, since that internal helper still expects the narrow (un-widened) type.

No runtime behavior changes — this is a type-only fix. Added a runtime test (`should not fetch when queryFn is skipToken, and fetch once it is replaced`) and a type test to `inject-query.test.ts`/`inject-query.test-d.ts`, matching the shape already used for `injectInfiniteQuery`'s skipToken test.

`injectInfiniteQuery`'s separate `TPageParam` inference gap (falls back to `unknown` with `skipToken`) is a related but distinct issue, not addressed here.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).