### PR TITLE
test(angular-query/inject-query): assert refetch queryKey outside the discarded promise callback

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -555,31 +555,30 @@ describe('injectQuery', () => {
 
     expect(fetchFn).not.toHaveBeenCalled()
 
-    void query.refetch().then(() => {
-      expect(fetchFn).toHaveBeenCalledTimes(1)
-      expect(fetchFn).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          queryKey: [...key, 'key11'],
-        }),
-      )
-    })
-
+    void query.refetch()
     await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        queryKey: [...key, 'key11'],
+      }),
+    )
 
     keySignal.set('key12')
 
-    void query.refetch().then(() => {
-      expect(fetchFn).toHaveBeenCalledTimes(2)
-      expect(fetchFn).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          queryKey: [...key, 'key12'],
-        }),
-      )
-    })
-
+    void query.refetch()
     await vi.advanceTimersByTimeAsync(10)
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        queryKey: [...key, 'key12'],
+      }),
+    )
+    expect(query.data()).toBe('Some data')
   })
 
   it('should keep initialData visible alongside the error when a refetch fails', async () => {


### PR DESCRIPTION
## 🎯 Changes

`should use the current value for the queryKey when refetch is called` put its four assertions inside `void query.refetch().then(() => { ... })`. The promise is discarded, so an assertion failure inside the callback never reaches the test — the rejection has nowhere to go.

That is not theoretical. On `main`, changing `toHaveBeenCalledTimes(2)` to `999`, or deleting the `keySignal.set('key12')` line the test exists to cover, both still pass. `expect.assertions(5)` also passes, so the callbacks do run — they just cannot report a failure.

Moving the assertions out of the callback, after the `advanceTimersByTimeAsync` that was already there, makes both mutations fail as they should. The assertions themselves are unchanged.

One assertion is added — `expect(query.data()).toBe('Some data')` — since nothing else confirmed the refetch actually completed rather than merely being invoked.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated refetch behavior coverage to account for asynchronous timer-driven updates.
  * Added verification that refreshed data reflects changes to the query key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->