### PR TITLE
test(svelte-query/createMutation): add tests for parallel 'mutateAsync' calls and concurrent 'mutate' calls

### DIFF
--- a/packages/svelte-query/tests/createMutation/ConcurrentMutate.svelte
+++ b/packages/svelte-query/tests/createMutation/ConcurrentMutate.svelte
@@ -27,3 +27,4 @@
 >
   mutate2
 </button>
+<div>data: {mutation.data ?? 'null'}, status: {mutation.status}</div>

--- a/packages/svelte-query/tests/createMutation/ConcurrentMutate.svelte
+++ b/packages/svelte-query/tests/createMutation/ConcurrentMutate.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { QueryClient } from '@tanstack/query-core'
+  import { createMutation, setQueryClientContext } from '../../src/index.js'
+  import { sleep } from '@tanstack/query-test-utils'
+
+  type Props = {
+    queryClient: QueryClient
+    onSuccessPerCall: (...args: Array<unknown>) => void
+  }
+
+  const { queryClient, onSuccessPerCall }: Props = $props()
+
+  setQueryClientContext(queryClient)
+
+  const mutation = createMutation(() => ({
+    mutationFn: (text: string) => sleep(10).then(() => text),
+  }))
+</script>
+
+<button
+  onclick={() => mutation.mutate('Todo 1', { onSuccess: onSuccessPerCall })}
+>
+  mutate1
+</button>
+<button
+  onclick={() => mutation.mutate('Todo 2', { onSuccess: onSuccessPerCall })}
+>
+  mutate2
+</button>

--- a/packages/svelte-query/tests/createMutation/ParallelMutateAsync.svelte
+++ b/packages/svelte-query/tests/createMutation/ParallelMutateAsync.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import type { QueryClient } from '@tanstack/query-core'
+  import { createMutation, setQueryClientContext } from '../../src/index.js'
+  import { sleep } from '@tanstack/query-test-utils'
+
+  type Props = {
+    queryClient: QueryClient
+    strategy: 'all' | 'allSettled'
+    failOn?: string
+  }
+
+  const { queryClient, strategy, failOn }: Props = $props()
+
+  let result = $state('idle')
+
+  setQueryClientContext(queryClient)
+
+  const mutation = createMutation(() => ({
+    mutationFn: (file: string) =>
+      sleep(10).then(() => {
+        if (file === failOn) {
+          throw new Error('upload failed')
+        }
+        return `uploaded: ${file}`
+      }),
+    retry: false,
+  }))
+
+  async function uploadAll() {
+    if (strategy === 'all') {
+      try {
+        const results = await Promise.all([
+          mutation.mutateAsync('file1'),
+          mutation.mutateAsync('file2'),
+          mutation.mutateAsync('file3'),
+        ])
+        result = results.join(', ')
+      } catch (error) {
+        result = `error: ${(error as Error).message}`
+      }
+    } else {
+      const results = await Promise.allSettled([
+        mutation.mutateAsync('file1'),
+        mutation.mutateAsync('file2'),
+        mutation.mutateAsync('file3'),
+      ])
+      result = results
+        .map((r) =>
+          r.status === 'fulfilled' ? r.value : `error: ${r.reason.message}`,
+        )
+        .join(', ')
+    }
+  }
+</script>
+
+<button onclick={uploadAll}>upload all</button>
+
+<div>result: {result}</div>

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -310,10 +310,16 @@ describe('createMutation', () => {
       props: { queryClient, onSuccessPerCall },
     })
 
+    expect(rendered.getByText('data: null, status: idle')).toBeInTheDocument()
+
     fireEvent.click(rendered.getByRole('button', { name: /mutate1/i }))
     fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
 
-    await vi.advanceTimersByTimeAsync(10)
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('data: Todo 2, status: success'),
+    ).toBeInTheDocument()
 
     expect(onSuccessPerCall).toHaveBeenCalledTimes(1)
     expect(onSuccessPerCall).toHaveBeenCalledWith(

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -13,6 +13,8 @@ import SuccessContext from './SuccessContext.svelte'
 import InvalidateFromContext from './InvalidateFromContext.svelte'
 import PerCallSuccess from './PerCallSuccess.svelte'
 import MutationFnContext from './MutationFnContext.svelte'
+import ParallelMutateAsync from './ParallelMutateAsync.svelte'
+import ConcurrentMutate from './ConcurrentMutate.svelte'
 
 describe('createMutation', () => {
   let queryClient: QueryClient
@@ -256,5 +258,69 @@ describe('createMutation', () => {
 
     expect(perCallOnSuccess).toHaveBeenCalledTimes(1)
     expect(perCallOnSuccess.mock.calls[0]?.[3].client).toBe(queryClient)
+  })
+
+  it('should be able to run multiple mutateAsync calls in parallel with Promise.all', async () => {
+    const rendered = render(ParallelMutateAsync, {
+      props: { queryClient, strategy: 'all' },
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText(
+        'result: uploaded: file1, uploaded: file2, uploaded: file3',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle Promise.all rejection when one parallel mutateAsync call fails', async () => {
+    const rendered = render(ParallelMutateAsync, {
+      props: { queryClient, strategy: 'all', failOn: 'file2' },
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText('result: error: upload failed'),
+    ).toBeInTheDocument()
+  })
+
+  it('should handle partial failure in parallel mutateAsync calls with Promise.allSettled', async () => {
+    const rendered = render(ParallelMutateAsync, {
+      props: { queryClient, strategy: 'allSettled', failOn: 'file2' },
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: /upload all/i }))
+    await vi.advanceTimersByTimeAsync(11)
+
+    expect(
+      rendered.getByText(
+        'result: uploaded: file1, error: upload failed, uploaded: file3',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('should only fire the per-call onSuccess for the last mutate() call', async () => {
+    const onSuccessPerCall = vi.fn()
+
+    const rendered = render(ConcurrentMutate, {
+      props: { queryClient, onSuccessPerCall },
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate1/i }))
+    fireEvent.click(rendered.getByRole('button', { name: /mutate2/i }))
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(onSuccessPerCall).toHaveBeenCalledTimes(1)
+    expect(onSuccessPerCall).toHaveBeenCalledWith(
+      'Todo 2',
+      'Todo 2',
+      undefined,
+      expect.anything(),
+    )
   })
 })


### PR DESCRIPTION
## 🎯 Changes

`createMutation.svelte.test.ts` was missing two test scenarios that already exist in the other adapters' `useMutation`/`injectMutation` test suites:

1. **Parallel `mutateAsync` calls** (`react-query` #2339–2477, `solid-query` #11430) — three tests added via a new `ParallelMutateAsync.svelte` component (`strategy`/`failOn` props select the scenario, following this file's existing pattern of reusable parameterized components like `OptimisticUpdate.svelte`):
   - `should be able to run multiple mutateAsync calls in parallel with Promise.all`
   - `should handle Promise.all rejection when one parallel mutateAsync call fails`
   - `should handle partial failure in parallel mutateAsync calls with Promise.allSettled`
2. **Concurrent `mutate()` calls** (`vue-query` #11403, `angular-query-experimental` #11415, `react-query` line 1650) — one test added via a new `ConcurrentMutate.svelte` component:
   - `should only fire the per-call onSuccess for the last mutate() call`

`svelte-query`'s `createMutation.svelte.test.ts` now has 15 runtime tests (was 11).

Left out of this PR: single-call `mutateAsync` success/error/`onSettled` coverage (a larger cluster present in `react-query`) — tracked separately.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for running multiple mutations concurrently.
  - Added validation for successful parallel operations and scenarios where one or more operations fail.
  - Added coverage for mixed outcomes when all operations are allowed to settle.
  - Verified that per-call success callbacks behave correctly when multiple mutations are triggered in quick succession.
  - Confirmed that mutation results and status remain accurate across concurrent and partially failed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->