### PR TITLE
test(svelte-query/createMutation): add tests for per-call callbacks when 'createMutation' has no callbacks

### DIFF
--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -45,6 +45,234 @@ describe('createMutation', () => {
     expect(rendered.getByText('Error: undefined')).toBeInTheDocument()
   })
 
+  it(
+    'should call mutate callbacks when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutate('todo', {
+        onSuccess: () => callbacks.push('mutate.onSuccess'),
+        onSettled: () => callbacks.push('mutate.onSettled'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutate.onSuccess', 'mutate.onSettled'])
+    }),
+  )
+
+  it(
+    'should call mutate error callbacks when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutate('todo', {
+        onError: () => callbacks.push('mutate.onError'),
+        onSettled: () => callbacks.push('mutate.onSettled'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutate.onError', 'mutate.onSettled'])
+    }),
+  )
+
+  it(
+    'should call only mutate onSuccess when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutate('todo', {
+        onSuccess: () => callbacks.push('mutate.onSuccess'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutate.onSuccess'])
+    }),
+  )
+
+  it(
+    'should call only mutate onError when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutate('todo', {
+        onError: () => callbacks.push('mutate.onError'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutate.onError'])
+    }),
+  )
+
+  it(
+    'should call only mutate onSettled when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutate('todo', {
+        onSettled: () => callbacks.push('mutate.onSettled'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutate.onSettled'])
+    }),
+  )
+
+  it(
+    'should call mutateAsync callbacks when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutateAsync('todo', {
+        onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+        onSettled: () => callbacks.push('mutateAsync.onSettled'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'mutateAsync.onSuccess',
+        'mutateAsync.onSettled',
+      ])
+    }),
+  )
+
+  it(
+    'should call mutateAsync error callbacks when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+          onSettled: () => callbacks.push('mutateAsync.onSettled'),
+        })
+        .catch(noop)
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'mutateAsync.onError',
+        'mutateAsync.onSettled',
+      ])
+    }),
+  )
+
+  it(
+    'should call only mutateAsync onSuccess when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutateAsync('todo', {
+        onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutateAsync.onSuccess'])
+    }),
+  )
+
+  it(
+    'should call only mutateAsync onError when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+        })
+        .catch(noop)
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutateAsync.onError'])
+    }),
+  )
+
+  it(
+    'should call only mutateAsync onSettled when createMutation has no callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutateAsync('todo', {
+        onSettled: () => callbacks.push('mutateAsync.onSettled'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutateAsync.onSettled'])
+    }),
+  )
+
   it('should be able to call `onSuccess` and `onSettled` after each successful mutate', async () => {
     const onSuccessMock = vi.fn()
     const onSettledMock = vi.fn()


### PR DESCRIPTION
## 🎯 Changes

`createMutation.svelte.test.ts` had no coverage for per-call callbacks (`mutate(vars, { onSuccess })` / `mutateAsync(vars, { onSuccess })`) when the hook-level options define **no** callbacks at all. Existing tests either define hook-level callbacks or assert something else about the per-call one (`should give a per-call onSuccess the same QueryClient instance via context` checks `context.client`, not callback invocation).

Ported from `solid-query`'s `useMutation.test.tsx` (lines 101–403) — `react-query`/`preact-query` carry the same ten. Placed right after `should be able to reset 'error'` to match both originals, so the file reads no-callbacks → hook-level callbacks → override.

Ten tests added, five per call style:
- `mutate` / `mutateAsync` with `onSuccess` + `onSettled`
- `mutate` / `mutateAsync` with `onError` + `onSettled`
- `mutate` / `mutateAsync` with only `onSuccess`, only `onError`, only `onSettled`

Implemented with the file's existing `withEffectRoot` pattern and `createMutation`'s `queryClient` accessor parameter, as in the previous `mutateAsync` tests — none of these assert on the DOM, and Svelte needs no mount-time trigger (`solid` uses `createEffect` + `setActTimeout` only to reach the same call site).

Per-call callbacks stay synchronous here, matching the originals: `query-core` fires them without awaiting (`mutationObserver.ts`'s `#notify`), so a delay inside them would assert a contract that doesn't exist.

`createMutation.svelte.test.ts` now has 30 runtime tests (was 20).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for per-call success, error, and settled callbacks when mutations are created without hook-level callbacks.
  - Verified callback execution order for both synchronous and asynchronous mutation calls.
  - Added coverage for individual callback configurations and handled rejected promises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->