### PR TITLE
test(query-core/environmentManager): add type tests for its public surface

### DIFF
--- a/packages/query-core/src/__tests__/environmentManager.test-d.ts
+++ b/packages/query-core/src/__tests__/environmentManager.test-d.ts
@@ -13,14 +13,14 @@ describe('environmentManager', () => {
       // @ts-expect-error the server check has to answer with a boolean
       const invalid: IsServerValue = () => 'server'
 
-      expectTypeOf(invalid).toEqualTypeOf<IsServerValue>()
+      expectTypeOf(invalid).toEqualTypeOf<() => boolean>()
     })
 
     it('should reject an override that requires an argument', () => {
       // @ts-expect-error the server check is called without any argument
       const invalid: IsServerValue = (_: string) => true
 
-      expectTypeOf(invalid).toEqualTypeOf<IsServerValue>()
+      expectTypeOf(invalid).toEqualTypeOf<() => boolean>()
     })
   })
 

--- a/packages/query-core/src/__tests__/environmentManager.test-d.ts
+++ b/packages/query-core/src/__tests__/environmentManager.test-d.ts
@@ -1,0 +1,62 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { environmentManager } from '..'
+import { isServer } from '../environmentManager'
+import type { IsServerValue } from '../environmentManager'
+
+describe('environmentManager', () => {
+  describe('IsServerValue', () => {
+    it('should take no arguments and return a boolean', () => {
+      expectTypeOf<IsServerValue>().toEqualTypeOf<() => boolean>()
+    })
+
+    it('should reject an override that returns a non-boolean', () => {
+      // @ts-expect-error the server check has to answer with a boolean
+      const invalid: IsServerValue = () => 'server'
+
+      expectTypeOf(invalid).toEqualTypeOf<IsServerValue>()
+    })
+
+    it('should reject an override that requires an argument', () => {
+      // @ts-expect-error the server check is called without any argument
+      const invalid: IsServerValue = (_: string) => true
+
+      expectTypeOf(invalid).toEqualTypeOf<IsServerValue>()
+    })
+  })
+
+  describe('isServer', () => {
+    it('should be a function returning a boolean, not a boolean constant', () => {
+      // `utils.isServer` is a boolean constant evaluated once at module load,
+      // while this one re-runs the (overridable) check on every call.
+      expectTypeOf(isServer).toEqualTypeOf<() => boolean>()
+      expectTypeOf(isServer()).toEqualTypeOf<boolean>()
+    })
+
+    it('should take no parameters', () => {
+      expectTypeOf(isServer).parameters.toEqualTypeOf<[]>()
+    })
+  })
+
+  describe('environmentManager', () => {
+    it('should expose exactly isServer and setIsServer', () => {
+      expectTypeOf<keyof typeof environmentManager>().toEqualTypeOf<
+        'isServer' | 'setIsServer'
+      >()
+    })
+
+    it('should expose isServer as the standalone check', () => {
+      expectTypeOf(environmentManager.isServer).toEqualTypeOf<() => boolean>()
+    })
+
+    describe('setIsServer', () => {
+      it('should only accept an IsServerValue and return void', () => {
+        expectTypeOf(environmentManager.setIsServer).parameters.toEqualTypeOf<
+          [isServerValue: IsServerValue]
+        >()
+        expectTypeOf(
+          environmentManager.setIsServer,
+        ).returns.toEqualTypeOf<void>()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`environmentManager.ts` had no type test. This adds one covering its three exports: the `IsServerValue` type, the standalone `isServer` check, and the `environmentManager` object with its `setIsServer` override.

### Why it is worth pinning

`isServer` exists twice in the package with different types, which is easy to confuse:

| | Type | Behaviour |
| --- | --- | --- |
| `utils.isServer` | `boolean` | constant, evaluated once at module load |
| `environmentManager.isServer` | `() => boolean` | re-runs the overridable check on every call |

The test states that difference explicitly so a future refactor cannot quietly collapse one into the other.

`setIsServer` is the public escape hatch for runtimes where the default detection gives the wrong answer (a Service Worker, for example). Its parameter is the only place where a user-supplied function enters the library, so the shape of `IsServerValue` — no parameters, `boolean` return — is what keeps that contract honest. Two `@ts-expect-error` assertions pin the rejections: a callback returning a non-boolean, and one that requires an argument.

### How the tests are organized

`describe` names the thing a failure would send you to fix — `IsServerValue`, `isServer`, `environmentManager` and its nested `setIsServer`. A failure therefore reads as `environmentManager > setIsServer`, which is where the fix goes.

### Notes

- All assertions use `toEqualTypeOf`. `toMatchTypeOf` is deprecated in expect-type and passes on `any`, so it is not used here.
- Each `@ts-expect-error` sits next to a positive assertion of the same type, so the test states both what is rejected and what the type actually is.
- `keyof typeof environmentManager` is asserted as an exact union rather than a subset, so adding a member to the object without a test is caught.
- Test file only; no source changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added TypeScript type coverage for environment detection and server-state management APIs.
  * Verified valid function signatures and rejected invalid override types or arguments.
  * Confirmed server detection returns a boolean without requiring parameters.
  * Ensured the environment manager exposes only its supported detection and state-management operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->