### PR TITLE
test(svelte-query/createMutation): group 'mutateAsync' callback tests with the 'mutate' ones

### DIFF
--- a/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
+++ b/packages/svelte-query/tests/createMutation/createMutation.svelte.test.ts
@@ -344,6 +344,152 @@ describe('createMutation', () => {
   })
 
   it(
+    'should be able to call `onSuccess` callback after successful mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+          onSuccess: () => callbacks.push('useMutation.onSuccess'),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutateAsync('todo', {
+        onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'useMutation.onSuccess',
+        'mutateAsync.onSuccess',
+      ])
+    }),
+  )
+
+  it(
+    'should be able to call `onError` callback after failed mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+          onError: () => callbacks.push('useMutation.onError'),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+        })
+        .catch(noop)
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['useMutation.onError', 'mutateAsync.onError'])
+    }),
+  )
+
+  it(
+    'should be able to call `onSettled` callback after mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+          onSettled: () => callbacks.push('useMutation.onSettled'),
+        }),
+        () => queryClient,
+      )
+
+      mutation.mutateAsync('todo', {
+        onSettled: () => callbacks.push('mutateAsync.onSettled'),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'useMutation.onSettled',
+        'mutateAsync.onSettled',
+      ])
+    }),
+  )
+
+  it(
+    'should be able to override the useMutation success callbacks',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (text: string) => sleep(10).then(() => text),
+          onSuccess: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onSuccess')),
+          onSettled: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onSettled')),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+          onSettled: () => callbacks.push('mutateAsync.onSettled'),
+        })
+        .then((result) => callbacks.push(`mutateAsync.result:${result}`))
+      await vi.advanceTimersByTimeAsync(30)
+
+      expect(callbacks).toEqual([
+        'useMutation.onSuccess',
+        'useMutation.onSettled',
+        'mutateAsync.onSuccess',
+        'mutateAsync.onSettled',
+        'mutateAsync.result:todo',
+      ])
+    }),
+  )
+
+  it(
+    'should be able to override the error callbacks when using mutateAsync',
+    withEffectRoot(async () => {
+      const callbacks: Array<string> = []
+
+      const mutation = createMutation(
+        () => ({
+          mutationFn: (_text: string) =>
+            sleep(10).then(() => Promise.reject(new Error('oops'))),
+          onError: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onError')),
+          onSettled: () =>
+            sleep(10).then(() => callbacks.push('useMutation.onSettled')),
+        }),
+        () => queryClient,
+      )
+
+      mutation
+        .mutateAsync('todo', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+          onSettled: () => callbacks.push('mutateAsync.onSettled'),
+        })
+        .catch((error) =>
+          callbacks.push(`mutateAsync.error:${(error as Error).message}`),
+        )
+      await vi.advanceTimersByTimeAsync(30)
+
+      expect(callbacks).toEqual([
+        'useMutation.onError',
+        'useMutation.onSettled',
+        'mutateAsync.onError',
+        'mutateAsync.onSettled',
+        'mutateAsync.error:oops',
+      ])
+    }),
+  )
+
+  it(
     'should recreate observer when queryClient changes',
     withEffectRoot(async () => {
       const queryClient1 = new QueryClient()
@@ -557,150 +703,4 @@ describe('createMutation', () => {
       expect.anything(),
     )
   })
-
-  it(
-    'should be able to call `onSuccess` callback after successful mutateAsync',
-    withEffectRoot(async () => {
-      const callbacks: Array<string> = []
-
-      const mutation = createMutation(
-        () => ({
-          mutationFn: (text: string) => sleep(10).then(() => text),
-          onSuccess: () => callbacks.push('useMutation.onSuccess'),
-        }),
-        () => queryClient,
-      )
-
-      mutation.mutateAsync('todo', {
-        onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
-      })
-      await vi.advanceTimersByTimeAsync(10)
-
-      expect(callbacks).toEqual([
-        'useMutation.onSuccess',
-        'mutateAsync.onSuccess',
-      ])
-    }),
-  )
-
-  it(
-    'should be able to call `onError` callback after failed mutateAsync',
-    withEffectRoot(async () => {
-      const callbacks: Array<string> = []
-
-      const mutation = createMutation(
-        () => ({
-          mutationFn: (_text: string) =>
-            sleep(10).then(() => Promise.reject(new Error('oops'))),
-          onError: () => callbacks.push('useMutation.onError'),
-        }),
-        () => queryClient,
-      )
-
-      mutation
-        .mutateAsync('todo', {
-          onError: () => callbacks.push('mutateAsync.onError'),
-        })
-        .catch(noop)
-      await vi.advanceTimersByTimeAsync(10)
-
-      expect(callbacks).toEqual(['useMutation.onError', 'mutateAsync.onError'])
-    }),
-  )
-
-  it(
-    'should be able to call `onSettled` callback after mutateAsync',
-    withEffectRoot(async () => {
-      const callbacks: Array<string> = []
-
-      const mutation = createMutation(
-        () => ({
-          mutationFn: (text: string) => sleep(10).then(() => text),
-          onSettled: () => callbacks.push('useMutation.onSettled'),
-        }),
-        () => queryClient,
-      )
-
-      mutation.mutateAsync('todo', {
-        onSettled: () => callbacks.push('mutateAsync.onSettled'),
-      })
-      await vi.advanceTimersByTimeAsync(10)
-
-      expect(callbacks).toEqual([
-        'useMutation.onSettled',
-        'mutateAsync.onSettled',
-      ])
-    }),
-  )
-
-  it(
-    'should be able to override the useMutation success callbacks',
-    withEffectRoot(async () => {
-      const callbacks: Array<string> = []
-
-      const mutation = createMutation(
-        () => ({
-          mutationFn: (text: string) => sleep(10).then(() => text),
-          onSuccess: () =>
-            sleep(10).then(() => callbacks.push('useMutation.onSuccess')),
-          onSettled: () =>
-            sleep(10).then(() => callbacks.push('useMutation.onSettled')),
-        }),
-        () => queryClient,
-      )
-
-      mutation
-        .mutateAsync('todo', {
-          onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
-          onSettled: () => callbacks.push('mutateAsync.onSettled'),
-        })
-        .then((result) => callbacks.push(`mutateAsync.result:${result}`))
-      await vi.advanceTimersByTimeAsync(30)
-
-      expect(callbacks).toEqual([
-        'useMutation.onSuccess',
-        'useMutation.onSettled',
-        'mutateAsync.onSuccess',
-        'mutateAsync.onSettled',
-        'mutateAsync.result:todo',
-      ])
-    }),
-  )
-
-  it(
-    'should be able to override the error callbacks when using mutateAsync',
-    withEffectRoot(async () => {
-      const callbacks: Array<string> = []
-
-      const mutation = createMutation(
-        () => ({
-          mutationFn: (_text: string) =>
-            sleep(10).then(() => Promise.reject(new Error('oops'))),
-          onError: () =>
-            sleep(10).then(() => callbacks.push('useMutation.onError')),
-          onSettled: () =>
-            sleep(10).then(() => callbacks.push('useMutation.onSettled')),
-        }),
-        () => queryClient,
-      )
-
-      mutation
-        .mutateAsync('todo', {
-          onError: () => callbacks.push('mutateAsync.onError'),
-          onSettled: () => callbacks.push('mutateAsync.onSettled'),
-        })
-        .catch((error) =>
-          callbacks.push(`mutateAsync.error:${(error as Error).message}`),
-        )
-      await vi.advanceTimersByTimeAsync(30)
-
-      expect(callbacks).toEqual([
-        'useMutation.onError',
-        'useMutation.onSettled',
-        'mutateAsync.onError',
-        'mutateAsync.onSettled',
-        'mutateAsync.error:oops',
-      ])
-    }),
-  )
 })


### PR DESCRIPTION
## 🎯 Changes

Pure reordering — no test was added, removed, or edited (146 insertions / 146 deletions, and the file's sorted contents are byte-identical before and after).

The callback-behaviour tests were split into two clusters ~500 lines apart: `mutate`'s hook-level callbacks sat at the top, while the matching `mutateAsync` ones and the two override tests sat at the very end of the file, separated by the observer, optimistic-update, context and parallel blocks. That split wasn't deliberate — those five were appended by #11452 and stayed where they landed.

Moving them up next to their `mutate` counterparts puts the whole callback story in one run:

- per-call callbacks with no hook-level ones (`mutate` ×5, `mutateAsync` ×5, from #11453)
- hook-level callbacks (`mutate`, then `mutateAsync`)
- overriding hook-level callbacks from `mutateAsync`

which is the same no-callbacks → hook-level → override progression `solid-query` and `preact-query` use, and it lets the `mutate` and `mutateAsync` variants of one assertion be read side by side. The observer/optimistic/context/parallel blocks that used to sit in between follow after, each still contiguous.

Verified the reorder didn't couple any test to a neighbour's `advanceTimersByTimeAsync`: full suite passes (30), and every test whose preceding test changed also passes in isolation via `-t`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Reorganized mutation behavior tests covering asynchronous callbacks and per-call success/error overrides.
  - Test coverage and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->