### PR TITLE
docs(query-core): add JSDoc for Subscribable and Removable base classes 🤖🤖🤖

### DIFF
--- a/packages/query-core/src/removable.ts
+++ b/packages/query-core/src/removable.ts
@@ -3,14 +3,33 @@ import { isServer as isServerEnvironment } from './environmentManager'
 import { isValidTimeout } from './utils'
 import type { ManagedTimerId } from './timeoutManager'
 
+/**
+ * Abstract base class for garbage collection: `Query` and `Mutation` extend it
+ * to remove themselves from their cache after `gcTime` milliseconds of
+ * inactivity.
+ */
 export abstract class Removable {
+  /**
+   * Time in milliseconds after which an inactive instance is removed by
+   * garbage collection. Managed via `updateGcTime`, which only ever raises it.
+   */
   gcTime!: number
   #gcTimeout?: ManagedTimerId
 
+  /**
+   * `destroy` cancels a scheduled garbage collection, if one is pending.
+   * Subclasses can extend it as part of their removal lifecycle — e.g.
+   * `Query#destroy` also cancels in-flight fetches.
+   */
   destroy(): void {
     this.clearGcTimeout()
   }
 
+  /**
+   * `scheduleGc` schedules the instance for removal after `gcTime`
+   * milliseconds, replacing any previously scheduled removal. If `gcTime` is
+   * not a valid timeout (e.g. `Infinity`), no garbage collection is scheduled.
+   */
   protected scheduleGc(): void {
     this.clearGcTimeout()
 
@@ -21,6 +40,11 @@ export abstract class Removable {
     }
   }
 
+  /**
+   * `updateGcTime` raises `gcTime` to the given value in milliseconds, keeping
+   * the previous value if it was larger. If no value is passed, it defaults to
+   * 5 minutes, or `Infinity` on the server, which disables garbage collection.
+   */
   protected updateGcTime(newGcTime: number | undefined): void {
     // Default to 5 minutes (Infinity for server-side) if no gcTime is set
     this.gcTime = Math.max(
@@ -29,6 +53,9 @@ export abstract class Removable {
     )
   }
 
+  /**
+   * `clearGcTimeout` cancels a scheduled garbage collection, if one is pending.
+   */
   protected clearGcTimeout() {
     if (this.#gcTimeout !== undefined) {
       timeoutManager.clearTimeout(this.#gcTimeout)
@@ -36,5 +63,9 @@ export abstract class Removable {
     }
   }
 
+  /**
+   * Removes the instance from the cache that holds it. Called when a scheduled
+   * garbage collection fires; subclasses must implement it.
+   */
   protected abstract optionalRemove(): void
 }

--- a/packages/query-core/src/subscribable.ts
+++ b/packages/query-core/src/subscribable.ts
@@ -1,3 +1,13 @@
+/**
+ * Base class that implements the subscribe/unsubscribe pattern used throughout
+ * TanStack Query. Caches, observers, and managers such as `QueryCache`,
+ * `MutationCache`, `QueryObserver`, `FocusManager`, and `OnlineManager` extend
+ * it to notify listeners about state changes.
+ *
+ * Subclasses can override the `onSubscribe` and `onUnsubscribe` hooks to set
+ * up and tear down resources (e.g. global event listeners) as listeners are
+ * added and removed.
+ */
 export class Subscribable<TListener extends Function> {
   protected listeners = new Set<TListener>()
 
@@ -5,6 +15,26 @@ export class Subscribable<TListener extends Function> {
     this.subscribe = this.subscribe.bind(this)
   }
 
+  /**
+   * `subscribe` registers a listener that is called whenever the subclass
+   * notifies about a change, and returns an unsubscribe function that removes
+   * the listener again.
+   *
+   * The method is bound to its instance, so it can be destructured or passed
+   * around as a standalone function.
+   *
+   * @example
+   * ```ts
+   * import { focusManager } from '@tanstack/query-core'
+   *
+   * const unsubscribe = focusManager.subscribe((focused) => {
+   *   console.log('focused:', focused)
+   * })
+   *
+   * // Stop listening
+   * unsubscribe()
+   * ```
+   */
   subscribe(listener: TListener): () => void {
     this.listeners.add(listener)
 
@@ -16,14 +46,27 @@ export class Subscribable<TListener extends Function> {
     }
   }
 
+  /**
+   * `hasListeners` can be used to check whether at least one listener is
+   * currently subscribed.
+   */
   hasListeners(): boolean {
     return this.listeners.size > 0
   }
 
+  /**
+   * Lifecycle hook that is called after a listener has subscribed. Subclasses
+   * can override it to set up resources, such as attaching global event
+   * listeners, when listeners subscribe.
+   */
   protected onSubscribe(): void {
     // Do nothing
   }
 
+  /**
+   * Lifecycle hook that is called after a listener has unsubscribed.
+   * Subclasses can override it to release resources when listeners unsubscribe.
+   */
   protected onUnsubscribe(): void {
     // Do nothing
   }


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #11438, which added JSDoc across `packages/query-core/src` but left the two internal base classes untouched: `subscribable.ts` and `removable.ts` had no JSDoc at all.

- **`Subscribable`** (extended by `QueryCache`, `MutationCache`, `QueryObserver`, `MutationObserver`, `QueriesObserver`, `FocusManager`, and `OnlineManager`): documents the class, `subscribe` (that it returns an unsubscribe function and is bound to the instance, with an example), `hasListeners`, and the `onSubscribe`/`onUnsubscribe` lifecycle hooks.
- **`Removable`** (extended by `Query` and `Mutation`): documents the class, the `gcTime` field, `destroy`, `scheduleGc`, `updateGcTime` (the 5 minutes / `Infinity` on the server default, and that it only ever raises `gcTime`), `clearGcTimeout`, and the abstract `optionalRemove`.

Since `subscribe`, `hasListeners`, and `destroy` are inherited by the public classes above, these docs now show up on hover for e.g. `queryCache.subscribe(...)`, which previously had none. Wording follows the style used in #11438.

JSDoc-only change: no runtime code is modified (74 added lines, 0 removed).

Verified locally in `packages/query-core`: `tsc --build` (no new errors), `vitest` (27 files / 680 tests passing), and `prettier --check`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added API documentation for lifecycle and subscription management classes and their public methods.
  - Clarified behaviors related to garbage-collection scheduling, listener management, and subscription lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->