### PR TITLE
test(query-core/queryObserver): move 'select' type assertions from the runtime test to 'test-d'

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient, QueryObserver } from '..'
-import type { DefaultError } from '..'
+import type { DefaultError, QueryObserverResult } from '..'
 
 describe('queryObserver', () => {
   let queryClient: QueryClient
@@ -98,6 +98,36 @@ describe('queryObserver', () => {
       expectTypeOf(result.status).toEqualTypeOf<'success'>()
       expectTypeOf(result.isPlaceholderData).toEqualTypeOf<true>()
     }
+  })
+
+  describe('select', () => {
+    it('should infer the selected type in the subscribe callback', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => ({ count: 1 }),
+        select: (data) => ({ myCount: data.count }),
+      })
+
+      observer.subscribe((result) => {
+        expectTypeOf(result).toEqualTypeOf<
+          QueryObserverResult<{ myCount: number }>
+        >()
+      })
+    })
+
+    it('should infer the selected type from the refetch result', async () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => ({ count: 1 }),
+        select: (data) => ({ myCount: data.count }),
+      })
+
+      const observerResult = await observer.refetch()
+
+      expectTypeOf(observerResult.data).toEqualTypeOf<
+        { myCount: number } | undefined
+      >()
+    })
   })
 
   describe('placeholderData', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test.tsx
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  expectTypeOf,
-  it,
-  vi,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { queryKey, sleep } from '@tanstack/query-test-utils'
 import {
   QueryClient,
@@ -331,9 +323,6 @@ describe('queryObserver', () => {
     })
     let observerResult
     const unsubscribe = observer.subscribe((result) => {
-      expectTypeOf(result).toEqualTypeOf<
-        QueryObserverResult<{ myCount: number }>
-      >()
       observerResult = result
     })
     await vi.advanceTimersByTimeAsync(0)
@@ -349,9 +338,6 @@ describe('queryObserver', () => {
       select: (data) => ({ myCount: data.count }),
     })
     const observerResult = await observer.refetch()
-    expectTypeOf(observerResult.data).toEqualTypeOf<
-      { myCount: number } | undefined
-    >()
     expect(observerResult.data).toMatchObject({ myCount: 1 })
   })
 


### PR DESCRIPTION
## 🎯 Changes

Two runtime tests in `queryObserver.test.tsx` (`should be able to fetch with a selector` and `... using the fetch method`) also asserted types with `expectTypeOf`. When such an assertion breaks there, the failure is reported as a bare `file:line` with no test name, and the run still prints `Type Errors  no errors`, so it is not attributed to any test.

This moves those two assertions into a new `select` describe in `queryObserver.test-d.tsx`. Both runtime tests keep their `expect(...).toMatchObject(...)` assertions — only the type assertions move.

The existing `test-d` file had no `select` coverage, so these are the first type assertions there for a selected result type.

Each was checked by flipping the expected type (`{ myCount: number }` → `{ myCount: string }`); both now fail as `FAIL … > queryObserver > select > …`, naming the test.

Type/test-only — no runtime or published code is touched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added type coverage confirming that data transformations through `select` are correctly reflected in subscription callbacks and `refetch()` results.
  - Simplified runtime tests while retaining assertions for the returned data values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->