### PR TITLE
test(angular-query/query-options): add type tests for 'getQueryState' and 'skipToken' inference

### DIFF
--- a/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
+++ b/packages/angular-query-experimental/src/__tests__/query-options.test-d.ts
@@ -173,6 +173,19 @@ it('should return the proper type when passed to getQueryData', () => {
   expectTypeOf(data).toEqualTypeOf<number | undefined>()
 })
 
+it('should return the proper type when passed to getQueryState', () => {
+  const key = queryKey()
+  const { queryKey: tagged } = queryOptions({
+    queryKey: key,
+    queryFn: () => Promise.resolve(5),
+  })
+
+  const queryClient = new QueryClient()
+  const state = queryClient.getQueryState(tagged)
+
+  expectTypeOf(state?.data).toEqualTypeOf<number | undefined>()
+})
+
 it('should properly type updaterFn when passed to setQueryData', () => {
   const key = queryKey()
   const { queryKey: tagged } = queryOptions({
@@ -206,4 +219,30 @@ it('should properly type value when passed to setQueryData', () => {
   const data = queryClient.setQueryData(tagged, 5)
 
   expectTypeOf(data).toEqualTypeOf<number | undefined>()
+})
+
+it('should infer even if there is a conditional skipToken', () => {
+  const key = queryKey()
+  const options = queryOptions({
+    queryKey: key,
+    queryFn: Math.random() > 0.5 ? skipToken : () => Promise.resolve(5),
+  })
+
+  const queryClient = new QueryClient()
+  const data = queryClient.getQueryData(options.queryKey)
+
+  expectTypeOf(data).toEqualTypeOf<number | undefined>()
+})
+
+it('should infer to unknown if we disable a query with just a skipToken', () => {
+  const key = queryKey()
+  const options = queryOptions({
+    queryKey: key,
+    queryFn: skipToken,
+  })
+
+  const queryClient = new QueryClient()
+  const data = queryClient.getQueryData(options.queryKey)
+
+  expectTypeOf(data).toEqualTypeOf<unknown>()
 })


### PR DESCRIPTION
## 🎯 Changes

`angular-query-experimental`'s `query-options.test-d.ts` was missing three cases that `react-query`, `preact-query`, `solid-query` and `svelte-query` already cover in their `queryOptions` type tests. This ports them over.

- **`should return the proper type when passed to getQueryState`** — asserts the tagged query key narrows `state?.data` to `number | undefined`. Placed right after the existing `getQueryData` case, matching where the other adapters put it.
- **`should infer even if there is a conditional skipToken`** — a `queryFn` that is either `skipToken` or a real function still infers `number | undefined`.
- **`should infer to unknown if we disable a query with just a skipToken`** — a `queryFn` that is only `skipToken` infers `unknown`.

Each one was checked by changing the *input* rather than the expected type: flipping the `queryFn` result type (or replacing `skipToken` with a real function) makes the corresponding assertion fail, so all three react to what they claim to test.

Type tests only — no runtime or published code is touched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded TypeScript type coverage for query state and data retrieval.
  * Added validation that tagged queries expose optional numeric data types correctly.
  * Confirmed data type inference for conditionally skipped queries.
  * Added coverage for queries configured exclusively with a skip token, ensuring their data is typed as unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->