### PR TITLE
docs: explain Chrome focus emulation in window focus refetching guide

### DIFF
--- a/docs/framework/react/guides/window-focus-refetching.md
+++ b/docs/framework/react/guides/window-focus-refetching.md
@@ -103,3 +103,9 @@ focusManager.setFocused(undefined)
 ```
 
 [//]: # 'Example4'
+
+## Troubleshooting
+
+If stale queries do not refetch when you return to a tab, check whether **Emulate a focused page** is enabled in Chrome DevTools. This setting keeps `document.visibilityState` set to `visible` and prevents `visibilitychange` events, which TanStack Query uses for its default focus handling.
+
+Disable **Emulate a focused page** in the DevTools **Rendering** panel, then switch to another tab and return to test window focus refetching. See the [Chrome DevTools documentation](https://developer.chrome.com/docs/devtools/rendering/apply-effects#emulate_a_focused_page) for more details.


### PR DESCRIPTION
## 🎯 Changes

When Chrome DevTools has **Emulate a focused page** enabled, switching away from a tab and returning does not trigger the default window focus refetching behavior. Chrome keeps the page visible and suppresses the `visibilitychange` events used by TanStack Query.

Add a troubleshooting note to the window focus refetching guide that explains this behavior and shows where to disable the setting. The note links to the Chrome DevTools documentation.

Related discussion: https://github.com/TanStack/query/discussions/6568

Validation:

- Checked the changed Markdown with the repository's Prettier configuration.
- Ran the repository's `scripts/verify-links.ts` via a local bundle: all 1,657 Markdown files passed its relative-link checks.
- Verified actual tab switching and local HTTP requests using the unmodified query-core source in Chromium: a stale query refetched normally, while focus emulation suppressed visibility events and refetching. Refetching resumed after the emulation CDP session ended. The DevTools checkbox itself was not automated.
- The full `pnpm run test:pr` suite and docs-site preview were not run for this prose-only change.

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added troubleshooting guidance for queries that do not refetch after returning to a browser tab when Chrome DevTools’ “Emulate a focused page” setting is enabled.
  - Included steps to disable the setting and verify window focus refetching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->