### PR TITLE
fix(query-core): keep nested mutate callbacks scoped to the settling mutation 🤖🤖🤖

### DIFF
--- a/.changeset/nested-mutate-onsettled.md
+++ b/.changeset/nested-mutate-onsettled.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Fix per-call mutate `onSettled` receiving another mutation's result when `mutate()` is called from `onSuccess` or `onError`.

--- a/packages/query-core/src/__tests__/mutationObserver.test.tsx
+++ b/packages/query-core/src/__tests__/mutationObserver.test.tsx
@@ -426,6 +426,276 @@ describe('mutationObserver', () => {
     unsubscribe()
   })
 
+  describe('nested mutate from per-call callbacks', () => {
+    it('should call the outer mutate onSettled with the outer result when nested mutate starts from onSuccess', async () => {
+      const outerOnSettled = vi.fn()
+      const innerOnSettled = vi.fn()
+
+      const mutationObserver = new MutationObserver(queryClient, {
+        mutationFn: (text: string) => Promise.resolve(text),
+      })
+      const unsubscribe = mutationObserver.subscribe(vi.fn())
+
+      mutationObserver.mutate('first', {
+        onSuccess: () => {
+          mutationObserver.mutate('second', {
+            onSettled: innerOnSettled,
+          })
+        },
+        onSettled: outerOnSettled,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(outerOnSettled).toHaveBeenCalledTimes(1)
+      expect(outerOnSettled).toHaveBeenCalledWith(
+        'first',
+        null,
+        'first',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+      expect(innerOnSettled).toHaveBeenCalledTimes(1)
+      expect(innerOnSettled).toHaveBeenCalledWith(
+        'second',
+        null,
+        'second',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+      expect(innerOnSettled).not.toHaveBeenCalledWith(
+        'first',
+        null,
+        'first',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+
+      unsubscribe()
+    })
+
+    it('should not invoke the inner mutate onSettled with the outer result while the inner mutation is still pending', async () => {
+      let resolveSecond: (value: string) => void
+      const secondPromise = new Promise<string>((resolve) => {
+        resolveSecond = resolve
+      })
+      const outerOnSettled = vi.fn()
+      const innerOnSettled = vi.fn()
+
+      const mutationObserver = new MutationObserver(queryClient, {
+        mutationFn: (text: string) =>
+          text === 'first' ? Promise.resolve(text) : secondPromise,
+      })
+      const unsubscribe = mutationObserver.subscribe(vi.fn())
+
+      mutationObserver.mutate('first', {
+        onSuccess: () => {
+          mutationObserver.mutate('second', {
+            onSettled: innerOnSettled,
+          })
+        },
+        onSettled: outerOnSettled,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(outerOnSettled).toHaveBeenCalledTimes(1)
+      expect(outerOnSettled).toHaveBeenCalledWith(
+        'first',
+        null,
+        'first',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+      expect(innerOnSettled).not.toHaveBeenCalled()
+
+      resolveSecond!('second')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(innerOnSettled).toHaveBeenCalledTimes(1)
+      expect(innerOnSettled).toHaveBeenCalledWith(
+        'second',
+        null,
+        'second',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+
+      unsubscribe()
+    })
+
+    it('should call the outer mutate onSettled with the outer error when nested mutate starts from onError', async () => {
+      const outerError = new Error('fail-first')
+      const outerOnSettled = vi.fn()
+      const innerOnSettled = vi.fn()
+
+      const mutationObserver = new MutationObserver(queryClient, {
+        mutationFn: (text: string) =>
+          text === 'first' ? Promise.reject(outerError) : Promise.resolve(text),
+      })
+      const unsubscribe = mutationObserver.subscribe(vi.fn())
+
+      mutationObserver
+        .mutate('first', {
+          onError: () => {
+            mutationObserver.mutate('second', {
+              onSettled: innerOnSettled,
+            })
+          },
+          onSettled: outerOnSettled,
+        })
+        .catch(() => {})
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(outerOnSettled).toHaveBeenCalledTimes(1)
+      expect(outerOnSettled).toHaveBeenCalledWith(
+        undefined,
+        outerError,
+        'first',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+      expect(innerOnSettled).toHaveBeenCalledTimes(1)
+      expect(innerOnSettled).toHaveBeenCalledWith(
+        'second',
+        null,
+        'second',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+      expect(innerOnSettled).not.toHaveBeenCalledWith(
+        undefined,
+        outerError,
+        'first',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+
+      unsubscribe()
+    })
+
+    it('should keep the outer onMutate result on the outer mutate onSettled when nested mutate starts from onSuccess', async () => {
+      const outerOnSettled = vi.fn()
+      const innerOnSettled = vi.fn()
+
+      const mutationObserver = new MutationObserver(queryClient, {
+        mutationFn: (text: string) => Promise.resolve(text),
+        onMutate: (text: string) => ({ label: text }),
+      })
+      const unsubscribe = mutationObserver.subscribe(vi.fn())
+
+      mutationObserver.mutate('first', {
+        onSuccess: () => {
+          mutationObserver.mutate('second', {
+            onSettled: innerOnSettled,
+          })
+        },
+        onSettled: outerOnSettled,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(outerOnSettled).toHaveBeenCalledWith(
+        'first',
+        null,
+        'first',
+        { label: 'first' },
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+      expect(innerOnSettled).toHaveBeenCalledWith(
+        'second',
+        null,
+        'second',
+        { label: 'second' },
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+
+      unsubscribe()
+    })
+
+    it('should not throw when nested mutate is called without options from onSuccess', async ({
+      onTestFinished,
+    }) => {
+      const unhandledRejectionFn = vi.fn()
+      process.on('unhandledRejection', unhandledRejectionFn)
+      onTestFinished(() => {
+        process.off('unhandledRejection', unhandledRejectionFn)
+      })
+
+      const outerOnSettled = vi.fn()
+      const mutationObserver = new MutationObserver(queryClient, {
+        mutationFn: (text: string) => Promise.resolve(text),
+      })
+      const unsubscribe = mutationObserver.subscribe(vi.fn())
+
+      mutationObserver.mutate('first', {
+        onSuccess: () => {
+          mutationObserver.mutate('second')
+        },
+        onSettled: outerOnSettled,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(unhandledRejectionFn).not.toHaveBeenCalled()
+      expect(outerOnSettled).toHaveBeenCalledTimes(1)
+      expect(outerOnSettled).toHaveBeenCalledWith(
+        'first',
+        null,
+        'first',
+        undefined,
+        {
+          client: queryClient,
+          meta: undefined,
+          mutationKey: undefined,
+        },
+      )
+
+      unsubscribe()
+    })
+  })
+
   describe('erroneous mutation callback', () => {
     it('onSuccess and onSettled is transferred to different execution context where it is reported', async ({
       onTestFinished,

--- a/packages/query-core/src/mutationObserver.ts
+++ b/packages/query-core/src/mutationObserver.ts
@@ -240,7 +240,11 @@ export class MutationObserver<
   #notify(action?: Action<TData, TError, TVariables, TOnMutateResult>): void {
     notifyManager.batch(() => {
       // First trigger the mutate callbacks
-      if (this.#mutateOptions && this.hasListeners()) {
+      // Snapshot this settlement's per-call options and result fields. A nested
+      // mutate() from onSuccess/onError overwrites #mutateOptions (and may
+      // update #currentResult) before onSettled runs.
+      const mutateOptions = this.#mutateOptions
+      if (mutateOptions && this.hasListeners()) {
         const variables = this.#currentResult.variables!
         const onMutateResult = this.#currentResult.context
 
@@ -252,7 +256,7 @@ export class MutationObserver<
 
         if (action?.type === 'success') {
           try {
-            this.#mutateOptions.onSuccess?.(
+            mutateOptions.onSuccess?.(
               action.data,
               variables,
               onMutateResult,
@@ -262,7 +266,7 @@ export class MutationObserver<
             void Promise.reject(e)
           }
           try {
-            this.#mutateOptions.onSettled?.(
+            mutateOptions.onSettled?.(
               action.data,
               null,
               variables,
@@ -274,7 +278,7 @@ export class MutationObserver<
           }
         } else if (action?.type === 'error') {
           try {
-            this.#mutateOptions.onError?.(
+            mutateOptions.onError?.(
               action.error,
               variables,
               onMutateResult,
@@ -284,7 +288,7 @@ export class MutationObserver<
             void Promise.reject(e)
           }
           try {
-            this.#mutateOptions.onSettled?.(
+            mutateOptions.onSettled?.(
               undefined,
               action.error,
               variables,

--- a/packages/react-query/src/__tests__/useMutation.test.tsx
+++ b/packages/react-query/src/__tests__/useMutation.test.tsx
@@ -2576,4 +2576,194 @@ describe('useMutation', () => {
 
     expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true)
   })
+
+  it('should call the outer mutate onSettled with the outer result when nested mutate starts from onSuccess', async () => {
+    const outerOnSettled = vi.fn()
+    const innerOnSettled = vi.fn()
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('first', {
+              onSuccess: () => {
+                mutate('second', {
+                  onSettled: innerOnSettled,
+                })
+              },
+              onSettled: outerOnSettled,
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(outerOnSettled).toHaveBeenCalledTimes(1)
+    expect(outerOnSettled).toHaveBeenCalledWith(
+      'first',
+      null,
+      'first',
+      undefined,
+      {
+        client: queryClient,
+        meta: undefined,
+        mutationKey: undefined,
+      },
+    )
+    expect(innerOnSettled).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(innerOnSettled).toHaveBeenCalledTimes(1)
+    expect(innerOnSettled).toHaveBeenCalledWith(
+      'second',
+      null,
+      'second',
+      undefined,
+      {
+        client: queryClient,
+        meta: undefined,
+        mutationKey: undefined,
+      },
+    )
+  })
+
+  it('should call the outer mutate onSettled with the outer error when nested mutate starts from onError', async () => {
+    const outerError = new Error('fail-first')
+    const outerOnSettled = vi.fn()
+    const innerOnSettled = vi.fn()
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) =>
+          sleep(10).then(() => {
+            if (text === 'first') {
+              throw outerError
+            }
+            return text
+          }),
+        retry: false,
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('first', {
+              onError: () => {
+                mutate('second', {
+                  onSettled: innerOnSettled,
+                })
+              },
+              onSettled: outerOnSettled,
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(outerOnSettled).toHaveBeenCalledTimes(1)
+    expect(outerOnSettled).toHaveBeenCalledWith(
+      undefined,
+      outerError,
+      'first',
+      undefined,
+      {
+        client: queryClient,
+        meta: undefined,
+        mutationKey: undefined,
+      },
+    )
+    expect(innerOnSettled).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(innerOnSettled).toHaveBeenCalledTimes(1)
+    expect(innerOnSettled).toHaveBeenCalledWith(
+      'second',
+      null,
+      'second',
+      undefined,
+      {
+        client: queryClient,
+        meta: undefined,
+        mutationKey: undefined,
+      },
+    )
+  })
+
+  it('should not throw when nested mutate is called without options from onSuccess', async ({
+    onTestFinished,
+  }) => {
+    const unhandledRejectionFn = vi.fn()
+    process.on('unhandledRejection', unhandledRejectionFn)
+    onTestFinished(() => {
+      process.off('unhandledRejection', unhandledRejectionFn)
+    })
+
+    const outerOnSettled = vi.fn()
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: (text: string) => sleep(10).then(() => text),
+      })
+
+      return (
+        <button
+          onClick={() =>
+            mutate('first', {
+              onSuccess: () => {
+                mutate('second')
+              },
+              onSettled: outerOnSettled,
+            })
+          }
+        >
+          mutate
+        </button>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+
+    fireEvent.click(rendered.getByRole('button', { name: /mutate/i }))
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(unhandledRejectionFn).not.toHaveBeenCalled()
+    expect(outerOnSettled).toHaveBeenCalledTimes(1)
+    expect(outerOnSettled).toHaveBeenCalledWith(
+      'first',
+      null,
+      'first',
+      undefined,
+      {
+        client: queryClient,
+        meta: undefined,
+        mutationKey: undefined,
+      },
+    )
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(unhandledRejectionFn).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

`MutationObserver.#notify` invoked per-call `onSettled` from the live `this.#mutateOptions` after `onSuccess`/`onError`. If those callbacks start another `mutate()` on the same observer, they overwrite `#mutateOptions` before `onSettled` runs. The inner callback then receives the outer mutation's data/variables, the outer `onSettled` never fires, and a nested `mutate()` with no options throws `TypeError: Cannot read properties of undefined (reading 'onSettled')`.

Capture the per-call options for the mutation that is settling (result fields were already snapshotted) and invoke callbacks from that snapshot.

Fixes #11451

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm nx run @tanstack/query-core:test:lib -- mutationObserver.test` and `pnpm nx run @tanstack/react-query:test:lib -- useMutation.test`.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

An AI coding assistant helped draft the regression tests and the `#notify` snapshot. I reproduced the bug on current `main`, confirmed the new tests fail for the missing outer `onSettled` / TypeError, and confirmed they pass after the snapshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested mutation handling so each mutation’s `onSettled` callback receives the correct result, error, variables, and context.
  * Prevented inner mutation activity from overwriting callbacks or settlement data for an ongoing outer mutation.
  * Prevented unhandled promise rejections when triggering nested mutations without callback options.

* **Tests**
  * Added coverage for nested mutations initiated from success and error callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->