### PR TITLE
test({react,preact,solid,angular}-query): remove 'fromGenericOptionsQueryFn' duplicating 'fromGenericQueryFn'

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/inject-query.test-d.ts
@@ -78,18 +78,6 @@ describe('injectQuery', () => {
     expectTypeOf(fromGenericQueryFn.data()).toEqualTypeOf<string | undefined>()
     expectTypeOf(fromGenericQueryFn.error()).toEqualTypeOf<Error | null>()
 
-    // todo use query options?
-    const fromGenericOptionsQueryFn = injectQuery(() => ({
-      queryKey: key,
-      queryFn: () => queryFn(),
-    }))
-    expectTypeOf(fromGenericOptionsQueryFn.data()).toEqualTypeOf<
-      string | undefined
-    >()
-    expectTypeOf(
-      fromGenericOptionsQueryFn.error(),
-    ).toEqualTypeOf<Error | null>()
-
     type MyData = number
     type MyQueryKey = readonly ['my-data', number]
 

--- a/packages/preact-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/preact-query/src/__tests__/useQuery.test-d.tsx
@@ -69,15 +69,6 @@ describe('useQuery', () => {
   expectTypeOf(fromGenericQueryFn.data).toEqualTypeOf<string | undefined>()
   expectTypeOf(fromGenericQueryFn.error).toEqualTypeOf<Error | null>()
 
-  const fromGenericOptionsQueryFn = useQuery({
-    queryKey: key,
-    queryFn: () => queryFn(),
-  })
-  expectTypeOf(fromGenericOptionsQueryFn.data).toEqualTypeOf<
-    string | undefined
-  >()
-  expectTypeOf(fromGenericOptionsQueryFn.error).toEqualTypeOf<Error | null>()
-
   type MyData = number
   type MyQueryKey = readonly ['my-data', number]
 

--- a/packages/react-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/react-query/src/__tests__/useQuery.test-d.tsx
@@ -68,15 +68,6 @@ describe('useQuery', () => {
   expectTypeOf(fromGenericQueryFn.data).toEqualTypeOf<string | undefined>()
   expectTypeOf(fromGenericQueryFn.error).toEqualTypeOf<Error | null>()
 
-  const fromGenericOptionsQueryFn = useQuery({
-    queryKey: key,
-    queryFn: () => queryFn(),
-  })
-  expectTypeOf(fromGenericOptionsQueryFn.data).toEqualTypeOf<
-    string | undefined
-  >()
-  expectTypeOf(fromGenericOptionsQueryFn.error).toEqualTypeOf<Error | null>()
-
   type MyData = number
   type MyQueryKey = readonly ['my-data', number]
 

--- a/packages/solid-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test-d.tsx
@@ -69,15 +69,6 @@ describe('useQuery', () => {
   expectTypeOf(fromGenericQueryFn.data).toEqualTypeOf<string | undefined>()
   expectTypeOf(fromGenericQueryFn.error).toEqualTypeOf<Error | null>()
 
-  const fromGenericOptionsQueryFn = useQuery(() => ({
-    queryKey: key,
-    queryFn: () => queryFn(),
-  }))
-  expectTypeOf(fromGenericOptionsQueryFn.data).toEqualTypeOf<
-    string | undefined
-  >()
-  expectTypeOf(fromGenericOptionsQueryFn.error).toEqualTypeOf<Error | null>()
-
   type MyData = number
   type MyQueryKey = readonly ['my-data', number]
 


### PR DESCRIPTION
## 🎯 Changes

`fromGenericOptionsQueryFn` is character-for-character the same query as the `fromGenericQueryFn` declared right above it, with the same two assertions. Despite the name, it never calls `queryOptions` — so it does not cover the generic-options path either, and asserts nothing the previous case did not.

```ts
const fromGenericQueryFn = useQuery({ queryKey: key, queryFn: () => queryFn() })
expectTypeOf(fromGenericQueryFn.data).toEqualTypeOf<string | undefined>()
expectTypeOf(fromGenericQueryFn.error).toEqualTypeOf<Error | null>()

const fromGenericOptionsQueryFn = useQuery({ queryKey: key, queryFn: () => queryFn() })  // identical
expectTypeOf(fromGenericOptionsQueryFn.data).toEqualTypeOf<string | undefined>()
expectTypeOf(fromGenericOptionsQueryFn.error).toEqualTypeOf<Error | null>()
```

Nothing is lost by removing it:

- **Generic `queryFn` inference** — still covered by `fromGenericQueryFn`, which stays and carries the identical assertions in all four adapters.
- **The `queryOptions` path** — covered by each adapter's dedicated `queryOptions.test-d` (`query-options.test-d.ts` in angular), which has a `should work when passed to useQuery` / `injectQuery` case plus 9–28 further assertions. The removed block never exercised this path at all.

`vue-query` and `svelte-query` never had this case, and their `queryOptions` type tests are among the most thorough (32 and 21 assertions).

The angular copy also carried a `// todo use query options?` comment, dropped with it.

Suites pass unchanged: 583 / 540 / 351 / 252, no type errors.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed redundant type-inference test cases across Angular, Preact, React, and Solid integrations.
  - Existing coverage for generic query-function type inference remains in place.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->