### PR TITLE
test(angular-query): tighten 'advanceTimersByTimeAsync' to the awaited 'sleep' duration

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-mutation.test.ts
@@ -244,7 +244,7 @@ describe('injectMutation', () => {
 
       mutation.mutate('')
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
 
       expect(onError).toHaveBeenCalledTimes(1)
     })
@@ -260,7 +260,7 @@ describe('injectMutation', () => {
 
       mutation.mutate('')
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
 
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
@@ -276,7 +276,7 @@ describe('injectMutation', () => {
 
       mutation.mutate('')
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
 
       expect(onSettled).toHaveBeenCalledTimes(1)
     })
@@ -292,7 +292,7 @@ describe('injectMutation', () => {
 
       mutation.mutate('', { onError })
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
 
       expect(onError).toHaveBeenCalledTimes(1)
     })
@@ -307,7 +307,7 @@ describe('injectMutation', () => {
 
       mutation.mutate('', { onSuccess })
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
 
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
@@ -322,7 +322,7 @@ describe('injectMutation', () => {
 
       mutation.mutate('', { onSettled })
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
 
       expect(onSettled).toHaveBeenCalledTimes(1)
     })
@@ -339,7 +339,7 @@ describe('injectMutation', () => {
 
       mutation.mutate('', { onSettled: onSettledOnFunction })
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
 
       expect(onSettled).toHaveBeenCalledTimes(1)
       expect(onSettledOnFunction).toHaveBeenCalledTimes(1)
@@ -635,7 +635,7 @@ describe('injectMutation', () => {
     })
 
     const promise = mutateAsync('Mock data')
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
 
     await expect(promise).resolves.toBe('Mock data')
   })

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -428,7 +428,7 @@ describe('injectQuery', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(spy).toHaveBeenCalledTimes(1)
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(query.status()).toBe('success')
 
     key.set(key2)
@@ -462,7 +462,7 @@ describe('injectQuery', () => {
 
     enabled.set(true)
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(spy).toHaveBeenCalledTimes(1)
     expect(query.status()).toBe('success')
   })
@@ -480,19 +480,19 @@ describe('injectQuery', () => {
       }))
     })
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(spy).toHaveBeenCalledTimes(1)
     expect(query.status()).toBe('success')
 
     filter.set('')
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(spy).toHaveBeenCalledTimes(1)
     expect(query.isFetching()).toBe(false)
 
     filter.set('b')
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
     expect(spy).toHaveBeenCalledTimes(2)
   })
 
@@ -565,7 +565,7 @@ describe('injectQuery', () => {
       )
     })
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
 
     keySignal.set('key12')
 
@@ -579,7 +579,7 @@ describe('injectQuery', () => {
       )
     })
 
-    await vi.advanceTimersByTimeAsync(11)
+    await vi.advanceTimersByTimeAsync(10)
   })
 
   it('should keep initialData visible alongside the error when a refetch fails', async () => {
@@ -716,7 +716,7 @@ describe('injectQuery', () => {
       expect(query.data()).toBeUndefined()
       expect(queryFn).toHaveBeenCalledTimes(0)
 
-      await vi.advanceTimersByTimeAsync(11)
+      await vi.advanceTimersByTimeAsync(10)
       expect(query.status()).toBe('pending')
       expect(query.fetchStatus()).toBe('idle')
       expect(query.data()).toBeUndefined()


### PR DESCRIPTION
## 🎯 Changes

16 `advanceTimersByTimeAsync(11)` calls advance one millisecond past the `sleep(10)` they wait on. Dropping them to `10` makes the number say what is actually being awaited.

Every one of the 16 shares the same shape: no component is rendered, the hook is obtained through `TestBed.runInInjectionContext`, and the only pending timer is a single `sleep(10)`. Without a render there is no change-detection pass to absorb, so the extra millisecond does nothing.

The other 35 occurrences of `11` in this package are left alone, for three distinct reasons:
- most render a component (`render()` / `fixture`), where 10 is genuinely not enough — dropping those fails
- two assert that *nothing* happens (`inject-queries.test.ts`, `inject-infinite-query.test.ts` under `skipToken`); any value passes there, and a value past the `sleep` states "waited long enough" more clearly
- `should properly execute dependent queries` chains `sleep(10)` into `sleep(1000)`, so its `11` and `1002` are both already minimal — 11 + 1001 and 10 + 1002 each fail

Verified by changing all 51 occurrences to `10` and running the suite, then narrowing to the 16 that pass, applying them together (245 pass), and confirming `9` fails for all of them.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated asynchronous test timing to match the configured 10 ms delays.
  - Improved consistency across mutation and query tests, including callbacks, refetching, enabled states, and state restoration.
  - Verified mutation settlement and resolution behavior using precise timer advancement.
  - Aligned coverage for success, error, and settled callbacks, including callbacks supplied through mutation options and invocation arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->