### PR TITLE
test(angular-query/inject-query): move type assertions from the runtime test to 'test-d'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -1,9 +1,211 @@
+import { TestBed } from '@angular/core/testing'
 import { describe, expectTypeOf, it } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { injectQuery, queryOptions } from '..'
 import type { Signal } from '@angular/core'
+import type { CreateQueryOptions, OmitKeyof, QueryFunction } from '..'
 
 describe('injectQuery', () => {
+  it('should return the correct types', () => {
+    const key = queryKey()
+    // unspecified query function should default to unknown
+    const noQueryFn = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: key,
+      })),
+    )
+    expectTypeOf(noQueryFn.data()).toEqualTypeOf<unknown>()
+    expectTypeOf(noQueryFn.error()).toEqualTypeOf<Error | null>()
+
+    // it should infer the result type from the query function
+    const fromQueryFn = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: key,
+        queryFn: () => 'test',
+      })),
+    )
+    expectTypeOf(fromQueryFn.data()).toEqualTypeOf<string | undefined>()
+    expectTypeOf(fromQueryFn.error()).toEqualTypeOf<Error | null>()
+
+    // it should be possible to specify the result type
+    const withResult = TestBed.runInInjectionContext(() =>
+      injectQuery<string>(() => ({
+        queryKey: key,
+        queryFn: () => 'test',
+      })),
+    )
+    expectTypeOf(withResult.data()).toEqualTypeOf<string | undefined>()
+    expectTypeOf(withResult.error()).toEqualTypeOf<Error | null>()
+
+    // it should be possible to specify the error type
+    type CustomErrorType = { message: string }
+    const withError = TestBed.runInInjectionContext(() =>
+      injectQuery<string, CustomErrorType>(() => ({
+        queryKey: key,
+        queryFn: () => 'test',
+      })),
+    )
+    expectTypeOf(withError.data()).toEqualTypeOf<string | undefined>()
+    expectTypeOf(withError.error()).toEqualTypeOf<CustomErrorType | null>()
+
+    // it should infer the result type from the configuration
+    const withResultInfer = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: key,
+        queryFn: () => true,
+      })),
+    )
+    expectTypeOf(withResultInfer.data()).toEqualTypeOf<boolean | undefined>()
+    expectTypeOf(withResultInfer.error()).toEqualTypeOf<Error | null>()
+
+    // it should be possible to specify a union type as result type
+    const unionTypeSync = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: key,
+        queryFn: () => (Math.random() > 0.5 ? ('a' as const) : ('b' as const)),
+      })),
+    )
+    expectTypeOf(unionTypeSync.data()).toEqualTypeOf<'a' | 'b' | undefined>()
+    const unionTypeAsync = TestBed.runInInjectionContext(() =>
+      injectQuery<'a' | 'b'>(() => ({
+        queryKey: key,
+        queryFn: () => Promise.resolve(Math.random() > 0.5 ? 'a' : 'b'),
+      })),
+    )
+    expectTypeOf(unionTypeAsync.data()).toEqualTypeOf<'a' | 'b' | undefined>()
+
+    // it should error when the query function result does not match with the specified type
+    TestBed.runInInjectionContext(() =>
+      // @ts-expect-error
+      injectQuery<number>(() => ({ queryKey: key, queryFn: () => 'test' })),
+    )
+
+    // it should infer the result type from a generic query function
+    /**
+     *
+     */
+    function queryFn<T = string>(): Promise<T> {
+      return Promise.resolve({} as T)
+    }
+
+    const fromGenericQueryFn = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: key,
+        queryFn: () => queryFn(),
+      })),
+    )
+    expectTypeOf(fromGenericQueryFn.data()).toEqualTypeOf<string | undefined>()
+    expectTypeOf(fromGenericQueryFn.error()).toEqualTypeOf<Error | null>()
+
+    // todo use query options?
+    const fromGenericOptionsQueryFn = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: key,
+        queryFn: () => queryFn(),
+      })),
+    )
+    expectTypeOf(fromGenericOptionsQueryFn.data()).toEqualTypeOf<
+      string | undefined
+    >()
+    expectTypeOf(
+      fromGenericOptionsQueryFn.error(),
+    ).toEqualTypeOf<Error | null>()
+
+    type MyData = number
+    type MyQueryKey = readonly ['my-data', number]
+
+    const getMyDataArrayKey: QueryFunction<MyData, MyQueryKey> = ({
+      queryKey: [, n],
+    }) => {
+      return n + 42
+    }
+
+    const fromMyDataArrayKeyQueryFn = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: ['my-data', 100] as const,
+        queryFn: getMyDataArrayKey,
+      })),
+    )
+    expectTypeOf(fromMyDataArrayKeyQueryFn.data()).toEqualTypeOf<
+      number | undefined
+    >()
+
+    // it should handle query-functions that return Promise<any>
+    const fromPromiseAnyQueryFn = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: key,
+        queryFn: () => fetch('return Promise<any>').then((resp) => resp.json()),
+      })),
+    )
+    expectTypeOf(fromPromiseAnyQueryFn.data()).toEqualTypeOf<any | undefined>()
+
+    const getMyDataStringKey: QueryFunction<MyData, ['1']> = (context) => {
+      expectTypeOf(context.queryKey).toEqualTypeOf<['1']>()
+      return Number(context.queryKey[0]) + 42
+    }
+
+    const fromGetMyDataStringKeyQueryFn = TestBed.runInInjectionContext(() =>
+      injectQuery(() => ({
+        queryKey: ['1'] as ['1'],
+        queryFn: getMyDataStringKey,
+      })),
+    )
+    expectTypeOf(fromGetMyDataStringKeyQueryFn.data()).toEqualTypeOf<
+      number | undefined
+    >()
+
+    // handles wrapped queries with custom fetcher passed as inline queryFn
+    const createWrappedQuery = <
+      TQueryKey extends [string, Record<string, unknown>?],
+      TQueryFnData,
+      TError,
+      TData = TQueryFnData,
+    >(
+      qk: TQueryKey,
+      fetcher: (
+        obj: TQueryKey[1],
+        token: string,
+        // return type must be wrapped with TQueryFnReturn
+      ) => Promise<TQueryFnData>,
+      options?: OmitKeyof<
+        CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+        'queryKey' | 'queryFn' | 'initialData',
+        'safely'
+      >,
+    ) =>
+      injectQuery(() => ({
+        queryKey: qk,
+        queryFn: () => fetcher(qk[1], 'token'),
+        ...options,
+      }))
+    const fromWrappedQuery = TestBed.runInInjectionContext(() =>
+      createWrappedQuery([''], () => Promise.resolve('1')),
+    )
+    expectTypeOf(fromWrappedQuery.data()).toEqualTypeOf<string | undefined>()
+
+    // handles wrapped queries with custom fetcher passed directly to createQuery
+    const createWrappedFuncStyleQuery = <
+      TQueryKey extends [string, Record<string, unknown>?],
+      TQueryFnData,
+      TError,
+      TData = TQueryFnData,
+    >(
+      qk: TQueryKey,
+      fetcher: () => Promise<TQueryFnData>,
+      options?: OmitKeyof<
+        CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+        'queryKey' | 'queryFn' | 'initialData',
+        'safely'
+      >,
+    ) => injectQuery(() => ({ queryKey: qk, queryFn: fetcher, ...options }))
+    const fromWrappedFuncStyleQuery = TestBed.runInInjectionContext(() =>
+      createWrappedFuncStyleQuery([''], () => Promise.resolve(true)),
+    )
+    expectTypeOf(fromWrappedFuncStyleQuery.data()).toEqualTypeOf<
+      boolean | undefined
+    >()
+  })
+
   describe('initialData', () => {
     describe('Config object overload', () => {
       it('TData should always be defined when initialData is provided as an object', () => {

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -1,4 +1,3 @@
-import { TestBed } from '@angular/core/testing'
 import { describe, expectTypeOf, it } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { injectQuery, queryOptions } from '..'
@@ -9,76 +8,60 @@ describe('injectQuery', () => {
   it('should return the correct types', () => {
     const key = queryKey()
     // unspecified query function should default to unknown
-    const noQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-      })),
-    )
+    const noQueryFn = injectQuery(() => ({
+      queryKey: key,
+    }))
     expectTypeOf(noQueryFn.data()).toEqualTypeOf<unknown>()
     expectTypeOf(noQueryFn.error()).toEqualTypeOf<Error | null>()
 
     // it should infer the result type from the query function
-    const fromQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => 'test',
-      })),
-    )
+    const fromQueryFn = injectQuery(() => ({
+      queryKey: key,
+      queryFn: () => 'test',
+    }))
     expectTypeOf(fromQueryFn.data()).toEqualTypeOf<string | undefined>()
     expectTypeOf(fromQueryFn.error()).toEqualTypeOf<Error | null>()
 
     // it should be possible to specify the result type
-    const withResult = TestBed.runInInjectionContext(() =>
-      injectQuery<string>(() => ({
-        queryKey: key,
-        queryFn: () => 'test',
-      })),
-    )
+    const withResult = injectQuery<string>(() => ({
+      queryKey: key,
+      queryFn: () => 'test',
+    }))
     expectTypeOf(withResult.data()).toEqualTypeOf<string | undefined>()
     expectTypeOf(withResult.error()).toEqualTypeOf<Error | null>()
 
     // it should be possible to specify the error type
     type CustomErrorType = { message: string }
-    const withError = TestBed.runInInjectionContext(() =>
-      injectQuery<string, CustomErrorType>(() => ({
-        queryKey: key,
-        queryFn: () => 'test',
-      })),
-    )
+    const withError = injectQuery<string, CustomErrorType>(() => ({
+      queryKey: key,
+      queryFn: () => 'test',
+    }))
     expectTypeOf(withError.data()).toEqualTypeOf<string | undefined>()
     expectTypeOf(withError.error()).toEqualTypeOf<CustomErrorType | null>()
 
     // it should infer the result type from the configuration
-    const withResultInfer = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => true,
-      })),
-    )
+    const withResultInfer = injectQuery(() => ({
+      queryKey: key,
+      queryFn: () => true,
+    }))
     expectTypeOf(withResultInfer.data()).toEqualTypeOf<boolean | undefined>()
     expectTypeOf(withResultInfer.error()).toEqualTypeOf<Error | null>()
 
     // it should be possible to specify a union type as result type
-    const unionTypeSync = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => (Math.random() > 0.5 ? ('a' as const) : ('b' as const)),
-      })),
-    )
+    const unionTypeSync = injectQuery(() => ({
+      queryKey: key,
+      queryFn: () => (Math.random() > 0.5 ? ('a' as const) : ('b' as const)),
+    }))
     expectTypeOf(unionTypeSync.data()).toEqualTypeOf<'a' | 'b' | undefined>()
-    const unionTypeAsync = TestBed.runInInjectionContext(() =>
-      injectQuery<'a' | 'b'>(() => ({
-        queryKey: key,
-        queryFn: () => Promise.resolve(Math.random() > 0.5 ? 'a' : 'b'),
-      })),
-    )
+    const unionTypeAsync = injectQuery<'a' | 'b'>(() => ({
+      queryKey: key,
+      queryFn: () => Promise.resolve(Math.random() > 0.5 ? 'a' : 'b'),
+    }))
     expectTypeOf(unionTypeAsync.data()).toEqualTypeOf<'a' | 'b' | undefined>()
 
     // it should error when the query function result does not match with the specified type
-    TestBed.runInInjectionContext(() =>
-      // @ts-expect-error
-      injectQuery<number>(() => ({ queryKey: key, queryFn: () => 'test' })),
-    )
+    // @ts-expect-error
+    injectQuery<number>(() => ({ queryKey: key, queryFn: () => 'test' }))
 
     // it should infer the result type from a generic query function
     /**
@@ -88,22 +71,18 @@ describe('injectQuery', () => {
       return Promise.resolve({} as T)
     }
 
-    const fromGenericQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => queryFn(),
-      })),
-    )
+    const fromGenericQueryFn = injectQuery(() => ({
+      queryKey: key,
+      queryFn: () => queryFn(),
+    }))
     expectTypeOf(fromGenericQueryFn.data()).toEqualTypeOf<string | undefined>()
     expectTypeOf(fromGenericQueryFn.error()).toEqualTypeOf<Error | null>()
 
     // todo use query options?
-    const fromGenericOptionsQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => queryFn(),
-      })),
-    )
+    const fromGenericOptionsQueryFn = injectQuery(() => ({
+      queryKey: key,
+      queryFn: () => queryFn(),
+    }))
     expectTypeOf(fromGenericOptionsQueryFn.data()).toEqualTypeOf<
       string | undefined
     >()
@@ -120,23 +99,19 @@ describe('injectQuery', () => {
       return n + 42
     }
 
-    const fromMyDataArrayKeyQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: ['my-data', 100] as const,
-        queryFn: getMyDataArrayKey,
-      })),
-    )
+    const fromMyDataArrayKeyQueryFn = injectQuery(() => ({
+      queryKey: ['my-data', 100] as const,
+      queryFn: getMyDataArrayKey,
+    }))
     expectTypeOf(fromMyDataArrayKeyQueryFn.data()).toEqualTypeOf<
       number | undefined
     >()
 
     // it should handle query-functions that return Promise<any>
-    const fromPromiseAnyQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => fetch('return Promise<any>').then((resp) => resp.json()),
-      })),
-    )
+    const fromPromiseAnyQueryFn = injectQuery(() => ({
+      queryKey: key,
+      queryFn: () => fetch('return Promise<any>').then((resp) => resp.json()),
+    }))
     expectTypeOf(fromPromiseAnyQueryFn.data()).toEqualTypeOf<any | undefined>()
 
     const getMyDataStringKey: QueryFunction<MyData, ['1']> = (context) => {
@@ -144,12 +119,10 @@ describe('injectQuery', () => {
       return Number(context.queryKey[0]) + 42
     }
 
-    const fromGetMyDataStringKeyQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: ['1'] as ['1'],
-        queryFn: getMyDataStringKey,
-      })),
-    )
+    const fromGetMyDataStringKeyQueryFn = injectQuery(() => ({
+      queryKey: ['1'] as ['1'],
+      queryFn: getMyDataStringKey,
+    }))
     expectTypeOf(fromGetMyDataStringKeyQueryFn.data()).toEqualTypeOf<
       number | undefined
     >()
@@ -178,8 +151,8 @@ describe('injectQuery', () => {
         queryFn: () => fetcher(qk[1], 'token'),
         ...options,
       }))
-    const fromWrappedQuery = TestBed.runInInjectionContext(() =>
-      createWrappedQuery([''], () => Promise.resolve('1')),
+    const fromWrappedQuery = createWrappedQuery([''], () =>
+      Promise.resolve('1'),
     )
     expectTypeOf(fromWrappedQuery.data()).toEqualTypeOf<string | undefined>()
 
@@ -198,8 +171,8 @@ describe('injectQuery', () => {
         'safely'
       >,
     ) => injectQuery(() => ({ queryKey: qk, queryFn: fetcher, ...options }))
-    const fromWrappedFuncStyleQuery = TestBed.runInInjectionContext(() =>
-      createWrappedFuncStyleQuery([''], () => Promise.resolve(true)),
+    const fromWrappedFuncStyleQuery = createWrappedFuncStyleQuery([''], () =>
+      Promise.resolve(true),
     )
     expectTypeOf(fromWrappedFuncStyleQuery.data()).toEqualTypeOf<
       boolean | undefined

--- a/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test.ts
@@ -3,7 +3,6 @@ import {
   Component,
   Injector,
   computed,
-  effect,
   input,
   provideZonelessChangeDetection,
   signal,
@@ -14,15 +13,7 @@ import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing'
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  expectTypeOf,
-  it,
-  vi,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/angular'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import { lastValueFrom } from 'rxjs'
@@ -34,7 +25,6 @@ import {
   provideTanStackQuery,
 } from '..'
 import { setSignalInputs } from './test-utils'
-import type { CreateQueryOptions, OmitKeyof, QueryFunction } from '..'
 
 describe('injectQuery', () => {
   let queryCache: QueryCache
@@ -54,218 +44,6 @@ describe('injectQuery', () => {
 
   afterEach(() => {
     vi.useRealTimers()
-  })
-
-  it('should return the correct types', () => {
-    const key = queryKey()
-    // unspecified query function should default to unknown
-    const noQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-      })),
-    )
-    expectTypeOf(noQueryFn.data()).toEqualTypeOf<unknown>()
-    expectTypeOf(noQueryFn.error()).toEqualTypeOf<Error | null>()
-
-    // it should infer the result type from the query function
-    const fromQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => 'test',
-      })),
-    )
-    expectTypeOf(fromQueryFn.data()).toEqualTypeOf<string | undefined>()
-    expectTypeOf(fromQueryFn.error()).toEqualTypeOf<Error | null>()
-
-    // it should be possible to specify the result type
-    const withResult = TestBed.runInInjectionContext(() =>
-      injectQuery<string>(() => ({
-        queryKey: key,
-        queryFn: () => 'test',
-      })),
-    )
-    expectTypeOf(withResult.data()).toEqualTypeOf<string | undefined>()
-    expectTypeOf(withResult.error()).toEqualTypeOf<Error | null>()
-
-    // it should be possible to specify the error type
-    type CustomErrorType = { message: string }
-    const withError = TestBed.runInInjectionContext(() =>
-      injectQuery<string, CustomErrorType>(() => ({
-        queryKey: key,
-        queryFn: () => 'test',
-      })),
-    )
-    expectTypeOf(withError.data()).toEqualTypeOf<string | undefined>()
-    expectTypeOf(withError.error()).toEqualTypeOf<CustomErrorType | null>()
-
-    // it should infer the result type from the configuration
-    const withResultInfer = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => true,
-      })),
-    )
-    expectTypeOf(withResultInfer.data()).toEqualTypeOf<boolean | undefined>()
-    expectTypeOf(withResultInfer.error()).toEqualTypeOf<Error | null>()
-
-    // it should be possible to specify a union type as result type
-    const unionTypeSync = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => (Math.random() > 0.5 ? ('a' as const) : ('b' as const)),
-      })),
-    )
-    expectTypeOf(unionTypeSync.data()).toEqualTypeOf<'a' | 'b' | undefined>()
-    const unionTypeAsync = TestBed.runInInjectionContext(() =>
-      injectQuery<'a' | 'b'>(() => ({
-        queryKey: key,
-        queryFn: () => Promise.resolve(Math.random() > 0.5 ? 'a' : 'b'),
-      })),
-    )
-    expectTypeOf(unionTypeAsync.data()).toEqualTypeOf<'a' | 'b' | undefined>()
-
-    // it should error when the query function result does not match with the specified type
-    TestBed.runInInjectionContext(() =>
-      // @ts-expect-error
-      injectQuery<number>(() => ({ queryKey: key, queryFn: () => 'test' })),
-    )
-
-    // it should infer the result type from a generic query function
-    /**
-     *
-     */
-    function queryFn<T = string>(): Promise<T> {
-      return Promise.resolve({} as T)
-    }
-
-    const fromGenericQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => queryFn(),
-      })),
-    )
-    expectTypeOf(fromGenericQueryFn.data()).toEqualTypeOf<string | undefined>()
-    expectTypeOf(fromGenericQueryFn.error()).toEqualTypeOf<Error | null>()
-
-    // todo use query options?
-    const fromGenericOptionsQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => queryFn(),
-      })),
-    )
-    expectTypeOf(fromGenericOptionsQueryFn.data()).toEqualTypeOf<
-      string | undefined
-    >()
-    expectTypeOf(
-      fromGenericOptionsQueryFn.error(),
-    ).toEqualTypeOf<Error | null>()
-
-    type MyData = number
-    type MyQueryKey = readonly ['my-data', number]
-
-    const getMyDataArrayKey: QueryFunction<MyData, MyQueryKey> = ({
-      queryKey: [, n],
-    }) => {
-      return n + 42
-    }
-
-    const fromMyDataArrayKeyQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: ['my-data', 100] as const,
-        queryFn: getMyDataArrayKey,
-      })),
-    )
-    expectTypeOf(fromMyDataArrayKeyQueryFn.data()).toEqualTypeOf<
-      number | undefined
-    >()
-
-    // it should handle query-functions that return Promise<any>
-    const fromPromiseAnyQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: key,
-        queryFn: () => fetch('return Promise<any>').then((resp) => resp.json()),
-      })),
-    )
-    expectTypeOf(fromPromiseAnyQueryFn.data()).toEqualTypeOf<any | undefined>()
-
-    TestBed.runInInjectionContext(() =>
-      effect(() => {
-        expect(fromMyDataArrayKeyQueryFn.data()).toBe(142)
-      }),
-    )
-
-    const getMyDataStringKey: QueryFunction<MyData, ['1']> = (context) => {
-      expectTypeOf(context.queryKey).toEqualTypeOf<['1']>()
-      return Number(context.queryKey[0]) + 42
-    }
-
-    const fromGetMyDataStringKeyQueryFn = TestBed.runInInjectionContext(() =>
-      injectQuery(() => ({
-        queryKey: ['1'] as ['1'],
-        queryFn: getMyDataStringKey,
-      })),
-    )
-    expectTypeOf(fromGetMyDataStringKeyQueryFn.data()).toEqualTypeOf<
-      number | undefined
-    >()
-
-    TestBed.runInInjectionContext(() =>
-      effect(() => {
-        expect(fromGetMyDataStringKeyQueryFn.data()).toBe(43)
-      }),
-    )
-
-    // handles wrapped queries with custom fetcher passed as inline queryFn
-    const createWrappedQuery = <
-      TQueryKey extends [string, Record<string, unknown>?],
-      TQueryFnData,
-      TError,
-      TData = TQueryFnData,
-    >(
-      qk: TQueryKey,
-      fetcher: (
-        obj: TQueryKey[1],
-        token: string,
-        // return type must be wrapped with TQueryFnReturn
-      ) => Promise<TQueryFnData>,
-      options?: OmitKeyof<
-        CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-        'queryKey' | 'queryFn' | 'initialData',
-        'safely'
-      >,
-    ) =>
-      injectQuery(() => ({
-        queryKey: qk,
-        queryFn: () => fetcher(qk[1], 'token'),
-        ...options,
-      }))
-    const fromWrappedQuery = TestBed.runInInjectionContext(() =>
-      createWrappedQuery([''], () => Promise.resolve('1')),
-    )
-    expectTypeOf(fromWrappedQuery.data()).toEqualTypeOf<string | undefined>()
-
-    // handles wrapped queries with custom fetcher passed directly to createQuery
-    const createWrappedFuncStyleQuery = <
-      TQueryKey extends [string, Record<string, unknown>?],
-      TQueryFnData,
-      TError,
-      TData = TQueryFnData,
-    >(
-      qk: TQueryKey,
-      fetcher: () => Promise<TQueryFnData>,
-      options?: OmitKeyof<
-        CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-        'queryKey' | 'queryFn' | 'initialData',
-        'safely'
-      >,
-    ) => injectQuery(() => ({ queryKey: qk, queryFn: fetcher, ...options }))
-    const fromWrappedFuncStyleQuery = TestBed.runInInjectionContext(() =>
-      createWrappedFuncStyleQuery([''], () => Promise.resolve(true)),
-    )
-    expectTypeOf(fromWrappedFuncStyleQuery.data()).toEqualTypeOf<
-      boolean | undefined
-    >()
   })
 
   it('should return pending status initially', () => {


### PR DESCRIPTION
## 🎯 Changes

`inject-query.test.ts` carried 22 `expectTypeOf` assertions in a single `should return the correct types` test. None of them were being checked: `typecheck` is enabled with its default include (`**/*.test-d.ts`), so type assertions in a `.test.ts` file are never type-checked. Changing `toEqualTypeOf<string | undefined>()` to `toEqualTypeOf<number>()` there passes; the same edit in `inject-query.test-d.ts` fails with a `TypeCheckError`. The `@ts-expect-error` case was dead in the same way — it now reports `Unused '@ts-expect-error' directive` when the error it guards stops occurring.

Moving the test into `inject-query.test-d.ts` puts all 22 under type-checking. This also matches how the other adapters split the two: `react-query`, `preact-query` and `vue-query` have zero `expectTypeOf` in their runtime `useQuery` tests.

The assertions themselves are unchanged. Two things around them are not carried over:

**`TestBed.runInInjectionContext` is dropped** (15 call sites). Type assertions are only compiled, never run, so the injection context buys nothing here — verified by mutating an assertion after removal and confirming the `TypeCheckError` still fires. It also matches the rest of this file, which has always called `injectQuery(...)` directly:

```ts
const noQueryFn = injectQuery(() => ({ queryKey: key }))
```

**Two runtime assertions are removed:**

```ts
TestBed.runInInjectionContext(() => effect(() => {
  expect(fromMyDataArrayKeyQueryFn.data()).toBe(142)
}))
```

The effects never ran — nothing calls `TestBed.tick()` or `detectChanges()` in this test, confirmed by logging from inside the callbacks. They asserted nothing, and a `test-d` file is not where runtime assertions belong.

No assertion was added or reworded, and coverage matches `react-query`'s `useQuery.test-d.tsx` case for case (several are stricter here — `react-query` calls `getMyDataArrayKey` / `getMyDataStringKey` / the `Promise<any>` query without asserting on the result).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded compile-time coverage for query type inference, including default, explicit, generic, union, and wrapped query configurations.
  - Moved type-inference validation into dedicated type-testing coverage and removed the corresponding runtime test setup.
  - Added checks for inferred results from different query function and key patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->