### PR TITLE
test(vue-query/useMutation): add tests for 'MutationFunctionContext' passed to mutationFn and callbacks

### DIFF
--- a/packages/vue-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useMutation.test-d.tsx
@@ -2,6 +2,7 @@ import { describe, expectTypeOf, it } from 'vitest'
 import { reactive } from 'vue-demi'
 import { sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
+import type { MutationFunctionContext, MutationKey } from '@tanstack/query-core'
 
 describe('Discriminated union return type', () => {
   it('data should be possibly undefined by default', () => {
@@ -95,5 +96,55 @@ describe('useMutation', () => {
 
     expectTypeOf(mutation.mutate).toBeCallableWith()
     expectTypeOf(mutation.mutateAsync).toBeCallableWith()
+  })
+
+  it('should type context as the last argument for every hook-level callback', () => {
+    // `mutationFn`'s `context` parameter is implicitly `any` here, unlike every other adapter and unlike
+    // this file's other callbacks — so it's excluded from the assertions below.
+    useMutation({
+      mutationFn: () => Promise.resolve('data'),
+      onMutate: (_variables, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onSuccess: (_data, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onError: (_error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onSettled: (_data, _error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+    })
+  })
+
+  it('should type context as the last argument for every per-call mutate option', () => {
+    const mutation = useMutation({
+      mutationFn: () => Promise.resolve('data'),
+    })
+
+    mutation.mutate(undefined, {
+      onSuccess: (_data, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onError: (_error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+      onSettled: (_data, _error, _variables, _onMutateResult, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+      },
+    })
+  })
+
+  it('should type context.mutationKey as MutationKey', () => {
+    useMutation({
+      mutationKey: ['todos', 'add'] as const,
+      mutationFn: () => Promise.resolve('data'),
+      onSuccess: (_data, _variables, _onMutateResult, context) => {
+        expectTypeOf(context.mutationKey).toEqualTypeOf<
+          MutationKey | undefined
+        >()
+      },
+    })
   })
 })

--- a/packages/vue-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useMutation.test-d.tsx
@@ -2,7 +2,11 @@ import { describe, expectTypeOf, it } from 'vitest'
 import { reactive } from 'vue-demi'
 import { sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
-import type { MutationFunctionContext, MutationKey } from '@tanstack/query-core'
+import type {
+  MutationFunctionContext,
+  MutationKey,
+  QueryClient,
+} from '@tanstack/query-core'
 
 describe('Discriminated union return type', () => {
   it('data should be possibly undefined by default', () => {
@@ -98,11 +102,13 @@ describe('useMutation', () => {
     expectTypeOf(mutation.mutateAsync).toBeCallableWith()
   })
 
-  it('should type context as the last argument for every hook-level callback', () => {
-    // `mutationFn`'s `context` parameter is implicitly `any` here, unlike every other adapter and unlike
-    // this file's other callbacks — so it's excluded from the assertions below.
+  it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     useMutation({
-      mutationFn: () => Promise.resolve('data'),
+      mutationFn: (_vars: string, context) => {
+        expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
+        expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
+        return Promise.resolve('data')
+      },
       onMutate: (_variables, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
       },

--- a/packages/vue-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useMutation.test-d.tsx
@@ -104,7 +104,7 @@ describe('useMutation', () => {
 
   it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     useMutation({
-      mutationFn: (_vars: string, context) => {
+      mutationFn: (_vars, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
         expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
         return Promise.resolve('data')

--- a/packages/vue-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/vue-query/src/__tests__/useMutation.test-d.tsx
@@ -104,7 +104,7 @@ describe('useMutation', () => {
 
   it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     useMutation({
-      mutationFn: (_vars, context) => {
+      mutationFn: (_variables, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
         expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
         return Promise.resolve('data')

--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -3,6 +3,7 @@ import { reactive, ref } from 'vue-demi'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
 import { useQueryClient } from '../useQueryClient'
+import type { MutationFunctionContext } from '@tanstack/query-core'
 
 vi.mock('../useQueryClient')
 
@@ -560,12 +561,88 @@ describe('useMutation', () => {
       await vi.advanceTimersByTimeAsync(10)
 
       expect(onSuccessPerCall).toHaveBeenCalledTimes(1)
-      expect(onSuccessPerCall).toHaveBeenCalledWith(
-        'Todo 2',
-        'Todo 2',
-        undefined,
-        expect.anything(),
-      )
+      const [data, variables, onMutateResult, context] =
+        onSuccessPerCall.mock.calls[0]!
+      expect(data).toBe('Todo 2')
+      expect(variables).toBe('Todo 2')
+      expect(onMutateResult).toBeUndefined()
+      expect(context.client).toBe(useQueryClient())
     })
+  })
+
+  it('should pass a non-undefined onMutateResult alongside context to onSuccess', async () => {
+    const onSuccess = vi.fn()
+    const mutation = useMutation({
+      mutationFn: (text: string) => sleep(10).then(() => text.toUpperCase()),
+      onMutate: (text: string) => ({ startedWith: text }),
+      onSuccess,
+    })
+
+    mutation.mutate('todo')
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    const [data, variables, onMutateResult, context] = onSuccess.mock.calls[0]!
+    expect(data).toBe('TODO')
+    expect(variables).toBe('todo')
+    expect(onMutateResult).toEqual({ startedWith: 'todo' })
+    expect(context.client).toBe(useQueryClient())
+    expect(context.meta).toBeUndefined()
+    expect(context.mutationKey).toBeUndefined()
+  })
+
+  it('should give mutationFn the same QueryClient instance via context', async () => {
+    const key = queryKey()
+    const queryClient = useQueryClient()
+    queryClient.setQueryData(key, 'tag-from-this-client')
+
+    const mutation = useMutation({
+      mutationFn: (_text: string, context: MutationFunctionContext) =>
+        sleep(10).then(() => context.client.getQueryData(key)),
+    })
+
+    mutation.mutate('todo')
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mutation.data.value).toBe('tag-from-this-client')
+  })
+
+  it('should include mutationKey in the context passed to hook-level callbacks', async () => {
+    const onSuccess = vi.fn()
+    const mutation = useMutation({
+      mutationKey: ['todos', 'add'],
+      mutationFn: (text: string) => sleep(10).then(() => text),
+      onSuccess,
+    })
+
+    mutation.mutate('todo')
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess.mock.calls[0]?.[3].mutationKey).toEqual(['todos', 'add'])
+  })
+
+  it('should let onSuccess invalidate queries via context.client without a useQueryClient() closure', async () => {
+    const key = queryKey()
+    const queryClient = useQueryClient()
+    queryClient.setQueryData(key, 'data')
+
+    const mutation = useMutation({
+      mutationFn: () => sleep(10).then(() => 'mutated'),
+      onSuccess: (_data, _variables, _onMutateResult, context) => {
+        context.client.invalidateQueries({ queryKey: key })
+      },
+    })
+
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(false)
+
+    mutation.mutate()
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true)
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Adds test coverage for `MutationFunctionContext` (the `{ client, meta, mutationKey }` object passed as the last argument to `mutationFn` and every mutation callback) in `vue-query`'s `useMutation.test.ts` and `useMutation.test-d.tsx`, mirroring the coverage added for `react-query`/`preact-query` (#11440), `solid-query` (#11441), `svelte-query` (#11442), and `angular-query-experimental` (#11443).

Runtime tests added:
- hook-level `onSuccess` receiving a non-undefined `onMutateResult` alongside `context`
- `mutationFn` accessing the same `QueryClient` instance via `context.client`
- `context.mutationKey` reflecting the `mutationKey` passed to `useMutation`
- `context.client.invalidateQueries()` actually invalidating the cache from within `onSuccess`

Also strengthens an existing test (`should only fire the per-call onSuccess for the last mutate() call`), which already asserted the `context` argument's presence with `expect.anything()`, to check `context.client` by identity instead.

**Type gap found, not fixed here:** `mutationFn`'s own `context` parameter type-checks as implicit `any` in this package only — `onMutate`/`onError`/`onSettled`/`onSuccess` and every per-call callback are unaffected, and runtime behavior is unaffected (core still passes the real object regardless of typing). `UseMutationOptions`' `MaybeRefDeep` wrapper is the suspected cause, unconfirmed. `injectMutation` in `angular-query-experimental`, which also takes an options-returning function, does not have this problem, so it looks vue-specific rather than inherent to the accessor pattern. The type test below excludes `mutationFn` from its assertion and documents the gap with a comment.

Type tests added:
- `context` typed as `MutationFunctionContext` for every hook-level callback except `mutationFn` (see gap above)
- `context` typed as `MutationFunctionContext` for every per-call `mutate` option
- `context.mutationKey` typed as `MutationKey | undefined`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded mutation coverage to verify consistent callback context delivery.
  - Confirmed context includes the mutation client, mutation key, result data, and mutation callback results.
  - Added type checks for correctly typed mutation-function and callback context.
  - Verified mutation callbacks can use the provided client to invalidate related queries without relying on an external client reference.
  - Added coverage for concurrent mutations and non-undefined results passed to success callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->