### PR TITLE
test(svelte-query/createMutation): add tests for 'onSuccess'/'onError'/'onSettled' callbacks and result timing after 'mutateAsync'

### DIFF
--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -413,7 +413,8 @@ describe('createMutation', () => {
       const mutation = createMutation(
         () => ({
           mutationFn: (text: string) => sleep(10).then(() => text),
-          onSuccess: () => callbacks.push('useMutation.onSuccess'),
+          onSuccess: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onSuccess')),
           onSettled: () => callbacks.push('useMutation.onSettled'),
         }),
         () => queryClient,
@@ -425,7 +426,7 @@ describe('createMutation', () => {
           onSettled: () => callbacks.push('mutateAsync.onSettled'),
         })
         .then((result) => callbacks.push(`mutateAsync.result:${result}`))
-      await vi.advanceTimersByTimeAsync(10)
+      await vi.advanceTimersByTimeAsync(20)
 
       expect(callbacks).toEqual([
         'useMutation.onSuccess',
@@ -446,7 +447,8 @@ describe('createMutation', () => {
         () => ({
           mutationFn: (_text: string) =>
             sleep(10).then(() => Promise.reject(new Error('oops'))),
-          onError: () => callbacks.push('useMutation.onError'),
+          onError: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onError')),
           onSettled: () => callbacks.push('useMutation.onSettled'),
         }),
         () => queryClient,
@@ -460,7 +462,7 @@ describe('createMutation', () => {
         .catch((error) =>
           callbacks.push(`mutateAsync.error:${(error as Error).message}`),
         )
-      await vi.advanceTimersByTimeAsync(10)
+      await vi.advanceTimersByTimeAsync(20)
 
       expect(callbacks).toEqual([
         'useMutation.onError',

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -415,7 +415,8 @@ describe('createMutation', () => {
           mutationFn: (text: string) => sleep(10).then(() => text),
           onSuccess: () =>
             sleep(10).then(() => callbacks.push('useMutation.onSuccess')),
-          onSettled: () => callbacks.push('useMutation.onSettled'),
+          onSettled: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onSettled')),
         }),
         () => queryClient,
       )
@@ -426,7 +427,7 @@ describe('createMutation', () => {
           onSettled: () => callbacks.push('mutateAsync.onSettled'),
         })
         .then((result) => callbacks.push(`mutateAsync.result:${result}`))
-      await vi.advanceTimersByTimeAsync(20)
+      await vi.advanceTimersByTimeAsync(30)
 
       expect(callbacks).toEqual([
         'useMutation.onSuccess',
@@ -449,7 +450,8 @@ describe('createMutation', () => {
             sleep(10).then(() => Promise.reject(new Error('oops'))),
           onError: () =>
             sleep(10).then(() => callbacks.push('useMutation.onError')),
-          onSettled: () => callbacks.push('useMutation.onSettled'),
+          onSettled: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onSettled')),
         }),
         () => queryClient,
       )
@@ -462,7 +464,7 @@ describe('createMutation', () => {
         .catch((error) =>
           callbacks.push(`mutateAsync.error:${(error as Error).message}`),
         )
-      await vi.advanceTimersByTimeAsync(20)
+      await vi.advanceTimersByTimeAsync(30)
 
       expect(callbacks).toEqual([
         'useMutation.onError',

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushSync } from 'svelte'
 import { fireEvent, render } from '@testing-library/svelte'
-import { QueryClient } from '@tanstack/query-core'
+import { QueryClient, noop } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { createMutation } from '../../src/index.js'
 import { withEffectRoot } from '../utils.svelte.js'
@@ -373,9 +373,7 @@ describe('createMutation', () => {
         .mutateAsync('todo', {
           onError: () => callbacks.push('mutateAsync.onError'),
         })
-        .catch(() => {
-          // asserted via the onError callbacks above
-        })
+        .catch(noop)
       await vi.advanceTimersByTimeAsync(10)
 
       expect(callbacks).toEqual(['useMutation.onError', 'mutateAsync.onError'])

--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -329,4 +329,148 @@ describe('createMutation', () => {
       expect.anything(),
     )
   })
+
+  it(
+    'should be able to call `onSuccess` callback after successful mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+          onSuccess: () => callbacks.push('useMutation.onSuccess'),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutateAsync('todo', {
+        onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'useMutation.onSuccess',
+        'mutateAsync.onSuccess',
+      ])
+    }),
+  )
+
+  it(
+    'should be able to call `onError` callback after failed mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+          onError: () => callbacks.push('useMutation.onError'),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+        })
+        .catch(() => {
+          // asserted via the onError callbacks above
+        })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['useMutation.onError', 'mutateAsync.onError'])
+    }),
+  )
+
+  it(
+    'should be able to call `onSettled` callback after mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+          onSettled: () => callbacks.push('useMutation.onSettled'),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutateAsync('todo', {
+        onSettled: () => callbacks.push('mutateAsync.onSettled'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'useMutation.onSettled',
+        'mutateAsync.onSettled',
+      ])
+    }),
+  )
+
+  it(
+    'should be able to override the useMutation success callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+          onSuccess: () => callbacks.push('useMutation.onSuccess'),
+          onSettled: () => callbacks.push('useMutation.onSettled'),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+          onSettled: () => callbacks.push('mutateAsync.onSettled'),
+        })
+        .then((result) => callbacks.push(`mutateAsync.result:${result}`))
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'useMutation.onSuccess',
+        'useMutation.onSettled',
+        'mutateAsync.onSuccess',
+        'mutateAsync.onSettled',
+        'mutateAsync.result:todo',
+      ])
+    }),
+  )
+
+  it(
+    'should be able to override the error callbacks when using mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+          onError: () => callbacks.push('useMutation.onError'),
+          onSettled: () => callbacks.push('useMutation.onSettled'),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+          onSettled: () => callbacks.push('mutateAsync.onSettled'),
+        })
+        .catch((error) =>
+          callbacks.push(`mutateAsync.error:${(error as Error).message}`),
+        )
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'useMutation.onError',
+        'useMutation.onSettled',
+        'mutateAsync.onError',
+        'mutateAsync.onSettled',
+        'mutateAsync.error:oops',
+      ])
+    }),
+  )
 })


### PR DESCRIPTION
## 🎯 Changes

`createMutation.svelte.test.ts` only covered hook-level callbacks via the `mutate()` (fire-and-forget) path. It had no coverage for `mutateAsync()` — neither the hook-level + per-call callback ordering, nor whether the resolved/rejected value only lands after the hook-level callbacks' returned promises settle.

Ported from `react-query`'s `useMutation.test.tsx` (lines 703, 737, 773, 807, 857), adapted to this file's existing `withEffectRoot` pattern (see `should recreate observer when queryClient changes`) rather than a rendered `.svelte` component — none of these tests assert on the DOM, so a component wasn't needed. `createMutation`'s `queryClient` accessor parameter is used directly instead of `setQueryClientContext`, since `$effect.root` doesn't provide Svelte's component context that `useQueryClient()` normally relies on.

Five tests added:
- `should be able to call 'onSuccess' callback after successful mutateAsync`
- `should be able to call 'onError' callback after failed mutateAsync`
- `should be able to call 'onSettled' callback after mutateAsync`
- `should be able to override the useMutation success callbacks` — both hook-level `onSuccess` and `onSettled` return a promise (`sleep(10)`), asserting `mutateAsync` waits for each of them (via `query-core`'s `await this.options.onSuccess?.(...)` / `await this.options.onSettled?.(...)`) before the per-call callbacks and the resolved value follow
- `should be able to override the error callbacks when using mutateAsync` — same, with the hook-level `onError` and `onSettled`

Note: per-call callbacks (passed to `mutateAsync(vars, { onSuccess, onError, onSettled })`) are fired without being awaited (`mutationObserver.ts`'s `#notify`), unlike hook-level callbacks — that asymmetry is intentional in `query-core` (so a per-call side effect can't stall the mutation), so the async delays in these two tests are on the hook-level callbacks only.

`react-query`'s five "no callbacks" variants (lines 136, 207, 339, 367, 400) were left out — their trigger (`React.useEffect`/`setActTimeout`) is React-specific, though the assertion itself (per-call callbacks firing when hook-level options define none) would be portable with a different trigger; not pursued here.

`createMutation.svelte.test.ts` now has 20 runtime tests (was 15).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for asynchronous mutation callbacks.
  * Verified hook-level success and error callbacks run before settled callbacks.
  * Verified per-call mutation options override configured success, error, and settled callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
