### PR TITLE
test(solid-query/useQuery): move type assertions from the runtime test to 'test-d'

### DIFF
--- a/packages/solid-query/src/__tests__/useQuery.test-d.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test-d.tsx
@@ -146,6 +146,24 @@ describe('useQuery', () => {
   )
   expectTypeOf(testFuncStyle.data).toEqualTypeOf<boolean | undefined>()
 
+  it('should return the correct states for a successful query', () => {
+    const state = useQuery<string, Error>(() => ({
+      queryKey: key,
+      queryFn: () => Promise.resolve('test'),
+    }))
+
+    if (state.isPending) {
+      expectTypeOf(state.data).toEqualTypeOf<undefined>()
+      expectTypeOf(state.error).toEqualTypeOf<null>()
+    } else if (state.isLoadingError) {
+      expectTypeOf(state.data).toEqualTypeOf<undefined>()
+      expectTypeOf(state.error).toEqualTypeOf<Error>()
+    } else {
+      expectTypeOf(state.data).toEqualTypeOf<string>()
+      expectTypeOf(state.error).toEqualTypeOf<Error | null>()
+    }
+  })
+
   describe('initialData', () => {
     describe('Config object overload', () => {
       it('TData should always be defined when initialData is provided as an object', () => {

--- a/packages/solid-query/src/__tests__/useQuery.test.tsx
+++ b/packages/solid-query/src/__tests__/useQuery.test.tsx
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  expectTypeOf,
-  it,
-  vi,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ErrorBoundary,
   Match,
@@ -95,17 +87,6 @@ describe('useQuery', () => {
       createRenderEffect(() => {
         states.push({ ...state })
       })
-
-      if (state.isPending) {
-        expectTypeOf(state.data).toEqualTypeOf<undefined>()
-        expectTypeOf(state.error).toEqualTypeOf<null>()
-      } else if (state.isLoadingError) {
-        expectTypeOf(state.data).toEqualTypeOf<undefined>()
-        expectTypeOf(state.error).toEqualTypeOf<Error>()
-      } else {
-        expectTypeOf(state.data).toEqualTypeOf<string>()
-        expectTypeOf(state.error).toEqualTypeOf<Error | null>()
-      }
 
       return (
         <Switch fallback={<span>{state.data}</span>}>


### PR DESCRIPTION
## 🎯 Changes

`useQuery.test.tsx` asserted types inside the runtime test `should return the correct states for a successful query`. When such an assertion breaks, the failure is reported as a bare `file:line` with no test name, and the run still prints `Type Errors  no errors` — so the type test is not attributed to anything. `react-query`, `preact-query` and `vue-query` keep zero type assertions in their runtime test files and assert this in `test-d` instead.

This moves the six `expectTypeOf` calls into `useQuery.test-d.tsx` as a test of the same name, matching `react-query`'s layout. The runtime test keeps its rendering and state assertions; only the type assertions move, unchanged.

Both narrowing branches were checked by flipping the expected type (`<undefined>` in the `isPending` branch and `<string>` in the `else` branch): each now fails as `FAIL … > should return the correct states for a successful query`, naming the test.

Type/test-only — no runtime or published code is touched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added type-level coverage confirming that query results correctly narrow across pending, loading-error, and success states.
  - Updated existing query tests by moving compile-time state assertions into dedicated type tests.
  - Simplified test imports and removed redundant inline type assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->