### PR TITLE
ref(hydration): remove outdated dehydratedAt fallback

### DIFF
--- a/.changeset/perky-jars-flow.md
+++ b/.changeset/perky-jars-flow.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+ref(hydration): remove outdated dehydratedAt fallback

--- a/packages/preact-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
+++ b/packages/preact-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
@@ -85,6 +85,7 @@ describe('useQueries with persist and memoized combine (preact)', () => {
         queries: [1, 2, 3].map((id) => ({
           queryHash: `["post",${id}]`,
           queryKey: ['post', id],
+          dehydratedAt: Date.now(),
           state: {
             data: id,
             dataUpdateCount: 1,

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -138,7 +138,6 @@ export const HydrationBoundary = ({
             (dehydratedQuery.promise &&
               existingQuery.state.status !== 'pending' &&
               existingQuery.state.fetchStatus !== 'fetching' &&
-              dehydratedQuery.dehydratedAt !== undefined &&
               dehydratedQuery.dehydratedAt > existingQuery.state.dataUpdatedAt)
 
           if (hydrationIsNewer) {

--- a/packages/query-core/src/hydration.ts
+++ b/packages/query-core/src/hydration.ts
@@ -61,13 +61,10 @@ interface DehydratedQuery {
   queryHash: string
   queryKey: QueryKey
   state: QueryState
+  dehydratedAt: number
   promise?: Promise<unknown>
   meta?: QueryMeta
   queryType?: 'infinite'
-  // This is only optional because older versions of Query might have dehydrated
-  // without it which we need to handle for backwards compatibility.
-  // This should be changed to required in the future.
-  dehydratedAt?: number
 }
 
 export interface DehydratedState {
@@ -240,11 +237,7 @@ export function hydrate(
       // Do not hydrate if an existing query exists with newer data
       if (query) {
         const hasNewerSyncData =
-          syncData &&
-          // We only need this undefined check to handle older dehydration
-          // payloads that might not have dehydratedAt
-          dehydratedAt !== undefined &&
-          dehydratedAt > query.state.dataUpdatedAt
+          syncData && dehydratedAt > query.state.dataUpdatedAt
         if (
           state.dataUpdatedAt > query.state.dataUpdatedAt ||
           hasNewerSyncData
@@ -262,7 +255,7 @@ export function hydrate(
             ...(state.status === 'pending' &&
               data !== undefined && {
                 status: 'success' as const,
-                dataUpdatedAt: dehydratedAt ?? Date.now(),
+                dataUpdatedAt: dehydratedAt,
                 // Preserve existing fetchStatus if the existing query is actively fetching.
                 ...(!existingQueryIsFetching && {
                   fetchStatus: 'idle' as const,
@@ -296,7 +289,7 @@ export function hydrate(
                 : state.status,
             ...(state.status === 'pending' &&
               data !== undefined && {
-                dataUpdatedAt: dehydratedAt ?? Date.now(),
+                dataUpdatedAt: dehydratedAt,
               }),
           },
         )
@@ -311,7 +304,7 @@ export function hydrate(
         !existingQueryIsFetching &&
         // Only hydrate if dehydration is newer than any existing data,
         // this is always true for new queries
-        (dehydratedAt === undefined || dehydratedAt > query.state.dataUpdatedAt)
+        dehydratedAt > query.state.dataUpdatedAt
       ) {
         // This doesn't actually fetch - it just creates a retryer
         // which will re-use the passed `initialPromise`

--- a/packages/react-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
+++ b/packages/react-query-persist-client/src/__tests__/use-queries-with-persist.test.tsx
@@ -73,6 +73,7 @@ describe('useQueries with persist and memoized combine', () => {
         queries: [1, 2, 3].map((id) => ({
           queryHash: `["post",${id}]`,
           queryKey: ['post', id],
+          dehydratedAt: Date.now(),
           state: {
             data: id,
             dataUpdateCount: 1,

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -139,7 +139,6 @@ export const HydrationBoundary = ({
               (dehydratedQuery.promise &&
                 existingQuery.state.status !== 'pending' &&
                 existingQuery.state.fetchStatus !== 'fetching' &&
-                dehydratedQuery.dehydratedAt !== undefined &&
                 dehydratedQuery.dehydratedAt >
                   existingQuery.state.dataUpdatedAt)
 


### PR DESCRIPTION
the check was only necessary for backwards compatibility with dehydrated cache versions created before May 2025.

This “grace period” has long passed, we can safely assume that all `DehydratedState`s contain a `dehydratedAt` attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query hydration by consistently applying recorded dehydration timestamps.
  - Restored pending queries and synchronized newer data more reliably.
  - Improved retry behavior for hydrated queries that continue fetching.
  - Improved hydration of existing queries with in-progress data updates.
  - Improved persistence compatibility for hydrated query state.

- **Release**
  - Included in a patch release of the query core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->