### PR TITLE
docs(angular-query-experimental): add 'readonly' and use descriptive names for class fields in guide examples

### DIFF
--- a/docs/framework/angular/angular-httpclient-and-other-data-fetching-clients.md
+++ b/docs/framework/angular/angular-httpclient-and-other-data-fetching-clients.md
@@ -25,7 +25,7 @@ As TanStack Query is a promise based library, observables from `HttpClient` need
 class ExampleComponent {
   private readonly http = inject(HttpClient)
 
-  readonly query = injectQuery(() => ({
+  readonly repoDataQuery = injectQuery(() => ({
     queryKey: ['repoData'],
     queryFn: () =>
       lastValueFrom(

--- a/docs/framework/angular/guides/background-fetching-indicators.md
+++ b/docs/framework/angular/guides/background-fetching-indicators.md
@@ -31,7 +31,7 @@ replace:
   `,
 })
 class TodosComponent {
-  todosQuery = injectQuery(() => ({
+  readonly todosQuery = injectQuery(() => ({
     queryKey: ['todos'],
     queryFn: fetchTodos,
   }))
@@ -53,7 +53,7 @@ import { injectIsFetching } from '@tanstack/angular-query-experimental'
   `,
 })
 export class GlobalLoadingIndicatorComponent {
-  isFetching = injectIsFetching()
+  readonly isFetching = injectIsFetching()
 }
 ```
 

--- a/docs/framework/angular/guides/default-query-function.md
+++ b/docs/framework/angular/guides/default-query-function.md
@@ -30,7 +30,7 @@ bootstrapApplication(MyAppComponent, {
 
 export class PostsComponent {
   // All you have to do now is pass a key!
-  postsQuery = injectQuery<Array<Post>>(() => ({
+  readonly postsQuery = injectQuery<Array<Post>>(() => ({
     queryKey: ['/posts'],
   }))
   // ...
@@ -38,7 +38,7 @@ export class PostsComponent {
 
 export class PostComponent {
   // You can even leave out the queryFn and just go straight into options
-  postQuery = injectQuery<Post>(() => ({
+  readonly postQuery = injectQuery<Post>(() => ({
     enabled: this.postIdSignal() > 0,
     queryKey: [`/posts/${this.postIdSignal()}`],
   }))

--- a/docs/framework/angular/guides/disabling-queries.md
+++ b/docs/framework/angular/guides/disabling-queries.md
@@ -11,29 +11,29 @@ replace: { 'useQuery': 'injectQuery' }
 @Component({
   selector: 'todos',
   template: `<div>
-    <button (click)="query.refetch()">Fetch Todos</button>
+    <button (click)="todosQuery.refetch()">Fetch Todos</button>
 
-    @if (query.data()) {
+    @if (todosQuery.data()) {
       <ul>
-        @for (todo of query.data(); track todo.id) {
+        @for (todo of todosQuery.data(); track todo.id) {
           <li>{{ todo.title }}</li>
         }
       </ul>
     } @else {
-      @if (query.isError()) {
-        <span>Error: {{ query.error().message }}</span>
-      } @else if (query.isLoading()) {
+      @if (todosQuery.isError()) {
+        <span>Error: {{ todosQuery.error().message }}</span>
+      } @else if (todosQuery.isLoading()) {
         <span>Loading...</span>
-      } @else if (!query.isLoading() && !query.isError()) {
+      } @else if (!todosQuery.isLoading() && !todosQuery.isError()) {
         <span>Not ready ...</span>
       }
     }
 
-    <div>{{ query.isLoading() ? 'Fetching...' : '' }}</div>
+    <div>{{ todosQuery.isLoading() ? 'Fetching...' : '' }}</div>
   </div>`,
 })
 export class TodosComponent {
-  query = injectQuery(() => ({
+  readonly todosQuery = injectQuery(() => ({
     queryKey: ['todos'],
     queryFn: fetchTodoList,
     enabled: false,
@@ -51,14 +51,14 @@ export class TodosComponent {
     <div>
       // 🚀 applying the filter will enable and execute the query
       <filters-form onApply="filter.set" />
-      <todos-table data="query.data()" />
+      <todos-table data="todosQuery.data()" />
     </div>
   `,
 })
 export class TodosComponent {
   filter = signal('')
 
-  todosQuery = injectQuery(() => ({
+  readonly todosQuery = injectQuery(() => ({
     queryKey: ['todos', this.filter()],
     queryFn: () => fetchTodos(this.filter()),
     enabled: !!this.filter(),
@@ -78,14 +78,14 @@ import { skipToken, injectQuery } from '@tanstack/angular-query-experimental'
     <div>
       // 🚀 applying the filter will enable and execute the query
       <filters-form onApply="filter.set" />
-      <todos-table data="query.data()" />
+      <todos-table data="todosQuery.data()" />
     </div>
   `,
 })
 export class TodosComponent {
   filter = signal('')
 
-  todosQuery = injectQuery(() => ({
+  readonly todosQuery = injectQuery(() => ({
     queryKey: ['todos', this.filter()],
     queryFn: this.filter() ? () => fetchTodos(this.filter()) : skipToken,
   }))

--- a/docs/framework/angular/guides/infinite-queries.md
+++ b/docs/framework/angular/guides/infinite-queries.md
@@ -19,9 +19,9 @@ import { ProjectsService } from './projects-service'
   templateUrl: './example.component.html',
 })
 export class Example {
-  projectsService = inject(ProjectsService)
+  readonly projectsService = inject(ProjectsService)
 
-  query = injectInfiniteQuery(() => ({
+  readonly projectsQuery = injectInfiniteQuery(() => ({
     queryKey: ['projects'],
     queryFn: async ({ pageParam }) => {
       return lastValueFrom(this.projectsService.getProjects(pageParam))
@@ -43,25 +43,28 @@ export class Example {
         : 'Nothing more to load',
   )
 
-  #hasNextPage = this.query.hasNextPage
-  #isFetchingNextPage = this.query.isFetchingNextPage
+  #hasNextPage = this.projectsQuery.hasNextPage
+  #isFetchingNextPage = this.projectsQuery.isFetchingNextPage
 }
 ```
 
 ```angular-html
 <div>
-  @if (query.isPending()) {
+  @if (projectsQuery.isPending()) {
     <p>Loading...</p>
-  } @else if (query.isError()) {
-    <span>Error: {{ query?.error().message }}</span>
+  } @else if (projectsQuery.isError()) {
+    <span>Error: {{ projectsQuery?.error().message }}</span>
   } @else {
-    @for (page of query?.data().pages; track $index) {
+    @for (page of projectsQuery?.data().pages; track $index) {
       @for (project of page.data; track project.id) {
         <p>{{ project.name }} {{ project.id }}</p>
       }
     }
     <div>
-      <button (click)="query.fetchNextPage()" [disabled]="nextButtonDisabled()">
+      <button
+        (click)="projectsQuery.fetchNextPage()"
+        [disabled]="nextButtonDisabled()"
+      >
         {{ nextButtonText() }}
       </button>
     </div>
@@ -77,7 +80,7 @@ export class Example {
   template: ` <list-component (endReached)="fetchNextPage()" /> `,
 })
 export class Example {
-  query = injectInfiniteQuery(() => ({
+  readonly projectsQuery = injectInfiniteQuery(() => ({
     queryKey: ['projects'],
     queryFn: async ({ pageParam }) => {
       return lastValueFrom(this.projectsService.getProjects(pageParam))
@@ -86,8 +89,8 @@ export class Example {
 
   fetchNextPage() {
     // Do nothing if already fetching
-    if (this.query.isFetching()) return
-    this.query.fetchNextPage()
+    if (this.projectsQuery.isFetching()) return
+    this.projectsQuery.fetchNextPage()
   }
 }
 ```
@@ -96,7 +99,7 @@ export class Example {
 [//]: # 'Example3'
 
 ```ts
-query = injectInfiniteQuery(() => ({
+projectsQuery = injectInfiniteQuery(() => ({
   queryKey: ['projects'],
   queryFn: fetchProjects,
   getNextPageParam: (lastPage, pages) => lastPage.nextCursor,
@@ -108,7 +111,7 @@ query = injectInfiniteQuery(() => ({
 [//]: # 'Example4'
 
 ```ts
-query = injectInfiniteQuery(() => ({
+projectsQuery = injectInfiniteQuery(() => ({
   queryKey: ['projects'],
   queryFn: fetchProjects,
   select: (data) => ({

--- a/docs/framework/angular/guides/initial-query-data.md
+++ b/docs/framework/angular/guides/initial-query-data.md
@@ -14,7 +14,7 @@ replace:
 [//]: # 'Example'
 
 ```ts
-result = injectQuery(() => ({
+todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: () => fetch('/todos'),
   initialData: initialTodos,
@@ -27,7 +27,7 @@ result = injectQuery(() => ({
 ```ts
 // Will show initialTodos immediately, but also immediately refetch todos
 // when an instance of the component or service is created
-result = injectQuery(() => ({
+todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: () => fetch('/todos'),
   initialData: initialTodos,
@@ -40,7 +40,7 @@ result = injectQuery(() => ({
 ```ts
 // Show initialTodos immediately, but won't refetch until
 // another interaction event is encountered after 1000 ms
-result = injectQuery(() => ({
+todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: () => fetch('/todos'),
   initialData: initialTodos,
@@ -54,7 +54,7 @@ result = injectQuery(() => ({
 ```ts
 // Show initialTodos immediately, but won't refetch until
 // another interaction event is encountered after 1000 ms
-result = injectQuery(() => ({
+todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: () => fetch('/todos'),
   initialData: initialTodos,
@@ -68,7 +68,7 @@ result = injectQuery(() => ({
 [//]: # 'Example5'
 
 ```ts
-result = injectQuery(() => ({
+todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: () => fetch('/todos'),
   initialData: () => getExpensiveTodos(),
@@ -79,7 +79,7 @@ result = injectQuery(() => ({
 [//]: # 'Example6'
 
 ```ts
-result = injectQuery(() => ({
+todoQuery = injectQuery(() => ({
   queryKey: ['todo', this.todoId()],
   queryFn: () => fetch('/todos'),
   initialData: () => {
@@ -95,7 +95,7 @@ result = injectQuery(() => ({
 [//]: # 'Example7'
 
 ```ts
-result = injectQuery(() => ({
+todoQuery = injectQuery(() => ({
   queryKey: ['todos', this.todoId()],
   queryFn: () => fetch(`/todos/${this.todoId()}`),
   initialData: () =>
@@ -109,7 +109,7 @@ result = injectQuery(() => ({
 [//]: # 'Example8'
 
 ```ts
-result = injectQuery(() => ({
+todoQuery = injectQuery(() => ({
   queryKey: ['todo', this.todoId()],
   queryFn: () => fetch(`/todos/${this.todoId()}`),
   initialData: () => {

--- a/docs/framework/angular/guides/invalidations-from-mutations.md
+++ b/docs/framework/angular/guides/invalidations-from-mutations.md
@@ -8,7 +8,7 @@ replace: { 'useMutation': 'injectMutation', 'hook': 'function' }
 [//]: # 'Example'
 
 ```ts
-mutation = injectMutation(() => ({
+postTodoMutation = injectMutation(() => ({
   mutationFn: postTodo,
 }))
 ```
@@ -23,10 +23,10 @@ import {
 } from '@tanstack/angular-query-experimental'
 
 export class TodosComponent {
-  queryClient = inject(QueryClient)
+  readonly queryClient = inject(QueryClient)
 
   // When this mutation succeeds, invalidate any queries with the `todos` or `reminders` query key
-  mutation = injectMutation(() => ({
+  readonly addTodoMutation = injectMutation(() => ({
     mutationFn: addTodo,
     onSuccess: () => {
       this.queryClient.invalidateQueries({ queryKey: ['todos'] })

--- a/docs/framework/angular/guides/mutation-options.md
+++ b/docs/framework/angular/guides/mutation-options.md
@@ -11,7 +11,7 @@ and you'll also get type inference and type safety for all of them.
 
 ```ts
 export class QueriesService {
-  private http = inject(HttpClient)
+  private readonly http = inject(HttpClient)
 
   updatePost(id: number) {
     return mutationOptions({

--- a/docs/framework/angular/guides/mutations.md
+++ b/docs/framework/angular/guides/mutations.md
@@ -18,20 +18,20 @@ replace:
 @Component({
   template: `
     <div>
-      @if (mutation.isPending()) {
+      @if (createTodoMutation.isPending()) {
         <span>Adding todo...</span>
-      } @else if (mutation.isError()) {
-        <div>An error occurred: {{ mutation.error()?.message }}</div>
-      } @else if (mutation.isSuccess()) {
+      } @else if (createTodoMutation.isError()) {
+        <div>An error occurred: {{ createTodoMutation.error()?.message }}</div>
+      } @else if (createTodoMutation.isSuccess()) {
         <div>Todo added!</div>
       }
-      <button (click)="mutation.mutate(1)">Create Todo</button>
+      <button (click)="createTodoMutation.mutate(1)">Create Todo</button>
     </div>
   `,
 })
 export class TodosComponent {
-  todoService = inject(TodoService)
-  mutation = injectMutation(() => ({
+  readonly todoService = inject(TodoService)
+  readonly createTodoMutation = injectMutation(() => ({
     mutationFn: (todoId: number) =>
       lastValueFrom(this.todoService.create(todoId)),
   }))
@@ -51,8 +51,10 @@ export class TodosComponent {
   imports: [ReactiveFormsModule],
   template: `
     <form [formGroup]="todoForm" (ngSubmit)="onCreateTodo()">
-      @if (mutation.error()) {
-        <h5 (click)="mutation.reset()">{{ mutation.error() }}</h5>
+      @if (createTodoMutation.error()) {
+        <h5 (click)="createTodoMutation.reset()">
+          {{ createTodoMutation.error() }}
+        </h5>
       }
       <input type="text" formControlName="title" />
       <br />
@@ -61,11 +63,11 @@ export class TodosComponent {
   `,
 })
 export class TodosComponent {
-  mutation = injectMutation(() => ({
+  readonly createTodoMutation = injectMutation(() => ({
     mutationFn: createTodo,
   }))
 
-  fb = inject(NonNullableFormBuilder)
+  readonly fb = inject(NonNullableFormBuilder)
 
   todoForm = this.fb.group({
     title: this.fb.control('', {
@@ -78,7 +80,7 @@ export class TodosComponent {
   })
 
   onCreateTodo = () => {
-    this.mutation.mutate(this.title())
+    this.createTodoMutation.mutate(this.title())
   }
 }
 ```
@@ -87,7 +89,7 @@ export class TodosComponent {
 [//]: # 'Example4'
 
 ```ts
-mutation = injectMutation(() => ({
+addTodoMutation = injectMutation(() => ({
   mutationFn: addTodo,
   onMutate: (variables, context) => {
     // A mutation is about to happen!
@@ -112,7 +114,7 @@ mutation = injectMutation(() => ({
 [//]: # 'Example5'
 
 ```ts
-mutation = injectMutation(() => ({
+addTodoMutation = injectMutation(() => ({
   mutationFn: addTodo,
   onSuccess: async () => {
     console.log("I'm first!")
@@ -127,7 +129,7 @@ mutation = injectMutation(() => ({
 [//]: # 'Example6'
 
 ```ts
-mutation = injectMutation(() => ({
+addTodoMutation = injectMutation(() => ({
   mutationFn: addTodo,
   onSuccess: (data, variables, onMutateResult, context) => {
     // I will fire first
@@ -140,7 +142,7 @@ mutation = injectMutation(() => ({
   },
 }))
 
-mutation.mutate(todo, {
+addTodoMutation.mutate(todo, {
   onSuccess: (data, variables, onMutateResult, context) => {
     // I will fire second!
   },
@@ -158,7 +160,7 @@ mutation.mutate(todo, {
 
 ```ts
 export class Example {
-  mutation = injectMutation(() => ({
+  readonly addTodoMutation = injectMutation(() => ({
     mutationFn: addTodo,
     onSuccess: (data, variables, onMutateResult, context) => {
       // Will be called 3 times
@@ -167,7 +169,7 @@ export class Example {
 
   doMutations() {
     ;['Todo 1', 'Todo 2', 'Todo 3'].forEach((todo) => {
-      this.mutation.mutate(todo, {
+      this.addTodoMutation.mutate(todo, {
         onSuccess: (data, variables, onMutateResult, context) => {
           // Will execute only once, for the last mutation (Todo 3),
           // regardless which mutation resolves first
@@ -182,10 +184,10 @@ export class Example {
 [//]: # 'Example8'
 
 ```ts
-mutation = injectMutation(() => ({ mutationFn: addTodo }))
+addTodoMutation = injectMutation(() => ({ mutationFn: addTodo }))
 
 try {
-  const todo = await mutation.mutateAsync(todo)
+  const todo = await addTodoMutation.mutateAsync(todo)
   console.log(todo)
 } catch (error) {
   console.error(error)
@@ -198,7 +200,7 @@ try {
 [//]: # 'Example9'
 
 ```ts
-mutation = injectMutation(() => ({
+addTodoMutation = injectMutation(() => ({
   mutationFn: addTodo,
   retry: 3,
 }))
@@ -245,10 +247,12 @@ queryClient.setMutationDefaults(['addTodo'], {
 
 class someComponent {
   // Start mutation in some component:
-  mutation = injectMutation(() => ({ mutationKey: ['addTodo'] }))
+  readonly addTodoMutation = injectMutation(() => ({
+    mutationKey: ['addTodo'],
+  }))
 
   someMethod() {
-    mutation.mutate({ title: 'title' })
+    addTodoMutation.mutate({ title: 'title' })
   }
 }
 

--- a/docs/framework/angular/guides/paginated-queries.md
+++ b/docs/framework/angular/guides/paginated-queries.md
@@ -13,7 +13,7 @@ replace:
 [//]: # 'Example'
 
 ```ts
-const result = injectQuery(() => ({
+const projectsQuery = injectQuery(() => ({
   queryKey: ['projects', page()],
   queryFn: fetchProjects,
 }))
@@ -35,15 +35,15 @@ const result = injectQuery(() => ({
         instantaneously while they are also re-fetched invisibly in the
         background.
       </p>
-      @if (query.status() === 'pending') {
+      @if (projectsQuery.status() === 'pending') {
         <div>Loading...</div>
-      } @else if (query.status() === 'error') {
-        <div>Error: {{ query.error().message }}</div>
+      } @else if (projectsQuery.status() === 'error') {
+        <div>Error: {{ projectsQuery.error().message }}</div>
       } @else {
         <!-- 'data' will either resolve to the latest page's data -->
         <!-- or if fetching a new page, the last successful page's data -->
         <div>
-          @for (project of query.data().projects; track project.id) {
+          @for (project of projectsQuery.data().projects; track project.id) {
             <p>{{ project.name }}</p>
           }
         </div>
@@ -55,14 +55,16 @@ const result = injectQuery(() => ({
       </button>
       <button
         (click)="nextPage()"
-        [disabled]="query.isPlaceholderData() || !query.data()?.hasMore"
+        [disabled]="
+          projectsQuery.isPlaceholderData() || !projectsQuery.data()?.hasMore
+        "
       >
         Next Page
       </button>
       <!-- Since the last page's data potentially sticks around between page requests, -->
       <!-- we can use 'isFetching' to show a background loading -->
       <!-- indicator since our status === 'pending' state won't be triggered -->
-      @if (query.isFetching()) {
+      @if (projectsQuery.isFetching()) {
         <span> Loading...</span>
       }
     </div>
@@ -70,9 +72,9 @@ const result = injectQuery(() => ({
 })
 export class PaginationExampleComponent {
   page = signal(0)
-  #queryClient = inject(QueryClient)
+  readonly #queryClient = inject(QueryClient)
 
-  query = injectQuery(() => ({
+  readonly projectsQuery = injectQuery(() => ({
     queryKey: ['projects', this.page()],
     queryFn: () => lastValueFrom(fetchProjects(this.page())),
     placeholderData: keepPreviousData,
@@ -82,7 +84,10 @@ export class PaginationExampleComponent {
   constructor() {
     effect(() => {
       // Prefetch the next page!
-      if (!this.query.isPlaceholderData() && this.query.data()?.hasMore) {
+      if (
+        !this.projectsQuery.isPlaceholderData() &&
+        this.projectsQuery.data()?.hasMore
+      ) {
         void this.#queryClient
           .query({
             queryKey: ['projects', this.page() + 1],
@@ -98,7 +103,9 @@ export class PaginationExampleComponent {
   }
 
   nextPage() {
-    this.page.update((old) => (this.query.data()?.hasMore ? old + 1 : old))
+    this.page.update((old) =>
+      this.projectsQuery.data()?.hasMore ? old + 1 : old,
+    )
   }
 }
 ```

--- a/docs/framework/angular/guides/parallel-queries.md
+++ b/docs/framework/angular/guides/parallel-queries.md
@@ -19,9 +19,15 @@ replace:
 ```ts
 export class AppComponent {
   // The following queries will execute in parallel
-  usersQuery = injectQuery(() => ({ queryKey: ['users'], queryFn: fetchUsers }))
-  teamsQuery = injectQuery(() => ({ queryKey: ['teams'], queryFn: fetchTeams }))
-  projectsQuery = injectQuery(() => ({
+  readonly usersQuery = injectQuery(() => ({
+    queryKey: ['users'],
+    queryFn: fetchUsers,
+  }))
+  readonly teamsQuery = injectQuery(() => ({
+    queryKey: ['teams'],
+    queryFn: fetchTeams,
+  }))
+  readonly projectsQuery = injectQuery(() => ({
     queryKey: ['projects'],
     queryFn: fetchProjects,
   }))
@@ -43,7 +49,7 @@ export class AppComponent {
   users = signal<Array<User>>([])
 
   // Please note injectQueries is under development and this code does not work yet
-  userQueries = injectQueries(() => ({
+  readonly userQueries = injectQueries(() => ({
     queries: users().map((user) => {
       return {
         queryKey: ['user', user.id],

--- a/docs/framework/angular/guides/placeholder-query-data.md
+++ b/docs/framework/angular/guides/placeholder-query-data.md
@@ -8,7 +8,7 @@ ref: docs/framework/react/guides/placeholder-query-data.md
 
 ```ts
 class TodosComponent {
-  readonly result = injectQuery(() => ({
+  readonly todosQuery = injectQuery(() => ({
     queryKey: ['todos'],
     queryFn: () => fetch('/todos'),
     placeholderData: placeholderTodos,
@@ -23,7 +23,7 @@ class TodosComponent {
 
 ```ts
 class TodosComponent {
-  readonly result = injectQuery(() => ({
+  readonly todoQuery = injectQuery(() => ({
     queryKey: ['todos', id()],
     queryFn: () => fetch(`/todos/${id}`),
     placeholderData: (previousData, previousQuery) => previousData,
@@ -39,7 +39,7 @@ export class BlogPostComponent {
   postId = input.required<number>()
   readonly queryClient = inject(QueryClient)
 
-  readonly result = injectQuery(() => ({
+  readonly blogPostQuery = injectQuery(() => ({
     queryKey: ['blogPost', this.postId()],
     queryFn: () => fetch(`/blogPosts/${this.postId()}`),
     placeholderData: () => {

--- a/docs/framework/angular/guides/placeholder-query-data.md
+++ b/docs/framework/angular/guides/placeholder-query-data.md
@@ -8,7 +8,7 @@ ref: docs/framework/react/guides/placeholder-query-data.md
 
 ```ts
 class TodosComponent {
-  result = injectQuery(() => ({
+  readonly result = injectQuery(() => ({
     queryKey: ['todos'],
     queryFn: () => fetch('/todos'),
     placeholderData: placeholderTodos,
@@ -23,7 +23,7 @@ class TodosComponent {
 
 ```ts
 class TodosComponent {
-  result = injectQuery(() => ({
+  readonly result = injectQuery(() => ({
     queryKey: ['todos', id()],
     queryFn: () => fetch(`/todos/${id}`),
     placeholderData: (previousData, previousQuery) => previousData,
@@ -37,9 +37,9 @@ class TodosComponent {
 ```ts
 export class BlogPostComponent {
   postId = input.required<number>()
-  queryClient = inject(QueryClient)
+  readonly queryClient = inject(QueryClient)
 
-  result = injectQuery(() => ({
+  readonly result = injectQuery(() => ({
     queryKey: ['blogPost', this.postId()],
     queryFn: () => fetch(`/blogPosts/${this.postId()}`),
     placeholderData: () => {

--- a/docs/framework/angular/guides/queries.md
+++ b/docs/framework/angular/guides/queries.md
@@ -20,7 +20,10 @@ replace:
 import { injectQuery } from '@tanstack/angular-query-experimental'
 
 export class TodosComponent {
-  info = injectQuery(() => ({ queryKey: ['todos'], queryFn: fetchTodoList }))
+  readonly info = injectQuery(() => ({
+    queryKey: ['todos'],
+    queryFn: fetchTodoList,
+  }))
 }
 ```
 
@@ -28,7 +31,10 @@ export class TodosComponent {
 [//]: # 'Example2'
 
 ```ts
-result = injectQuery(() => ({ queryKey: ['todos'], queryFn: fetchTodoList }))
+todosQuery = injectQuery(() => ({
+  queryKey: ['todos'],
+  queryFn: fetchTodoList,
+}))
 ```
 
 [//]: # 'Example2'
@@ -53,7 +59,7 @@ result = injectQuery(() => ({ queryKey: ['todos'], queryFn: fetchTodoList }))
   `,
 })
 export class PostsComponent {
-  todos = injectQuery(() => ({
+  readonly todos = injectQuery(() => ({
     queryKey: ['todos'],
     queryFn: fetchTodoList,
   }))

--- a/docs/framework/angular/guides/query-cancellation.md
+++ b/docs/framework/angular/guides/query-cancellation.md
@@ -32,7 +32,7 @@ postQuery = injectQuery(() => ({
 [//]: # 'Example2'
 
 ```ts
-query = injectQuery(() => ({
+todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: async ({ signal }) => {
     const todosResponse = await fetch('/todos', {
@@ -63,7 +63,7 @@ query = injectQuery(() => ({
 ```ts
 import axios from 'axios'
 
-const query = injectQuery(() => ({
+const todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: ({ signal }) =>
     axios.get('/todos', {
@@ -86,7 +86,7 @@ You might want to cancel a query manually. For example, if the request takes a l
   template: `<button (click)="onCancel()">Cancel</button>`,
 })
 export class TodosComponent {
-  query = injectQuery(() => ({
+  readonly todosQuery = injectQuery(() => ({
     queryKey: ['todos'],
     queryFn: async ({ signal }) => {
       const resp = await fetch('/todos', { signal })
@@ -94,7 +94,7 @@ export class TodosComponent {
     },
   }))
 
-  queryClient = inject(QueryClient)
+  readonly queryClient = inject(QueryClient)
 
   onCancel() {
     this.queryClient.cancelQueries(['todos'])

--- a/docs/framework/angular/guides/query-functions.md
+++ b/docs/framework/angular/guides/query-functions.md
@@ -64,7 +64,7 @@ todos = injectQuery(() => ({
 [//]: # 'Example4'
 
 ```ts
-result = injectQuery(() => ({
+todosQuery = injectQuery(() => ({
   queryKey: ['todos', { status: status(), page: page() }],
   queryFn: fetchTodoList,
 }))

--- a/docs/framework/angular/guides/query-invalidation.md
+++ b/docs/framework/angular/guides/query-invalidation.md
@@ -11,7 +11,7 @@ replace: { 'useQuery': 'injectQuery', 'hooks': 'functions' }
 import { injectQuery, QueryClient } from '@tanstack/angular-query-experimental'
 
 class QueryInvalidationExample {
-  queryClient = inject(QueryClient)
+  readonly queryClient = inject(QueryClient)
 
   invalidateQueries() {
     this.queryClient.invalidateQueries({ queryKey: ['todos'] })

--- a/docs/framework/angular/guides/query-options.md
+++ b/docs/framework/angular/guides/query-options.md
@@ -13,7 +13,7 @@ import { queryOptions, noop } from '@tanstack/angular-query-experimental'
   providedIn: 'root',
 })
 export class QueriesService {
-  private http = inject(HttpClient)
+  private readonly http = inject(HttpClient)
 
   post(postId: number) {
     return queryOptions({
@@ -46,10 +46,10 @@ queryClient.setQueryData(this.queries.post(42).queryKey, newPost)
 [//]: # 'Example2'
 
 ```ts
-// Type inference still works, so query.data will be the return type of select instead of queryFn
+// Type inference still works, so groupQuery.data will be the return type of select instead of queryFn
 queries = inject(QueriesService)
 
-query = injectQuery(() => ({
+groupQuery = injectQuery(() => ({
   ...groupOptions(1),
   select: (data) => data.title,
 }))

--- a/docs/framework/angular/guides/query-retries.md
+++ b/docs/framework/angular/guides/query-retries.md
@@ -18,7 +18,7 @@ replace:
 import { injectQuery } from '@tanstack/angular-query-experimental'
 
 // Make a specific query retry a certain number of times
-const result = injectQuery(() => ({
+const todoQuery = injectQuery(() => ({
   queryKey: ['todos', 1],
   queryFn: fetchTodoListPage,
   retry: 10, // Will retry failed requests 10 times before displaying an error
@@ -56,7 +56,7 @@ Though it is not recommended, you can obviously override the `retryDelay` functi
 [//]: # 'Example3'
 
 ```ts
-const result = injectQuery(() => ({
+const todosQuery = injectQuery(() => ({
   queryKey: ['todos'],
   queryFn: fetchTodoList,
   retryDelay: 1000, // Will always wait 1000ms to retry, regardless of how many retries

--- a/docs/framework/angular/overview.md
+++ b/docs/framework/angular/overview.md
@@ -71,13 +71,13 @@ import { lastValueFrom } from 'rxjs'
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'simple-example',
   template: `
-    @if (query.isPending()) {
+    @if (repoDataQuery.isPending()) {
       Loading...
     }
-    @if (query.error()) {
-      An error has occurred: {{ query.error().message }}
+    @if (repoDataQuery.error()) {
+      An error has occurred: {{ repoDataQuery.error().message }}
     }
-    @if (query.data(); as data) {
+    @if (repoDataQuery.data(); as data) {
       <h1>{{ data.name }}</h1>
       <p>{{ data.description }}</p>
       <strong>👀 {{ data.subscribers_count }}</strong>
@@ -87,9 +87,9 @@ import { lastValueFrom } from 'rxjs'
   `,
 })
 export class SimpleExampleComponent {
-  http = inject(HttpClient)
+  readonly http = inject(HttpClient)
 
-  query = injectQuery(() => ({
+  readonly repoDataQuery = injectQuery(() => ({
     queryKey: ['repoData'],
     queryFn: () =>
       lastValueFrom(

--- a/docs/framework/angular/quick-start.md
+++ b/docs/framework/angular/quick-start.md
@@ -60,7 +60,7 @@ import {
       <button (click)="onAddTodo()">Add Todo</button>
 
       <ul>
-        @for (todo of query.data(); track todo.title) {
+        @for (todo of todosQuery.data(); track todo.title) {
           <li>{{ todo.title }}</li>
         }
       </ul>
@@ -68,15 +68,15 @@ import {
   `,
 })
 export class TodosComponent {
-  todoService = inject(TodoService)
-  queryClient = inject(QueryClient)
+  readonly todoService = inject(TodoService)
+  readonly queryClient = inject(QueryClient)
 
-  query = injectQuery(() => ({
+  readonly todosQuery = injectQuery(() => ({
     queryKey: ['todos'],
     queryFn: () => this.todoService.getTodos(),
   }))
 
-  mutation = injectMutation(() => ({
+  readonly addTodoMutation = injectMutation(() => ({
     mutationFn: (todo: Todo) => this.todoService.addTodo(todo),
     onSuccess: () => {
       this.queryClient.invalidateQueries({ queryKey: ['todos'] })
@@ -84,7 +84,7 @@ export class TodosComponent {
   }))
 
   onAddTodo() {
-    this.mutation.mutate({
+    this.addTodoMutation.mutate({
       id: Date.now().toString(),
       title: 'Do Laundry',
     })
@@ -93,7 +93,7 @@ export class TodosComponent {
 
 @Injectable({ providedIn: 'root' })
 export class TodoService {
-  private http = inject(HttpClient)
+  private readonly http = inject(HttpClient)
 
   getTodos(): Promise<Todo[]> {
     return lastValueFrom(


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11416, which added `readonly` to class fields in the package's JSDoc `@example` blocks (`src/*.ts`). The same convention was missing from `docs/framework/angular`'s hand-written guides (`overview.md`, `quick-start.md`, `guides/*.md`), which are separate from the JSDoc-derived reference docs.

Two related changes across 20 files:

1. **Add `readonly`** to class fields that are assigned once inside a class body, including `injectQuery`/`injectMutation`/`injectInfiniteQuery` results and plain `inject(...)` DI fields (e.g. `queryClient = inject(QueryClient)`). Left unchanged:
   - `typescript.md` — its comparison block assigns the same field (`postQuery`) three different ways to illustrate the options; adding `readonly` there would make the snippet a redeclaration error.
   - `guides/query-invalidation.md` — several snippets declare the same field name (`todoListQuery`) twice within one class to contrast which query gets invalidated; same redeclaration issue.
   - Bare code fragments with no enclosing class (e.g. `result = injectQuery(...)` outside a class) — `readonly` isn't meaningful without a class to attach it to.

2. **Rename generic field names** (`result`, `query`, `mutation`) to names that reflect their `queryKey`/`mutationFn` (e.g. `todosQuery`, `projectsQuery`, `addTodoMutation`, `createTodoMutation`), updating every reference to that field in the same snippet (constructor bodies, methods, and templates).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Angular documentation examples to mark query, mutation, service, and client properties as read-only.
  - Renamed example variables to use clearer, query-specific names and updated their references throughout templates and code samples.
  - Reformatted selected query examples for improved readability.
  - No runtime behavior, query configuration, or control-flow changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->