### PR TITLE
test({vue,svelte}-query): add type tests for inferring the result type from a generic 'queryFn'

### DIFF
--- a/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
@@ -96,4 +96,22 @@ describe('createQuery', () => {
       })
     })
   })
+
+  describe('generic queryFn', () => {
+    it('should infer the result type from a generic query function', () => {
+      const key = queryKey()
+
+      function queryFn<T = string>(): Promise<T> {
+        return Promise.resolve({} as T)
+      }
+
+      const query = createQuery(() => ({
+        queryKey: key,
+        queryFn: () => queryFn(),
+      }))
+
+      expectTypeOf(query.data).toEqualTypeOf<string | undefined>()
+      expectTypeOf(query.error).toEqualTypeOf<Error | null>()
+    })
+  })
 })

--- a/packages/vue-query/src/__tests__/useQuery.test-d.ts
+++ b/packages/vue-query/src/__tests__/useQuery.test-d.ts
@@ -153,6 +153,26 @@ describe('useQuery', () => {
     })
   })
 
+  describe('generic queryFn', () => {
+    it('should infer the result type from a generic query function', () => {
+      const key = queryKey()
+
+      function queryFn<T = string>(): Promise<T> {
+        return Promise.resolve({} as T)
+      }
+
+      const query = reactive(
+        useQuery({
+          queryKey: key,
+          queryFn: () => queryFn(),
+        }),
+      )
+
+      expectTypeOf(query.data).toEqualTypeOf<string | undefined>()
+      expectTypeOf(query.error).toEqualTypeOf<Error | null>()
+    })
+  })
+
   describe('generic queryKey inference (#8199)', () => {
     it('should not error when wrapping useQuery in a composable that propagates a generic type to the queryKey', () => {
       const basket = { fruit: 'apple', vegetable: 'broccoli' } as const


### PR DESCRIPTION
## 🎯 Changes

`vue-query` and `svelte-query` were the only adapters without a type test covering result type inference through a **generic** `queryFn`. `react-query`, `preact-query`, `solid-query`, and `angular-query-experimental` all assert this in their `useQuery`/`injectQuery` type tests, so this brings the two remaining adapters in line.

Each new test declares a generic function whose type parameter defaults to `string`, passes it as the `queryFn`, and asserts that the default propagates to `data`:

```ts
function queryFn<T = string>(): Promise<T> {
  return Promise.resolve({} as T)
}
```

- **`packages/vue-query/src/__tests__/useQuery.test-d.ts`** — new `generic queryFn` describe, placed before `generic queryKey inference (#8199)` so the `queryFn` case precedes the `queryKey` one.
- **`packages/svelte-query/tests/createQuery/createQuery.test-d.ts`** — new `generic queryFn` describe as a sibling of the existing `initialData` block.

Both assert `data` is `string | undefined` and `error` is `Error | null`, matching the assertions the other adapters already make.

Type tests only — no runtime or published code is touched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify correct type inference for generic query functions.
  * Confirmed query data resolves to the expected value type and query errors retain the expected error type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->