### PR TITLE
test(query-core/focusManager): add type tests for 'FocusManager' public surface

### DIFF
--- a/packages/query-core/src/__tests__/focusManager.test-d.tsx
+++ b/packages/query-core/src/__tests__/focusManager.test-d.tsx
@@ -1,0 +1,108 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { focusManager } from '..'
+import type { FocusManager } from '..'
+
+describe('focusManager', () => {
+  describe('FocusManager', () => {
+    it('should type the singleton as a FocusManager', () => {
+      expectTypeOf(focusManager).toEqualTypeOf<FocusManager>()
+    })
+
+    it('should only expose its documented members', () => {
+      expectTypeOf<keyof FocusManager>().toEqualTypeOf<
+        | 'subscribe'
+        | 'hasListeners'
+        | 'setEventListener'
+        | 'setFocused'
+        | 'onFocus'
+        | 'isFocused'
+      >()
+    })
+  })
+
+  describe('subscribe', () => {
+    it('should take a listener of the focus state and return an unsubscribe function', () => {
+      expectTypeOf(focusManager.subscribe).parameters.toEqualTypeOf<
+        [listener: (focused: boolean) => void]
+      >()
+      expectTypeOf(focusManager.subscribe).returns.toEqualTypeOf<() => void>()
+    })
+
+    it('should reject a listener that takes a non-boolean focus state', () => {
+      // @ts-expect-error the focus state handed to a listener is a boolean
+      const unsubscribe = focusManager.subscribe((focused: string) => focused)
+
+      expectTypeOf(unsubscribe).toEqualTypeOf<() => void>()
+    })
+  })
+
+  describe('hasListeners', () => {
+    it('should take no arguments and return a boolean', () => {
+      expectTypeOf(focusManager.hasListeners).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(focusManager.hasListeners).returns.toEqualTypeOf<boolean>()
+    })
+  })
+
+  describe('setEventListener', () => {
+    it('should only accept a setup function and return void', () => {
+      expectTypeOf(focusManager.setEventListener).parameters.toEqualTypeOf<
+        [
+          setup: (
+            setFocused: (focused?: boolean) => void,
+          ) => (() => void) | undefined,
+        ]
+      >()
+      expectTypeOf(focusManager.setEventListener).returns.toEqualTypeOf<void>()
+    })
+
+    it('should hand the setup function a setFocused callback whose argument is optional', () => {
+      // Unlike `onlineManager`, the focus callback may be called with no
+      // argument at all to re-evaluate the current focus state.
+      type Setup = Parameters<FocusManager['setEventListener']>[0]
+
+      expectTypeOf<Parameters<Setup>[0]>().toEqualTypeOf<
+        (focused?: boolean) => void
+      >()
+      expectTypeOf<Parameters<Parameters<Setup>[0]>['length']>().toEqualTypeOf<
+        0 | 1
+      >()
+    })
+
+    it('should let the setup function opt out of returning a cleanup function', () => {
+      type Setup = Parameters<FocusManager['setEventListener']>[0]
+
+      expectTypeOf<ReturnType<Setup>>().toEqualTypeOf<
+        (() => void) | undefined
+      >()
+    })
+  })
+
+  describe('setFocused', () => {
+    it('should take an optional boolean and return void', () => {
+      expectTypeOf(focusManager.setFocused).parameters.toEqualTypeOf<
+        [focused?: boolean]
+      >()
+      expectTypeOf(focusManager.setFocused).returns.toEqualTypeOf<void>()
+    })
+
+    it('should be callable with no argument to fall back to the default check', () => {
+      expectTypeOf<
+        Parameters<FocusManager['setFocused']>['length']
+      >().toEqualTypeOf<0 | 1>()
+    })
+  })
+
+  describe('onFocus', () => {
+    it('should take no arguments and return void', () => {
+      expectTypeOf(focusManager.onFocus).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(focusManager.onFocus).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('isFocused', () => {
+    it('should take no arguments and return a boolean', () => {
+      expectTypeOf(focusManager.isFocused).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(focusManager.isFocused).returns.toEqualTypeOf<boolean>()
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`focusManager` had no type test file, so nothing pinned the types of the `FocusManager` public surface. This adds `packages/query-core/src/__tests__/focusManager.test-d.tsx` with 12 type tests covering every public member.

Each `describe` is named after a source identifier, so the file maps one-to-one onto `focusManager.ts`:

- **`FocusManager`** — types the exported singleton, and pins the exact member keyset (`subscribe` / `hasListeners` / `setEventListener` / `setFocused` / `onFocus` / `isFocused`) so that adding or removing a public member fails the test.
- **`subscribe`** — the listener receives a `boolean` focus state and the call returns an unsubscribe function; a listener taking a non-`boolean` is rejected.
- **`hasListeners`** — takes no arguments, returns `boolean`.
- **`setEventListener`** — accepts a single setup function and returns `void`; the `setFocused` callback handed to that setup takes an *optional* `boolean`, and the setup may opt out of returning a cleanup function.
- **`setFocused`** — takes an optional `boolean` and returns `void`; it is callable with no argument at all, which is what falls back to the default focus check.
- **`onFocus`** — takes no arguments, returns `void`.
- **`isFocused`** — takes no arguments, returns `boolean`.

The optional argument is the detail worth pinning here. Both `setFocused` and the `setFocused` callback passed to `setEventListener` accept zero arguments so callers can re-evaluate the current focus state, which is exactly where `FocusManager` differs from the otherwise parallel `OnlineManager` (whose callbacks require the state explicitly). The tests assert the parameter tuple arity as `0 | 1` so that making either argument required would fail.

Assertions pin parameter tuples and return types separately (`.parameters` / `.returns`) rather than comparing whole function types, so a signature change is reported against the specific member that changed.

No source files are touched — this PR only adds a test file.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added type-level coverage for the public focus management API.
  - Verified method signatures, parameter types, return values, listener requirements, optional callbacks, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->