### PR TITLE
fix(query-core): clear mutations before notifying subscribers

### DIFF
--- a/.changeset/clear-mutation-cache-before-notifying.md
+++ b/.changeset/clear-mutation-cache-before-notifying.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Clear the mutation cache before notifying subscribers so `useMutationState` and `useIsMutating` update correctly after `queryClient.clear()`.

--- a/packages/query-core/src/__tests__/mutationCache.test.tsx
+++ b/packages/query-core/src/__tests__/mutationCache.test.tsx
@@ -446,6 +446,49 @@ describe('mutationCache', () => {
     })
   })
 
+  describe('clear', () => {
+    it('should notify subscribers after all mutations have been removed', () => {
+      const testCache = new MutationCache()
+      const testClient = new QueryClient({ mutationCache: testCache })
+      const mutation1 = testCache.build(testClient, {})
+      const mutation2 = testCache.build(testClient, {})
+      const callback = vi.fn(() => testCache.getAll())
+      testCache.subscribe(callback)
+
+      testCache.clear()
+
+      expect(callback).toHaveBeenCalledTimes(2)
+      expect(callback).toHaveBeenNthCalledWith(1, {
+        type: 'removed',
+        mutation: mutation1,
+      })
+      expect(callback).toHaveBeenNthCalledWith(2, {
+        type: 'removed',
+        mutation: mutation2,
+      })
+      expect(callback).toHaveNthReturnedWith(1, [])
+      expect(callback).toHaveNthReturnedWith(2, [])
+      expect(testCache.getAll()).toEqual([])
+    })
+
+    it('should preserve mutations added by removal subscribers', () => {
+      const testCache = new MutationCache()
+      const testClient = new QueryClient({ mutationCache: testCache })
+      const original = testCache.build(testClient, {})
+      const key = queryKey()
+      testCache.subscribe((event) => {
+        if (event.type === 'removed' && event.mutation === original) {
+          testCache.build(testClient, { mutationKey: key })
+        }
+      })
+
+      testCache.clear()
+
+      expect(testCache.getAll()).toHaveLength(1)
+      expect(testCache.getAll()[0]?.options.mutationKey).toEqual(key)
+    })
+  })
+
   describe('remove', () => {
     it('should remove only the target mutation from scope when multiple scoped mutations exist', () => {
       const testCache = new MutationCache()

--- a/packages/query-core/src/mutationCache.ts
+++ b/packages/query-core/src/mutationCache.ts
@@ -235,11 +235,12 @@ export class MutationCache extends Subscribable<MutationCacheListener> {
    */
   clear(): void {
     notifyManager.batch(() => {
-      this.#mutations.forEach((mutation) => {
-        this.notify({ type: 'removed', mutation })
-      })
+      const mutations = this.getAll()
       this.#mutations.clear()
       this.#scopes.clear()
+      mutations.forEach((mutation) => {
+        this.notify({ type: 'removed', mutation })
+      })
     })
   }
 

--- a/packages/react-query/src/__tests__/useMutationState.test.tsx
+++ b/packages/react-query/src/__tests__/useMutationState.test.tsx
@@ -77,6 +77,37 @@ describe('useIsMutating', () => {
     expect(isMutatingArray).toEqual([0, 1, 2, 1, 0])
   })
 
+  it('should update when the query client is cleared', async () => {
+    const queryClient = new QueryClient()
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: () => sleep(1000).then(() => 'data'),
+      })
+      const isMutating = useIsMutating()
+
+      return (
+        <div>
+          <div>mutating: {isMutating}</div>
+          <button onClick={() => mutate()}>mutate</button>
+          <button onClick={() => queryClient.clear()}>clear</button>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+    fireEvent.click(rendered.getByRole('button', { name: 'mutate' }))
+    await vi.advanceTimersByTimeAsync(1)
+    expect(rendered.getByText('mutating: 1')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: 'clear' }))
+    await vi.advanceTimersByTimeAsync(1)
+    expect(queryClient.isMutating()).toBe(0)
+    expect(rendered.getByText('mutating: 0')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(1000)
+  })
+
   it('should filter correctly by mutationKey', async () => {
     const isMutatingArray: Array<number> = []
     const queryClient = new QueryClient()
@@ -190,6 +221,38 @@ describe('useMutationState', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('should remove successful mutations when the query client is cleared', async () => {
+    const queryClient = new QueryClient()
+
+    function Page() {
+      const { mutate } = useMutation({
+        mutationFn: () => Promise.resolve('saved'),
+      })
+      const data = useMutationState({
+        filters: { status: 'success' },
+        select: (mutation) => mutation.state.data,
+      })
+
+      return (
+        <div>
+          <div>data: {JSON.stringify(data)}</div>
+          <button onClick={() => mutate()}>mutate</button>
+          <button onClick={() => queryClient.clear()}>clear</button>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <Page />)
+    fireEvent.click(rendered.getByRole('button', { name: 'mutate' }))
+    await vi.advanceTimersByTimeAsync(1)
+    expect(rendered.getByText('data: ["saved"]')).toBeInTheDocument()
+
+    fireEvent.click(rendered.getByRole('button', { name: 'clear' }))
+    await vi.advanceTimersByTimeAsync(1)
+    expect(queryClient.getMutationCache().getAll()).toEqual([])
+    expect(rendered.getByText('data: []')).toBeInTheDocument()
   })
 
   it('should return variables after calling mutate', async () => {


### PR DESCRIPTION
## 🎯 Changes

`queryClient.clear()` empties the mutation cache, but `useMutationState()` can keep showing successful results and `useIsMutating()` can keep reporting pending mutations. `MutationCache.clear()` notifies synchronous subscribers before removing entries, so they read the old cache and see no change.

Clear the mutations and scopes before emitting removal events. Snapshot the removed mutations first so each receives its event and mutations added by a subscriber are preserved.

Adds four regression tests covering the cache seen by subscribers, mutations added during notification, and the two React hooks. All four failed before the fix.

Validation: all 682 query-core and 585 react-query tests pass, along with their TypeScript checks (5.6, 5.7, 5.8, 5.9, current, and 7.0), lint, builds, and package validation. The full `pnpm run test:pr --parallel=3` check also passed for 98 affected projects and their dependency tasks, including the other adapters and examples. Existing lint warnings are in unchanged files; the run also emitted non-fatal warnings about generated example tsconfig files.

Implemented and verified with AI assistance.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
