### PR TITLE
test(vue-query/useMutation): add tests for per-call callbacks passed as arguments of 'mutate'/'mutateAsync'

### DIFF
--- a/packages/vue-query/src/__tests__/useMutation.test.ts
+++ b/packages/vue-query/src/__tests__/useMutation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { reactive, ref } from 'vue-demi'
+import { noop } from '@tanstack/query-core'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { useMutation } from '../useMutation'
 import { useQueryClient } from '../useQueryClient'
@@ -327,6 +328,128 @@ describe('useMutation', () => {
       await vi.advanceTimersByTimeAsync(10)
 
       expect(onSettled).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onSuccess and onSettled when passed as arguments of mutate function', async () => {
+      const callbacks: Array<string> = []
+      const mutation = useMutation({
+        mutationFn: (params: string) => sleep(10).then(() => params),
+      })
+
+      mutation.mutate('', {
+        onSuccess: () => callbacks.push('mutate.onSuccess'),
+        onSettled: () => callbacks.push('mutate.onSettled'),
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutate.onSuccess', 'mutate.onSettled'])
+    })
+
+    it('should call onError and onSettled when passed as arguments of mutate function', async () => {
+      const callbacks: Array<string> = []
+      const mutation = useMutation({
+        mutationFn: (_params: string) =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+      })
+
+      mutation.mutate('', {
+        onError: () => callbacks.push('mutate.onError'),
+        onSettled: () => callbacks.push('mutate.onSettled'),
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutate.onError', 'mutate.onSettled'])
+    })
+
+    it('should call onSuccess and onSettled when passed as arguments of mutateAsync function', async () => {
+      const callbacks: Array<string> = []
+      const mutation = useMutation({
+        mutationFn: (params: string) => sleep(10).then(() => params),
+      })
+
+      mutation.mutateAsync('', {
+        onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+        onSettled: () => callbacks.push('mutateAsync.onSettled'),
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'mutateAsync.onSuccess',
+        'mutateAsync.onSettled',
+      ])
+    })
+
+    it('should call onError and onSettled when passed as arguments of mutateAsync function', async () => {
+      const callbacks: Array<string> = []
+      const mutation = useMutation({
+        mutationFn: (_params: string) =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+      })
+
+      mutation
+        .mutateAsync('', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+          onSettled: () => callbacks.push('mutateAsync.onSettled'),
+        })
+        .catch(noop)
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual([
+        'mutateAsync.onError',
+        'mutateAsync.onSettled',
+      ])
+    })
+
+    it('should call onSuccess when passed as an argument of mutateAsync function', async () => {
+      const callbacks: Array<string> = []
+      const mutation = useMutation({
+        mutationFn: (params: string) => sleep(10).then(() => params),
+      })
+
+      mutation.mutateAsync('', {
+        onSuccess: () => callbacks.push('mutateAsync.onSuccess'),
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutateAsync.onSuccess'])
+    })
+
+    it('should call onError when passed as an argument of mutateAsync function', async () => {
+      const callbacks: Array<string> = []
+      const mutation = useMutation({
+        mutationFn: (_params: string) =>
+          sleep(10).then(() => Promise.reject(new Error('Some error'))),
+      })
+
+      mutation
+        .mutateAsync('', {
+          onError: () => callbacks.push('mutateAsync.onError'),
+        })
+        .catch(noop)
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutateAsync.onError'])
+    })
+
+    it('should call onSettled when passed as an argument of mutateAsync function', async () => {
+      const callbacks: Array<string> = []
+      const mutation = useMutation({
+        mutationFn: (params: string) => sleep(10).then(() => params),
+      })
+
+      mutation.mutateAsync('', {
+        onSettled: () => callbacks.push('mutateAsync.onSettled'),
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(callbacks).toEqual(['mutateAsync.onSettled'])
     })
 
     it('should fire both onSettled functions', async () => {


### PR DESCRIPTION
## 🎯 Changes

`useMutation.test.ts` covered per-call callbacks (`mutate(vars, { onSuccess })`) only for the three single-callback cases, and not at all for `mutateAsync`. The `side effects` block already contrasts hook-level (`as an option`) against per-call (`as an argument of mutate function`); this fills in the per-call half.

Ported from `react-query`/`preact-query`/`solid-query`'s `useMutation.test.tsx`, where these exist as the `when useMutation has no callbacks` cluster. Kept this file's own vocabulary (`as an argument of mutate function`) rather than importing the react wording, so the existing three and the new seven read as one group.

Seven tests added, placed right after the existing per-call tests:
- `mutate` with `onSuccess` + `onSettled`, and with `onError` + `onSettled`
- `mutateAsync` with `onSuccess` + `onSettled`, and with `onError` + `onSettled`
- `mutateAsync` with only `onSuccess`, only `onError`, only `onSettled`

Like the originals, each asserts through a `callbacks` array so the combined cases pin the order (`onSuccess` before `onSettled`), not just that both ran.

The two rejecting `mutateAsync` calls use `.catch(noop)` — their return value isn't asserted here, and swallowing a rejection nobody consumes is what `guides/prefetching.md` documents for `queryClient.query(...)`; `usePrefetchQuery.ts` imports `noop` for the same purpose. Without it the rejection lands unhandled once fake timers advance. The successful calls need nothing, and `mutate` never returns a promise.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying callback ordering for mutation success and error flows.
  * Added tests confirming independent callback configuration and rejected-promise handling for asynchronous mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->