### PR TITLE
docs(react-query): link Start SSR integration guide

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -7,6 +7,8 @@ redirect_from:
 
 In this guide you'll learn how to use React Query with server rendering.
 
+For TanStack Start, use the [Start + TanStack Query guide](https://tanstack.com/start/latest/docs/framework/react/guide/tanstack-query) for its SSR integration, request-scoped QueryClient setup, and mutation invalidation example.
+
 See the guide on [Prefetching & Router Integration](./prefetching.md) for some background. You might also want to check out the [Performance & Request Waterfalls guide](./request-waterfalls.md) before that.
 
 For deeper examples on hydration + prefetching (including code splitting), see the [Dependent Queries & Code Splitting](./prefetching.md#dependent-queries-code-splitting) section.


### PR DESCRIPTION
## 🎯 Changes

Link the React SSR guide to the dedicated TanStack Start integration guide, covering request-scoped QueryClients, hydration, and mutation invalidation.

Depends on https://github.com/TanStack/router/pull/8372. Merge that guide first so the destination exists.

Validation: reviewed the destination source and formatted this two-line documentation change. Code tests do not apply.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for integrating server-side rendering with TanStack Start.
  - Linked readers to the Start and TanStack Query guide, including request-scoped query client setup and mutation invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->