### PR TITLE
test(query-core/queryCache): add type tests for 'QueryCache', its config, store and notify events

### DIFF
--- a/packages/query-core/src/__tests__/queryCache.test-d.tsx
+++ b/packages/query-core/src/__tests__/queryCache.test-d.tsx
@@ -1,0 +1,496 @@
+import { afterEach, beforeEach, describe, expectTypeOf, it } from 'vitest'
+import { queryKey } from '@tanstack/query-test-utils'
+import { QueryCache, QueryClient } from '..'
+import type {
+  DefaultError,
+  NotifyEvent,
+  NotifyEventType,
+  Query,
+  QueryCacheConfig,
+  QueryCacheNotifyEvent,
+  QueryFilters,
+  QueryKey,
+  QueryObserver,
+  QueryState,
+} from '..'
+import type { Action } from '../query'
+import type { QueryStore } from '../queryCache'
+
+class CustomError extends Error {
+  name = 'CustomError' as const
+}
+
+describe('queryCache', () => {
+  let queryClient: QueryClient
+  let queryCache: QueryCache
+
+  beforeEach(() => {
+    queryClient = new QueryClient()
+    queryClient.mount()
+    queryCache = queryClient.getQueryCache()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  describe('QueryCache', () => {
+    it('should only expose its documented members', () => {
+      expectTypeOf<keyof QueryCache>().toEqualTypeOf<
+        | 'subscribe'
+        | 'hasListeners'
+        | 'config'
+        | 'build'
+        | 'add'
+        | 'remove'
+        | 'clear'
+        | 'get'
+        | 'getAll'
+        | 'find'
+        | 'findAll'
+        | 'notify'
+        | 'onFocus'
+        | 'onOnline'
+      >()
+    })
+  })
+
+  describe('config', () => {
+    it('should be typed as the cache config', () => {
+      expectTypeOf(queryCache.config).toEqualTypeOf<QueryCacheConfig>()
+      expectTypeOf(new QueryCache().config).toEqualTypeOf<QueryCacheConfig>()
+    })
+
+    it('should stay writable', () => {
+      type Config = Pick<QueryCache, 'config'>
+
+      expectTypeOf<Config>().toEqualTypeOf<{
+        -readonly [K in keyof Config]: Config[K]
+      }>()
+    })
+
+    it('should be optional when constructing a cache', () => {
+      expectTypeOf(QueryCache).constructorParameters.toEqualTypeOf<
+        [config?: QueryCacheConfig]
+      >()
+    })
+  })
+
+  describe('QueryCacheConfig', () => {
+    it('should declare every callback as optional', () => {
+      expectTypeOf<QueryCacheConfig>().toEqualTypeOf<{
+        onError?: (
+          error: DefaultError,
+          query: Query<unknown, unknown, unknown>,
+        ) => void
+        onSuccess?: (
+          data: unknown,
+          query: Query<unknown, unknown, unknown>,
+        ) => void
+        onSettled?: (
+          data: unknown | undefined,
+          error: DefaultError | null,
+          query: Query<unknown, unknown, unknown>,
+        ) => void
+      }>()
+    })
+
+    describe('onError', () => {
+      it('should type the error and the query it is given', () => {
+        expectTypeOf<
+          NonNullable<QueryCacheConfig['onError']>
+        >().parameters.toEqualTypeOf<
+          [error: DefaultError, query: Query<unknown, unknown, unknown>]
+        >()
+      })
+
+      it('should not await its return value', () => {
+        expectTypeOf<
+          NonNullable<QueryCacheConfig['onError']>
+        >().returns.toEqualTypeOf<void>()
+      })
+    })
+
+    describe('onSuccess', () => {
+      it('should type the data and the query it is given', () => {
+        expectTypeOf<
+          NonNullable<QueryCacheConfig['onSuccess']>
+        >().parameters.toEqualTypeOf<
+          [data: unknown, query: Query<unknown, unknown, unknown>]
+        >()
+      })
+
+      it('should not await its return value', () => {
+        expectTypeOf<
+          NonNullable<QueryCacheConfig['onSuccess']>
+        >().returns.toEqualTypeOf<void>()
+      })
+    })
+
+    describe('onSettled', () => {
+      it('should type the data, error and query it is given', () => {
+        expectTypeOf<
+          NonNullable<QueryCacheConfig['onSettled']>
+        >().parameters.toEqualTypeOf<
+          [
+            data: unknown,
+            error: DefaultError | null,
+            query: Query<unknown, unknown, unknown>,
+          ]
+        >()
+      })
+
+      it('should not await its return value', () => {
+        expectTypeOf<
+          NonNullable<QueryCacheConfig['onSettled']>
+        >().returns.toEqualTypeOf<void>()
+      })
+    })
+  })
+
+  describe('NotifyEventType', () => {
+    it('should union exactly the seven event type literals', () => {
+      // Every `QueryCacheNotifyEvent` variant redeclares `type` with its own
+      // literal, so the base union is only observable through this alias.
+      expectTypeOf<NotifyEventType>().toEqualTypeOf<
+        | 'added'
+        | 'removed'
+        | 'updated'
+        | 'observerAdded'
+        | 'observerRemoved'
+        | 'observerResultsUpdated'
+        | 'observerOptionsUpdated'
+      >()
+    })
+  })
+
+  describe('NotifyEvent', () => {
+    it('should declare a single type property taken from NotifyEventType', () => {
+      expectTypeOf<keyof NotifyEvent>().toEqualTypeOf<'type'>()
+      expectTypeOf<NotifyEvent['type']>().toEqualTypeOf<NotifyEventType>()
+    })
+  })
+
+  describe('QueryCacheNotifyEvent', () => {
+    it('should union exactly the seven event type literals', () => {
+      expectTypeOf<QueryCacheNotifyEvent['type']>().toEqualTypeOf<
+        | 'added'
+        | 'removed'
+        | 'updated'
+        | 'observerAdded'
+        | 'observerRemoved'
+        | 'observerResultsUpdated'
+        | 'observerOptionsUpdated'
+      >()
+    })
+
+    it('should carry an action only on the updated event', () => {
+      type Updated = Extract<QueryCacheNotifyEvent, { type: 'updated' }>
+
+      expectTypeOf<keyof Updated>().toEqualTypeOf<'type' | 'query' | 'action'>()
+      expectTypeOf<Updated['query']>().toEqualTypeOf<
+        Query<any, any, any, any>
+      >()
+      expectTypeOf<Updated['action']>().toEqualTypeOf<Action<any, any>>()
+    })
+
+    it('should declare only a query on the added event', () => {
+      expectTypeOf<
+        keyof Extract<QueryCacheNotifyEvent, { type: 'added' }>
+      >().toEqualTypeOf<'type' | 'query'>()
+    })
+
+    it('should declare only a query on the removed event', () => {
+      expectTypeOf<
+        keyof Extract<QueryCacheNotifyEvent, { type: 'removed' }>
+      >().toEqualTypeOf<'type' | 'query'>()
+    })
+
+    it('should carry an observer on the observerAdded event', () => {
+      expectTypeOf<
+        keyof Extract<QueryCacheNotifyEvent, { type: 'observerAdded' }>
+      >().toEqualTypeOf<'type' | 'query' | 'observer'>()
+      expectTypeOf<
+        Extract<QueryCacheNotifyEvent, { type: 'observerAdded' }>['observer']
+      >().toEqualTypeOf<QueryObserver<any, any, any, any, any>>()
+    })
+
+    it('should carry an observer on the observerRemoved event', () => {
+      expectTypeOf<
+        keyof Extract<QueryCacheNotifyEvent, { type: 'observerRemoved' }>
+      >().toEqualTypeOf<'type' | 'query' | 'observer'>()
+      expectTypeOf<
+        Extract<QueryCacheNotifyEvent, { type: 'observerRemoved' }>['observer']
+      >().toEqualTypeOf<QueryObserver<any, any, any, any, any>>()
+    })
+
+    it('should carry an observer on the observerOptionsUpdated event', () => {
+      expectTypeOf<
+        keyof Extract<QueryCacheNotifyEvent, { type: 'observerOptionsUpdated' }>
+      >().toEqualTypeOf<'type' | 'query' | 'observer'>()
+      expectTypeOf<
+        Extract<
+          QueryCacheNotifyEvent,
+          { type: 'observerOptionsUpdated' }
+        >['observer']
+      >().toEqualTypeOf<QueryObserver<any, any, any, any, any>>()
+    })
+
+    it('should require the query on every event', () => {
+      type EventsWithRequiredQuery = Extract<
+        QueryCacheNotifyEvent,
+        { query: Query<any, any, any, any> }
+      >['type']
+
+      expectTypeOf<EventsWithRequiredQuery>().toEqualTypeOf<
+        QueryCacheNotifyEvent['type']
+      >()
+    })
+
+    it('should not carry an observer on the observerResultsUpdated event', () => {
+      expectTypeOf<
+        keyof Extract<QueryCacheNotifyEvent, { type: 'observerResultsUpdated' }>
+      >().toEqualTypeOf<'type' | 'query'>()
+    })
+  })
+
+  describe('QueryStore', () => {
+    it('should type every method of the store', () => {
+      expectTypeOf<QueryStore>().toEqualTypeOf<{
+        has: (queryHash: string) => boolean
+        set: (queryHash: string, query: Query) => void
+        get: (queryHash: string) => Query | undefined
+        delete: (queryHash: string) => void
+        values: () => IterableIterator<Query>
+      }>()
+    })
+  })
+
+  describe('subscribe', () => {
+    it('should type the event given to a listener', () => {
+      queryCache.subscribe((event) => {
+        expectTypeOf(event).toEqualTypeOf<QueryCacheNotifyEvent>()
+      })
+    })
+
+    it('should return an unsubscribe function', () => {
+      expectTypeOf(queryCache.subscribe(() => {})).toEqualTypeOf<() => void>()
+    })
+  })
+
+  describe('build', () => {
+    it('should carry its type parameters into the query it returns', () => {
+      const query = queryCache.build<{ value: string }, CustomError>(
+        queryClient,
+        {
+          queryKey: queryKey(),
+          queryFn: () => Promise.resolve({ value: 'data' }),
+        },
+      )
+
+      expectTypeOf(query).toEqualTypeOf<
+        Query<
+          { value: string },
+          CustomError,
+          { value: string },
+          ReadonlyArray<unknown>
+        >
+      >()
+      expectTypeOf(query.state).toEqualTypeOf<
+        QueryState<{ value: string }, CustomError>
+      >()
+    })
+
+    it('should preserve a literal queryKey', () => {
+      const key = ['a', 1] as const
+
+      expectTypeOf(
+        queryCache.build(queryClient, {
+          queryKey: key,
+          queryFn: () => Promise.resolve('data'),
+        }).queryKey,
+      ).toEqualTypeOf<readonly ['a', 1]>()
+    })
+
+    it('should require a queryKey in the options it is given', () => {
+      // @ts-expect-error a queryKey is required
+      queryCache.build(queryClient, {
+        queryFn: () => Promise.resolve('data'),
+      })
+
+      expectTypeOf(queryCache.build)
+        .parameter(1)
+        .toHaveProperty('queryKey')
+        .toEqualTypeOf<ReadonlyArray<unknown>>()
+    })
+
+    it('should accept an optional initial state', () => {
+      expectTypeOf(queryCache.build<{ value: string }, CustomError>)
+        .parameter(2)
+        .toEqualTypeOf<QueryState<{ value: string }, CustomError> | undefined>()
+    })
+
+    it('should default its type parameters', () => {
+      const query = queryCache.build(queryClient, { queryKey: queryKey() })
+
+      expectTypeOf(query.state).toEqualTypeOf<
+        QueryState<unknown, DefaultError>
+      >()
+      expectTypeOf(query.state.data).toEqualTypeOf<unknown>()
+      expectTypeOf(query.state.error).toEqualTypeOf<DefaultError | null>()
+    })
+  })
+
+  describe('get', () => {
+    it('should carry its type parameters into the query it returns', () => {
+      expectTypeOf(
+        queryCache.get<{ value: string }, CustomError>('hash'),
+      ).toEqualTypeOf<
+        | Query<
+            { value: string },
+            CustomError,
+            { value: string },
+            ReadonlyArray<unknown>
+          >
+        | undefined
+      >()
+    })
+
+    it('should take a query hash and default its type parameters', () => {
+      expectTypeOf(queryCache.get).parameters.toEqualTypeOf<
+        [queryHash: string]
+      >()
+      expectTypeOf(queryCache.get('hash')).toEqualTypeOf<
+        Query<unknown, DefaultError, unknown, QueryKey> | undefined
+      >()
+    })
+
+    it('should accept a queryKey type parameter, unlike find', () => {
+      expectTypeOf(
+        queryCache.get<
+          { value: string },
+          CustomError,
+          { value: string },
+          readonly ['a', 1]
+        >('hash'),
+      ).toEqualTypeOf<
+        | Query<
+            { value: string },
+            CustomError,
+            { value: string },
+            readonly ['a', 1]
+          >
+        | undefined
+      >()
+    })
+  })
+
+  describe('getAll', () => {
+    it('should return an array of fully defaulted queries', () => {
+      expectTypeOf(queryCache.getAll()).toEqualTypeOf<
+        Array<Query<unknown, DefaultError, unknown, QueryKey>>
+      >()
+    })
+
+    it('should take no arguments', () => {
+      expectTypeOf(queryCache.getAll).parameters.toEqualTypeOf<[]>()
+    })
+  })
+
+  describe('find', () => {
+    it('should carry its type parameters into the query it returns', () => {
+      expectTypeOf(
+        queryCache.find<{ value: string }, CustomError>({
+          queryKey: queryKey(),
+        }),
+      ).toEqualTypeOf<
+        | Query<{ value: string }, CustomError, { value: string }, QueryKey>
+        | undefined
+      >()
+    })
+
+    it('should require a queryKey in the filters it is given', () => {
+      // @ts-expect-error a queryKey is required
+      queryCache.find({})
+
+      expectTypeOf(queryCache.find)
+        .parameter(0)
+        .toHaveProperty('queryKey')
+        .toEqualTypeOf<ReadonlyArray<unknown>>()
+    })
+
+    it('should default its type parameters', () => {
+      expectTypeOf(queryCache.find({ queryKey: queryKey() })).toEqualTypeOf<
+        Query<unknown, DefaultError, unknown, QueryKey> | undefined
+      >()
+    })
+  })
+
+  describe('findAll', () => {
+    it('should return an array of fully defaulted queries', () => {
+      expectTypeOf(queryCache.findAll({ queryKey: queryKey() })).toEqualTypeOf<
+        Array<Query<unknown, DefaultError, unknown, QueryKey>>
+      >()
+    })
+
+    it('should accept filters or nothing', () => {
+      queryCache.findAll()
+      queryCache.findAll({ queryKey: queryKey() })
+      queryCache.findAll({ stale: true })
+      // @ts-expect-error stale must be a boolean
+      queryCache.findAll({ stale: 'yes' })
+
+      expectTypeOf(queryCache.findAll).parameters.toEqualTypeOf<
+        [filters?: QueryFilters<any>]
+      >()
+    })
+  })
+
+  describe('add', () => {
+    it('should take a single query and return void', () => {
+      expectTypeOf(queryCache.add).returns.toEqualTypeOf<void>()
+      expectTypeOf(queryCache.add).parameters.toEqualTypeOf<
+        [query: Query<any, any, any, any>]
+      >()
+    })
+  })
+
+  describe('remove', () => {
+    it('should take a single query and return void', () => {
+      expectTypeOf(queryCache.remove).returns.toEqualTypeOf<void>()
+      expectTypeOf(queryCache.remove).parameters.toEqualTypeOf<
+        [query: Query<any, any, any, any>]
+      >()
+    })
+  })
+
+  describe('clear', () => {
+    it('should take no arguments and return void', () => {
+      expectTypeOf(queryCache.clear).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(queryCache.clear).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('notify', () => {
+    it('should only accept a notify event and return void', () => {
+      expectTypeOf(queryCache.notify).parameters.toEqualTypeOf<
+        [event: QueryCacheNotifyEvent]
+      >()
+      expectTypeOf(queryCache.notify).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('onFocus', () => {
+    it('should take no arguments and return void', () => {
+      expectTypeOf(queryCache.onFocus).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(queryCache.onFocus).returns.toEqualTypeOf<void>()
+    })
+  })
+
+  describe('onOnline', () => {
+    it('should take no arguments and return void', () => {
+      expectTypeOf(queryCache.onOnline).parameters.toEqualTypeOf<[]>()
+      expectTypeOf(queryCache.onOnline).returns.toEqualTypeOf<void>()
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`queryCache` had no type test file, so nothing pinned `QueryCacheConfig`'s global callbacks, the `QueryStore` interface, the `QueryCacheNotifyEvent` union, or the `QueryCache` method surface. This adds `packages/query-core/src/__tests__/queryCache.test-d.tsx` with 46 type tests.

Each `describe` is named after a source identifier, so the file maps one-to-one onto `queryCache.ts`:

- **`QueryCache`** — pins the exact public member keyset, inherited `subscribe` / `hasListeners` included.
- **`config`** — typed as `QueryCacheConfig`, stays writable, is `public`, and is optional when constructing a cache.
- **`QueryCacheConfig`** — three optional callbacks, each pinning its parameter tuple. All three return `void` rather than `Promise<unknown> | unknown`, which is what distinguishes them from `MutationCacheConfig`'s callbacks: these are fire-and-forget and their return value is never awaited, so each has a test asserting exactly that.
- **`NotifyEventType`** / **`NotifyEvent`** — the seven event type literals, and the single `type` property carried by the base event.
- **`QueryCacheNotifyEvent`** — each arm's keyset is extracted and pinned on its own, along with the `observer` type on the three observer events and the complementary check that every event requires `query`. `observerResultsUpdated` is the one observer event that carries no `observer`, so it is asserted explicitly.
- **`QueryStore`** — all five methods (`has` / `set` / `get` / `delete` / `values`) pinned as one object type, including `get` returning `Query | undefined` and `values` returning an `IterableIterator`.
- **`subscribe`** — the listener receives a `QueryCacheNotifyEvent`; subscribing returns an unsubscribe function.
- **`build`** — carries its four type parameters into the returned `Query`, preserves a literal `queryKey`, requires `queryKey` in the options it is given, takes an optional initial state, and defaults its type parameters.
- **`get`** / **`find`** / **`findAll`** / **`getAll`** — `get` takes a query hash and accepts a `TQueryKey` type parameter (unlike `find`, which does not); `find` requires `queryKey` in its filters and returns `Query | undefined`; `findAll` accepts filters or nothing.
- **`add`** / **`remove`** / **`clear`** / **`notify`** / **`onFocus`** / **`onOnline`** — parameter tuples and return types pinned.

Each arm of the notify-event union is pinned via `Extract` rather than through `keyof QueryCacheNotifyEvent`, because `keyof` on a union yields the *intersection* of its members' keys — here just `type` — which would let a field be added to or removed from any individual arm unnoticed. For the same reason each observer event's `observer` is asserted directly: its keyset alone cannot see a change in the observer's own type arguments.

No source files are touched — this PR only adds a test file.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive TypeScript coverage for `QueryCache` APIs, including subscriptions, filtering, notifications, cache operations, and focus/online event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->