### PR TITLE
test(query-core/onlineManager): add type tests for 'OnlineManager' public surface

### DIFF
--- a/packages/query-core/src/__tests__/onlineManager.test-d.tsx
+++ b/packages/query-core/src/__tests__/onlineManager.test-d.tsx
@@ -1,0 +1,100 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { onlineManager } from '..'
+import type { OnlineManager } from '..'
+
+describe('onlineManager', () => {
+  describe('OnlineManager', () => {
+    it('should type the singleton as an OnlineManager', () => {
+      expectTypeOf(onlineManager).toEqualTypeOf<OnlineManager>()
+    })
+
+    it('should only expose its documented members', () => {
+      expectTypeOf<keyof OnlineManager>().toEqualTypeOf<
+        | 'subscribe'
+        | 'hasListeners'
+        | 'setEventListener'
+        | 'setOnline'
+        | 'isOnline'
+      >()
+    })
+  })
+
+  describe('subscribe', () => {
+    it('should take a listener of the online state and return an unsubscribe function', () => {
+      expectTypeOf(onlineManager.subscribe).parameters.toEqualTypeOf<
+        [listener: (online: boolean) => void]
+      >()
+      expectTypeOf(onlineManager.subscribe).returns.toEqualTypeOf<() => void>()
+    })
+
+    it('should reject a listener that takes a non-boolean online state', () => {
+      // @ts-expect-error the online state handed to a listener is a boolean
+      const unsubscribe = onlineManager.subscribe((online: string) => online)
+
+      expectTypeOf(unsubscribe).toEqualTypeOf<() => void>()
+    })
+  })
+
+  describe('hasListeners', () => {
+    it('should take no arguments and return a boolean', () => {
+      expectTypeOf(onlineManager.hasListeners).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(onlineManager.hasListeners).returns.toEqualTypeOf<boolean>()
+    })
+  })
+
+  describe('setEventListener', () => {
+    it('should only accept a setup function and return void', () => {
+      expectTypeOf(onlineManager.setEventListener).parameters.toEqualTypeOf<
+        [
+          setup: (
+            setOnline: (online: boolean) => void,
+          ) => (() => void) | undefined,
+        ]
+      >()
+      expectTypeOf(onlineManager.setEventListener).returns.toEqualTypeOf<void>()
+    })
+
+    it('should require an argument on the setOnline callback', () => {
+      // Unlike `focusManager`, there is no "re-evaluate the current state"
+      // mode here, so the online state always has to be passed explicitly.
+      type Setup = Parameters<OnlineManager['setEventListener']>[0]
+
+      expectTypeOf<Parameters<Setup>[0]>().toEqualTypeOf<
+        (online: boolean) => void
+      >()
+      expectTypeOf<
+        Parameters<Parameters<Setup>[0]>['length']
+      >().toEqualTypeOf<1>()
+    })
+
+    it('should let the setup function opt out of returning a cleanup function', () => {
+      type Setup = Parameters<OnlineManager['setEventListener']>[0]
+
+      expectTypeOf<ReturnType<Setup>>().toEqualTypeOf<
+        (() => void) | undefined
+      >()
+    })
+  })
+
+  describe('setOnline', () => {
+    it('should require a boolean and return void', () => {
+      expectTypeOf(onlineManager.setOnline).parameters.toEqualTypeOf<
+        [online: boolean]
+      >()
+      expectTypeOf(onlineManager.setOnline).returns.toEqualTypeOf<void>()
+    })
+
+    it('should not be callable without the online state', () => {
+      expectTypeOf<
+        Parameters<OnlineManager['setOnline']>['length']
+      >().toEqualTypeOf<1>()
+    })
+  })
+
+  describe('isOnline', () => {
+    it('should take no arguments and return a boolean', () => {
+      expectTypeOf(onlineManager.isOnline).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(onlineManager.isOnline).returns.toEqualTypeOf<boolean>()
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`onlineManager` had no type test file, so nothing pinned the types of the `OnlineManager` public surface. This adds `packages/query-core/src/__tests__/onlineManager.test-d.tsx` with 11 type tests covering every public member.

Each `describe` is named after a source identifier, so the file maps one-to-one onto `onlineManager.ts`:

- **`OnlineManager`** — types the exported singleton, and pins the exact member keyset (`subscribe` / `hasListeners` / `setEventListener` / `setOnline` / `isOnline`) so that adding or removing a public member fails the test.
- **`subscribe`** — the listener receives a `boolean` online state and the call returns an unsubscribe function; a listener taking a non-`boolean` is rejected.
- **`hasListeners`** — takes no arguments, returns `boolean`.
- **`setEventListener`** — accepts a single setup function and returns `void`; the `setOnline` callback handed to that setup requires exactly one argument (unlike `focusManager`, there is no "re-evaluate the current state" mode here), and the setup may opt out of returning a cleanup function.
- **`setOnline`** — requires a `boolean` and returns `void`; it is not callable without the online state.
- **`isOnline`** — takes no arguments, returns `boolean`.

Assertions pin parameter tuples and return types separately (`.parameters` / `.returns`) rather than comparing whole function types, so a signature change is reported against the specific member that changed.

No source files are touched — this PR only adds a test file.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added TypeScript type coverage for online-state management APIs, including subscriptions, listener counts, event handling, state updates, and online-state queries.
  * Added checks confirming that invalid listeners and missing arguments are correctly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->