### PR TITLE
test(query-core/notifyManager): add type tests for its batching, scheduling and configuration API

### DIFF
--- a/packages/query-core/src/__tests__/notifyManager.test-d.tsx
+++ b/packages/query-core/src/__tests__/notifyManager.test-d.tsx
@@ -1,22 +1,167 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
-import { createNotifyManager } from '../notifyManager'
+import {
+  createNotifyManager,
+  defaultScheduler,
+  notifyManager,
+} from '../notifyManager'
 
 describe('notifyManager', () => {
-  it('typeDefs should catch proper signatures', () => {
-    const notifyManagerTest = createNotifyManager()
+  it('should expose the same type as the factory', () => {
+    expectTypeOf(notifyManager).toEqualTypeOf<
+      ReturnType<typeof createNotifyManager>
+    >()
+  })
 
-    // we define some fn with its signature:
-    const fn: (a: string, b: number) => string = (a, b) => a + b
+  describe('batch', () => {
+    it('should pass the return type of the callback through', () => {
+      const notifyManagerTest = createNotifyManager()
 
-    // now someFn expect to be called with args [a: string, b: number]
-    const someFn = notifyManagerTest.batchCalls(fn)
+      expectTypeOf(notifyManagerTest.batch(() => 5)).toEqualTypeOf<number>()
+      expectTypeOf(
+        notifyManagerTest.batch(() => 'im happy' as const),
+      ).toEqualTypeOf<'im happy'>()
+      expectTypeOf(notifyManagerTest.batch(() => ({ a: 1 }))).toEqualTypeOf<{
+        a: number
+      }>()
+    })
 
-    expectTypeOf(someFn).parameters.toEqualTypeOf<Parameters<typeof fn>>()
-    assertType<Parameters<typeof someFn>>(['im happy', 4])
-    assertType<Parameters<typeof someFn>>([
-      'im not happy',
-      // @ts-expect-error
-      false,
-    ])
+    it('should be void when the callback returns nothing', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(notifyManagerTest.batch(() => {})).toEqualTypeOf<void>()
+    })
+  })
+
+  describe('batchCalls', () => {
+    it('typeDefs should catch proper signatures', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      // we define some fn with its signature:
+      const fn: (a: string, b: number) => string = (a, b) => a + b
+
+      // now someFn expect to be called with args [a: string, b: number]
+      const someFn = notifyManagerTest.batchCalls(fn)
+
+      expectTypeOf(someFn).parameters.toEqualTypeOf<Parameters<typeof fn>>()
+      assertType<Parameters<typeof someFn>>(['im happy', 4])
+      assertType<Parameters<typeof someFn>>([
+        'im not happy',
+        // @ts-expect-error
+        false,
+      ])
+    })
+
+    it('should discard the return type of the wrapped function', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      const fn: (a: string) => string = (a) => a
+      const someFn = notifyManagerTest.batchCalls(fn)
+
+      expectTypeOf(someFn).returns.toEqualTypeOf<void>()
+    })
+
+    it('should accept a callback without parameters', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      const someFn = notifyManagerTest.batchCalls(() => {})
+
+      expectTypeOf(someFn).parameters.toEqualTypeOf<[]>()
+    })
+
+    it('should preserve optional parameters', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      const someFn = notifyManagerTest.batchCalls(
+        (_a: string, _b?: number) => {},
+      )
+
+      expectTypeOf(someFn).parameters.toEqualTypeOf<[_a: string, _b?: number]>()
+    })
+
+    it('should preserve rest parameters', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      const someFn = notifyManagerTest.batchCalls(
+        (..._args: Array<number>) => {},
+      )
+
+      expectTypeOf(someFn).parameters.toEqualTypeOf<Array<number>>()
+    })
+  })
+
+  describe('schedule', () => {
+    it('should only accept a callback taking no arguments', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(notifyManagerTest.schedule).parameters.toEqualTypeOf<
+        [callback: () => void]
+      >()
+    })
+
+    it('should return void', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(notifyManagerTest.schedule).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('setNotifyFunction', () => {
+    it('should only accept a function taking a callback', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(
+        notifyManagerTest.setNotifyFunction,
+      ).parameters.toEqualTypeOf<[fn: (callback: () => void) => void]>()
+    })
+
+    it('should return void', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(
+        notifyManagerTest.setNotifyFunction,
+      ).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('setBatchNotifyFunction', () => {
+    it('should only accept a function taking a callback', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(
+        notifyManagerTest.setBatchNotifyFunction,
+      ).parameters.toEqualTypeOf<[fn: (callback: () => void) => void]>()
+    })
+
+    it('should return void', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(
+        notifyManagerTest.setBatchNotifyFunction,
+      ).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('setScheduler', () => {
+    it('should only accept a function taking a callback', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(notifyManagerTest.setScheduler).parameters.toEqualTypeOf<
+        [fn: (callback: () => void) => void]
+      >()
+    })
+
+    it('should accept the exported defaultScheduler', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(defaultScheduler).toEqualTypeOf<
+        Parameters<typeof notifyManagerTest.setScheduler>[0]
+      >()
+    })
+
+    it('should return void', () => {
+      const notifyManagerTest = createNotifyManager()
+
+      expectTypeOf(notifyManagerTest.setScheduler).returns.toEqualTypeOf<void>()
+    })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

`notifyManager.test-d.tsx` covered a single `batchCalls` signature. This fills in the rest of the module's public surface, one `describe` per member in source order, the way `mutation.test-d.tsx` groups `onMutate` and `MutateFunction`. Each added test makes one assertion about one member.

**`batch`** — previously untested. Its JSDoc states "The return value of `callback` is passed through", so this asserts the return type propagates (`number`, a literal, an object) and is `void` when the callback returns nothing.

**`batchCalls`** — the existing test is unchanged; four cases are added:

- the wrapped function's return type is discarded (`BatchCallsCallback` returns `void`)
- a callback with no parameters stays parameterless
- optional parameters keep their optionality
- rest parameters are preserved

**`schedule`** — previously untested, though it is the member adapters call most directly (`react-query` / `preact-query` `useMutationState`, `query-persist-client-core`'s `createPersister`).

**`setNotifyFunction`, `setBatchNotifyFunction`, `setScheduler`** — previously untested. All three are documented as public API in every framework's reference page (`docs/framework/*/reference/variables/notifyManager.md`) and are what the adapter `test-setup.ts` files call to wrap notifications in `act`. Their `=> void` return is declared in those docs but only inferred in the source, so it is asserted alongside the parameter type. `setScheduler` additionally accepts the exported `defaultScheduler`.

Finally, the exported `notifyManager` singleton is asserted to have the same type as `createNotifyManager()`, which is the form adapters actually consume.

Every case was checked against a deliberately broken implementation rather than only a flipped expectation:

| Implementation change | Caught by |
| --- | --- |
| `batch: <T>(cb: () => T): T` → `: void`, `: T \| undefined`, or the generic dropped | `batch > should pass the return type of the callback through` |
| `BatchCallsCallback` → `(...args: T) => unknown` | `batchCalls > should discard the return type of the wrapped function` |
| `batchCalls: <T extends Array<unknown>>` → `Array<string>` | `typeDefs …`, `… optional parameters`, `… rest parameters` |
| `batchCalls(callback: BatchCallsCallback<T>)` → `(...args: any) => void` | the four `batchCalls` parameter tests |
| `schedule(callback: NotifyCallback)` → `(callback: any)`, or `NotifyCallback` taking arguments | `schedule > should only accept a callback taking no arguments` |
| `schedule` return → `unknown` | `schedule > should return void` |
| any setter's `fn` → `any`, or its `NotifyFunction` / `BatchNotifyFunction` / `ScheduleFunction` alias changed | that setter's `should only accept a function taking a callback` |
| any setter's return → `unknown` | that setter's `should return void` |
| `defaultScheduler: ScheduleFunction` → `any`, or its `export` removed | `setScheduler > should accept the exported defaultScheduler` |
| removing `batch`, `batchCalls`, `schedule` or any setter from the returned object | the tests for that member |
| singleton narrowed to a partial type | `should expose the same type as the factory` |

Type tests only — no runtime or published code is touched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).