### PR TITLE
test(svelte-query/createQuery): move type assertions from the runtime test to 'test-d'

### DIFF
--- a/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.svelte.test.ts
@@ -1,14 +1,6 @@
 import { fireEvent, render } from '@testing-library/svelte'
 import { flushSync } from 'svelte'
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  expectTypeOf,
-  it,
-  vi,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   QueryClient,
@@ -52,17 +44,6 @@ describe('createQuery', () => {
         }),
         () => queryClient,
       )
-
-      if (query.isPending) {
-        expectTypeOf(query.data).toEqualTypeOf<undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<null>()
-      } else if (query.isLoadingError) {
-        expectTypeOf(query.data).toEqualTypeOf<undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<Error>()
-      } else {
-        expectTypeOf(query.data).toEqualTypeOf<string>()
-        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
-      }
 
       expect(query).toEqual({
         data: undefined,

--- a/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
+++ b/packages/svelte-query/tests/createQuery/createQuery.test-d.ts
@@ -3,6 +3,25 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { createQuery, queryOptions } from '../../src/index.js'
 
 describe('createQuery', () => {
+  it('should return the correct states for a successful query', () => {
+    const key = queryKey()
+    const query = createQuery<string, Error>(() => ({
+      queryKey: key,
+      queryFn: () => Promise.resolve('test'),
+    }))
+
+    if (query.isPending) {
+      expectTypeOf(query.data).toEqualTypeOf<undefined>()
+      expectTypeOf(query.error).toEqualTypeOf<null>()
+    } else if (query.isLoadingError) {
+      expectTypeOf(query.data).toEqualTypeOf<undefined>()
+      expectTypeOf(query.error).toEqualTypeOf<Error>()
+    } else {
+      expectTypeOf(query.data).toEqualTypeOf<string>()
+      expectTypeOf(query.error).toEqualTypeOf<Error | null>()
+    }
+  })
+
   describe('initialData', () => {
     describe('Config object overload', () => {
       it('TData should always be defined when initialData is provided as an object', () => {


### PR DESCRIPTION
## 🎯 Changes

`createQuery.svelte.test.ts` asserted types inside the runtime test `should return the correct states for a successful query`. When such an assertion breaks, the failure is reported as a bare `file:line` with no test name, and the run still prints `Type Errors  no errors` — so the type test is not attributed to anything. `react-query`, `preact-query` and `vue-query` keep zero type assertions in their runtime test files and assert this in `test-d` instead.

This moves the six `expectTypeOf` calls into `createQuery.test-d.ts` as a test of the same name, matching `react-query`'s layout. The runtime test keeps its `toEqual` state assertions; only the type assertions move, unchanged.

Both narrowing branches were checked by flipping the expected type (`<undefined>` in the `isPending` branch and `<string>` in the `else` branch): each now fails as `FAIL … > should return the correct states for a successful query`, naming the test.

Type/test-only — no runtime or published code is touched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added type-level coverage for `createQuery` with explicitly defined data and error types.
  - Verified type behavior across pending, loading-error, and successful query states.
  - Simplified existing query tests by removing redundant runtime type assertions while preserving coverage through dedicated type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->