### PR TITLE
docs(*): clarify 'Promise.all' only waits for all mutateAsync calls when they succeed

### DIFF
--- a/docs/framework/angular/reference/functions/injectMutation.md
+++ b/docs/framework/angular/reference/functions/injectMutation.md
@@ -125,7 +125,7 @@ export class Todos {
 ```
 
 Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a promise per
-call instead, so you can wait for all of them:
+call instead, so you can wait for all of them when they succeed:
 ```angular-ts
 @Component({
   selector: 'todos',

--- a/docs/framework/preact/reference/functions/useMutation.md
+++ b/docs/framework/preact/reference/functions/useMutation.md
@@ -152,7 +152,7 @@ function AddTodo() {
 ```
 
 Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
-promise per call instead, so you can wait for all of them:
+promise per call instead, so you can wait for all of them when they succeed:
 ```tsx
 import { useMutation, useQueryClient } from '@tanstack/preact-query'
 

--- a/docs/framework/react/reference/functions/useMutation.md
+++ b/docs/framework/react/reference/functions/useMutation.md
@@ -154,7 +154,7 @@ function AddTodo() {
 ```
 
 Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
-promise per call instead, so you can wait for all of them:
+promise per call instead, so you can wait for all of them when they succeed:
 ```tsx
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 

--- a/docs/framework/svelte/reference/functions/createMutation.md
+++ b/docs/framework/svelte/reference/functions/createMutation.md
@@ -142,7 +142,7 @@ Optimistic update via `onMutate`, rolling back on `onError`:
 ```
 
 Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
-promise per call instead, so you can wait for all of them:
+promise per call instead, so you can wait for all of them when they succeed:
 ```svelte
 <script lang="ts">
   import { createMutation, useQueryClient } from '@tanstack/svelte-query'

--- a/docs/framework/vue/reference/functions/useMutation.md
+++ b/docs/framework/vue/reference/functions/useMutation.md
@@ -145,7 +145,7 @@ const addMutation = useMutation({
 ```
 
 Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
-promise per call instead, so you can wait for all of them:
+promise per call instead, so you can wait for all of them when they succeed:
 ```vue
 <script setup lang="ts">
 import { useMutation, useQueryClient } from '@tanstack/vue-query'

--- a/packages/angular-query-experimental/src/inject-mutation.ts
+++ b/packages/angular-query-experimental/src/inject-mutation.ts
@@ -112,7 +112,7 @@ export interface InjectMutationOptions {
  *
  * @example
  * Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a promise per
- * call instead, so you can wait for all of them:
+ * call instead, so you can wait for all of them when they succeed:
  * ```angular-ts
  * @Component({
  *   selector: 'todos',

--- a/packages/preact-query/src/useMutation.ts
+++ b/packages/preact-query/src/useMutation.ts
@@ -126,7 +126,7 @@ import { useSyncExternalStore } from './utils'
  *
  * @example
  * Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
- * promise per call instead, so you can wait for all of them:
+ * promise per call instead, so you can wait for all of them when they succeed:
  * ```tsx
  * import { useMutation, useQueryClient } from '@tanstack/preact-query'
  *

--- a/packages/react-query/src/useMutation.ts
+++ b/packages/react-query/src/useMutation.ts
@@ -125,7 +125,7 @@ import type { DefaultError, QueryClient } from '@tanstack/query-core'
  *
  * @example
  * Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
- * promise per call instead, so you can wait for all of them:
+ * promise per call instead, so you can wait for all of them when they succeed:
  * ```tsx
  * import { useMutation, useQueryClient } from '@tanstack/react-query'
  *

--- a/packages/svelte-query/src/createMutation.svelte.ts
+++ b/packages/svelte-query/src/createMutation.svelte.ts
@@ -109,7 +109,7 @@ import type { DefaultError, QueryClient } from '@tanstack/query-core'
  *
  * @example
  * Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
- * promise per call instead, so you can wait for all of them:
+ * promise per call instead, so you can wait for all of them when they succeed:
  * ```svelte
  * <script lang="ts">
  *   import { createMutation, useQueryClient } from '@tanstack/svelte-query'

--- a/packages/vue-query/src/useMutation.ts
+++ b/packages/vue-query/src/useMutation.ts
@@ -169,7 +169,7 @@ export type UseMutationReturnType<
  *
  * @example
  * Callbacks passed per call to `mutate` only fire for the last call — `mutateAsync` gives you a
- * promise per call instead, so you can wait for all of them:
+ * promise per call instead, so you can wait for all of them when they succeed:
  * ```vue
  * <script setup lang="ts">
  * import { useMutation, useQueryClient } from '@tanstack/vue-query'


### PR DESCRIPTION
## 🎯 Changes

CodeRabbit flagged this on #11431 (solid-query): `Promise.all` rejects on the first rejection, so the other `mutateAsync` calls can remain pending — "wait for all of them" doesn't describe that. Found the same imprecise wording already present in react-query and preact-query's original JSDoc (which solid-query's example was ported from), and in angular-query-experimental, svelte-query, and vue-query as well.

Changes the wording to "wait for all of them when they succeed" in `useMutation`/`injectMutation`/`createMutation`'s `Promise.all` example across `react-query`, `preact-query`, `angular-query-experimental`, `svelte-query`, and `vue-query`, and regenerates the affected reference docs. `solid-query` already has the corrected wording (fixed directly in #11431).

The neighboring `Promise.allSettled` example's wording was reviewed and is accurate as-is — not changed here.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified across framework guides and API references that `mutateAsync` returns a promise for each mutation call.
  - Explained that callers can await all returned promises when the mutations succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->