### PR TITLE
test(solid-query/useMutation): add tests for 'MutationFunctionContext' passed to mutationFn and callbacks

### DIFF
--- a/packages/solid-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test-d.tsx
@@ -1,7 +1,12 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { useMutation } from '../useMutation'
 import { QueryClient } from '../QueryClient'
-import type { DefaultError } from '@tanstack/query-core'
+import type {
+  DefaultError,
+  MutationFunctionContext,
+  MutationKey,
+  QueryClient as QueryCoreClient,
+} from '@tanstack/query-core'
 import type { UseMutationResult } from '../types'
 
 describe('useMutation', () => {
@@ -143,5 +148,57 @@ describe('useMutation', () => {
     )
 
     expectTypeOf(mutation.data).toEqualTypeOf<string | undefined>()
+  })
+
+  it('should type context as the last argument for mutationFn and every hook-level callback', () => {
+    useMutation(() => ({
+      mutationFn: (_vars: string, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+        expectTypeOf(context.client).toEqualTypeOf<QueryCoreClient>()
+        return Promise.resolve('data')
+      },
+      onMutate: (_variables, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onSuccess: (_data, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onError: (_error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onSettled: (_data, _error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+    }))
+  })
+
+  it('should type context as the last argument for every per-call mutate option', () => {
+    const mutation = useMutation(() => ({
+      mutationFn: () => Promise.resolve('data'),
+    }))
+
+    mutation.mutate(undefined, {
+      onSuccess: (_data, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onError: (_error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onSettled: (_data, _error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+    })
+  })
+
+  it('should type context.mutationKey as MutationKey', () => {
+    useMutation(() => ({
+      mutationKey: ['todos', 'add'] as const,
+      mutationFn: () => Promise.resolve('data'),
+      onSuccess: (_data, _variables, _onMutateResult, context) => {
+        expectTypeOf(context.mutationKey).toEqualTypeOf<
+          MutationKey | undefined
+        >()
+      },
+    }))
   })
 })

--- a/packages/solid-query/src/__tests__/useMutation.test.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test.tsx
@@ -1741,4 +1741,105 @@ describe('useMutation', () => {
       ),
     ).toBeInTheDocument()
   })
+
+  it('should pass a non-undefined onMutateResult alongside context to onSuccess', async () => {
+    const onSuccess = vi.fn()
+
+    function Page() {
+      const mutation = useMutation(() => ({
+        mutationFn: (text: string) => sleep(10).then(() => text.toUpperCase()),
+        onMutate: (text: string) => ({ startedWith: text }),
+        onSuccess,
+      }))
+
+      return <button onClick={() => mutation.mutate('todo')}>mutate</button>
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    const [data, variables, onMutateResult, context] = onSuccess.mock.calls[0]!
+    expect(data).toBe('TODO')
+    expect(variables).toBe('todo')
+    expect(onMutateResult).toEqual({ startedWith: 'todo' })
+    expect(context.client).toBe(queryClient)
+    expect(context.meta).toBeUndefined()
+    expect(context.mutationKey).toBeUndefined()
+  })
+
+  it('should give mutationFn the same QueryClient instance via context', async () => {
+    const key = queryKey()
+    queryClient.setQueryData(key, 'tag-from-this-client')
+
+    function Page() {
+      const mutation = useMutation(() => ({
+        mutationFn: (_text: string, context) =>
+          sleep(10).then(() => context.client.getQueryData(key)),
+      }))
+
+      return (
+        <div>
+          <div>data: {String(mutation.data)}</div>
+          <button onClick={() => mutation.mutate('todo')}>mutate</button>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(rendered.getByText('data: tag-from-this-client')).toBeInTheDocument()
+  })
+
+  it('should include mutationKey in the context passed to hook-level callbacks', async () => {
+    const onSuccess = vi.fn()
+
+    function Page() {
+      const mutation = useMutation(() => ({
+        mutationKey: ['todos', 'add'],
+        mutationFn: (text: string) => sleep(10).then(() => text),
+        onSuccess,
+      }))
+
+      return <button onClick={() => mutation.mutate('todo')}>mutate</button>
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess.mock.calls[0]?.[3].mutationKey).toEqual(['todos', 'add'])
+  })
+
+  it('should let onSuccess invalidate queries via context.client without a useQueryClient() closure', async () => {
+    const key = queryKey()
+    queryClient.setQueryData(key, 'data')
+
+    function Page() {
+      const mutation = useMutation(() => ({
+        mutationFn: () => sleep(10).then(() => 'mutated'),
+        onSuccess: (_data, _variables, _onMutateResult, context) => {
+          context.client.invalidateQueries({ queryKey: key })
+        },
+      }))
+
+      return <button onClick={() => mutation.mutate()}>mutate</button>
+    }
+
+    const rendered = renderWithClient(queryClient, () => <Page />)
+
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(false)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds test coverage for `MutationFunctionContext` (the `{ client, meta, mutationKey }` object passed as the last argument to `mutationFn` and every mutation callback) in `solid-query`'s `useMutation.test.tsx` and `useMutation.test-d.tsx`, mirroring the coverage added for `react-query`/`preact-query` in #11440.

Runtime tests added:
- hook-level `onSuccess` receiving a non-undefined `onMutateResult` alongside `context`
- `mutationFn` accessing the same `QueryClient` instance via `context.client`
- `context.mutationKey` reflecting the `mutationKey` passed to `useMutation`
- `context.client.invalidateQueries()` actually invalidating the cache from within `onSuccess`

Type tests added:
- `context` typed as `MutationFunctionContext` for `mutationFn` and every hook-level callback, and `context.client` typed as `@tanstack/query-core`'s `QueryClient` (not solid-query's `QueryClient` subclass — `MutationFunctionContext` is non-generic)
- `context` typed as `MutationFunctionContext` for every per-call `mutate` option
- `context.mutationKey` typed as `MutationKey | undefined`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded mutation testing to verify that mutation functions and callbacks receive the expected execution context.
  - Added coverage for access to the query client, mutation key, and results returned by mutation setup callbacks.
  - Verified that mutation callbacks can use the provided client to invalidate queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->