### PR TITLE
test({react,preact,solid,svelte}-query,angular-query-experimental): rename 'mutationFn' param to '_variables' in 'MutationFunctionContext' tests

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test-d.ts
@@ -106,7 +106,7 @@ describe('injectMutation', () => {
 
   it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     injectMutation(() => ({
-      mutationFn: (_vars: string, context) => {
+      mutationFn: (_variables, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
         expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
         return Promise.resolve('data')

--- a/packages/preact-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useMutation.test-d.tsx
@@ -151,7 +151,7 @@ describe('useMutation', () => {
 
   it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     useMutation({
-      mutationFn: (_vars: string, context) => {
+      mutationFn: (_variables, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
         expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
         return Promise.resolve('data')

--- a/packages/react-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test-d.tsx
@@ -151,7 +151,7 @@ describe('useMutation', () => {
 
   it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     useMutation({
-      mutationFn: (_vars: string, context) => {
+      mutationFn: (_variables, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
         expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
         return Promise.resolve('data')

--- a/packages/solid-query/src/__tests__/useMutation.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useMutation.test-d.tsx
@@ -152,7 +152,7 @@ describe('useMutation', () => {
 
   it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     useMutation(() => ({
-      mutationFn: (_vars: string, context) => {
+      mutationFn: (_variables, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
         expectTypeOf(context.client).toEqualTypeOf<QueryCoreClient>()
         return Promise.resolve('data')

--- a/packages/svelte-query/tests/createMutation/createMutation.test-d.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.test-d.ts
@@ -151,7 +151,7 @@ describe('createMutation', () => {
 
   it('should type context as the last argument for mutationFn and every hook-level callback', () => {
     createMutation(() => ({
-      mutationFn: (_vars: string, context) => {
+      mutationFn: (_variables, context) => {
         expectTypeOf(context).toEqualTypeOf<MutationFunctionContext>()
         expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
         return Promise.resolve('data')


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11440–#11444, which added a `should type context as the last argument for mutationFn and every hook-level callback` type test to `react-query`, `preact-query`, `solid-query`, `svelte-query`, `angular-query-experimental`, and `vue-query`.

In each file's test, the `mutationFn`'s first parameter was named `_vars: string`, while the sibling `onMutate`/`onSuccess`/`onError`/`onSettled` callbacks in the same test (and every other `mutationFn` in the file) use `_variables`. `vue-query`'s copy was already fixed in #11444; this applies the same fix — renaming to `_variables` and dropping the now-redundant `: string` annotation (the type is still contextually inferred from `useMutation`/`injectMutation`/`createMutation`, as verified by each package's `--typecheck` run) — to the remaining 5 adapters.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mutation typing tests across Angular, Preact, React, Solid, and Svelte integrations to rely on inferred variable types.
  * Standardized mutation function parameter naming in context callback tests.
  * Existing behavior and type assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->