### PR TITLE
test(query-core/queryObserver): add type tests for its public surface

### DIFF
--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -11,6 +11,7 @@ import type {
   QueryObserverBaseResult,
   QueryObserverOptions,
   QueryObserverResult,
+  QueryPersister,
   QueryStatus,
   RefetchOptions,
 } from '..'
@@ -665,6 +666,14 @@ describe('queryObserver', () => {
           NonNullable<QueryObserverOptions<{ value: string }>['persister']>
         >().returns.toEqualTypeOf<
           { value: string } | Promise<{ value: string }>
+        >()
+      })
+
+      it('should differ from the persister of a paged query', () => {
+        expectTypeOf<
+          QueryPersister<{ value: string }, ReadonlyArray<unknown>, never>
+        >().not.toEqualTypeOf<
+          QueryPersister<{ value: string }, ReadonlyArray<unknown>, number>
         >()
       })
     })

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -622,6 +622,62 @@ describe('queryObserver', () => {
         }
       })
     })
+
+    describe('discriminants', () => {
+      it('should fix isPending to true on the pending branch', () => {
+        type Pending = Extract<
+          QueryObserverResult<{ value: string }>,
+          { status: 'pending'; isLoading: boolean }
+        >
+
+        expectTypeOf<Pending['isPending']>().toEqualTypeOf<true>()
+      })
+
+      it('should fix isLoading to true on the loading branch', () => {
+        type Loading = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isLoading: true }
+        >
+
+        expectTypeOf<Loading['isLoading']>().toEqualTypeOf<true>()
+      })
+
+      it('should fix isSuccess to true on the success branch', () => {
+        type Success = Extract<
+          QueryObserverResult<{ value: string }>,
+          { status: 'success'; isPlaceholderData: false }
+        >
+
+        expectTypeOf<Success['isSuccess']>().toEqualTypeOf<true>()
+      })
+
+      it('should fix isPlaceholderData to true on the placeholder branch', () => {
+        type Placeholder = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isPlaceholderData: true }
+        >
+
+        expectTypeOf<Placeholder['isPlaceholderData']>().toEqualTypeOf<true>()
+      })
+
+      it('should fix isLoadingError to true on the loading error branch', () => {
+        type LoadingError = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isLoadingError: true }
+        >
+
+        expectTypeOf<LoadingError['isLoadingError']>().toEqualTypeOf<true>()
+      })
+
+      it('should fix isRefetchError to true on the refetch error branch', () => {
+        type RefetchError = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isRefetchError: true }
+        >
+
+        expectTypeOf<RefetchError['isRefetchError']>().toEqualTypeOf<true>()
+      })
+    })
   })
 
   describe('setOptions', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -672,8 +672,59 @@ describe('queryObserver', () => {
 
   describe('QueryObserverResult', () => {
     describe('QueryObserverBaseResult', () => {
-      describe('timestamps and counters', () => {
-        it('should type its timestamps and counters as numbers', () => {
+      it('should keep every property writable', () => {
+        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
+
+        expectTypeOf<Base>().toEqualTypeOf<{
+          -readonly [K in keyof Base]: Base[K]
+        }>()
+      })
+
+      it('should keep every property of each result branch writable', () => {
+        type Writable<T> = { -readonly [K in keyof T]: T[K] }
+        type Branch<TFilter> = Extract<
+          QueryObserverResult<{ value: string }, CustomError>,
+          TFilter
+        >
+
+        expectTypeOf<
+          Branch<{ status: 'pending'; isLoading: boolean }>
+        >().toEqualTypeOf<
+          Writable<Branch<{ status: 'pending'; isLoading: boolean }>>
+        >()
+        expectTypeOf<Branch<{ isLoading: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isLoading: true }>>
+        >()
+        expectTypeOf<Branch<{ isSuccess: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isSuccess: true }>>
+        >()
+        expectTypeOf<Branch<{ isLoadingError: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isLoadingError: true }>>
+        >()
+        expectTypeOf<Branch<{ isRefetchError: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isRefetchError: true }>>
+        >()
+        expectTypeOf<Branch<{ isPlaceholderData: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isPlaceholderData: true }>>
+        >()
+      })
+
+      it('should always declare data and refetch', () => {
+        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
+        type OptionalKeys = {
+          [K in keyof Base]-?: {} extends Pick<Base, K> ? K : never
+        }[keyof Base]
+
+        expectTypeOf<
+          'data' extends OptionalKeys ? true : false
+        >().toEqualTypeOf<false>()
+        expectTypeOf<
+          'refetch' extends OptionalKeys ? true : false
+        >().toEqualTypeOf<false>()
+      })
+
+      describe('dataUpdatedAt', () => {
+        it('should be typed as a number', () => {
           const observer = new QueryObserver(queryClient, {
             queryKey: queryKey(),
             queryFn: () => Promise.resolve({ value: 'data' }),
@@ -682,14 +733,50 @@ describe('queryObserver', () => {
           const result = observer.getCurrentResult()
 
           expectTypeOf(result.dataUpdatedAt).toEqualTypeOf<number>()
+        })
+      })
+
+      describe('errorUpdatedAt', () => {
+        it('should be typed as a number', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.errorUpdatedAt).toEqualTypeOf<number>()
+        })
+      })
+
+      describe('failureCount', () => {
+        it('should be typed as a number', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.failureCount).toEqualTypeOf<number>()
+        })
+      })
+
+      describe('errorUpdateCount', () => {
+        it('should be typed as a number', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.errorUpdateCount).toEqualTypeOf<number>()
         })
       })
 
-      describe('state flags', () => {
-        it('should type its state flags as booleans', () => {
+      describe('isFetching', () => {
+        it('should be typed as a boolean', () => {
           const observer = new QueryObserver(queryClient, {
             queryKey: queryKey(),
             queryFn: () => Promise.resolve({ value: 'data' }),
@@ -698,110 +785,181 @@ describe('queryObserver', () => {
           const result = observer.getCurrentResult()
 
           expectTypeOf(result.isFetching).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isRefetching', () => {
+        it('should be typed as a boolean', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.isRefetching).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isPaused', () => {
+        it('should be typed as a boolean', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.isPaused).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isStale', () => {
+        it('should be typed as a boolean', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.isStale).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isEnabled', () => {
+        it('should be typed as a boolean', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.isEnabled).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isFetched', () => {
+        it('should be typed as a boolean', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isFetchedAfterMount', () => {
+        it('should be typed as a boolean', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isInitialLoading', () => {
+        it('should be typed as a boolean', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
           expectTypeOf(result.isInitialLoading).toEqualTypeOf<boolean>()
         })
       })
 
       describe('data', () => {
-        it('should type data from the observed data type on the base result', () => {
+        it('should be typed from the observed data type', () => {
           expectTypeOf<
             QueryObserverBaseResult<{ value: string }, CustomError>['data']
           >().toEqualTypeOf<{ value: string } | undefined>()
         })
-
-        it('should keep every property of the base result writable', () => {
-          type Base = QueryObserverBaseResult<{ value: string }, CustomError>
-
-          expectTypeOf<Base>().toEqualTypeOf<{
-            -readonly [K in keyof Base]: Base[K]
-          }>()
-        })
-
-        it('should keep every property of each result branch writable', () => {
-          type Writable<T> = { -readonly [K in keyof T]: T[K] }
-          type Branch<TFilter> = Extract<
-            QueryObserverResult<{ value: string }, CustomError>,
-            TFilter
-          >
-
-          expectTypeOf<
-            Branch<{ status: 'pending'; isLoading: boolean }>
-          >().toEqualTypeOf<
-            Writable<Branch<{ status: 'pending'; isLoading: boolean }>>
-          >()
-          expectTypeOf<Branch<{ isLoading: true }>>().toEqualTypeOf<
-            Writable<Branch<{ isLoading: true }>>
-          >()
-          expectTypeOf<Branch<{ isSuccess: true }>>().toEqualTypeOf<
-            Writable<Branch<{ isSuccess: true }>>
-          >()
-          expectTypeOf<Branch<{ isLoadingError: true }>>().toEqualTypeOf<
-            Writable<Branch<{ isLoadingError: true }>>
-          >()
-          expectTypeOf<Branch<{ isRefetchError: true }>>().toEqualTypeOf<
-            Writable<Branch<{ isRefetchError: true }>>
-          >()
-          expectTypeOf<Branch<{ isPlaceholderData: true }>>().toEqualTypeOf<
-            Writable<Branch<{ isPlaceholderData: true }>>
-          >()
-        })
-
-        it('should always declare data and refetch on the base result', () => {
-          type Base = QueryObserverBaseResult<{ value: string }, CustomError>
-          type OptionalKeys = {
-            [K in keyof Base]-?: {} extends Pick<Base, K> ? K : never
-          }[keyof Base]
-
-          expectTypeOf<
-            'data' extends OptionalKeys ? true : false
-          >().toEqualTypeOf<false>()
-          expectTypeOf<
-            'refetch' extends OptionalKeys ? true : false
-          >().toEqualTypeOf<false>()
-        })
       })
 
       describe('error', () => {
-        it('should type error from the observed error type on the base result', () => {
+        it('should be typed from the observed error type', () => {
           expectTypeOf<
             QueryObserverBaseResult<{ value: string }, CustomError>['error']
           >().toEqualTypeOf<CustomError | null>()
         })
 
-        it('should default the error type of the base result', () => {
+        it('should default to the default error type', () => {
           expectTypeOf<
             QueryObserverBaseResult<{ value: string }>['error']
           >().toEqualTypeOf<DefaultError | null>()
         })
       })
 
-      describe('discriminant flags', () => {
-        it('should type them as booleans on the base result', () => {
-          type Base = QueryObserverBaseResult<{ value: string }, CustomError>
-
-          expectTypeOf<Base['isPending']>().toEqualTypeOf<boolean>()
-          expectTypeOf<Base['isSuccess']>().toEqualTypeOf<boolean>()
-          expectTypeOf<Base['isError']>().toEqualTypeOf<boolean>()
-          expectTypeOf<Base['isLoadingError']>().toEqualTypeOf<boolean>()
-          expectTypeOf<Base['isRefetchError']>().toEqualTypeOf<boolean>()
-          expectTypeOf<Base['isPlaceholderData']>().toEqualTypeOf<boolean>()
-        })
-
-        it('should type status as the query status union on the base result', () => {
+      describe('isPending', () => {
+        it('should be typed as a boolean', () => {
           expectTypeOf<
-            QueryObserverBaseResult<{ value: string }, CustomError>['status']
-          >().toEqualTypeOf<'pending' | 'error' | 'success'>()
+            QueryObserverBaseResult<{ value: string }, CustomError>['isPending']
+          >().toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isSuccess', () => {
+        it('should be typed as a boolean', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<{ value: string }, CustomError>['isSuccess']
+          >().toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isError', () => {
+        it('should be typed as a boolean', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<{ value: string }, CustomError>['isError']
+          >().toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isLoadingError', () => {
+        it('should be typed as a boolean', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<
+              { value: string },
+              CustomError
+            >['isLoadingError']
+          >().toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isRefetchError', () => {
+        it('should be typed as a boolean', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<
+              { value: string },
+              CustomError
+            >['isRefetchError']
+          >().toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('isPlaceholderData', () => {
+        it('should be typed as a boolean', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<
+              { value: string },
+              CustomError
+            >['isPlaceholderData']
+          >().toEqualTypeOf<boolean>()
         })
       })
 
       describe('failureReason', () => {
-        it('should type failureReason from the error type', () => {
+        it('should be typed from the observed error type', () => {
           const observer = new QueryObserver<boolean, CustomError>(
             queryClient,
             {
@@ -816,7 +974,7 @@ describe('queryObserver', () => {
       })
 
       describe('refetch', () => {
-        it('should type its refetch from the observed types', () => {
+        it('should be typed from the observed types', () => {
           const observer = new QueryObserver(queryClient, {
             queryKey: queryKey(),
             queryFn: () => Promise.resolve({ value: 'data' }),
@@ -829,7 +987,7 @@ describe('queryObserver', () => {
           >()
         })
 
-        it('should only accept RefetchOptions in its refetch', () => {
+        it('should only accept RefetchOptions', () => {
           const observer = new QueryObserver(queryClient, {
             queryKey: queryKey(),
             queryFn: () => Promise.resolve({ value: 'data' }),
@@ -842,7 +1000,7 @@ describe('queryObserver', () => {
       })
 
       describe('status', () => {
-        it('should type status as the query status union', () => {
+        it('should be typed as the query status union', () => {
           const observer = new QueryObserver(queryClient, {
             queryKey: queryKey(),
             queryFn: () => Promise.resolve({ value: 'data' }),
@@ -855,10 +1013,16 @@ describe('queryObserver', () => {
             'pending' | 'error' | 'success'
           >()
         })
+
+        it('should be typed as the query status union on the base result', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<{ value: string }, CustomError>['status']
+          >().toEqualTypeOf<'pending' | 'error' | 'success'>()
+        })
       })
 
       describe('fetchStatus', () => {
-        it('should type fetchStatus as the fetch status union', () => {
+        it('should be typed as the fetch status union', () => {
           const observer = new QueryObserver(queryClient, {
             queryKey: queryKey(),
             queryFn: () => Promise.resolve({ value: 'data' }),

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1,7 +1,24 @@
 import { afterEach, beforeEach, describe, expectTypeOf, it } from 'vitest'
 import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient, QueryObserver } from '..'
-import type { DefaultError, QueryObserverResult } from '..'
+import type {
+  DefaultError,
+  FetchStatus,
+  InitialDataFunction,
+  NetworkMode,
+  NotifyOnChangeProps,
+  PlaceholderDataFunction,
+  QueryMeta,
+  QueryObserverOptions,
+  QueryObserverResult,
+  QueryPersister,
+  QueryStatus,
+  RefetchOptions,
+} from '..'
+
+class CustomError extends Error {
+  name = 'CustomError' as const
+}
 
 describe('queryObserver', () => {
   let queryClient: QueryClient
@@ -100,7 +117,856 @@ describe('queryObserver', () => {
     }
   })
 
+  describe('the result', () => {
+    it('should type dataUpdatedAt as a number', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().dataUpdatedAt,
+      ).toEqualTypeOf<number>()
+    })
+
+    it('should type errorUpdatedAt as a number', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().errorUpdatedAt,
+      ).toEqualTypeOf<number>()
+    })
+
+    it('should type failureCount as a number', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().failureCount,
+      ).toEqualTypeOf<number>()
+    })
+
+    it('should type errorUpdateCount as a number', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().errorUpdateCount,
+      ).toEqualTypeOf<number>()
+    })
+
+    it('should type isFetching as a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().isFetching,
+      ).toEqualTypeOf<boolean>()
+    })
+
+    it('should type isRefetching as a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().isRefetching,
+      ).toEqualTypeOf<boolean>()
+    })
+
+    it('should type isPaused as a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().isPaused,
+      ).toEqualTypeOf<boolean>()
+    })
+
+    it('should type isStale as a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.getCurrentResult().isStale).toEqualTypeOf<boolean>()
+    })
+
+    it('should type isEnabled as a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().isEnabled,
+      ).toEqualTypeOf<boolean>()
+    })
+
+    it('should type isFetched as a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().isFetched,
+      ).toEqualTypeOf<boolean>()
+    })
+
+    it('should type isFetchedAfterMount as a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().isFetchedAfterMount,
+      ).toEqualTypeOf<boolean>()
+    })
+
+    it('should type failureReason from the error type', () => {
+      const observer = new QueryObserver<boolean, CustomError>(queryClient, {
+        queryKey: queryKey(),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().failureReason,
+      ).toEqualTypeOf<CustomError | null>()
+    })
+
+    it('should type its refetch from the observed types', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.getCurrentResult().refetch).returns.toEqualTypeOf<
+        Promise<QueryObserverResult<{ value: string }, DefaultError>>
+      >()
+    })
+
+    it('should only accept RefetchOptions in its refetch', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().refetch,
+      ).parameters.toEqualTypeOf<[options?: RefetchOptions]>()
+    })
+
+    it('should type status as the query status union', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().status,
+      ).toEqualTypeOf<QueryStatus>()
+    })
+
+    it('should type fetchStatus as the fetch status union', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().fetchStatus,
+      ).toEqualTypeOf<FetchStatus>()
+    })
+  })
+
+  describe('narrowing the result', () => {
+    it('should narrow error to the error type on an isError check', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const result = observer.getCurrentResult()
+
+      if (result.isError) {
+        expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+      }
+    })
+
+    it('should keep data possibly undefined on an isError check', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const result = observer.getCurrentResult()
+
+      if (result.isError) {
+        expectTypeOf(result.data).toEqualTypeOf<{ value: string } | undefined>()
+      }
+    })
+
+    it('should narrow data to be defined on a success status check', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const result = observer.getCurrentResult()
+
+      if (result.status === 'success') {
+        expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
+      }
+    })
+
+    it('should narrow error to the error type on an error status check', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const result = observer.getCurrentResult()
+
+      if (result.status === 'error') {
+        expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+      }
+    })
+
+    it('should narrow data to undefined on a pending status check', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const result = observer.getCurrentResult()
+
+      if (result.status === 'pending') {
+        expectTypeOf(result.data).toEqualTypeOf<undefined>()
+      }
+    })
+  })
+
+  describe('setOptions', () => {
+    it('should keep the observed data type in the options it is given', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      observer.setOptions({
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        select: (data) => {
+          expectTypeOf(data).toEqualTypeOf<{ value: string }>()
+          return data
+        },
+      })
+
+      observer.setOptions({
+        queryKey: queryKey(),
+        // @ts-expect-error the queryFn must return the observed data type
+        queryFn: () => 42,
+      })
+    })
+  })
+
+  describe('the options', () => {
+    it('should type the queryKey given to the queryFn', () => {
+      const key = ['a', 1] as const
+
+      new QueryObserver(queryClient, {
+        queryKey: key,
+        queryFn: (context) => {
+          expectTypeOf(context.queryKey).toEqualTypeOf<readonly ['a', 1]>()
+          return Promise.resolve('data')
+        },
+      })
+    })
+
+    it('should type the signal given to the queryFn', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: (context) => {
+          expectTypeOf(context.signal).toEqualTypeOf<AbortSignal>()
+          return Promise.resolve('data')
+        },
+      })
+    })
+
+    it('should type the client given to the queryFn', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: (context) => {
+          expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
+          return Promise.resolve('data')
+        },
+      })
+    })
+
+    it('should type the query given to an enabled callback', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        enabled: (query) => {
+          expectTypeOf(query.state.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+          return true
+        },
+      })
+    })
+
+    it('should type the query given to a staleTime callback', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        staleTime: (query) => {
+          expectTypeOf(query.state.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+          return 0
+        },
+      })
+    })
+
+    it('should type the query given to a refetchInterval callback', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        refetchInterval: (query) => {
+          expectTypeOf(query.state.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+          return false
+        },
+      })
+    })
+
+    it('should type the query given to a refetchOnWindowFocus callback', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        refetchOnWindowFocus: (query) => {
+          expectTypeOf(query.state.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+          return true
+        },
+      })
+    })
+
+    it('should type the query given to a refetchOnReconnect callback', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        refetchOnReconnect: (query) => {
+          expectTypeOf(query.state.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+          return true
+        },
+      })
+    })
+
+    it('should type the query given to a refetchOnMount callback', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        refetchOnMount: (query) => {
+          expectTypeOf(query.state.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+          return true
+        },
+      })
+    })
+
+    it('should type the query given to a retryOnMount callback', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        retryOnMount: (query) => {
+          expectTypeOf(query.state.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+          return true
+        },
+      })
+    })
+
+    it('should type persister from the queryFn data', () => {
+      expectTypeOf<
+        QueryObserverOptions<{ value: string }>['persister']
+      >().toEqualTypeOf<
+        | QueryPersister<{ value: string }, ReadonlyArray<unknown>, never>
+        | undefined
+      >()
+    })
+
+    it('should type meta as its named type', () => {
+      expectTypeOf<QueryObserverOptions['meta']>().toEqualTypeOf<
+        QueryMeta | undefined
+      >()
+    })
+
+    it('should type notifyOnChangeProps as its named type', () => {
+      expectTypeOf<QueryObserverOptions['notifyOnChangeProps']>().toEqualTypeOf<
+        NotifyOnChangeProps | undefined
+      >()
+    })
+
+    it('should type the error given to a throwOnError callback', () => {
+      new QueryObserver<{ value: string }, CustomError>(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        throwOnError: (error) => {
+          expectTypeOf(error).toEqualTypeOf<CustomError>()
+          return false
+        },
+      })
+    })
+
+    it('should type suspense as a boolean', () => {
+      expectTypeOf<QueryObserverOptions['suspense']>().toEqualTypeOf<
+        boolean | undefined
+      >()
+    })
+
+    it('should type refetchIntervalInBackground as a boolean', () => {
+      expectTypeOf<
+        QueryObserverOptions['refetchIntervalInBackground']
+      >().toEqualTypeOf<boolean | undefined>()
+    })
+
+    it('should reject a non-number gcTime', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve('data'),
+        // @ts-expect-error gcTime must be a number
+        gcTime: 'nope',
+      })
+
+      expectTypeOf<QueryObserverOptions['gcTime']>().toEqualTypeOf<
+        number | undefined
+      >()
+    })
+
+    it('should type networkMode as the network mode union', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve('data'),
+        // @ts-expect-error networkMode must be one of the NetworkMode values
+        networkMode: 'nope',
+      })
+
+      expectTypeOf<QueryObserverOptions['networkMode']>().toEqualTypeOf<
+        NetworkMode | undefined
+      >()
+    })
+
+    it('should reject a non-string queryHash', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve('data'),
+        // @ts-expect-error queryHash must be a string
+        queryHash: 42,
+      })
+
+      expectTypeOf<QueryObserverOptions['queryHash']>().toEqualTypeOf<
+        string | undefined
+      >()
+    })
+
+    it('should accept a function for initialDataUpdatedAt', () => {
+      expectTypeOf<
+        QueryObserverOptions['initialDataUpdatedAt']
+      >().toEqualTypeOf<number | (() => number | undefined) | undefined>()
+    })
+
+    it('should type the error given to a retry callback', () => {
+      new QueryObserver<boolean, CustomError>(queryClient, {
+        queryKey: queryKey(),
+        retry: (_failureCount, error) => {
+          expectTypeOf(error).toEqualTypeOf<CustomError>()
+          return false
+        },
+      })
+    })
+
+    it('should type the error given to a retryDelay callback', () => {
+      new QueryObserver<boolean, CustomError>(queryClient, {
+        queryKey: queryKey(),
+        retryDelay: (_failureCount, error) => {
+          expectTypeOf(error).toEqualTypeOf<CustomError>()
+          return 0
+        },
+      })
+    })
+
+    it('should type the queryKey given to a queryKeyHashFn', () => {
+      const key = ['a', 1] as const
+
+      new QueryObserver(queryClient, {
+        queryKey: key,
+        queryFn: () => Promise.resolve('data'),
+        queryKeyHashFn: (queryKeyToHash) => {
+          expectTypeOf(queryKeyToHash).toEqualTypeOf<readonly ['a', 1]>()
+          return 'hash'
+        },
+      })
+    })
+
+    it('should type an initialData function from the data type', () => {
+      expectTypeOf<
+        InitialDataFunction<{ value: string }>
+      >().returns.toEqualTypeOf<{ value: string } | undefined>()
+    })
+
+    it('should type a structuralSharing callback as unknown', () => {
+      new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        structuralSharing: (_oldData, newData) => {
+          expectTypeOf(newData).toEqualTypeOf<unknown>()
+          return newData
+        },
+      })
+    })
+  })
+
+  describe('destroy', () => {
+    it('should return void', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.destroy).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('updateResult', () => {
+    it('should return void', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.updateResult).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('onQueryUpdate', () => {
+    it('should return void', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.onQueryUpdate).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('shouldFetchOnReconnect', () => {
+    it('should return a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.shouldFetchOnReconnect,
+      ).returns.toEqualTypeOf<boolean>()
+    })
+  })
+
+  describe('shouldFetchOnWindowFocus', () => {
+    it('should return a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.shouldFetchOnWindowFocus,
+      ).returns.toEqualTypeOf<boolean>()
+    })
+  })
+
+  describe('trackProp', () => {
+    it('should only accept a key of the result', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.trackProp).parameters.toEqualTypeOf<
+        [key: keyof QueryObserverResult]
+      >()
+    })
+  })
+
+  describe('getOptimisticResult', () => {
+    it('should be typed from the options it is given', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const options = queryClient.defaultQueryOptions({
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.getOptimisticResult(options)).toEqualTypeOf<
+        QueryObserverResult<{ value: string }, DefaultError>
+      >()
+    })
+
+    it('should use the error type given to the observer', () => {
+      const observer = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      const options = queryClient.defaultQueryOptions<
+        { value: string },
+        CustomError
+      >({
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getOptimisticResult(options).error,
+      ).toEqualTypeOf<CustomError | null>()
+    })
+  })
+
+  describe('getCurrentResult', () => {
+    it('should be typed from the queryFn', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.getCurrentResult()).toEqualTypeOf<
+        QueryObserverResult<{ value: string }, DefaultError>
+      >()
+    })
+
+    it('should use the error type given to the observer', () => {
+      const observer = new QueryObserver<boolean, CustomError>(queryClient, {
+        queryKey: queryKey(),
+      })
+
+      expectTypeOf(
+        observer.getCurrentResult().error,
+      ).toEqualTypeOf<CustomError | null>()
+    })
+  })
+
+  describe('trackResult', () => {
+    it('should return the same result type it is given', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.trackResult(observer.getCurrentResult()),
+      ).toEqualTypeOf<QueryObserverResult<{ value: string }, DefaultError>>()
+    })
+
+    it('should use the error type given to the observer', () => {
+      const observer = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      expectTypeOf(
+        observer.trackResult(observer.getCurrentResult()).error,
+      ).toEqualTypeOf<CustomError | null>()
+    })
+
+    it('should type the tracked property in the onPropTracked callback', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      observer.trackResult(observer.getCurrentResult(), (key) => {
+        expectTypeOf(key).toEqualTypeOf<keyof QueryObserverResult>()
+      })
+    })
+  })
+
+  describe('getCurrentQuery', () => {
+    it('should carry the data type into the query state', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.getCurrentQuery().state.data).toEqualTypeOf<
+        { value: string } | undefined
+      >()
+    })
+
+    it('should carry the error type into the query state', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.getCurrentQuery().state.error,
+      ).toEqualTypeOf<DefaultError | null>()
+    })
+
+    it('should use the error type given to the observer', () => {
+      const observer = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      expectTypeOf(
+        observer.getCurrentQuery().state.error,
+      ).toEqualTypeOf<CustomError | null>()
+    })
+
+    it('should keep the data type from before select', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ count: 1 }),
+        select: (data) => data.count,
+      })
+
+      expectTypeOf(observer.getCurrentQuery().state.data).toEqualTypeOf<
+        { count: number } | undefined
+      >()
+    })
+
+    it('should preserve a literal queryKey', () => {
+      const key = ['a', 1] as const
+
+      const observer = new QueryObserver(queryClient, {
+        queryKey: key,
+        queryFn: () => Promise.resolve('data'),
+      })
+
+      expectTypeOf(observer.getCurrentQuery().queryKey).toEqualTypeOf<
+        readonly ['a', 1]
+      >()
+    })
+  })
+
+  describe('refetch', () => {
+    it('should resolve with the observed result type', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.refetch()).toEqualTypeOf<
+        Promise<QueryObserverResult<{ value: string }, DefaultError>>
+      >()
+    })
+
+    it('should use the error type given to the observer', () => {
+      const observer = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      expectTypeOf<
+        Awaited<ReturnType<typeof observer.refetch>>['error']
+      >().toEqualTypeOf<CustomError | null>()
+    })
+
+    it('should only accept RefetchOptions', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.refetch).parameters.toEqualTypeOf<
+        [options?: RefetchOptions]
+      >()
+    })
+  })
+
+  describe('fetchOptimistic', () => {
+    it('should keep the observed types in its options and result', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.fetchOptimistic).returns.toEqualTypeOf<
+        Promise<QueryObserverResult<{ value: string }, DefaultError>>
+      >()
+
+      observer.fetchOptimistic({
+        queryKey: queryKey(),
+        // @ts-expect-error the queryFn must return the observed data type
+        queryFn: () => 42,
+      })
+    })
+
+    it('should use the error type given to the observer', () => {
+      const observer = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      expectTypeOf<
+        Awaited<ReturnType<typeof observer.fetchOptimistic>>['error']
+      >().toEqualTypeOf<CustomError | null>()
+    })
+  })
+
   describe('select', () => {
+    it('should type the result data as what select returns', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ count: 1 }),
+        select: (data) => data.count,
+      })
+
+      expectTypeOf(observer.getCurrentResult().data).toEqualTypeOf<
+        number | undefined
+      >()
+    })
+
     it('should infer the selected type in the subscribe callback', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
@@ -131,6 +997,12 @@ describe('queryObserver', () => {
   })
 
   describe('placeholderData', () => {
+    it('should return the query data type or undefined', () => {
+      expectTypeOf<
+        PlaceholderDataFunction<{ value: string }>
+      >().returns.toEqualTypeOf<{ value: string } | undefined>()
+    })
+
     it('previousQuery should have typed queryKey', () => {
       const testQueryKey = ['SomeQuery', 42, { foo: 'bar' }] as const
 
@@ -147,10 +1019,6 @@ describe('queryObserver', () => {
     })
 
     it('previousQuery should have typed error', () => {
-      class CustomError extends Error {
-        name = 'CustomError' as const
-      }
-
       new QueryObserver<boolean, CustomError>(new QueryClient(), {
         queryKey: queryKey(),
         placeholderData: (_, previousQuery) => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -117,157 +117,352 @@ describe('queryObserver', () => {
     }
   })
 
-  describe('the result', () => {
-    it('should type its timestamps and counters as numbers', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+  describe('constructor', () => {
+    describe('queryFn', () => {
+      it('should type the context given to the queryFn', () => {
+        const key = ['a', 1] as const
+
+        new QueryObserver(queryClient, {
+          queryKey: key,
+          queryFn: (context) => {
+            expectTypeOf(context.queryKey).toEqualTypeOf<readonly ['a', 1]>()
+            expectTypeOf(context.signal).toEqualTypeOf<AbortSignal>()
+            expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
+            return Promise.resolve('data')
+          },
+        })
       })
-
-      const result = observer.getCurrentResult()
-
-      expectTypeOf(result.dataUpdatedAt).toEqualTypeOf<number>()
-      expectTypeOf(result.errorUpdatedAt).toEqualTypeOf<number>()
-      expectTypeOf(result.failureCount).toEqualTypeOf<number>()
-      expectTypeOf(result.errorUpdateCount).toEqualTypeOf<number>()
     })
 
-    it('should type its state flags as booleans', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+    describe('callbacks', () => {
+      it('should type the query given to an enabled callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          enabled: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+            return true
+          },
+        })
       })
 
-      const result = observer.getCurrentResult()
+      it('should type the query given to a staleTime callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          staleTime: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+            return 0
+          },
+        })
+      })
 
-      expectTypeOf(result.isFetching).toEqualTypeOf<boolean>()
-      expectTypeOf(result.isRefetching).toEqualTypeOf<boolean>()
-      expectTypeOf(result.isPaused).toEqualTypeOf<boolean>()
-      expectTypeOf(result.isStale).toEqualTypeOf<boolean>()
-      expectTypeOf(result.isEnabled).toEqualTypeOf<boolean>()
-      expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
-      expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
+      it('should type the query given to a refetchInterval callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          refetchInterval: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+            return false
+          },
+        })
+      })
+
+      it('should type the query given to a refetchOnWindowFocus callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          refetchOnWindowFocus: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+            return true
+          },
+        })
+      })
+
+      it('should type the query given to a refetchOnReconnect callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          refetchOnReconnect: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+            return true
+          },
+        })
+      })
+
+      it('should type the query given to a refetchOnMount callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          refetchOnMount: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+            return true
+          },
+        })
+      })
+
+      it('should type the query given to a retryOnMount callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          retryOnMount: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+            return true
+          },
+        })
+      })
+
+      it('should type the error given to a throwOnError callback', () => {
+        new QueryObserver<{ value: string }, CustomError>(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          throwOnError: (error) => {
+            expectTypeOf(error).toEqualTypeOf<CustomError>()
+            return false
+          },
+        })
+      })
+
+      it('should type the error given to a retry callback', () => {
+        new QueryObserver<boolean, CustomError>(queryClient, {
+          queryKey: queryKey(),
+          retry: (_failureCount, error) => {
+            expectTypeOf(error).toEqualTypeOf<CustomError>()
+            return false
+          },
+        })
+      })
+
+      it('should type the error given to a retryDelay callback', () => {
+        new QueryObserver<boolean, CustomError>(queryClient, {
+          queryKey: queryKey(),
+          retryDelay: (_failureCount, error) => {
+            expectTypeOf(error).toEqualTypeOf<CustomError>()
+            return 0
+          },
+        })
+      })
+
+      it('should type the queryKey given to a queryKeyHashFn', () => {
+        const key = ['a', 1] as const
+
+        new QueryObserver(queryClient, {
+          queryKey: key,
+          queryFn: () => Promise.resolve('data'),
+          queryKeyHashFn: (queryKeyToHash) => {
+            expectTypeOf(queryKeyToHash).toEqualTypeOf<readonly ['a', 1]>()
+            return 'hash'
+          },
+        })
+      })
+
+      it('should type a structuralSharing callback as unknown', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          structuralSharing: (_oldData, newData) => {
+            expectTypeOf(newData).toEqualTypeOf<unknown>()
+            return newData
+          },
+        })
+      })
     })
 
-    it('should type failureReason from the error type', () => {
-      const observer = new QueryObserver<boolean, CustomError>(queryClient, {
-        queryKey: queryKey(),
+    describe('select', () => {
+      it('should type the result data as what select returns', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ count: 1 }),
+          select: (data) => data.count,
+        })
+
+        expectTypeOf(observer.getCurrentResult().data).toEqualTypeOf<
+          number | undefined
+        >()
       })
 
-      expectTypeOf(
-        observer.getCurrentResult().failureReason,
-      ).toEqualTypeOf<CustomError | null>()
+      it('should infer the selected type in the subscribe callback', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => ({ count: 1 }),
+          select: (data) => ({ myCount: data.count }),
+        })
+
+        observer.subscribe((result) => {
+          expectTypeOf(result).toEqualTypeOf<
+            QueryObserverResult<{ myCount: number }>
+          >()
+        })
+      })
+
+      it('should infer the selected type from the refetch result', async () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => ({ count: 1 }),
+          select: (data) => ({ myCount: data.count }),
+        })
+
+        const observerResult = await observer.refetch()
+
+        expectTypeOf(observerResult.data).toEqualTypeOf<
+          { myCount: number } | undefined
+        >()
+      })
     })
 
-    it('should type its refetch from the observed types', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+    describe('initialData', () => {
+      it('should type an initialData function from the data type', () => {
+        expectTypeOf<
+          InitialDataFunction<{ value: string }>
+        >().returns.toEqualTypeOf<{ value: string } | undefined>()
       })
 
-      expectTypeOf(observer.getCurrentResult().refetch).returns.toEqualTypeOf<
-        Promise<QueryObserverResult<{ value: string }, DefaultError>>
-      >()
+      it('should accept a function for initialDataUpdatedAt', () => {
+        expectTypeOf<
+          QueryObserverOptions['initialDataUpdatedAt']
+        >().toEqualTypeOf<number | (() => number | undefined) | undefined>()
+      })
     })
 
-    it('should only accept RefetchOptions in its refetch', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+    describe('placeholderData', () => {
+      it('should return the query data type or undefined', () => {
+        expectTypeOf<
+          PlaceholderDataFunction<{ value: string }>
+        >().returns.toEqualTypeOf<{ value: string } | undefined>()
       })
 
-      expectTypeOf(
-        observer.getCurrentResult().refetch,
-      ).parameters.toEqualTypeOf<[options?: RefetchOptions]>()
+      it('previousQuery should have typed queryKey', () => {
+        const testQueryKey = ['SomeQuery', 42, { foo: 'bar' }] as const
+
+        new QueryObserver(new QueryClient(), {
+          queryKey: testQueryKey,
+          placeholderData: (_, previousQuery) => {
+            if (previousQuery) {
+              expectTypeOf(previousQuery.queryKey).toEqualTypeOf<
+                typeof testQueryKey
+              >()
+            }
+          },
+        })
+      })
+
+      it('previousQuery should have typed error', () => {
+        new QueryObserver<boolean, CustomError>(new QueryClient(), {
+          queryKey: queryKey(),
+          placeholderData: (_, previousQuery) => {
+            if (previousQuery) {
+              expectTypeOf(
+                previousQuery.state.error,
+              ).toEqualTypeOf<CustomError | null>()
+            }
+            return undefined
+          },
+        })
+      })
+
+      it('previousData should have the same type as query data', () => {
+        const queryData = { foo: 'bar' } as const
+
+        new QueryObserver(new QueryClient(), {
+          queryKey: queryKey(),
+          queryFn: () => queryData,
+          select: (data) => data.foo,
+          placeholderData: (previousData) => {
+            expectTypeOf(previousData).toEqualTypeOf<
+              typeof queryData | undefined
+            >()
+            return undefined
+          },
+        })
+      })
     })
 
-    it('should type status as the query status union', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+    describe('plain options', () => {
+      it('should reject a non-number gcTime', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error gcTime must be a number
+          gcTime: 'nope',
+        })
+
+        expectTypeOf<QueryObserverOptions['gcTime']>().toEqualTypeOf<
+          number | undefined
+        >()
       })
 
-      expectTypeOf(
-        observer.getCurrentResult().status,
-      ).toEqualTypeOf<QueryStatus>()
-    })
+      it('should reject a non-string queryHash', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error queryHash must be a string
+          queryHash: 42,
+        })
 
-    it('should type fetchStatus as the fetch status union', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+        expectTypeOf<QueryObserverOptions['queryHash']>().toEqualTypeOf<
+          string | undefined
+        >()
       })
 
-      expectTypeOf(
-        observer.getCurrentResult().fetchStatus,
-      ).toEqualTypeOf<FetchStatus>()
-    })
-  })
+      it('should type networkMode as the network mode union', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error networkMode must be one of the NetworkMode values
+          networkMode: 'nope',
+        })
 
-  describe('narrowing the result', () => {
-    it('should narrow error to the error type on an isError check', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+        expectTypeOf<QueryObserverOptions['networkMode']>().toEqualTypeOf<
+          NetworkMode | undefined
+        >()
       })
 
-      const result = observer.getCurrentResult()
-
-      if (result.isError) {
-        expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
-      }
-    })
-
-    it('should keep data possibly undefined on an isError check', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+      it('should type suspense as a boolean', () => {
+        expectTypeOf<QueryObserverOptions['suspense']>().toEqualTypeOf<
+          boolean | undefined
+        >()
       })
 
-      const result = observer.getCurrentResult()
-
-      if (result.isError) {
-        expectTypeOf(result.data).toEqualTypeOf<{ value: string } | undefined>()
-      }
-    })
-
-    it('should narrow data to be defined on a success status check', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+      it('should type refetchIntervalInBackground as a boolean', () => {
+        expectTypeOf<
+          QueryObserverOptions['refetchIntervalInBackground']
+        >().toEqualTypeOf<boolean | undefined>()
       })
 
-      const result = observer.getCurrentResult()
-
-      if (result.status === 'success') {
-        expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
-      }
-    })
-
-    it('should narrow error to the error type on an error status check', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+      it('should type meta as its named type', () => {
+        expectTypeOf<QueryObserverOptions['meta']>().toEqualTypeOf<
+          QueryMeta | undefined
+        >()
       })
 
-      const result = observer.getCurrentResult()
-
-      if (result.status === 'error') {
-        expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
-      }
-    })
-
-    it('should narrow data to undefined on a pending status check', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
+      it('should type notifyOnChangeProps as its named type', () => {
+        expectTypeOf<
+          QueryObserverOptions['notifyOnChangeProps']
+        >().toEqualTypeOf<NotifyOnChangeProps | undefined>()
       })
 
-      const result = observer.getCurrentResult()
-
-      if (result.status === 'pending') {
-        expectTypeOf(result.data).toEqualTypeOf<undefined>()
-      }
+      it('should type persister from the queryFn data', () => {
+        expectTypeOf<
+          QueryObserverOptions<{ value: string }>['persister']
+        >().toEqualTypeOf<
+          | QueryPersister<{ value: string }, ReadonlyArray<unknown>, never>
+          | undefined
+        >()
+      })
     })
   })
 
@@ -292,324 +487,6 @@ describe('queryObserver', () => {
         // @ts-expect-error the queryFn must return the observed data type
         queryFn: () => 42,
       })
-    })
-  })
-
-  describe('the options', () => {
-    it('should type the context given to the queryFn', () => {
-      const key = ['a', 1] as const
-
-      new QueryObserver(queryClient, {
-        queryKey: key,
-        queryFn: (context) => {
-          expectTypeOf(context.queryKey).toEqualTypeOf<readonly ['a', 1]>()
-          expectTypeOf(context.signal).toEqualTypeOf<AbortSignal>()
-          expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
-          return Promise.resolve('data')
-        },
-      })
-    })
-
-    it('should type the query given to an enabled callback', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        enabled: (query) => {
-          expectTypeOf(query.state.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-          return true
-        },
-      })
-    })
-
-    it('should type the query given to a staleTime callback', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        staleTime: (query) => {
-          expectTypeOf(query.state.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-          return 0
-        },
-      })
-    })
-
-    it('should type the query given to a refetchInterval callback', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        refetchInterval: (query) => {
-          expectTypeOf(query.state.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-          return false
-        },
-      })
-    })
-
-    it('should type the query given to a refetchOnWindowFocus callback', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        refetchOnWindowFocus: (query) => {
-          expectTypeOf(query.state.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-          return true
-        },
-      })
-    })
-
-    it('should type the query given to a refetchOnReconnect callback', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        refetchOnReconnect: (query) => {
-          expectTypeOf(query.state.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-          return true
-        },
-      })
-    })
-
-    it('should type the query given to a refetchOnMount callback', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        refetchOnMount: (query) => {
-          expectTypeOf(query.state.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-          return true
-        },
-      })
-    })
-
-    it('should type the query given to a retryOnMount callback', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        retryOnMount: (query) => {
-          expectTypeOf(query.state.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-          return true
-        },
-      })
-    })
-
-    it('should type persister from the queryFn data', () => {
-      expectTypeOf<
-        QueryObserverOptions<{ value: string }>['persister']
-      >().toEqualTypeOf<
-        | QueryPersister<{ value: string }, ReadonlyArray<unknown>, never>
-        | undefined
-      >()
-    })
-
-    it('should type meta as its named type', () => {
-      expectTypeOf<QueryObserverOptions['meta']>().toEqualTypeOf<
-        QueryMeta | undefined
-      >()
-    })
-
-    it('should type notifyOnChangeProps as its named type', () => {
-      expectTypeOf<QueryObserverOptions['notifyOnChangeProps']>().toEqualTypeOf<
-        NotifyOnChangeProps | undefined
-      >()
-    })
-
-    it('should type the error given to a throwOnError callback', () => {
-      new QueryObserver<{ value: string }, CustomError>(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        throwOnError: (error) => {
-          expectTypeOf(error).toEqualTypeOf<CustomError>()
-          return false
-        },
-      })
-    })
-
-    it('should type suspense as a boolean', () => {
-      expectTypeOf<QueryObserverOptions['suspense']>().toEqualTypeOf<
-        boolean | undefined
-      >()
-    })
-
-    it('should type refetchIntervalInBackground as a boolean', () => {
-      expectTypeOf<
-        QueryObserverOptions['refetchIntervalInBackground']
-      >().toEqualTypeOf<boolean | undefined>()
-    })
-
-    it('should reject a non-number gcTime', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve('data'),
-        // @ts-expect-error gcTime must be a number
-        gcTime: 'nope',
-      })
-
-      expectTypeOf<QueryObserverOptions['gcTime']>().toEqualTypeOf<
-        number | undefined
-      >()
-    })
-
-    it('should type networkMode as the network mode union', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve('data'),
-        // @ts-expect-error networkMode must be one of the NetworkMode values
-        networkMode: 'nope',
-      })
-
-      expectTypeOf<QueryObserverOptions['networkMode']>().toEqualTypeOf<
-        NetworkMode | undefined
-      >()
-    })
-
-    it('should reject a non-string queryHash', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve('data'),
-        // @ts-expect-error queryHash must be a string
-        queryHash: 42,
-      })
-
-      expectTypeOf<QueryObserverOptions['queryHash']>().toEqualTypeOf<
-        string | undefined
-      >()
-    })
-
-    it('should accept a function for initialDataUpdatedAt', () => {
-      expectTypeOf<
-        QueryObserverOptions['initialDataUpdatedAt']
-      >().toEqualTypeOf<number | (() => number | undefined) | undefined>()
-    })
-
-    it('should type the error given to a retry callback', () => {
-      new QueryObserver<boolean, CustomError>(queryClient, {
-        queryKey: queryKey(),
-        retry: (_failureCount, error) => {
-          expectTypeOf(error).toEqualTypeOf<CustomError>()
-          return false
-        },
-      })
-    })
-
-    it('should type the error given to a retryDelay callback', () => {
-      new QueryObserver<boolean, CustomError>(queryClient, {
-        queryKey: queryKey(),
-        retryDelay: (_failureCount, error) => {
-          expectTypeOf(error).toEqualTypeOf<CustomError>()
-          return 0
-        },
-      })
-    })
-
-    it('should type the queryKey given to a queryKeyHashFn', () => {
-      const key = ['a', 1] as const
-
-      new QueryObserver(queryClient, {
-        queryKey: key,
-        queryFn: () => Promise.resolve('data'),
-        queryKeyHashFn: (queryKeyToHash) => {
-          expectTypeOf(queryKeyToHash).toEqualTypeOf<readonly ['a', 1]>()
-          return 'hash'
-        },
-      })
-    })
-
-    it('should type an initialData function from the data type', () => {
-      expectTypeOf<
-        InitialDataFunction<{ value: string }>
-      >().returns.toEqualTypeOf<{ value: string } | undefined>()
-    })
-
-    it('should type a structuralSharing callback as unknown', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        structuralSharing: (_oldData, newData) => {
-          expectTypeOf(newData).toEqualTypeOf<unknown>()
-          return newData
-        },
-      })
-    })
-  })
-
-  describe('destroy', () => {
-    it('should return void', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(observer.destroy).returns.toEqualTypeOf<void>()
-    })
-  })
-
-  describe('updateResult', () => {
-    it('should return void', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(observer.updateResult).returns.toEqualTypeOf<void>()
-    })
-  })
-
-  describe('onQueryUpdate', () => {
-    it('should return void', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(observer.onQueryUpdate).returns.toEqualTypeOf<void>()
-    })
-  })
-
-  describe('shouldFetchOnReconnect', () => {
-    it('should return a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.shouldFetchOnReconnect,
-      ).returns.toEqualTypeOf<boolean>()
-    })
-  })
-
-  describe('shouldFetchOnWindowFocus', () => {
-    it('should return a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.shouldFetchOnWindowFocus,
-      ).returns.toEqualTypeOf<boolean>()
-    })
-  })
-
-  describe('trackProp', () => {
-    it('should only accept a key of the result', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(observer.trackProp).parameters.toEqualTypeOf<
-        [key: keyof QueryObserverResult]
-      >()
     })
   })
 
@@ -674,6 +551,162 @@ describe('queryObserver', () => {
         QueryObserverResult<{ value: string }, CustomError>
       >()
     })
+
+    describe('properties', () => {
+      it('should type its timestamps and counters as numbers', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        expectTypeOf(result.dataUpdatedAt).toEqualTypeOf<number>()
+        expectTypeOf(result.errorUpdatedAt).toEqualTypeOf<number>()
+        expectTypeOf(result.failureCount).toEqualTypeOf<number>()
+        expectTypeOf(result.errorUpdateCount).toEqualTypeOf<number>()
+      })
+
+      it('should type its state flags as booleans', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        expectTypeOf(result.isFetching).toEqualTypeOf<boolean>()
+        expectTypeOf(result.isRefetching).toEqualTypeOf<boolean>()
+        expectTypeOf(result.isPaused).toEqualTypeOf<boolean>()
+        expectTypeOf(result.isStale).toEqualTypeOf<boolean>()
+        expectTypeOf(result.isEnabled).toEqualTypeOf<boolean>()
+        expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
+        expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
+      })
+
+      it('should type failureReason from the error type', () => {
+        const observer = new QueryObserver<boolean, CustomError>(queryClient, {
+          queryKey: queryKey(),
+        })
+
+        expectTypeOf(
+          observer.getCurrentResult().failureReason,
+        ).toEqualTypeOf<CustomError | null>()
+      })
+
+      it('should type its refetch from the observed types', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        expectTypeOf(observer.getCurrentResult().refetch).returns.toEqualTypeOf<
+          Promise<QueryObserverResult<{ value: string }, DefaultError>>
+        >()
+      })
+
+      it('should only accept RefetchOptions in its refetch', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        expectTypeOf(
+          observer.getCurrentResult().refetch,
+        ).parameters.toEqualTypeOf<[options?: RefetchOptions]>()
+      })
+
+      it('should type status as the query status union', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        expectTypeOf(
+          observer.getCurrentResult().status,
+        ).toEqualTypeOf<QueryStatus>()
+      })
+
+      it('should type fetchStatus as the fetch status union', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        expectTypeOf(
+          observer.getCurrentResult().fetchStatus,
+        ).toEqualTypeOf<FetchStatus>()
+      })
+    })
+
+    describe('narrowing', () => {
+      it('should narrow error to the error type on an isError check', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isError) {
+          expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+        }
+      })
+
+      it('should keep data possibly undefined on an isError check', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isError) {
+          expectTypeOf(result.data).toEqualTypeOf<
+            { value: string } | undefined
+          >()
+        }
+      })
+
+      it('should narrow data to be defined on a success status check', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.status === 'success') {
+          expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
+        }
+      })
+
+      it('should narrow error to the error type on an error status check', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.status === 'error') {
+          expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+        }
+      })
+
+      it('should narrow data to undefined on a pending status check', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.status === 'pending') {
+          expectTypeOf(result.data).toEqualTypeOf<undefined>()
+        }
+      })
+    })
   })
 
   describe('trackResult', () => {
@@ -709,6 +742,19 @@ describe('queryObserver', () => {
       observer.trackResult(observer.getCurrentResult(), (key) => {
         expectTypeOf(key).toEqualTypeOf<keyof QueryObserverResult>()
       })
+    })
+  })
+
+  describe('trackProp', () => {
+    it('should only accept a key of the result', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.trackProp).parameters.toEqualTypeOf<
+        [key: keyof QueryObserverResult]
+      >()
     })
   })
 
@@ -832,98 +878,62 @@ describe('queryObserver', () => {
     })
   })
 
-  describe('select', () => {
-    it('should type the result data as what select returns', () => {
+  describe('destroy', () => {
+    it('should return void', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ count: 1 }),
-        select: (data) => data.count,
+        queryFn: () => Promise.resolve({ value: 'data' }),
       })
 
-      expectTypeOf(observer.getCurrentResult().data).toEqualTypeOf<
-        number | undefined
-      >()
-    })
-
-    it('should infer the selected type in the subscribe callback', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => ({ count: 1 }),
-        select: (data) => ({ myCount: data.count }),
-      })
-
-      observer.subscribe((result) => {
-        expectTypeOf(result).toEqualTypeOf<
-          QueryObserverResult<{ myCount: number }>
-        >()
-      })
-    })
-
-    it('should infer the selected type from the refetch result', async () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => ({ count: 1 }),
-        select: (data) => ({ myCount: data.count }),
-      })
-
-      const observerResult = await observer.refetch()
-
-      expectTypeOf(observerResult.data).toEqualTypeOf<
-        { myCount: number } | undefined
-      >()
+      expectTypeOf(observer.destroy).returns.toEqualTypeOf<void>()
     })
   })
 
-  describe('placeholderData', () => {
-    it('should return the query data type or undefined', () => {
-      expectTypeOf<
-        PlaceholderDataFunction<{ value: string }>
-      >().returns.toEqualTypeOf<{ value: string } | undefined>()
-    })
-
-    it('previousQuery should have typed queryKey', () => {
-      const testQueryKey = ['SomeQuery', 42, { foo: 'bar' }] as const
-
-      new QueryObserver(new QueryClient(), {
-        queryKey: testQueryKey,
-        placeholderData: (_, previousQuery) => {
-          if (previousQuery) {
-            expectTypeOf(previousQuery.queryKey).toEqualTypeOf<
-              typeof testQueryKey
-            >()
-          }
-        },
-      })
-    })
-
-    it('previousQuery should have typed error', () => {
-      new QueryObserver<boolean, CustomError>(new QueryClient(), {
+  describe('updateResult', () => {
+    it('should return void', () => {
+      const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
-        placeholderData: (_, previousQuery) => {
-          if (previousQuery) {
-            expectTypeOf(
-              previousQuery.state.error,
-            ).toEqualTypeOf<CustomError | null>()
-          }
-          return undefined
-        },
+        queryFn: () => Promise.resolve({ value: 'data' }),
       })
+
+      expectTypeOf(observer.updateResult).returns.toEqualTypeOf<void>()
     })
+  })
 
-    it('previousData should have the same type as query data', () => {
-      const queryData = { foo: 'bar' } as const
-
-      new QueryObserver(new QueryClient(), {
+  describe('onQueryUpdate', () => {
+    it('should return void', () => {
+      const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
-        queryFn: () => queryData,
-        select: (data) => data.foo,
-        placeholderData: (previousData) => {
-          expectTypeOf(previousData).toEqualTypeOf<
-            typeof queryData | undefined
-          >()
-          return undefined
-        },
+        queryFn: () => Promise.resolve({ value: 'data' }),
       })
+
+      expectTypeOf(observer.onQueryUpdate).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('shouldFetchOnReconnect', () => {
+    it('should return a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.shouldFetchOnReconnect,
+      ).returns.toEqualTypeOf<boolean>()
+    })
+  })
+
+  describe('shouldFetchOnWindowFocus', () => {
+    it('should return a boolean', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        observer.shouldFetchOnWindowFocus,
+      ).returns.toEqualTypeOf<boolean>()
     })
   })
 })

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -38,6 +38,17 @@ describe('queryObserver', () => {
       >().toEqualTypeOf<QueryObserverResult<unknown, DefaultError>>()
     })
 
+    it('should derive the remaining type parameters from the data type alone', () => {
+      expectTypeOf<
+        QueryObserverOptions<{ value: string }>['select']
+      >().toEqualTypeOf<
+        ((data: { value: string }) => { value: string }) | undefined
+      >()
+      expectTypeOf<
+        QueryObserverBaseResult<{ value: string }>['error']
+      >().toEqualTypeOf<DefaultError | null>()
+    })
+
     it('should only accept an array as its queryKey', () => {
       const observer = new QueryObserver(queryClient, {
         // @ts-expect-error a query key must be an array

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1337,6 +1337,26 @@ describe('queryObserver', () => {
       expectTypeOf(state.fetchFailureCount).toEqualTypeOf<number>()
     })
 
+    it('should always declare data on the query state', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      type State = (typeof observer)['getCurrentQuery'] extends () => {
+        state: infer TState
+      }
+        ? TState
+        : never
+      type OptionalKeys = {
+        [K in keyof State]-?: {} extends Pick<State, K> ? K : never
+      }[keyof State]
+
+      expectTypeOf<
+        'data' extends OptionalKeys ? true : false
+      >().toEqualTypeOf<false>()
+    })
+
     it('should type the remaining fields of the query state', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -671,196 +671,203 @@ describe('queryObserver', () => {
   })
 
   describe('QueryObserverResult', () => {
-    describe('timestamps and counters', () => {
-      it('should type its timestamps and counters as numbers', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
+    describe('QueryObserverBaseResult', () => {
+      describe('timestamps and counters', () => {
+        it('should type its timestamps and counters as numbers', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
+          expectTypeOf(result.dataUpdatedAt).toEqualTypeOf<number>()
+          expectTypeOf(result.errorUpdatedAt).toEqualTypeOf<number>()
+          expectTypeOf(result.failureCount).toEqualTypeOf<number>()
+          expectTypeOf(result.errorUpdateCount).toEqualTypeOf<number>()
+        })
+      })
+
+      describe('state flags', () => {
+        it('should type its state flags as booleans', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
+          expectTypeOf(result.isFetching).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isRefetching).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isPaused).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isStale).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isEnabled).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isInitialLoading).toEqualTypeOf<boolean>()
+        })
+      })
+
+      describe('data', () => {
+        it('should type data from the observed data type on the base result', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<{ value: string }, CustomError>['data']
+          >().toEqualTypeOf<{ value: string } | undefined>()
         })
 
-        const result = observer.getCurrentResult()
+        it('should keep every property of the base result writable', () => {
+          type Base = QueryObserverBaseResult<{ value: string }, CustomError>
 
-        expectTypeOf(result.dataUpdatedAt).toEqualTypeOf<number>()
-        expectTypeOf(result.errorUpdatedAt).toEqualTypeOf<number>()
-        expectTypeOf(result.failureCount).toEqualTypeOf<number>()
-        expectTypeOf(result.errorUpdateCount).toEqualTypeOf<number>()
-      })
-    })
-
-    describe('state flags', () => {
-      it('should type its state flags as booleans', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
+          expectTypeOf<Base>().toEqualTypeOf<{
+            -readonly [K in keyof Base]: Base[K]
+          }>()
         })
 
-        const result = observer.getCurrentResult()
+        it('should keep every property of each result branch writable', () => {
+          type Writable<T> = { -readonly [K in keyof T]: T[K] }
+          type Branch<TFilter> = Extract<
+            QueryObserverResult<{ value: string }, CustomError>,
+            TFilter
+          >
 
-        expectTypeOf(result.isFetching).toEqualTypeOf<boolean>()
-        expectTypeOf(result.isRefetching).toEqualTypeOf<boolean>()
-        expectTypeOf(result.isPaused).toEqualTypeOf<boolean>()
-        expectTypeOf(result.isStale).toEqualTypeOf<boolean>()
-        expectTypeOf(result.isEnabled).toEqualTypeOf<boolean>()
-        expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
-        expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
-        expectTypeOf(result.isInitialLoading).toEqualTypeOf<boolean>()
-      })
-    })
-
-    describe('data', () => {
-      it('should type data from the observed data type on the base result', () => {
-        expectTypeOf<
-          QueryObserverBaseResult<{ value: string }, CustomError>['data']
-        >().toEqualTypeOf<{ value: string } | undefined>()
-      })
-
-      it('should keep every property of the base result writable', () => {
-        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
-
-        expectTypeOf<Base>().toEqualTypeOf<{
-          -readonly [K in keyof Base]: Base[K]
-        }>()
-      })
-
-      it('should keep every property of each result branch writable', () => {
-        type Writable<T> = { -readonly [K in keyof T]: T[K] }
-        type Branch<TFilter> = Extract<
-          QueryObserverResult<{ value: string }, CustomError>,
-          TFilter
-        >
-
-        expectTypeOf<
-          Branch<{ status: 'pending'; isLoading: boolean }>
-        >().toEqualTypeOf<
-          Writable<Branch<{ status: 'pending'; isLoading: boolean }>>
-        >()
-        expectTypeOf<Branch<{ isLoading: true }>>().toEqualTypeOf<
-          Writable<Branch<{ isLoading: true }>>
-        >()
-        expectTypeOf<Branch<{ isSuccess: true }>>().toEqualTypeOf<
-          Writable<Branch<{ isSuccess: true }>>
-        >()
-        expectTypeOf<Branch<{ isLoadingError: true }>>().toEqualTypeOf<
-          Writable<Branch<{ isLoadingError: true }>>
-        >()
-        expectTypeOf<Branch<{ isRefetchError: true }>>().toEqualTypeOf<
-          Writable<Branch<{ isRefetchError: true }>>
-        >()
-        expectTypeOf<Branch<{ isPlaceholderData: true }>>().toEqualTypeOf<
-          Writable<Branch<{ isPlaceholderData: true }>>
-        >()
-      })
-
-      it('should always declare data and refetch on the base result', () => {
-        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
-        type OptionalKeys = {
-          [K in keyof Base]-?: {} extends Pick<Base, K> ? K : never
-        }[keyof Base]
-
-        expectTypeOf<
-          'data' extends OptionalKeys ? true : false
-        >().toEqualTypeOf<false>()
-        expectTypeOf<
-          'refetch' extends OptionalKeys ? true : false
-        >().toEqualTypeOf<false>()
-      })
-    })
-
-    describe('error', () => {
-      it('should type error from the observed error type on the base result', () => {
-        expectTypeOf<
-          QueryObserverBaseResult<{ value: string }, CustomError>['error']
-        >().toEqualTypeOf<CustomError | null>()
-      })
-
-      it('should default the error type of the base result', () => {
-        expectTypeOf<
-          QueryObserverBaseResult<{ value: string }>['error']
-        >().toEqualTypeOf<DefaultError | null>()
-      })
-    })
-
-    describe('discriminant flags', () => {
-      it('should type them as booleans on the base result', () => {
-        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
-
-        expectTypeOf<Base['isPending']>().toEqualTypeOf<boolean>()
-        expectTypeOf<Base['isSuccess']>().toEqualTypeOf<boolean>()
-        expectTypeOf<Base['isError']>().toEqualTypeOf<boolean>()
-        expectTypeOf<Base['isLoadingError']>().toEqualTypeOf<boolean>()
-        expectTypeOf<Base['isRefetchError']>().toEqualTypeOf<boolean>()
-        expectTypeOf<Base['isPlaceholderData']>().toEqualTypeOf<boolean>()
-      })
-
-      it('should type status as the query status union on the base result', () => {
-        expectTypeOf<
-          QueryObserverBaseResult<{ value: string }, CustomError>['status']
-        >().toEqualTypeOf<'pending' | 'error' | 'success'>()
-      })
-    })
-
-    describe('failureReason', () => {
-      it('should type failureReason from the error type', () => {
-        const observer = new QueryObserver<boolean, CustomError>(queryClient, {
-          queryKey: queryKey(),
+          expectTypeOf<
+            Branch<{ status: 'pending'; isLoading: boolean }>
+          >().toEqualTypeOf<
+            Writable<Branch<{ status: 'pending'; isLoading: boolean }>>
+          >()
+          expectTypeOf<Branch<{ isLoading: true }>>().toEqualTypeOf<
+            Writable<Branch<{ isLoading: true }>>
+          >()
+          expectTypeOf<Branch<{ isSuccess: true }>>().toEqualTypeOf<
+            Writable<Branch<{ isSuccess: true }>>
+          >()
+          expectTypeOf<Branch<{ isLoadingError: true }>>().toEqualTypeOf<
+            Writable<Branch<{ isLoadingError: true }>>
+          >()
+          expectTypeOf<Branch<{ isRefetchError: true }>>().toEqualTypeOf<
+            Writable<Branch<{ isRefetchError: true }>>
+          >()
+          expectTypeOf<Branch<{ isPlaceholderData: true }>>().toEqualTypeOf<
+            Writable<Branch<{ isPlaceholderData: true }>>
+          >()
         })
 
-        expectTypeOf(
-          observer.getCurrentResult().failureReason,
-        ).toEqualTypeOf<CustomError | null>()
-      })
-    })
+        it('should always declare data and refetch on the base result', () => {
+          type Base = QueryObserverBaseResult<{ value: string }, CustomError>
+          type OptionalKeys = {
+            [K in keyof Base]-?: {} extends Pick<Base, K> ? K : never
+          }[keyof Base]
 
-    describe('refetch', () => {
-      it('should type its refetch from the observed types', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
+          expectTypeOf<
+            'data' extends OptionalKeys ? true : false
+          >().toEqualTypeOf<false>()
+          expectTypeOf<
+            'refetch' extends OptionalKeys ? true : false
+          >().toEqualTypeOf<false>()
         })
-
-        expectTypeOf(observer.getCurrentResult().refetch).returns.toEqualTypeOf<
-          Promise<QueryObserverResult<{ value: string }, DefaultError>>
-        >()
       })
 
-      it('should only accept RefetchOptions in its refetch', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
+      describe('error', () => {
+        it('should type error from the observed error type on the base result', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<{ value: string }, CustomError>['error']
+          >().toEqualTypeOf<CustomError | null>()
         })
 
-        expectTypeOf(
-          observer.getCurrentResult().refetch,
-        ).parameters.toEqualTypeOf<[options?: RefetchOptions]>()
+        it('should default the error type of the base result', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<{ value: string }>['error']
+          >().toEqualTypeOf<DefaultError | null>()
+        })
       })
-    })
 
-    describe('status', () => {
-      it('should type status as the query status union', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
+      describe('discriminant flags', () => {
+        it('should type them as booleans on the base result', () => {
+          type Base = QueryObserverBaseResult<{ value: string }, CustomError>
+
+          expectTypeOf<Base['isPending']>().toEqualTypeOf<boolean>()
+          expectTypeOf<Base['isSuccess']>().toEqualTypeOf<boolean>()
+          expectTypeOf<Base['isError']>().toEqualTypeOf<boolean>()
+          expectTypeOf<Base['isLoadingError']>().toEqualTypeOf<boolean>()
+          expectTypeOf<Base['isRefetchError']>().toEqualTypeOf<boolean>()
+          expectTypeOf<Base['isPlaceholderData']>().toEqualTypeOf<boolean>()
         })
 
-        expectTypeOf(observer.getCurrentResult().status).toEqualTypeOf<
-          'pending' | 'error' | 'success'
-        >()
-        expectTypeOf<QueryStatus>().toEqualTypeOf<
-          'pending' | 'error' | 'success'
-        >()
+        it('should type status as the query status union on the base result', () => {
+          expectTypeOf<
+            QueryObserverBaseResult<{ value: string }, CustomError>['status']
+          >().toEqualTypeOf<'pending' | 'error' | 'success'>()
+        })
       })
-    })
 
-    describe('fetchStatus', () => {
-      it('should type fetchStatus as the fetch status union', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
+      describe('failureReason', () => {
+        it('should type failureReason from the error type', () => {
+          const observer = new QueryObserver<boolean, CustomError>(
+            queryClient,
+            {
+              queryKey: queryKey(),
+            },
+          )
+
+          expectTypeOf(
+            observer.getCurrentResult().failureReason,
+          ).toEqualTypeOf<CustomError | null>()
+        })
+      })
+
+      describe('refetch', () => {
+        it('should type its refetch from the observed types', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          expectTypeOf(
+            observer.getCurrentResult().refetch,
+          ).returns.toEqualTypeOf<
+            Promise<QueryObserverResult<{ value: string }, DefaultError>>
+          >()
         })
 
-        expectTypeOf(observer.getCurrentResult().fetchStatus).toEqualTypeOf<
-          'fetching' | 'paused' | 'idle'
-        >()
+        it('should only accept RefetchOptions in its refetch', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          expectTypeOf(
+            observer.getCurrentResult().refetch,
+          ).parameters.toEqualTypeOf<[options?: RefetchOptions]>()
+        })
+      })
+
+      describe('status', () => {
+        it('should type status as the query status union', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          expectTypeOf(observer.getCurrentResult().status).toEqualTypeOf<
+            'pending' | 'error' | 'success'
+          >()
+          expectTypeOf<QueryStatus>().toEqualTypeOf<
+            'pending' | 'error' | 'success'
+          >()
+        })
+      })
+
+      describe('fetchStatus', () => {
+        it('should type fetchStatus as the fetch status union', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          expectTypeOf(observer.getCurrentResult().fetchStatus).toEqualTypeOf<
+            'fetching' | 'paused' | 'idle'
+          >()
+        })
       })
     })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -263,9 +263,19 @@ describe('queryObserver', () => {
 
     describe('initialData', () => {
       it('should type an initialData function from the data type', () => {
-        expectTypeOf<
-          InitialDataFunction<{ value: string }>
-        >().returns.toEqualTypeOf<{ value: string } | undefined>()
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          initialData: () => {
+            expectTypeOf<
+              QueryObserverOptions<{ value: string }>['initialData']
+            >()
+              .extract<InitialDataFunction<any>>()
+              .returns.toEqualTypeOf<{ value: string } | undefined>()
+
+            return { value: 'data' }
+          },
+        })
       })
     })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1312,6 +1312,7 @@ describe('queryObserver', () => {
 
       const state = observer.getCurrentQuery().state
 
+      expectTypeOf(observer.getCurrentQuery().queryHash).toEqualTypeOf<string>()
       expectTypeOf(state.isInvalidated).toEqualTypeOf<boolean>()
       expectTypeOf(state.fetchMeta).toEqualTypeOf<{
         fetchMore?: { direction: 'forward' | 'backward' }

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -52,6 +52,20 @@ describe('queryObserver', () => {
   })
 
   describe('QueryObserverOptions', () => {
+    it('should keep every option writable', () => {
+      type Options = QueryObserverOptions<
+        { value: string },
+        CustomError,
+        { value: string },
+        { value: string },
+        ReadonlyArray<unknown>
+      >
+
+      expectTypeOf<Options>().toEqualTypeOf<{
+        -readonly [K in keyof Options]: Options[K]
+      }>()
+    })
+
     describe('queryKey', () => {
       it('should be required', () => {
         // @ts-expect-error queryKey is required

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -7,10 +7,10 @@ import type {
   InitialDataFunction,
   NetworkMode,
   PlaceholderDataFunction,
+  Query,
   QueryMeta,
   QueryObserverOptions,
   QueryObserverResult,
-  QueryPersister,
   QueryStatus,
   RefetchOptions,
 } from '..'
@@ -599,11 +599,23 @@ describe('queryObserver', () => {
 
     describe('persister', () => {
       it('should type persister from the queryFn data', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          persister: (persistedQueryFn, _context, query) => {
+            expectTypeOf(persistedQueryFn).returns.toEqualTypeOf<
+              { value: string } | Promise<{ value: string }>
+            >()
+            expectTypeOf(query).toEqualTypeOf<Query>()
+
+            return { value: 'data' }
+          },
+        })
+
         expectTypeOf<
-          QueryObserverOptions<{ value: string }>['persister']
-        >().toEqualTypeOf<
-          | QueryPersister<{ value: string }, ReadonlyArray<unknown>, never>
-          | undefined
+          NonNullable<QueryObserverOptions<{ value: string }>['persister']>
+        >().returns.toEqualTypeOf<
+          { value: string } | Promise<{ value: string }>
         >()
       })
     })

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1350,6 +1350,38 @@ describe('queryObserver', () => {
         >()
       })
     })
+
+    describe('DefinedQueryObserverResult', () => {
+      it('should only hold the branches that always have data', () => {
+        expectTypeOf<
+          DefinedQueryObserverResult<{ value: string }, CustomError>
+        >().toEqualTypeOf<
+          | QueryObserverRefetchErrorResult<{ value: string }, CustomError>
+          | QueryObserverSuccessResult<{ value: string }, CustomError>
+        >()
+      })
+
+      it('should always define data on every one of its branches', () => {
+        expectTypeOf<
+          DefinedQueryObserverResult<{ value: string }>['data']
+        >().toEqualTypeOf<{ value: string }>()
+      })
+
+      it('should be a subset of the result union', () => {
+        expectTypeOf<
+          Exclude<
+            DefinedQueryObserverResult<{ value: string }>,
+            QueryObserverResult<{ value: string }>
+          >
+        >().toEqualTypeOf<never>()
+      })
+
+      it('should default its data to unknown and its error to the default error', () => {
+        expectTypeOf<DefinedQueryObserverResult>().toEqualTypeOf<
+          DefinedQueryObserverResult<unknown, DefaultError>
+        >()
+      })
+    })
   })
 
   describe('setOptions', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1139,6 +1139,9 @@ describe('queryObserver', () => {
       expectTypeOf(
         withCustomError.getCurrentQuery().state.error,
       ).toEqualTypeOf<CustomError | null>()
+      expectTypeOf(
+        withCustomError.getCurrentQuery().state.fetchFailureReason,
+      ).toEqualTypeOf<CustomError | null>()
     })
 
     it('should keep the data type from before select', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1084,6 +1084,17 @@ describe('queryObserver', () => {
     })
   })
 
+  describe('subscribe', () => {
+    it('should return an unsubscribe function', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve('data'),
+      })
+
+      expectTypeOf(observer.subscribe(() => {})).toEqualTypeOf<() => void>()
+    })
+  })
+
   describe('destroy', () => {
     it('should return void', () => {
       const observer = new QueryObserver(queryClient, {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -700,6 +700,43 @@ describe('queryObserver', () => {
         >().toEqualTypeOf<{ value: string } | undefined>()
       })
 
+      it('should keep every property of the base result writable', () => {
+        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
+
+        expectTypeOf<Base>().toEqualTypeOf<{
+          -readonly [K in keyof Base]: Base[K]
+        }>()
+      })
+
+      it('should keep every property of each result branch writable', () => {
+        type Writable<T> = { -readonly [K in keyof T]: T[K] }
+        type Branch<TFilter> = Extract<
+          QueryObserverResult<{ value: string }, CustomError>,
+          TFilter
+        >
+
+        expectTypeOf<
+          Branch<{ status: 'pending'; isLoading: boolean }>
+        >().toEqualTypeOf<
+          Writable<Branch<{ status: 'pending'; isLoading: boolean }>>
+        >()
+        expectTypeOf<Branch<{ isLoading: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isLoading: true }>>
+        >()
+        expectTypeOf<Branch<{ isSuccess: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isSuccess: true }>>
+        >()
+        expectTypeOf<Branch<{ isLoadingError: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isLoadingError: true }>>
+        >()
+        expectTypeOf<Branch<{ isRefetchError: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isRefetchError: true }>>
+        >()
+        expectTypeOf<Branch<{ isPlaceholderData: true }>>().toEqualTypeOf<
+          Writable<Branch<{ isPlaceholderData: true }>>
+        >()
+      })
+
       it('should always declare data and refetch on the base result', () => {
         type Base = QueryObserverBaseResult<{ value: string }, CustomError>
         type OptionalKeys = {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1417,6 +1417,24 @@ describe('queryObserver', () => {
         'fetching' | 'paused' | 'idle'
       >()
     })
+
+    it('should keep the query state and its own fields writable', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      type CurrentQuery = ReturnType<typeof observer.getCurrentQuery>
+      type Fields = Pick<CurrentQuery, 'queryKey' | 'queryHash' | 'state'>
+      type State = CurrentQuery['state']
+
+      expectTypeOf<Fields>().toEqualTypeOf<{
+        -readonly [K in keyof Fields]: Fields[K]
+      }>()
+      expectTypeOf<State>().toEqualTypeOf<{
+        -readonly [K in keyof State]: State[K]
+      }>()
+    })
   })
 
   describe('refetch', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -297,7 +297,7 @@ describe('queryObserver', () => {
       it('should type the queryKey of the previousQuery it is given', () => {
         const testQueryKey = ['SomeQuery', 42, { foo: 'bar' }] as const
 
-        new QueryObserver(new QueryClient(), {
+        new QueryObserver(queryClient, {
           queryKey: testQueryKey,
           placeholderData: (_, previousQuery) => {
             if (previousQuery) {
@@ -310,7 +310,7 @@ describe('queryObserver', () => {
       })
 
       it('should type the error of the previousQuery it is given', () => {
-        new QueryObserver<boolean, CustomError>(new QueryClient(), {
+        new QueryObserver<boolean, CustomError>(queryClient, {
           queryKey: queryKey(),
           placeholderData: (_, previousQuery) => {
             if (previousQuery) {
@@ -326,7 +326,7 @@ describe('queryObserver', () => {
       it('should type previousData as the query data', () => {
         const queryData = { foo: 'bar' } as const
 
-        new QueryObserver(new QueryClient(), {
+        new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => queryData,
           select: (data) => data.foo,

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -296,32 +296,14 @@ describe('queryObserver', () => {
   })
 
   describe('the options', () => {
-    it('should type the queryKey given to the queryFn', () => {
+    it('should type the context given to the queryFn', () => {
       const key = ['a', 1] as const
 
       new QueryObserver(queryClient, {
         queryKey: key,
         queryFn: (context) => {
           expectTypeOf(context.queryKey).toEqualTypeOf<readonly ['a', 1]>()
-          return Promise.resolve('data')
-        },
-      })
-    })
-
-    it('should type the signal given to the queryFn', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: (context) => {
           expectTypeOf(context.signal).toEqualTypeOf<AbortSignal>()
-          return Promise.resolve('data')
-        },
-      })
-    })
-
-    it('should type the client given to the queryFn', () => {
-      new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: (context) => {
           expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
           return Promise.resolve('data')
         },

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1054,6 +1054,31 @@ describe('queryObserver', () => {
         .parameter(0)
         .toEqualTypeOf<typeof options>()
     })
+
+    it('should require the options that are always defaulted', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      type Options = Parameters<typeof observer.getOptimisticResult>[0]
+      type OptionalKeys = {
+        [K in keyof Options]-?: {} extends Pick<Options, K> ? K : never
+      }[keyof Options]
+
+      expectTypeOf<
+        'throwOnError' extends OptionalKeys ? true : false
+      >().toEqualTypeOf<false>()
+      expectTypeOf<
+        'refetchOnReconnect' extends OptionalKeys ? true : false
+      >().toEqualTypeOf<false>()
+      expectTypeOf<
+        'queryHash' extends OptionalKeys ? true : false
+      >().toEqualTypeOf<false>()
+      expectTypeOf<Options['select']>().toEqualTypeOf<
+        ((data: { value: string }) => { value: string }) | undefined
+      >()
+    })
   })
 
   describe('getCurrentResult', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -53,6 +53,19 @@ describe('queryObserver', () => {
   })
 
   describe('QueryObserverOptions', () => {
+    describe('queryKey', () => {
+      it('should be required', () => {
+        // @ts-expect-error queryKey is required
+        new QueryObserver(queryClient, {
+          queryFn: () => Promise.resolve('data'),
+        })
+
+        expectTypeOf(
+          new QueryObserver(queryClient, { queryKey: queryKey() }),
+        ).toBeObject()
+      })
+    })
+
     describe('queryFn', () => {
       it('should type the context given to the queryFn', () => {
         const key = ['a', 1] as const
@@ -482,6 +495,7 @@ describe('queryObserver', () => {
         expectTypeOf(result.isEnabled).toEqualTypeOf<boolean>()
         expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
         expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
+        expectTypeOf(result.isInitialLoading).toEqualTypeOf<boolean>()
       })
     })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -118,123 +118,35 @@ describe('queryObserver', () => {
   })
 
   describe('the result', () => {
-    it('should type dataUpdatedAt as a number', () => {
+    it('should type its timestamps and counters as numbers', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
         queryFn: () => Promise.resolve({ value: 'data' }),
       })
 
-      expectTypeOf(
-        observer.getCurrentResult().dataUpdatedAt,
-      ).toEqualTypeOf<number>()
+      const result = observer.getCurrentResult()
+
+      expectTypeOf(result.dataUpdatedAt).toEqualTypeOf<number>()
+      expectTypeOf(result.errorUpdatedAt).toEqualTypeOf<number>()
+      expectTypeOf(result.failureCount).toEqualTypeOf<number>()
+      expectTypeOf(result.errorUpdateCount).toEqualTypeOf<number>()
     })
 
-    it('should type errorUpdatedAt as a number', () => {
+    it('should type its state flags as booleans', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
         queryFn: () => Promise.resolve({ value: 'data' }),
       })
 
-      expectTypeOf(
-        observer.getCurrentResult().errorUpdatedAt,
-      ).toEqualTypeOf<number>()
-    })
+      const result = observer.getCurrentResult()
 
-    it('should type failureCount as a number', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().failureCount,
-      ).toEqualTypeOf<number>()
-    })
-
-    it('should type errorUpdateCount as a number', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().errorUpdateCount,
-      ).toEqualTypeOf<number>()
-    })
-
-    it('should type isFetching as a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().isFetching,
-      ).toEqualTypeOf<boolean>()
-    })
-
-    it('should type isRefetching as a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().isRefetching,
-      ).toEqualTypeOf<boolean>()
-    })
-
-    it('should type isPaused as a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().isPaused,
-      ).toEqualTypeOf<boolean>()
-    })
-
-    it('should type isStale as a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(observer.getCurrentResult().isStale).toEqualTypeOf<boolean>()
-    })
-
-    it('should type isEnabled as a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().isEnabled,
-      ).toEqualTypeOf<boolean>()
-    })
-
-    it('should type isFetched as a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().isFetched,
-      ).toEqualTypeOf<boolean>()
-    })
-
-    it('should type isFetchedAfterMount as a boolean', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        observer.getCurrentResult().isFetchedAfterMount,
-      ).toEqualTypeOf<boolean>()
+      expectTypeOf(result.isFetching).toEqualTypeOf<boolean>()
+      expectTypeOf(result.isRefetching).toEqualTypeOf<boolean>()
+      expectTypeOf(result.isPaused).toEqualTypeOf<boolean>()
+      expectTypeOf(result.isStale).toEqualTypeOf<boolean>()
+      expectTypeOf(result.isEnabled).toEqualTypeOf<boolean>()
+      expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
+      expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
     })
 
     it('should type failureReason from the error type', () => {
@@ -734,10 +646,8 @@ describe('queryObserver', () => {
       expectTypeOf(observer.getOptimisticResult(options)).toEqualTypeOf<
         QueryObserverResult<{ value: string }, DefaultError>
       >()
-    })
 
-    it('should use the error type given to the observer', () => {
-      const observer = new QueryObserver<{ value: string }, CustomError>(
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
         queryClient,
         {
           queryKey: queryKey(),
@@ -745,7 +655,7 @@ describe('queryObserver', () => {
         },
       )
 
-      const options = queryClient.defaultQueryOptions<
+      const customErrorOptions = queryClient.defaultQueryOptions<
         { value: string },
         CustomError
       >({
@@ -754,13 +664,13 @@ describe('queryObserver', () => {
       })
 
       expectTypeOf(
-        observer.getOptimisticResult(options).error,
-      ).toEqualTypeOf<CustomError | null>()
+        withCustomError.getOptimisticResult(customErrorOptions),
+      ).toEqualTypeOf<QueryObserverResult<{ value: string }, CustomError>>()
     })
   })
 
   describe('getCurrentResult', () => {
-    it('should be typed from the queryFn', () => {
+    it('should be typed from the observed types', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
         queryFn: () => Promise.resolve({ value: 'data' }),
@@ -769,16 +679,18 @@ describe('queryObserver', () => {
       expectTypeOf(observer.getCurrentResult()).toEqualTypeOf<
         QueryObserverResult<{ value: string }, DefaultError>
       >()
-    })
 
-    it('should use the error type given to the observer', () => {
-      const observer = new QueryObserver<boolean, CustomError>(queryClient, {
-        queryKey: queryKey(),
-      })
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
 
-      expectTypeOf(
-        observer.getCurrentResult().error,
-      ).toEqualTypeOf<CustomError | null>()
+      expectTypeOf(withCustomError.getCurrentResult()).toEqualTypeOf<
+        QueryObserverResult<{ value: string }, CustomError>
+      >()
     })
   })
 
@@ -792,10 +704,8 @@ describe('queryObserver', () => {
       expectTypeOf(
         observer.trackResult(observer.getCurrentResult()),
       ).toEqualTypeOf<QueryObserverResult<{ value: string }, DefaultError>>()
-    })
 
-    it('should use the error type given to the observer', () => {
-      const observer = new QueryObserver<{ value: string }, CustomError>(
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
         queryClient,
         {
           queryKey: queryKey(),
@@ -804,8 +714,8 @@ describe('queryObserver', () => {
       )
 
       expectTypeOf(
-        observer.trackResult(observer.getCurrentResult()).error,
-      ).toEqualTypeOf<CustomError | null>()
+        withCustomError.trackResult(withCustomError.getCurrentResult()),
+      ).toEqualTypeOf<QueryObserverResult<{ value: string }, CustomError>>()
     })
 
     it('should type the tracked property in the onPropTracked callback', () => {
@@ -821,7 +731,7 @@ describe('queryObserver', () => {
   })
 
   describe('getCurrentQuery', () => {
-    it('should carry the data type into the query state', () => {
+    it('should carry the observed types into the query state', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),
         queryFn: () => Promise.resolve({ value: 'data' }),
@@ -830,21 +740,11 @@ describe('queryObserver', () => {
       expectTypeOf(observer.getCurrentQuery().state.data).toEqualTypeOf<
         { value: string } | undefined
       >()
-    })
-
-    it('should carry the error type into the query state', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
       expectTypeOf(
         observer.getCurrentQuery().state.error,
       ).toEqualTypeOf<DefaultError | null>()
-    })
 
-    it('should use the error type given to the observer', () => {
-      const observer = new QueryObserver<{ value: string }, CustomError>(
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
         queryClient,
         {
           queryKey: queryKey(),
@@ -853,7 +753,7 @@ describe('queryObserver', () => {
       )
 
       expectTypeOf(
-        observer.getCurrentQuery().state.error,
+        withCustomError.getCurrentQuery().state.error,
       ).toEqualTypeOf<CustomError | null>()
     })
 
@@ -893,10 +793,8 @@ describe('queryObserver', () => {
       expectTypeOf(observer.refetch()).toEqualTypeOf<
         Promise<QueryObserverResult<{ value: string }, DefaultError>>
       >()
-    })
 
-    it('should use the error type given to the observer', () => {
-      const observer = new QueryObserver<{ value: string }, CustomError>(
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
         queryClient,
         {
           queryKey: queryKey(),
@@ -904,9 +802,9 @@ describe('queryObserver', () => {
         },
       )
 
-      expectTypeOf<
-        Awaited<ReturnType<typeof observer.refetch>>['error']
-      >().toEqualTypeOf<CustomError | null>()
+      expectTypeOf(withCustomError.refetch()).toEqualTypeOf<
+        Promise<QueryObserverResult<{ value: string }, CustomError>>
+      >()
     })
 
     it('should only accept RefetchOptions', () => {
@@ -937,10 +835,8 @@ describe('queryObserver', () => {
         // @ts-expect-error the queryFn must return the observed data type
         queryFn: () => 42,
       })
-    })
 
-    it('should use the error type given to the observer', () => {
-      const observer = new QueryObserver<{ value: string }, CustomError>(
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
         queryClient,
         {
           queryKey: queryKey(),
@@ -948,9 +844,9 @@ describe('queryObserver', () => {
         },
       )
 
-      expectTypeOf<
-        Awaited<ReturnType<typeof observer.fetchOptimistic>>['error']
-      >().toEqualTypeOf<CustomError | null>()
+      expectTypeOf(withCustomError.fetchOptimistic).returns.toEqualTypeOf<
+        Promise<QueryObserverResult<{ value: string }, CustomError>>
+      >()
     })
   })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -3,10 +3,9 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient, QueryObserver } from '..'
 import type {
   DefaultError,
-  FetchStatus,
+  InfiniteQueryObserverResult,
   InitialDataFunction,
   NetworkMode,
-  NotifyOnChangeProps,
   PlaceholderDataFunction,
   QueryMeta,
   QueryObserverOptions,
@@ -95,6 +94,19 @@ describe('queryObserver', () => {
           },
         })
       })
+
+      it('should only accept a boolean from an enabled callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          // @ts-expect-error an enabled callback must return a boolean
+          enabled: () => 'yes',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['enabled'], Function>
+        >().returns.toEqualTypeOf<boolean>()
+      })
     })
 
     describe('staleTime', () => {
@@ -109,6 +121,19 @@ describe('queryObserver', () => {
             return 0
           },
         })
+      })
+
+      it('should only accept a StaleTime from a staleTime callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+          // @ts-expect-error a staleTime callback must return a StaleTime
+          staleTime: () => 'soon',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['staleTime'], Function>
+        >().returns.toEqualTypeOf<number | 'static'>()
       })
     })
 
@@ -125,6 +150,19 @@ describe('queryObserver', () => {
           },
         })
       })
+
+      it('should only accept a number, false or undefined from a refetchInterval callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error a refetchInterval callback must return a number, false or undefined
+          refetchInterval: () => 'often',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['refetchInterval'], Function>
+        >().returns.toEqualTypeOf<number | false | undefined>()
+      })
     })
 
     describe('refetchOnWindowFocus', () => {
@@ -139,6 +177,19 @@ describe('queryObserver', () => {
             return true
           },
         })
+      })
+
+      it('should only accept a boolean or the always literal from a refetchOnWindowFocus callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error the callback must return a boolean or the always literal
+          refetchOnWindowFocus: () => 'sometimes',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['refetchOnWindowFocus'], Function>
+        >().returns.toEqualTypeOf<boolean | 'always'>()
       })
     })
 
@@ -155,6 +206,19 @@ describe('queryObserver', () => {
           },
         })
       })
+
+      it('should only accept a boolean or the always literal from a refetchOnReconnect callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error the callback must return a boolean or the always literal
+          refetchOnReconnect: () => 'sometimes',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['refetchOnReconnect'], Function>
+        >().returns.toEqualTypeOf<boolean | 'always'>()
+      })
     })
 
     describe('refetchOnMount', () => {
@@ -169,6 +233,19 @@ describe('queryObserver', () => {
             return true
           },
         })
+      })
+
+      it('should only accept a boolean or the always literal from a refetchOnMount callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error the callback must return a boolean or the always literal
+          refetchOnMount: () => 'sometimes',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['refetchOnMount'], Function>
+        >().returns.toEqualTypeOf<boolean | 'always'>()
       })
     })
 
@@ -198,6 +275,19 @@ describe('queryObserver', () => {
           },
         })
       })
+
+      it('should only accept a boolean from a throwOnError callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error the callback must return a boolean
+          throwOnError: () => 'yes',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['throwOnError'], Function>
+        >().returns.toEqualTypeOf<boolean>()
+      })
     })
 
     describe('retry', () => {
@@ -210,6 +300,19 @@ describe('queryObserver', () => {
           },
         })
       })
+
+      it('should only accept a boolean from a retry callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error the callback must return a boolean
+          retry: () => 'maybe',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['retry'], Function>
+        >().returns.toEqualTypeOf<boolean>()
+      })
     })
 
     describe('retryDelay', () => {
@@ -221,6 +324,19 @@ describe('queryObserver', () => {
             return 0
           },
         })
+      })
+
+      it('should only accept a number from a retryDelay callback', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error the callback must return a number
+          retryDelay: () => 'soon',
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['retryDelay'], Function>
+        >().returns.toEqualTypeOf<number>()
       })
     })
 
@@ -237,6 +353,19 @@ describe('queryObserver', () => {
           },
         })
       })
+
+      it('should only accept a string from a queryKeyHashFn', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve('data'),
+          // @ts-expect-error the callback must return a string
+          queryKeyHashFn: () => 42,
+        })
+
+        expectTypeOf<
+          Extract<QueryObserverOptions['queryKeyHashFn'], Function>
+        >().returns.toEqualTypeOf<string>()
+      })
     })
 
     describe('structuralSharing', () => {
@@ -249,6 +378,12 @@ describe('queryObserver', () => {
             return newData
           },
         })
+      })
+
+      it('should only accept unknown from a structuralSharing callback', () => {
+        expectTypeOf<
+          Extract<QueryObserverOptions['structuralSharing'], Function>
+        >().returns.toEqualTypeOf<unknown>()
       })
     })
 
@@ -446,7 +581,12 @@ describe('queryObserver', () => {
       it('should type notifyOnChangeProps as its named type', () => {
         expectTypeOf<
           QueryObserverOptions['notifyOnChangeProps']
-        >().toEqualTypeOf<NotifyOnChangeProps | undefined>()
+        >().toEqualTypeOf<
+          | Array<keyof InfiniteQueryObserverResult>
+          | 'all'
+          | undefined
+          | (() => Array<keyof InfiniteQueryObserverResult> | 'all' | undefined)
+        >()
       })
     })
 
@@ -542,9 +682,12 @@ describe('queryObserver', () => {
           queryFn: () => Promise.resolve({ value: 'data' }),
         })
 
-        expectTypeOf(
-          observer.getCurrentResult().status,
-        ).toEqualTypeOf<QueryStatus>()
+        expectTypeOf(observer.getCurrentResult().status).toEqualTypeOf<
+          'pending' | 'error' | 'success'
+        >()
+        expectTypeOf<QueryStatus>().toEqualTypeOf<
+          'pending' | 'error' | 'success'
+        >()
       })
     })
 
@@ -555,9 +698,9 @@ describe('queryObserver', () => {
           queryFn: () => Promise.resolve({ value: 'data' }),
         })
 
-        expectTypeOf(
-          observer.getCurrentResult().fetchStatus,
-        ).toEqualTypeOf<FetchStatus>()
+        expectTypeOf(observer.getCurrentResult().fetchStatus).toEqualTypeOf<
+          'fetching' | 'paused' | 'idle'
+        >()
       })
     })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1081,6 +1081,25 @@ describe('queryObserver', () => {
     })
   })
 
+  describe('options', () => {
+    it('should expose the observed types through the options it holds', () => {
+      const observer = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      expectTypeOf<Extract<typeof observer.options.throwOnError, Function>>()
+        .parameter(0)
+        .toEqualTypeOf<CustomError>()
+      expectTypeOf(observer.options.select).toEqualTypeOf<
+        ((data: { value: string }) => { value: string }) | undefined
+      >()
+    })
+  })
+
   describe('getOptimisticResult', () => {
     it('should be typed from the options it is given', () => {
       const observer = new QueryObserver(queryClient, {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -49,7 +49,7 @@ describe('queryObserver', () => {
       })
     })
 
-    describe('callbacks', () => {
+    describe('enabled', () => {
       it('should type the query given to an enabled callback', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -62,7 +62,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('staleTime', () => {
       it('should type the query given to a staleTime callback', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -75,7 +77,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('refetchInterval', () => {
       it('should type the query given to a refetchInterval callback', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -88,7 +92,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('refetchOnWindowFocus', () => {
       it('should type the query given to a refetchOnWindowFocus callback', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -101,7 +107,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('refetchOnReconnect', () => {
       it('should type the query given to a refetchOnReconnect callback', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -114,7 +122,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('refetchOnMount', () => {
       it('should type the query given to a refetchOnMount callback', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -127,7 +137,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('retryOnMount', () => {
       it('should type the query given to a retryOnMount callback', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -140,7 +152,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('throwOnError', () => {
       it('should type the error given to a throwOnError callback', () => {
         new QueryObserver<{ value: string }, CustomError>(queryClient, {
           queryKey: queryKey(),
@@ -151,7 +165,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('retry', () => {
       it('should type the error given to a retry callback', () => {
         new QueryObserver<boolean, CustomError>(queryClient, {
           queryKey: queryKey(),
@@ -161,7 +177,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('retryDelay', () => {
       it('should type the error given to a retryDelay callback', () => {
         new QueryObserver<boolean, CustomError>(queryClient, {
           queryKey: queryKey(),
@@ -171,7 +189,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('queryKeyHashFn', () => {
       it('should type the queryKey given to a queryKeyHashFn', () => {
         const key = ['a', 1] as const
 
@@ -184,7 +204,9 @@ describe('queryObserver', () => {
           },
         })
       })
+    })
 
+    describe('structuralSharing', () => {
       it('should type a structuralSharing callback as unknown', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -245,7 +267,9 @@ describe('queryObserver', () => {
           InitialDataFunction<{ value: string }>
         >().returns.toEqualTypeOf<{ value: string } | undefined>()
       })
+    })
 
+    describe('initialDataUpdatedAt', () => {
       it('should accept a function for initialDataUpdatedAt', () => {
         expectTypeOf<
           QueryObserverOptions['initialDataUpdatedAt']
@@ -306,7 +330,7 @@ describe('queryObserver', () => {
       })
     })
 
-    describe('plain options', () => {
+    describe('gcTime', () => {
       it('should reject a non-number gcTime', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -319,7 +343,9 @@ describe('queryObserver', () => {
           number | undefined
         >()
       })
+    })
 
+    describe('queryHash', () => {
       it('should reject a non-string queryHash', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -332,7 +358,9 @@ describe('queryObserver', () => {
           string | undefined
         >()
       })
+    })
 
+    describe('networkMode', () => {
       it('should type networkMode as the network mode union', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -345,31 +373,41 @@ describe('queryObserver', () => {
           NetworkMode | undefined
         >()
       })
+    })
 
+    describe('suspense', () => {
       it('should type suspense as a boolean', () => {
         expectTypeOf<QueryObserverOptions['suspense']>().toEqualTypeOf<
           boolean | undefined
         >()
       })
+    })
 
+    describe('refetchIntervalInBackground', () => {
       it('should type refetchIntervalInBackground as a boolean', () => {
         expectTypeOf<
           QueryObserverOptions['refetchIntervalInBackground']
         >().toEqualTypeOf<boolean | undefined>()
       })
+    })
 
+    describe('meta', () => {
       it('should type meta as its named type', () => {
         expectTypeOf<QueryObserverOptions['meta']>().toEqualTypeOf<
           QueryMeta | undefined
         >()
       })
+    })
 
+    describe('notifyOnChangeProps', () => {
       it('should type notifyOnChangeProps as its named type', () => {
         expectTypeOf<
           QueryObserverOptions['notifyOnChangeProps']
         >().toEqualTypeOf<NotifyOnChangeProps | undefined>()
       })
+    })
 
+    describe('persister', () => {
       it('should type persister from the queryFn data', () => {
         expectTypeOf<
           QueryObserverOptions<{ value: string }>['persister']
@@ -382,7 +420,7 @@ describe('queryObserver', () => {
   })
 
   describe('QueryObserverResult', () => {
-    describe('properties', () => {
+    describe('timestamps and counters', () => {
       it('should type its timestamps and counters as numbers', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -396,7 +434,9 @@ describe('queryObserver', () => {
         expectTypeOf(result.failureCount).toEqualTypeOf<number>()
         expectTypeOf(result.errorUpdateCount).toEqualTypeOf<number>()
       })
+    })
 
+    describe('state flags', () => {
       it('should type its state flags as booleans', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -413,7 +453,9 @@ describe('queryObserver', () => {
         expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
         expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
       })
+    })
 
+    describe('failureReason', () => {
       it('should type failureReason from the error type', () => {
         const observer = new QueryObserver<boolean, CustomError>(queryClient, {
           queryKey: queryKey(),
@@ -423,7 +465,9 @@ describe('queryObserver', () => {
           observer.getCurrentResult().failureReason,
         ).toEqualTypeOf<CustomError | null>()
       })
+    })
 
+    describe('refetch', () => {
       it('should type its refetch from the observed types', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -445,7 +489,9 @@ describe('queryObserver', () => {
           observer.getCurrentResult().refetch,
         ).parameters.toEqualTypeOf<[options?: RefetchOptions]>()
       })
+    })
 
+    describe('status', () => {
       it('should type status as the query status union', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
@@ -456,7 +502,9 @@ describe('queryObserver', () => {
           observer.getCurrentResult().status,
         ).toEqualTypeOf<QueryStatus>()
       })
+    })
 
+    describe('fetchStatus', () => {
       it('should type fetchStatus as the fetch status union', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -586,8 +586,8 @@ describe('queryObserver', () => {
       })
     })
 
-    describe('discriminants', () => {
-      it('should fix isPending to true on the pending branch', () => {
+    describe('QueryObserverPendingResult', () => {
+      it('should be extractable from the result union by its isPending literal', () => {
         type Pending = Extract<
           QueryObserverResult<{ value: string }>,
           { status: 'pending'; isLoading: boolean }
@@ -596,54 +596,7 @@ describe('queryObserver', () => {
         expectTypeOf<Pending['isPending']>().toEqualTypeOf<true>()
       })
 
-      it('should fix isLoading to true on the loading branch', () => {
-        type Loading = Extract<
-          QueryObserverResult<{ value: string }>,
-          { isLoading: true }
-        >
-
-        expectTypeOf<Loading['isLoading']>().toEqualTypeOf<true>()
-      })
-
-      it('should fix isSuccess to true on the success branch', () => {
-        type Success = Extract<
-          QueryObserverResult<{ value: string }>,
-          { status: 'success'; isPlaceholderData: false }
-        >
-
-        expectTypeOf<Success['isSuccess']>().toEqualTypeOf<true>()
-      })
-
-      it('should fix isPlaceholderData to true on the placeholder branch', () => {
-        type Placeholder = Extract<
-          QueryObserverResult<{ value: string }>,
-          { isPlaceholderData: true }
-        >
-
-        expectTypeOf<Placeholder['isPlaceholderData']>().toEqualTypeOf<true>()
-      })
-
-      it('should fix isLoadingError to true on the loading error branch', () => {
-        type LoadingError = Extract<
-          QueryObserverResult<{ value: string }>,
-          { isLoadingError: true }
-        >
-
-        expectTypeOf<LoadingError['isLoadingError']>().toEqualTypeOf<true>()
-      })
-
-      it('should fix isRefetchError to true on the refetch error branch', () => {
-        type RefetchError = Extract<
-          QueryObserverResult<{ value: string }>,
-          { isRefetchError: true }
-        >
-
-        expectTypeOf<RefetchError['isRefetchError']>().toEqualTypeOf<true>()
-      })
-    })
-
-    describe('branches', () => {
-      it('should type every flag on the pending branch', () => {
+      it('should pin every flag along with its data and error types', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),
@@ -663,8 +616,19 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
       })
+    })
 
-      it('should type every flag on the loading branch', () => {
+    describe('QueryObserverLoadingResult', () => {
+      it('should be extractable from the result union by its isLoading literal', () => {
+        type Loading = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isLoading: true }
+        >
+
+        expectTypeOf<Loading['isLoading']>().toEqualTypeOf<true>()
+      })
+
+      it('should pin every flag along with its data and error types', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),
@@ -685,8 +649,19 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
       })
+    })
 
-      it('should type every flag on the loading error branch', () => {
+    describe('QueryObserverLoadingErrorResult', () => {
+      it('should be extractable from the result union by its isLoadingError literal', () => {
+        type LoadingError = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isLoadingError: true }
+        >
+
+        expectTypeOf<LoadingError['isLoadingError']>().toEqualTypeOf<true>()
+      })
+
+      it('should pin every flag along with its data and error types', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),
@@ -707,8 +682,19 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
       })
+    })
 
-      it('should type every flag on the refetch error branch', () => {
+    describe('QueryObserverRefetchErrorResult', () => {
+      it('should be extractable from the result union by its isRefetchError literal', () => {
+        type RefetchError = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isRefetchError: true }
+        >
+
+        expectTypeOf<RefetchError['isRefetchError']>().toEqualTypeOf<true>()
+      })
+
+      it('should pin every flag along with its data and error types', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),
@@ -729,8 +715,19 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
       })
+    })
 
-      it('should type every flag on the success branch', () => {
+    describe('QueryObserverSuccessResult', () => {
+      it('should be extractable from the result union by its isSuccess literal', () => {
+        type Success = Extract<
+          QueryObserverResult<{ value: string }>,
+          { status: 'success'; isPlaceholderData: false }
+        >
+
+        expectTypeOf<Success['isSuccess']>().toEqualTypeOf<true>()
+      })
+
+      it('should pin every flag along with its data and error types', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),
@@ -751,8 +748,19 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<boolean>()
         }
       })
+    })
 
-      it('should type every flag on the placeholder branch', () => {
+    describe('QueryObserverPlaceholderResult', () => {
+      it('should be extractable from the result union by its isPlaceholderData literal', () => {
+        type Placeholder = Extract<
+          QueryObserverResult<{ value: string }>,
+          { isPlaceholderData: true }
+        >
+
+        expectTypeOf<Placeholder['isPlaceholderData']>().toEqualTypeOf<true>()
+      })
+
+      it('should pin every flag along with its data and error types', () => {
         const observer = new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -8,6 +8,7 @@ import type {
   PlaceholderDataFunction,
   Query,
   QueryMeta,
+  QueryObserverBaseResult,
   QueryObserverOptions,
   QueryObserverResult,
   QueryStatus,
@@ -686,6 +687,22 @@ describe('queryObserver', () => {
         expectTypeOf(result.isFetched).toEqualTypeOf<boolean>()
         expectTypeOf(result.isFetchedAfterMount).toEqualTypeOf<boolean>()
         expectTypeOf(result.isInitialLoading).toEqualTypeOf<boolean>()
+      })
+    })
+
+    describe('data', () => {
+      it('should type data from the observed data type on the base result', () => {
+        expectTypeOf<
+          QueryObserverBaseResult<{ value: string }, CustomError>['data']
+        >().toEqualTypeOf<{ value: string } | undefined>()
+      })
+    })
+
+    describe('error', () => {
+      it('should type error from the observed error type on the base result', () => {
+        expectTypeOf<
+          QueryObserverBaseResult<{ value: string }, CustomError>['error']
+        >().toEqualTypeOf<CustomError | null>()
       })
     })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -706,6 +706,25 @@ describe('queryObserver', () => {
       })
     })
 
+    describe('discriminant flags', () => {
+      it('should type them as booleans on the base result', () => {
+        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
+
+        expectTypeOf<Base['isPending']>().toEqualTypeOf<boolean>()
+        expectTypeOf<Base['isSuccess']>().toEqualTypeOf<boolean>()
+        expectTypeOf<Base['isError']>().toEqualTypeOf<boolean>()
+        expectTypeOf<Base['isLoadingError']>().toEqualTypeOf<boolean>()
+        expectTypeOf<Base['isRefetchError']>().toEqualTypeOf<boolean>()
+        expectTypeOf<Base['isPlaceholderData']>().toEqualTypeOf<boolean>()
+      })
+
+      it('should type status as the query status union on the base result', () => {
+        expectTypeOf<
+          QueryObserverBaseResult<{ value: string }, CustomError>['status']
+        >().toEqualTypeOf<'pending' | 'error' | 'success'>()
+      })
+    })
+
     describe('failureReason', () => {
       it('should type failureReason from the error type', () => {
         const observer = new QueryObserver<boolean, CustomError>(queryClient, {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -3,14 +3,21 @@ import { queryKey } from '@tanstack/query-test-utils'
 import { QueryClient, QueryObserver } from '..'
 import type {
   DefaultError,
+  DefinedQueryObserverResult,
   InfiniteQueryObserverResult,
   InitialDataFunction,
   PlaceholderDataFunction,
   Query,
   QueryMeta,
   QueryObserverBaseResult,
+  QueryObserverLoadingErrorResult,
+  QueryObserverLoadingResult,
   QueryObserverOptions,
+  QueryObserverPendingResult,
+  QueryObserverPlaceholderResult,
+  QueryObserverRefetchErrorResult,
   QueryObserverResult,
+  QueryObserverSuccessResult,
   QueryPersister,
   QueryStatus,
   RefetchOptions,
@@ -1141,6 +1148,12 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
       })
+
+      it('should declare exactly the base and narrowed keys', () => {
+        expectTypeOf<keyof QueryObserverPendingResult>().toEqualTypeOf<
+          keyof QueryObserverBaseResult
+        >()
+      })
     })
 
     describe('QueryObserverLoadingResult', () => {
@@ -1173,6 +1186,12 @@ describe('queryObserver', () => {
           expectTypeOf(result.status).toEqualTypeOf<'pending'>()
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
+      })
+
+      it('should declare exactly the base and narrowed keys', () => {
+        expectTypeOf<keyof QueryObserverLoadingResult>().toEqualTypeOf<
+          keyof QueryObserverBaseResult
+        >()
       })
     })
 
@@ -1207,6 +1226,12 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
       })
+
+      it('should declare exactly the base and narrowed keys', () => {
+        expectTypeOf<keyof QueryObserverLoadingErrorResult>().toEqualTypeOf<
+          keyof QueryObserverBaseResult
+        >()
+      })
     })
 
     describe('QueryObserverRefetchErrorResult', () => {
@@ -1239,6 +1264,12 @@ describe('queryObserver', () => {
           expectTypeOf(result.status).toEqualTypeOf<'error'>()
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
         }
+      })
+
+      it('should declare exactly the base and narrowed keys', () => {
+        expectTypeOf<keyof QueryObserverRefetchErrorResult>().toEqualTypeOf<
+          keyof QueryObserverBaseResult
+        >()
       })
     })
 
@@ -1273,6 +1304,12 @@ describe('queryObserver', () => {
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<boolean>()
         }
       })
+
+      it('should declare exactly the base and narrowed keys', () => {
+        expectTypeOf<keyof QueryObserverSuccessResult>().toEqualTypeOf<
+          keyof QueryObserverBaseResult
+        >()
+      })
     })
 
     describe('QueryObserverPlaceholderResult', () => {
@@ -1305,6 +1342,12 @@ describe('queryObserver', () => {
           expectTypeOf(result.status).toEqualTypeOf<'success'>()
           expectTypeOf(result.isPlaceholderData).toEqualTypeOf<true>()
         }
+      })
+
+      it('should declare exactly the base and narrowed keys', () => {
+        expectTypeOf<keyof QueryObserverPlaceholderResult>().toEqualTypeOf<
+          keyof QueryObserverBaseResult
+        >()
       })
     })
   })

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -696,6 +696,20 @@ describe('queryObserver', () => {
           QueryObserverBaseResult<{ value: string }, CustomError>['data']
         >().toEqualTypeOf<{ value: string } | undefined>()
       })
+
+      it('should always declare data and refetch on the base result', () => {
+        type Base = QueryObserverBaseResult<{ value: string }, CustomError>
+        type OptionalKeys = {
+          [K in keyof Base]-?: {} extends Pick<Base, K> ? K : never
+        }[keyof Base]
+
+        expectTypeOf<
+          'data' extends OptionalKeys ? true : false
+        >().toEqualTypeOf<false>()
+        expectTypeOf<
+          'refetch' extends OptionalKeys ? true : false
+        >().toEqualTypeOf<false>()
+      })
     })
 
     describe('error', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -32,6 +32,26 @@ describe('queryObserver', () => {
     queryClient.clear()
   })
 
+  describe('type parameters', () => {
+    it('should default to an unknown data type and the default error', () => {
+      expectTypeOf<
+        Awaited<ReturnType<QueryObserver['refetch']>>
+      >().toEqualTypeOf<QueryObserverResult<unknown, DefaultError>>()
+    })
+
+    it('should only accept an array as its queryKey', () => {
+      const observer = new QueryObserver(queryClient, {
+        // @ts-expect-error a query key must be an array
+        queryKey: 'not-an-array',
+        queryFn: () => Promise.resolve('data'),
+      })
+
+      expectTypeOf(observer.getCurrentQuery().queryKey).toEqualTypeOf<
+        ReadonlyArray<unknown>
+      >()
+    })
+  })
+
   describe('QueryObserverOptions', () => {
     describe('queryFn', () => {
       it('should type the context given to the queryFn', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -163,6 +163,9 @@ describe('queryObserver', () => {
         expectTypeOf<
           Extract<QueryObserverOptions['refetchInterval'], Function>
         >().returns.toEqualTypeOf<number | false | undefined>()
+        expectTypeOf<
+          Exclude<QueryObserverOptions['refetchInterval'], Function>
+        >().toEqualTypeOf<number | false | undefined>()
       })
     })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -433,6 +433,38 @@ describe('queryObserver', () => {
           { myCount: number } | undefined
         >()
       })
+
+      it('should keep the query data type on the options that precede it', () => {
+        new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ count: 1 }),
+          select: (data) => data.count,
+          placeholderData: (previousData) => {
+            expectTypeOf(previousData).toEqualTypeOf<
+              { count: number } | undefined
+            >()
+            return { count: 0 }
+          },
+          enabled: (query) => {
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { count: number } | undefined
+            >()
+            return true
+          },
+        })
+
+        expectTypeOf<
+          QueryObserverOptions<
+            { count: number },
+            DefaultError,
+            number,
+            { count: number }
+          >['placeholderData']
+        >()
+          .extract<Function>()
+          .parameter(0)
+          .toEqualTypeOf<{ count: number } | undefined>()
+      })
     })
 
     describe('initialData', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1288,6 +1288,41 @@ describe('queryObserver', () => {
         readonly ['a', 1]
       >()
     })
+
+    it('should type the counters and timestamps of the query state as numbers', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const state = observer.getCurrentQuery().state
+
+      expectTypeOf(state.dataUpdateCount).toEqualTypeOf<number>()
+      expectTypeOf(state.dataUpdatedAt).toEqualTypeOf<number>()
+      expectTypeOf(state.errorUpdateCount).toEqualTypeOf<number>()
+      expectTypeOf(state.errorUpdatedAt).toEqualTypeOf<number>()
+      expectTypeOf(state.fetchFailureCount).toEqualTypeOf<number>()
+    })
+
+    it('should type the remaining fields of the query state', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const state = observer.getCurrentQuery().state
+
+      expectTypeOf(state.isInvalidated).toEqualTypeOf<boolean>()
+      expectTypeOf(state.fetchMeta).toEqualTypeOf<{
+        fetchMore?: { direction: 'forward' | 'backward' }
+      } | null>()
+      expectTypeOf(state.status).toEqualTypeOf<
+        'pending' | 'error' | 'success'
+      >()
+      expectTypeOf(state.fetchStatus).toEqualTypeOf<
+        'fetching' | 'paused' | 'idle'
+      >()
+    })
   })
 
   describe('refetch', () => {

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1252,6 +1252,10 @@ describe('queryObserver', () => {
       expectTypeOf(observer.refetch).parameters.toEqualTypeOf<
         [options?: RefetchOptions]
       >()
+      expectTypeOf<RefetchOptions>().toEqualTypeOf<{
+        throwOnError?: boolean
+        cancelRefetch?: boolean
+      }>()
     })
   })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -885,6 +885,47 @@ describe('queryObserver', () => {
             QueryObserverBaseResult<{ value: string }, CustomError>['data']
           >().toEqualTypeOf<{ value: string } | undefined>()
         })
+
+        it('should stay possibly undefined on an isError check', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
+          if (result.isError) {
+            expectTypeOf(result.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
+          }
+        })
+
+        it('should be defined on a success status check', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
+          if (result.status === 'success') {
+            expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
+          }
+        })
+
+        it('should be undefined on a pending status check', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
+          if (result.status === 'pending') {
+            expectTypeOf(result.data).toEqualTypeOf<undefined>()
+          }
+        })
       })
 
       describe('error', () => {
@@ -898,6 +939,32 @@ describe('queryObserver', () => {
           expectTypeOf<
             QueryObserverBaseResult<{ value: string }>['error']
           >().toEqualTypeOf<DefaultError | null>()
+        })
+
+        it('should be the observed error type on an isError check', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
+          if (result.isError) {
+            expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+          }
+        })
+
+        it('should be the observed error type on an error status check', () => {
+          const observer = new QueryObserver(queryClient, {
+            queryKey: queryKey(),
+            queryFn: () => Promise.resolve({ value: 'data' }),
+          })
+
+          const result = observer.getCurrentResult()
+
+          if (result.status === 'error') {
+            expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+          }
         })
       })
 
@@ -1032,75 +1099,6 @@ describe('queryObserver', () => {
             'fetching' | 'paused' | 'idle'
           >()
         })
-      })
-    })
-
-    describe('narrowing', () => {
-      it('should narrow error to the error type on an isError check', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
-        })
-
-        const result = observer.getCurrentResult()
-
-        if (result.isError) {
-          expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
-        }
-      })
-
-      it('should keep data possibly undefined on an isError check', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
-        })
-
-        const result = observer.getCurrentResult()
-
-        if (result.isError) {
-          expectTypeOf(result.data).toEqualTypeOf<
-            { value: string } | undefined
-          >()
-        }
-      })
-
-      it('should narrow data to be defined on a success status check', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
-        })
-
-        const result = observer.getCurrentResult()
-
-        if (result.status === 'success') {
-          expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
-        }
-      })
-
-      it('should narrow error to the error type on an error status check', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
-        })
-
-        const result = observer.getCurrentResult()
-
-        if (result.status === 'error') {
-          expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
-        }
-      })
-
-      it('should narrow data to undefined on a pending status check', () => {
-        const observer = new QueryObserver(queryClient, {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
-        })
-
-        const result = observer.getCurrentResult()
-
-        if (result.status === 'pending') {
-          expectTypeOf(result.data).toEqualTypeOf<undefined>()
-        }
       })
     })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1109,6 +1109,10 @@ describe('queryObserver', () => {
       expectTypeOf<Options['select']>().toEqualTypeOf<
         ((data: { value: string }) => { value: string }) | undefined
       >()
+      expectTypeOf<Options['_optimisticResults']>().toEqualTypeOf<
+        'optimistic' | 'isRestoring' | undefined
+      >()
+      expectTypeOf<Options['_defaulted']>().toEqualTypeOf<boolean | undefined>()
     })
   })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -1049,6 +1049,10 @@ describe('queryObserver', () => {
       expectTypeOf(
         withCustomError.getOptimisticResult(customErrorOptions),
       ).toEqualTypeOf<QueryObserverResult<{ value: string }, CustomError>>()
+
+      expectTypeOf(observer.getOptimisticResult)
+        .parameter(0)
+        .toEqualTypeOf<typeof options>()
     })
   })
 
@@ -1099,6 +1103,14 @@ describe('queryObserver', () => {
       expectTypeOf(
         withCustomError.trackResult(withCustomError.getCurrentResult()),
       ).toEqualTypeOf<QueryObserverResult<{ value: string }, CustomError>>()
+
+      expectTypeOf(observer.trackResult)
+        .parameter(0)
+        .toEqualTypeOf<QueryObserverResult<{ value: string }, DefaultError>>()
+
+      expectTypeOf(withCustomError.trackResult)
+        .parameter(0)
+        .toEqualTypeOf<QueryObserverResult<{ value: string }, CustomError>>()
     })
 
     it('should type the tracked property in the onPropTracked callback', () => {
@@ -1246,6 +1258,13 @@ describe('queryObserver', () => {
       expectTypeOf(withCustomError.fetchOptimistic).returns.toEqualTypeOf<
         Promise<QueryObserverResult<{ value: string }, CustomError>>
       >()
+
+      expectTypeOf(observer.fetchOptimistic)
+        .parameter(0)
+        .toHaveProperty('select')
+        .toEqualTypeOf<
+          ((data: { value: string }) => { value: string }) | undefined
+        >()
     })
   })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -117,7 +117,7 @@ describe('queryObserver', () => {
     }
   })
 
-  describe('constructor', () => {
+  describe('QueryObserverOptions', () => {
     describe('queryFn', () => {
       it('should type the context given to the queryFn', () => {
         const key = ['a', 1] as const
@@ -345,7 +345,7 @@ describe('queryObserver', () => {
         >().returns.toEqualTypeOf<{ value: string } | undefined>()
       })
 
-      it('previousQuery should have typed queryKey', () => {
+      it('should type the queryKey of the previousQuery it is given', () => {
         const testQueryKey = ['SomeQuery', 42, { foo: 'bar' }] as const
 
         new QueryObserver(new QueryClient(), {
@@ -360,7 +360,7 @@ describe('queryObserver', () => {
         })
       })
 
-      it('previousQuery should have typed error', () => {
+      it('should type the error of the previousQuery it is given', () => {
         new QueryObserver<boolean, CustomError>(new QueryClient(), {
           queryKey: queryKey(),
           placeholderData: (_, previousQuery) => {
@@ -374,7 +374,7 @@ describe('queryObserver', () => {
         })
       })
 
-      it('previousData should have the same type as query data', () => {
+      it('should type previousData as the query data', () => {
         const queryData = { foo: 'bar' } as const
 
         new QueryObserver(new QueryClient(), {
@@ -466,92 +466,7 @@ describe('queryObserver', () => {
     })
   })
 
-  describe('setOptions', () => {
-    it('should keep the observed data type in the options it is given', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      observer.setOptions({
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-        select: (data) => {
-          expectTypeOf(data).toEqualTypeOf<{ value: string }>()
-          return data
-        },
-      })
-
-      observer.setOptions({
-        queryKey: queryKey(),
-        // @ts-expect-error the queryFn must return the observed data type
-        queryFn: () => 42,
-      })
-    })
-  })
-
-  describe('getOptimisticResult', () => {
-    it('should be typed from the options it is given', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      const options = queryClient.defaultQueryOptions({
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(observer.getOptimisticResult(options)).toEqualTypeOf<
-        QueryObserverResult<{ value: string }, DefaultError>
-      >()
-
-      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
-        queryClient,
-        {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
-        },
-      )
-
-      const customErrorOptions = queryClient.defaultQueryOptions<
-        { value: string },
-        CustomError
-      >({
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(
-        withCustomError.getOptimisticResult(customErrorOptions),
-      ).toEqualTypeOf<QueryObserverResult<{ value: string }, CustomError>>()
-    })
-  })
-
-  describe('getCurrentResult', () => {
-    it('should be typed from the observed types', () => {
-      const observer = new QueryObserver(queryClient, {
-        queryKey: queryKey(),
-        queryFn: () => Promise.resolve({ value: 'data' }),
-      })
-
-      expectTypeOf(observer.getCurrentResult()).toEqualTypeOf<
-        QueryObserverResult<{ value: string }, DefaultError>
-      >()
-
-      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
-        queryClient,
-        {
-          queryKey: queryKey(),
-          queryFn: () => Promise.resolve({ value: 'data' }),
-        },
-      )
-
-      expectTypeOf(withCustomError.getCurrentResult()).toEqualTypeOf<
-        QueryObserverResult<{ value: string }, CustomError>
-      >()
-    })
-
+  describe('QueryObserverResult', () => {
     describe('properties', () => {
       it('should type its timestamps and counters as numbers', () => {
         const observer = new QueryObserver(queryClient, {
@@ -706,6 +621,93 @@ describe('queryObserver', () => {
           expectTypeOf(result.data).toEqualTypeOf<undefined>()
         }
       })
+    })
+  })
+
+  describe('setOptions', () => {
+    it('should keep the observed data type in the options it is given', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      observer.setOptions({
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+        select: (data) => {
+          expectTypeOf(data).toEqualTypeOf<{ value: string }>()
+          return data
+        },
+      })
+
+      observer.setOptions({
+        queryKey: queryKey(),
+        // @ts-expect-error the queryFn must return the observed data type
+        queryFn: () => 42,
+      })
+    })
+  })
+
+  describe('getOptimisticResult', () => {
+    it('should be typed from the options it is given', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      const options = queryClient.defaultQueryOptions({
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.getOptimisticResult(options)).toEqualTypeOf<
+        QueryObserverResult<{ value: string }, DefaultError>
+      >()
+
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      const customErrorOptions = queryClient.defaultQueryOptions<
+        { value: string },
+        CustomError
+      >({
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(
+        withCustomError.getOptimisticResult(customErrorOptions),
+      ).toEqualTypeOf<QueryObserverResult<{ value: string }, CustomError>>()
+    })
+  })
+
+  describe('getCurrentResult', () => {
+    it('should be typed from the observed types', () => {
+      const observer = new QueryObserver(queryClient, {
+        queryKey: queryKey(),
+        queryFn: () => Promise.resolve({ value: 'data' }),
+      })
+
+      expectTypeOf(observer.getCurrentResult()).toEqualTypeOf<
+        QueryObserverResult<{ value: string }, DefaultError>
+      >()
+
+      const withCustomError = new QueryObserver<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      expectTypeOf(withCustomError.getCurrentResult()).toEqualTypeOf<
+        QueryObserverResult<{ value: string }, CustomError>
+      >()
     })
   })
 

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -75,6 +75,7 @@ describe('queryObserver', () => {
             expectTypeOf(context.queryKey).toEqualTypeOf<readonly ['a', 1]>()
             expectTypeOf(context.signal).toEqualTypeOf<AbortSignal>()
             expectTypeOf(context.client).toEqualTypeOf<QueryClient>()
+            expectTypeOf(context.meta).toEqualTypeOf<QueryMeta | undefined>()
             return Promise.resolve('data')
           },
         })
@@ -269,8 +270,11 @@ describe('queryObserver', () => {
         new QueryObserver<{ value: string }, CustomError>(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),
-          throwOnError: (error) => {
+          throwOnError: (error, query) => {
             expectTypeOf(error).toEqualTypeOf<CustomError>()
+            expectTypeOf(query.state.data).toEqualTypeOf<
+              { value: string } | undefined
+            >()
             return false
           },
         })
@@ -294,7 +298,8 @@ describe('queryObserver', () => {
       it('should type the error given to a retry callback', () => {
         new QueryObserver<boolean, CustomError>(queryClient, {
           queryKey: queryKey(),
-          retry: (_failureCount, error) => {
+          retry: (failureCount, error) => {
+            expectTypeOf(failureCount).toEqualTypeOf<number>()
             expectTypeOf(error).toEqualTypeOf<CustomError>()
             return false
           },
@@ -319,7 +324,8 @@ describe('queryObserver', () => {
       it('should type the error given to a retryDelay callback', () => {
         new QueryObserver<boolean, CustomError>(queryClient, {
           queryKey: queryKey(),
-          retryDelay: (_failureCount, error) => {
+          retryDelay: (failureCount, error) => {
+            expectTypeOf(failureCount).toEqualTypeOf<number>()
             expectTypeOf(error).toEqualTypeOf<CustomError>()
             return 0
           },
@@ -373,7 +379,8 @@ describe('queryObserver', () => {
         new QueryObserver(queryClient, {
           queryKey: queryKey(),
           queryFn: () => Promise.resolve({ value: 'data' }),
-          structuralSharing: (_oldData, newData) => {
+          structuralSharing: (oldData, newData) => {
+            expectTypeOf(oldData).toEqualTypeOf<unknown>()
             expectTypeOf(newData).toEqualTypeOf<unknown>()
             return newData
           },

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -31,37 +31,6 @@ describe('queryObserver', () => {
     queryClient.clear()
   })
 
-  describe('type parameters', () => {
-    it('should default to an unknown data type and the default error', () => {
-      expectTypeOf<
-        Awaited<ReturnType<QueryObserver['refetch']>>
-      >().toEqualTypeOf<QueryObserverResult<unknown, DefaultError>>()
-    })
-
-    it('should derive the remaining type parameters from the data type alone', () => {
-      expectTypeOf<
-        QueryObserverOptions<{ value: string }>['select']
-      >().toEqualTypeOf<
-        ((data: { value: string }) => { value: string }) | undefined
-      >()
-      expectTypeOf<
-        QueryObserverBaseResult<{ value: string }>['error']
-      >().toEqualTypeOf<DefaultError | null>()
-    })
-
-    it('should only accept an array as its queryKey', () => {
-      const observer = new QueryObserver(queryClient, {
-        // @ts-expect-error a query key must be an array
-        queryKey: 'not-an-array',
-        queryFn: () => Promise.resolve('data'),
-      })
-
-      expectTypeOf(observer.getCurrentQuery().queryKey).toEqualTypeOf<
-        ReadonlyArray<unknown>
-      >()
-    })
-  })
-
   describe('QueryObserverOptions', () => {
     it('should keep every option writable', () => {
       type Options = QueryObserverOptions<
@@ -77,7 +46,27 @@ describe('queryObserver', () => {
       }>()
     })
 
+    it('should derive its remaining type parameters from the data type', () => {
+      expectTypeOf<
+        QueryObserverOptions<{ value: string }>['select']
+      >().toEqualTypeOf<
+        ((data: { value: string }) => { value: string }) | undefined
+      >()
+    })
+
     describe('queryKey', () => {
+      it('should only accept an array', () => {
+        const observer = new QueryObserver(queryClient, {
+          // @ts-expect-error a query key must be an array
+          queryKey: 'not-an-array',
+          queryFn: () => Promise.resolve('data'),
+        })
+
+        expectTypeOf(observer.getCurrentQuery().queryKey).toEqualTypeOf<
+          ReadonlyArray<unknown>
+        >()
+      })
+
       it('should be required', () => {
         // @ts-expect-error queryKey is required
         new QueryObserver(queryClient, {
@@ -783,6 +772,12 @@ describe('queryObserver', () => {
           QueryObserverBaseResult<{ value: string }, CustomError>['error']
         >().toEqualTypeOf<CustomError | null>()
       })
+
+      it('should default the error type of the base result', () => {
+        expectTypeOf<
+          QueryObserverBaseResult<{ value: string }>['error']
+        >().toEqualTypeOf<DefaultError | null>()
+      })
     })
 
     describe('discriminant flags', () => {
@@ -1463,6 +1458,12 @@ describe('queryObserver', () => {
   })
 
   describe('refetch', () => {
+    it('should resolve with an unknown data type when no type parameter is given', () => {
+      expectTypeOf<
+        Awaited<ReturnType<QueryObserver['refetch']>>
+      >().toEqualTypeOf<QueryObserverResult<unknown, DefaultError>>()
+    })
+
     it('should resolve with the observed result type', () => {
       const observer = new QueryObserver(queryClient, {
         queryKey: queryKey(),

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -32,91 +32,6 @@ describe('queryObserver', () => {
     queryClient.clear()
   })
 
-  it('should be inferred as a correct result type', () => {
-    const observer = new QueryObserver(queryClient, {
-      queryKey: queryKey(),
-      queryFn: () => Promise.resolve({ value: 'data' }),
-    })
-
-    const result = observer.getCurrentResult()
-
-    if (result.isPending) {
-      expectTypeOf(result.data).toEqualTypeOf<undefined>()
-      expectTypeOf(result.error).toEqualTypeOf<null>()
-      expectTypeOf(result.isError).toEqualTypeOf<false>()
-      expectTypeOf(result.isPending).toEqualTypeOf<true>()
-      expectTypeOf(result.isLoading).toEqualTypeOf<boolean>()
-      expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
-      expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
-      expectTypeOf(result.status).toEqualTypeOf<'pending'>()
-      expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
-    }
-    if (result.isLoading) {
-      expectTypeOf(result.data).toEqualTypeOf<undefined>()
-      expectTypeOf(result.error).toEqualTypeOf<null>()
-      expectTypeOf(result.isError).toEqualTypeOf<false>()
-      expectTypeOf(result.isPending).toEqualTypeOf<true>()
-      expectTypeOf(result.isLoading).toEqualTypeOf<true>()
-      expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
-      expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
-      expectTypeOf(result.isSuccess).toEqualTypeOf<false>()
-      expectTypeOf(result.status).toEqualTypeOf<'pending'>()
-      expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
-    }
-
-    if (result.isLoadingError) {
-      expectTypeOf(result.data).toEqualTypeOf<undefined>()
-      expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
-      expectTypeOf(result.isError).toEqualTypeOf<true>()
-      expectTypeOf(result.isPending).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoading).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoadingError).toEqualTypeOf<true>()
-      expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
-      expectTypeOf(result.isSuccess).toEqualTypeOf<false>()
-      expectTypeOf(result.status).toEqualTypeOf<'error'>()
-      expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
-    }
-
-    if (result.isRefetchError) {
-      expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
-      expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
-      expectTypeOf(result.isError).toEqualTypeOf<true>()
-      expectTypeOf(result.isPending).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoading).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
-      expectTypeOf(result.isRefetchError).toEqualTypeOf<true>()
-      expectTypeOf(result.isSuccess).toEqualTypeOf<false>()
-      expectTypeOf(result.status).toEqualTypeOf<'error'>()
-      expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
-    }
-
-    if (result.isSuccess) {
-      expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
-      expectTypeOf(result.error).toEqualTypeOf<null>()
-      expectTypeOf(result.isError).toEqualTypeOf<false>()
-      expectTypeOf(result.isPending).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoading).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
-      expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
-      expectTypeOf(result.isSuccess).toEqualTypeOf<true>()
-      expectTypeOf(result.status).toEqualTypeOf<'success'>()
-      expectTypeOf(result.isPlaceholderData).toEqualTypeOf<boolean>()
-    }
-
-    if (result.isPlaceholderData) {
-      expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
-      expectTypeOf(result.error).toEqualTypeOf<null>()
-      expectTypeOf(result.isError).toEqualTypeOf<false>()
-      expectTypeOf(result.isPending).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoading).toEqualTypeOf<false>()
-      expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
-      expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
-      expectTypeOf(result.isSuccess).toEqualTypeOf<true>()
-      expectTypeOf(result.status).toEqualTypeOf<'success'>()
-      expectTypeOf(result.isPlaceholderData).toEqualTypeOf<true>()
-    }
-  })
-
   describe('QueryObserverOptions', () => {
     describe('queryFn', () => {
       it('should type the context given to the queryFn', () => {
@@ -676,6 +591,139 @@ describe('queryObserver', () => {
         >
 
         expectTypeOf<RefetchError['isRefetchError']>().toEqualTypeOf<true>()
+      })
+    })
+
+    describe('branches', () => {
+      it('should type every flag on the pending branch', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isPending) {
+          expectTypeOf(result.data).toEqualTypeOf<undefined>()
+          expectTypeOf(result.error).toEqualTypeOf<null>()
+          expectTypeOf(result.isError).toEqualTypeOf<false>()
+          expectTypeOf(result.isPending).toEqualTypeOf<true>()
+          expectTypeOf(result.isLoading).toEqualTypeOf<boolean>()
+          expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
+          expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
+          expectTypeOf(result.status).toEqualTypeOf<'pending'>()
+          expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
+        }
+      })
+
+      it('should type every flag on the loading branch', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isLoading) {
+          expectTypeOf(result.data).toEqualTypeOf<undefined>()
+          expectTypeOf(result.error).toEqualTypeOf<null>()
+          expectTypeOf(result.isError).toEqualTypeOf<false>()
+          expectTypeOf(result.isPending).toEqualTypeOf<true>()
+          expectTypeOf(result.isLoading).toEqualTypeOf<true>()
+          expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
+          expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
+          expectTypeOf(result.isSuccess).toEqualTypeOf<false>()
+          expectTypeOf(result.status).toEqualTypeOf<'pending'>()
+          expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
+        }
+      })
+
+      it('should type every flag on the loading error branch', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isLoadingError) {
+          expectTypeOf(result.data).toEqualTypeOf<undefined>()
+          expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+          expectTypeOf(result.isError).toEqualTypeOf<true>()
+          expectTypeOf(result.isPending).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoading).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoadingError).toEqualTypeOf<true>()
+          expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
+          expectTypeOf(result.isSuccess).toEqualTypeOf<false>()
+          expectTypeOf(result.status).toEqualTypeOf<'error'>()
+          expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
+        }
+      })
+
+      it('should type every flag on the refetch error branch', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isRefetchError) {
+          expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
+          expectTypeOf(result.error).toEqualTypeOf<DefaultError>()
+          expectTypeOf(result.isError).toEqualTypeOf<true>()
+          expectTypeOf(result.isPending).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoading).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
+          expectTypeOf(result.isRefetchError).toEqualTypeOf<true>()
+          expectTypeOf(result.isSuccess).toEqualTypeOf<false>()
+          expectTypeOf(result.status).toEqualTypeOf<'error'>()
+          expectTypeOf(result.isPlaceholderData).toEqualTypeOf<false>()
+        }
+      })
+
+      it('should type every flag on the success branch', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isSuccess) {
+          expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
+          expectTypeOf(result.error).toEqualTypeOf<null>()
+          expectTypeOf(result.isError).toEqualTypeOf<false>()
+          expectTypeOf(result.isPending).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoading).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
+          expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
+          expectTypeOf(result.isSuccess).toEqualTypeOf<true>()
+          expectTypeOf(result.status).toEqualTypeOf<'success'>()
+          expectTypeOf(result.isPlaceholderData).toEqualTypeOf<boolean>()
+        }
+      })
+
+      it('should type every flag on the placeholder branch', () => {
+        const observer = new QueryObserver(queryClient, {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        })
+
+        const result = observer.getCurrentResult()
+
+        if (result.isPlaceholderData) {
+          expectTypeOf(result.data).toEqualTypeOf<{ value: string }>()
+          expectTypeOf(result.error).toEqualTypeOf<null>()
+          expectTypeOf(result.isError).toEqualTypeOf<false>()
+          expectTypeOf(result.isPending).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoading).toEqualTypeOf<false>()
+          expectTypeOf(result.isLoadingError).toEqualTypeOf<false>()
+          expectTypeOf(result.isRefetchError).toEqualTypeOf<false>()
+          expectTypeOf(result.isSuccess).toEqualTypeOf<true>()
+          expectTypeOf(result.status).toEqualTypeOf<'success'>()
+          expectTypeOf(result.isPlaceholderData).toEqualTypeOf<true>()
+        }
       })
     })
   })

--- a/packages/query-core/src/__tests__/queryObserver.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryObserver.test-d.tsx
@@ -5,7 +5,6 @@ import type {
   DefaultError,
   InfiniteQueryObserverResult,
   InitialDataFunction,
-  NetworkMode,
   PlaceholderDataFunction,
   Query,
   QueryMeta,
@@ -555,7 +554,7 @@ describe('queryObserver', () => {
         })
 
         expectTypeOf<QueryObserverOptions['networkMode']>().toEqualTypeOf<
-          NetworkMode | undefined
+          'online' | 'always' | 'offlineFirst' | undefined
         >()
       })
     })
@@ -579,7 +578,7 @@ describe('queryObserver', () => {
     describe('meta', () => {
       it('should type meta as its named type', () => {
         expectTypeOf<QueryObserverOptions['meta']>().toEqualTypeOf<
-          QueryMeta | undefined
+          Record<string, unknown> | undefined
         >()
       })
     })


### PR DESCRIPTION
## 🎯 Changes

`queryObserver.test-d.tsx` covered 3 of the 14 public members of `QueryObserver` (`getCurrentResult`, `refetch`, `subscribe`). This expands it to all 14, and groups every test under the option, result member, or method it asserts.

6 tests → 129 tests, 65 assertions → 247.

### What was missing

Eleven public members had no type test at all: `setOptions`, `getOptimisticResult`, `trackResult`, `trackProp`, `getCurrentQuery`, `fetchOptimistic`, `destroy`, `updateResult`, `onQueryUpdate`, `shouldFetchOnReconnect` and `shouldFetchOnWindowFocus`.

On the options side, most of `QueryObserverOptions` was untested — the callbacks that receive a typed `Query` (`enabled`, `staleTime`, `refetchInterval`, `refetchOnWindowFocus`, `refetchOnReconnect`, `refetchOnMount`, `retryOnMount`), the ones that receive a typed error (`throwOnError`, `retry`, `retryDelay`), and plain options such as `gcTime`, `queryHash`, `networkMode`, `meta`, `notifyOnChangeProps` and `persister`. Only the parameters of those callbacks were covered, never their return types, so a callback could return anything.

`QueryObserverResult` was covered only through one large test. Its individual properties (`dataUpdatedAt`, `failureReason`, `isStale`, `fetchStatus`, …), the discriminant literals of each branch, the key set of each branch, and the properties declared on `QueryObserverBaseResult` had no test of their own.

### How the tests are organized

`describe` names the thing a failure would send you to fix:

| `describe` | Named after | Examples |
| --- | --- | --- |
| `QueryObserverOptions > …` | one per option | `queryFn`, `enabled`, `select`, `placeholderData`, `gcTime`, `persister` |
| `QueryObserverResult > …` | one per member interface, plus `QueryObserverBaseResult` for the shared properties | `QueryObserverPendingResult`, `QueryObserverSuccessResult`, `DefinedQueryObserverResult` |
| `<method name>` | one per public member | `setOptions`, `refetch`, `destroy`, `trackProp` |

So a failure reads as `QueryObserverOptions > gcTime` or `QueryObserverResult > QueryObserverSuccessResult`, which is where the fix goes — `types.ts` for the first two groups, `queryObserver.ts` for the methods.

Each test asserts one thing. The exceptions are the few cases where several properties break together and splitting them would only duplicate the same failure.

### The tests under each member interface

Every branch of the union gets three tests, because each guards a different regression:

- **`should be extractable from the result union by its … literal`** — asserted through `Extract<QueryObserverResult<T>, …>`. An `if (result.isLoading)` check cannot cover this: if `isLoading: true` widens to `boolean`, the narrowing just resolves to a different union member and every assertion inside the block still holds.
- **`should pin every flag along with its data and error types`** — inside the narrowed branch, the *other* flags must stay `false` (for example `isPending: false` on the success branch), and `data`/`error` must have the branch's types.
- **`should declare exactly the base and narrowed keys`** — the branch's key set. Without it a property added to a single branch goes unnoticed, since the per-property assertions above only check the properties they name.

`DefinedQueryObserverResult` gets its own describe for the same reason: the outer union already contains every branch, so widening this alias is absorbed unless its composition is pinned directly.

### `QueryObserverBaseResult` is asserted directly

The six member interfaces redeclare `data`, `error` and every discriminant flag, so a break on the base interface is shadowed: widening `QueryObserverBaseResult['data']` to `any` leaves every assertion that goes through a branch passing. The base interface therefore gets its own tests, addressed as `QueryObserverBaseResult<TData, TError>['data']`.

### Notes

- All assertions use `toEqualTypeOf`. `toMatchTypeOf` is deprecated in expect-type and passes on `any`, so it is not used here (0 occurrences in this file, as in the rest of the repository).
- Named type aliases are asserted by their actual shape rather than by their own name (`number | 'static'` instead of `StaleTime`). Repeating the alias on the right-hand side makes the assertion tautological — it keeps passing when the alias itself changes.
- The `@ts-expect-error` comments each sit next to a positive assertion of the same option, so the test states both what is rejected and what the type actually is.
- Test file only; no source changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
