### PR TITLE
test(query-core/notifyManager): move 'batchCalls' signature type test to 'test-d'

### DIFF
--- a/packages/query-core/src/__tests__/notifyManager.test-d.tsx
+++ b/packages/query-core/src/__tests__/notifyManager.test-d.tsx
@@ -1,0 +1,22 @@
+import { assertType, describe, expectTypeOf, it } from 'vitest'
+import { createNotifyManager } from '../notifyManager'
+
+describe('notifyManager', () => {
+  it('typeDefs should catch proper signatures', () => {
+    const notifyManagerTest = createNotifyManager()
+
+    // we define some fn with its signature:
+    const fn: (a: string, b: number) => string = (a, b) => a + b
+
+    // now someFn expect to be called with args [a: string, b: number]
+    const someFn = notifyManagerTest.batchCalls(fn)
+
+    expectTypeOf(someFn).parameters.toEqualTypeOf<Parameters<typeof fn>>()
+    assertType<Parameters<typeof someFn>>(['im happy', 4])
+    assertType<Parameters<typeof someFn>>([
+      'im not happy',
+      // @ts-expect-error
+      false,
+    ])
+  })
+})

--- a/packages/query-core/src/__tests__/notifyManager.test.tsx
+++ b/packages/query-core/src/__tests__/notifyManager.test.tsx
@@ -1,13 +1,4 @@
-import {
-  afterEach,
-  assertType,
-  beforeEach,
-  describe,
-  expect,
-  expectTypeOf,
-  it,
-  vi,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { sleep } from '@tanstack/query-test-utils'
 import { createNotifyManager } from '../notifyManager'
 
@@ -77,24 +68,6 @@ describe('notifyManager', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(notifySpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('typeDefs should catch proper signatures', () => {
-    const notifyManagerTest = createNotifyManager()
-
-    // we define some fn with its signature:
-    const fn: (a: string, b: number) => string = (a, b) => a + b
-
-    // now someFn expect to be called with args [a: string, b: number]
-    const someFn = notifyManagerTest.batchCalls(fn)
-
-    expectTypeOf(someFn).parameters.toEqualTypeOf<Parameters<typeof fn>>()
-    assertType<Parameters<typeof someFn>>(['im happy', 4])
-    assertType<Parameters<typeof someFn>>([
-      'im not happy',
-      // @ts-expect-error
-      false,
-    ])
   })
 
   it('should use custom batch notify function', async () => {


### PR DESCRIPTION
## 🎯 Changes

`typeDefs should catch proper signatures` in `notifyManager.test.tsx` is a type-only test — it has no runtime `expect()` at all, only `expectTypeOf`, `assertType` and a `@ts-expect-error`. Living in a runtime test file, a broken assertion there is reported as a bare `file:line` with no test name while the run still prints `Type Errors  no errors`.

This moves the test unchanged into a new `notifyManager.test-d.tsx`, following the `X.ts` → `X.test.tsx` + `X.test-d.tsx` layout that `queryObserver`, `queryClient`, `mutation`, `infiniteQueryObserver` and `utils` already use in this package.

Verified two ways:

- Flipping the expected parameters (`Parameters<typeof fn>` → `[a: number, b: number]`) now fails as `FAIL … > notifyManager > typeDefs should catch proper signatures`, naming the test.
- The `@ts-expect-error` is genuinely checked after the move: changing the offending argument to a valid one reports `TypeCheckError: Unused '@ts-expect-error' directive`, which did not surface while the test lived in the runtime file.

Type/test-only — no runtime or published code is touched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added compile-time coverage to verify that batched notification callbacks preserve their parameter types.
  - Retained runtime coverage for notification and batching behavior while streamlining related test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->