### PR TITLE
ref(HydrationBoundary): remove checks that are guarded by types

### DIFF
--- a/.changeset/salty-hotels-turn.md
+++ b/.changeset/salty-hotels-turn.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/preact-query': patch
+'@tanstack/react-query': patch
+---
+
+ref(HydrationBoundary): remove checks that are guarded by types

--- a/packages/preact-query/src/HydrationBoundary.tsx
+++ b/packages/preact-query/src/HydrationBoundary.tsx
@@ -18,7 +18,7 @@ export interface HydrationBoundaryProps {
   /**
    * The state to hydrate.
    */
-  state: DehydratedState | null | undefined
+  state: DehydratedState
   /**
    * Optional. Note: unlike `hydrate`, `mutations` cannot be set here.
    */
@@ -113,49 +113,36 @@ export const HydrationBoundary = ({
   // we throw away the fresh data for any existing ones to avoid unexpectedly
   // updating the UI.
   const hydrationQueue: DehydratedState['queries'] | undefined = useMemo(() => {
-    if (state) {
-      if (typeof state !== 'object') {
-        return
-      }
+    const queryCache = client.getQueryCache()
 
-      const queryCache = client.getQueryCache()
-      // State is supplied from the outside and we might as well fail
-      // gracefully if it has the wrong shape, so while we type `queries`
-      // as required, we still provide a fallback.
-      const queries = state.queries || []
+    const newQueries: DehydratedState['queries'] = []
+    const existingQueries: DehydratedState['queries'] = []
+    for (const dehydratedQuery of state.queries) {
+      const existingQuery = queryCache.get(dehydratedQuery.queryHash)
 
-      const newQueries: DehydratedState['queries'] = []
-      const existingQueries: DehydratedState['queries'] = []
-      for (const dehydratedQuery of queries) {
-        const existingQuery = queryCache.get(dehydratedQuery.queryHash)
+      if (!existingQuery) {
+        newQueries.push(dehydratedQuery)
+      } else {
+        const hydrationIsNewer =
+          dehydratedQuery.state.dataUpdatedAt >
+            existingQuery.state.dataUpdatedAt ||
+          (dehydratedQuery.promise &&
+            existingQuery.state.status !== 'pending' &&
+            existingQuery.state.fetchStatus !== 'fetching' &&
+            dehydratedQuery.dehydratedAt > existingQuery.state.dataUpdatedAt)
 
-        if (!existingQuery) {
-          newQueries.push(dehydratedQuery)
-        } else {
-          const hydrationIsNewer =
-            dehydratedQuery.state.dataUpdatedAt >
-              existingQuery.state.dataUpdatedAt ||
-            (dehydratedQuery.promise &&
-              existingQuery.state.status !== 'pending' &&
-              existingQuery.state.fetchStatus !== 'fetching' &&
-              dehydratedQuery.dehydratedAt > existingQuery.state.dataUpdatedAt)
-
-          if (hydrationIsNewer) {
-            existingQueries.push(dehydratedQuery)
-          }
+        if (hydrationIsNewer) {
+          existingQueries.push(dehydratedQuery)
         }
       }
-
-      if (newQueries.length > 0) {
-        // It's actually fine to call this with queries/state that already exists
-        // in the cache, or is older. hydrate() is idempotent for queries.
-        hydrate(client, { queries: newQueries }, optionsRef.current)
-      }
-      if (existingQueries.length > 0) {
-        return existingQueries
-      }
     }
-    return undefined
+
+    if (newQueries.length > 0) {
+      // It's actually fine to call this with queries/state that already exists
+      // in the cache, or is older. hydrate() is idempotent for queries.
+      hydrate(client, { queries: newQueries }, optionsRef.current)
+    }
+    return existingQueries.length > 0 ? existingQueries : undefined
   }, [client, state])
 
   useEffect(() => {

--- a/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
@@ -322,54 +322,6 @@ describe('Preact hydration', () => {
     })
   })
 
-  it('should not hydrate queries if state is not an object', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={'invalid-state' as any}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await vi.advanceTimersByTimeAsync(0)
-    expect(hydrateSpy).toHaveBeenCalledTimes(0)
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
-  it('should handle state without queries property gracefully', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={{} as any}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await vi.advanceTimersByTimeAsync(0)
-    expect(hydrateSpy).toHaveBeenCalledTimes(0)
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
   // https://github.com/TanStack/query/issues/8677
   it('should not infinite loop when hydrating promises that resolve to errors', async () => {
     const originalHydrate = coreModule.hydrate

--- a/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/preact-query/src/__tests__/HydrationBoundary.test.tsx
@@ -322,58 +322,6 @@ describe('Preact hydration', () => {
     })
   })
 
-  it('should not hydrate queries if state is null', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={null}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await Promise.all(
-      Array.from({ length: 1000 }).map(async (_, index) => {
-        await vi.advanceTimersByTimeAsync(index)
-        expect(hydrateSpy).toHaveBeenCalledTimes(0)
-      }),
-    )
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
-  it('should not hydrate queries if state is undefined', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={undefined}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await vi.advanceTimersByTimeAsync(0)
-    expect(hydrateSpy).toHaveBeenCalledTimes(0)
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
   it('should not hydrate queries if state is not an object', async () => {
     const queryClient = new QueryClient()
 

--- a/packages/react-query/src/HydrationBoundary.tsx
+++ b/packages/react-query/src/HydrationBoundary.tsx
@@ -17,7 +17,7 @@ export interface HydrationBoundaryProps {
   /**
    * The state to hydrate.
    */
-  state: DehydratedState | null | undefined
+  state: DehydratedState
   /**
    * Optional. Note: unlike `hydrate`, `mutations` cannot be set here.
    */
@@ -113,52 +113,37 @@ export const HydrationBoundary = ({
   // updating the UI.
   const hydrationQueue: DehydratedState['queries'] | undefined =
     React.useMemo(() => {
-      if (state) {
-        if (typeof state !== 'object') {
-          return
-        }
+      const queryCache = client.getQueryCache()
 
-        const queryCache = client.getQueryCache()
-        // State is supplied from the outside and we might as well fail
-        // gracefully if it has the wrong shape, so while we type `queries`
-        // as required, we still provide a fallback.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        const queries = state.queries || []
+      const newQueries: DehydratedState['queries'] = []
+      const existingQueries: DehydratedState['queries'] = []
+      for (const dehydratedQuery of state.queries) {
+        const existingQuery = queryCache.get(dehydratedQuery.queryHash)
 
-        const newQueries: DehydratedState['queries'] = []
-        const existingQueries: DehydratedState['queries'] = []
-        for (const dehydratedQuery of queries) {
-          const existingQuery = queryCache.get(dehydratedQuery.queryHash)
+        if (!existingQuery) {
+          newQueries.push(dehydratedQuery)
+        } else {
+          const hydrationIsNewer =
+            dehydratedQuery.state.dataUpdatedAt >
+              existingQuery.state.dataUpdatedAt ||
+            (dehydratedQuery.promise &&
+              existingQuery.state.status !== 'pending' &&
+              existingQuery.state.fetchStatus !== 'fetching' &&
+              dehydratedQuery.dehydratedAt > existingQuery.state.dataUpdatedAt)
 
-          if (!existingQuery) {
-            newQueries.push(dehydratedQuery)
-          } else {
-            const hydrationIsNewer =
-              dehydratedQuery.state.dataUpdatedAt >
-                existingQuery.state.dataUpdatedAt ||
-              (dehydratedQuery.promise &&
-                existingQuery.state.status !== 'pending' &&
-                existingQuery.state.fetchStatus !== 'fetching' &&
-                dehydratedQuery.dehydratedAt >
-                  existingQuery.state.dataUpdatedAt)
-
-            if (hydrationIsNewer) {
-              existingQueries.push(dehydratedQuery)
-            }
+          if (hydrationIsNewer) {
+            existingQueries.push(dehydratedQuery)
           }
         }
-
-        if (newQueries.length > 0) {
-          // It's actually fine to call this with queries/state that already exists
-          // in the cache, or is older. hydrate() is idempotent for queries.
-          // eslint-disable-next-line react-hooks/refs
-          hydrate(client, { queries: newQueries }, optionsRef.current)
-        }
-        if (existingQueries.length > 0) {
-          return existingQueries
-        }
       }
-      return undefined
+
+      if (newQueries.length > 0) {
+        // It's actually fine to call this with queries/state that already exists
+        // in the cache, or is older. hydrate() is idempotent for queries.
+        // eslint-disable-next-line react-hooks/refs
+        hydrate(client, { queries: newQueries }, optionsRef.current)
+      }
+      return existingQueries.length > 0 ? existingQueries : undefined
     }, [client, state])
 
   React.useEffect(() => {

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -318,54 +318,6 @@ describe('React hydration', () => {
     })
   })
 
-  it('should not hydrate queries if state is not an object', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={'invalid-state' as any}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await vi.advanceTimersByTimeAsync(0)
-    expect(hydrateSpy).toHaveBeenCalledTimes(0)
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
-  it('should handle state without queries property gracefully', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={{} as any}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await vi.advanceTimersByTimeAsync(0)
-    expect(hydrateSpy).toHaveBeenCalledTimes(0)
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
   // https://github.com/TanStack/query/issues/8677
   it('should not infinite loop when hydrating promises that resolve to errors', async () => {
     const originalHydrate = coreModule.hydrate

--- a/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
+++ b/packages/react-query/src/__tests__/HydrationBoundary.test.tsx
@@ -318,58 +318,6 @@ describe('React hydration', () => {
     })
   })
 
-  it('should not hydrate queries if state is null', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={null}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await Promise.all(
-      Array.from({ length: 1000 }).map(async (_, index) => {
-        await vi.advanceTimersByTimeAsync(index)
-        expect(hydrateSpy).toHaveBeenCalledTimes(0)
-      }),
-    )
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
-  it('should not hydrate queries if state is undefined', async () => {
-    const queryClient = new QueryClient()
-
-    const hydrateSpy = vi.spyOn(coreModule, 'hydrate')
-
-    function Page() {
-      return null
-    }
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={undefined}>
-          <Page />
-        </HydrationBoundary>
-      </QueryClientProvider>,
-    )
-
-    await vi.advanceTimersByTimeAsync(0)
-    expect(hydrateSpy).toHaveBeenCalledTimes(0)
-
-    hydrateSpy.mockRestore()
-    queryClient.clear()
-  })
-
   it('should not hydrate queries if state is not an object', async () => {
     const queryClient = new QueryClient()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Updated `HydrationBoundary` for React Query and Preact Query so the `state` property is required and must use the supported dehydrated-state format.
  - Hydration now processes query state directly while preserving deferred hydration for newer existing queries.
  - Invalid or incomplete hydration state values are no longer accepted.

- **Release**
  - Included in a patch release for the React Query and Preact Query packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->